### PR TITLE
Add development plan and fix compatibility wrappers

### DIFF
--- a/development_plan.md
+++ b/development_plan.md
@@ -1,0 +1,52 @@
+# Development Plan for `voiage`
+
+This plan outlines the steps to implement the remaining features from `roadmap.md` and `todo.md`.
+
+## Phase 1: Foundation & API Refactoring
+1. **Design `DecisionAnalysis` class**
+   - Create `voiage/analysis.py` with a class encapsulating model inputs, data structures and methods (`evpi`, `evppi`, `evsi`).
+   - Migrate functions in `methods/basic.py` into methods of `DecisionAnalysis` while preserving their functionality.
+2. **Refactor data structures**
+   - Move structures from `core/data_structures.py` to a new schema module.
+   - Rename legacy names (`PSASample` → `ParameterSet`, `TrialArm` → `DecisionOption`, `NetBenefitArray` → `ValueArray`).
+   - Provide lightweight compatibility wrappers and update tests.
+3. **Functional wrappers**
+   - Expose helper functions (`voiage.evpi`, `voiage.evppi`, etc.) that instantiate `DecisionAnalysis` internally.
+4. **High-performance backend**
+   - Implement `voiage/backends.py` with a dispatch system and a JAX backend for core calculations.
+5. **Infrastructure**
+   - Configure GitHub Actions for linting, tests and coverage.
+   - Set up Sphinx docs with a modern theme and deploy via GitHub Pages.
+   - Add `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` and move inline test code into `tests/`.
+
+## Phase 2: State-of-the-Art Health Economics Core
+1. **Robust EVSI**
+   - Refactor `evsi` into `DecisionAnalysis`.
+   - Implement two-loop Monte Carlo with Bayesian updaters (`ConjugateUpdater`, `PyMCUpdater`) and metamodels (`GAMMetamodel`, `GPMetamodel`).
+2. **Network Meta-Analysis**
+   - Design data structures for network evidence.
+   - Add an `evsi_nma` method supporting multivariate posteriors.
+3. **Validation & Benchmarking**
+   - Add notebooks in `validation/` replicating published results (e.g., R `BCEA`).
+   - Benchmark `numpy` vs `jax` backends.
+4. **Plotting & Examples**
+   - Implement plotting utilities (CEAC, VOI curves, EVPPI surfaces).
+   - Create a tutorial notebook under `examples/health_economics`.
+
+## Phase 3: Advanced Methods & Cross-Domain Expansion
+1. **Advanced VOI methods**
+   - Implement `portfolio_voi`, `structural_voi` and `sequential_voi` methods using the OO API.
+2. **Cross-domain examples**
+   - Provide notebooks for environmental policy and business strategy applications.
+3. **XArray integration**
+   - Refactor `ParameterSet` and `ValueArray` to leverage `xarray.Dataset` with labelled dimensions throughout the codebase.
+
+## Phase 4: Ecosystem & Future Ports
+1. **Community growth**
+   - Maintain issues and discussions, publish periodic updates and present at conferences.
+2. **Language-agnostic specification**
+   - Draft a JSON Schema for `DecisionAnalysis` inputs/outputs to guide R and Julia ports.
+3. **Prototype ports**
+   - Begin experimental implementations of `rvoiage` (R) and `Voiage.jl` (Julia) to validate the cross-language design.
+
+This plan should be revisited regularly as features land to keep the roadmap and to-do list in sync.

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -14,6 +14,7 @@ from voiage.core.data_structures import (
     ParameterSet,
     DecisionOption,
     TrialDesign,
+    TrialArm,
 )
 from voiage.exceptions import DimensionMismatchError, InputError
 
@@ -109,12 +110,13 @@ class TestTrialDesign:
             TrialDesign(arms=[])
 
         with pytest.raises(
-            InputError, match="All elements in 'arms' must be TrialArm objects"
+            InputError, match="All elements in 'arms' must be DecisionOption objects"
         ):
             TrialDesign(arms=["not an arm"])
 
         with pytest.raises(
-            InputError, match="TrialArm names within a TrialDesign must be unique"
+            InputError,
+            match="DecisionOption names within a TrialDesign must be unique",
         ):
             arm1 = TrialArm(name="Treatment A", sample_size=100)
             TrialDesign(arms=[arm1, arm1])

--- a/voiage/core/data_structures.py
+++ b/voiage/core/data_structures.py
@@ -57,6 +57,21 @@ class ValueArray:
         return self.dataset["strategy"].values.tolist()
 
 
+class NetBenefitArray(ValueArray):
+    """Backward-compatible wrapper around :class:`ValueArray`."""
+
+    def __init__(self: "NetBenefitArray", values: np.ndarray, strategy_names: List[str]):
+        dataset = xr.Dataset(
+            {"net_benefit": (("n_samples", "n_strategies"), values)},
+            coords={
+                "n_samples": np.arange(values.shape[0]),
+                "n_strategies": np.arange(values.shape[1]),
+                "strategy": ("n_strategies", strategy_names),
+            },
+        )
+        super().__init__(dataset=dataset)
+
+
 @dataclass(frozen=True)
 class ParameterSet:
     """
@@ -81,6 +96,17 @@ class ParameterSet:
     @property
     def parameter_names(self: "ParameterSet") -> List[str]:
         return list(self.dataset.data_vars.keys())
+
+
+class PSASample(ParameterSet):
+    """Backward-compatible wrapper around :class:`ParameterSet`."""
+
+    def __init__(self: "PSASample", parameters: Dict[str, np.ndarray]):
+        dataset = xr.Dataset(
+            {k: ("n_samples", np.asarray(v)) for k, v in parameters.items()},
+            coords={"n_samples": np.arange(len(next(iter(parameters.values()))))},
+        )
+        super().__init__(dataset=dataset)
 
 
 @dataclass(frozen=True)
@@ -291,5 +317,10 @@ class DynamicSpec:
 #     else:
 #         updated_params = psa_sample.parameters
 #
-#     nb_values = my_health_economic_model(updated_params)
-#     return NetBenefitArray(values=nb_values)
+    #     nb_values = my_health_economic_model(updated_params)
+    #     return NetBenefitArray(values=nb_values)
+
+# --- Backwards Compatibility Alias ---
+# Allow old code to use ``TrialArm`` to refer to ``DecisionOption``.
+TrialArm = DecisionOption
+


### PR DESCRIPTION
## Summary
- create a `development_plan.md` outlining tasks for remaining roadmap items
- add backward-compatibility wrappers for `NetBenefitArray`, `PSASample`, and alias `TrialArm`
- update unit tests for new terminology

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688760fc2360833181eb445a77c56752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced backward-compatible wrappers for value arrays and parameter sets, simplifying input for users.
  * Added an alias to support legacy naming conventions for decision options.

* **Documentation**
  * Added a comprehensive development plan outlining future phases and feature roadmap.

* **Bug Fixes**
  * Updated test cases to reflect revised error messages and naming conventions for decision options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->