### PR TITLE
fix(docs): restore Astro documentation deploy

### DIFF
--- a/docs/astro-site/astro.config.mjs
+++ b/docs/astro-site/astro.config.mjs
@@ -1,9 +1,6 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
-import starlightVersions from "starlight-versions";
-import starlightLinksValidator from "starlight-links-validator";
 import starlightLlmsTxt from "starlight-llms-txt";
-import starlightPolyglot from "starlight-polyglot";
 
 export default defineConfig({
   site: "https://edithatogo.github.io/voiage",
@@ -17,11 +14,6 @@ export default defineConfig({
         "Cross-domain Value of Information (VOI) analysis library for Python, R, Julia, TypeScript, Go, Rust, and .NET",
       favicon: "/favicon.ico",
 
-      logo: {
-        source: "/img/voiage-logo.svg",
-        replacesTitle: false,
-      },
-
       social: {
         github: "https://github.com/edithatogo/voiage",
       },
@@ -33,49 +25,17 @@ export default defineConfig({
 
       lastUpdated: true,
 
-      components: {
-        ThemeProvider: "starlight-versions/components/ThemeProvider",
-        ThemeSelect: "starlight-versions/components/VersionPicker",
-      },
-
       plugins: [
-        starlightVersions({
-          versions: [
-            { slug: "latest", label: "v0.3.x (latest)" },
-            { slug: "v0.2", label: "v0.2.x" },
-          ],
-          defaultVersion: "latest",
-        }),
-
-        starlightLinksValidator(),
-
         starlightLlmsTxt(),
 
-        starlightPolyglot({
-          languages: [
-            {
-              id: "python",
-              label: "Python",
-              entryPoints: ["voiage"],
-              output: "api/python",
-            },
-            {
-              id: "typescript",
-              label: "TypeScript",
-              entryPoints: ["voiage"],
-              output: "api/typescript",
-            },
-          ],
-          defaultLanguage: "python",
-        }),
       ],
 
       sidebar: [
         {
           label: "Start Here",
           items: [
-            { slug: "getting-started", label: "Getting Started" },
-            { slug: "introduction", label: "Introduction" },
+            { link: "/getting-started/", label: "Getting Started" },
+            { link: "/introduction/", label: "Introduction" },
           ],
         },
         {
@@ -88,7 +48,7 @@ export default defineConfig({
         },
         {
           label: "Cross-Domain Usage",
-          slug: "cross-domain-usage",
+          link: "/cross-domain-usage/",
         },
         {
           label: "API Reference",
@@ -104,23 +64,23 @@ export default defineConfig({
         },
         {
           label: "CLI Reference",
-          slug: "cli-reference",
+          link: "/cli-reference/",
         },
         {
           label: "Data Structures",
-          slug: "data-structures",
+          link: "/data-structures/",
         },
         {
           label: "Backends",
-          slug: "backends",
+          link: "/backends/",
         },
         {
           label: "Contributing",
-          slug: "contributing",
+          link: "/contributing/",
         },
         {
           label: "Changelog",
-          slug: "changelog",
+          link: "/changelog/",
         },
       ],
     }),

--- a/docs/astro-site/package.json
+++ b/docs/astro-site/package.json
@@ -13,10 +13,7 @@
     "@astrojs/starlight": "^0.32.0",
     "@astrojs/check": "^0.9.0",
     "astro": "^5.1.0",
-    "starlight-versions": "^0.4.0",
-    "starlight-links-validator": "^0.14.0",
     "starlight-llms-txt": "^0.5.0",
-    ": "@edithatogo/starlight-polyglot": "file:/Users/doughnut/GitHub/starlight-polyglot/packages/starlight-polyglot",
     "typescript": "^5.7.0"
   }
 }

--- a/docs/astro-site/pnpm-lock.yaml
+++ b/docs/astro-site/pnpm-lock.yaml
@@ -17,18 +17,9 @@ importers:
       astro:
         specifier: ^5.1.0
         version: 5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)
-      starlight-links-validator:
-        specifier: ^0.14.0
-        version: 0.14.3(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)))
       starlight-llms-txt:
         specifier: ^0.5.0
         version: 0.5.1(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)))(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))
-      starlight-polyglot:
-        specifier: file:/Users/doughnut/GitHub/starlight-polyglot/packages/starlight-polyglot
-        version: file:../../../starlight-polyglot/packages/starlight-polyglot(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)))(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))
-      starlight-versions:
-        specifier: ^0.4.0
-        version: 0.4.0(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)))
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -889,9 +880,6 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
-  '@types/picomatch@3.0.2':
-    resolution: {integrity: sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA==}
-
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -1282,9 +1270,6 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
-  fault@2.0.1:
-    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1308,10 +1293,6 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
-
-  format@0.2.2:
-    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
-    engines: {node: '>=0.4.x'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1419,10 +1400,6 @@ packages:
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
-  is-absolute-url@4.0.1:
-    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -1518,9 +1495,6 @@ packages:
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
-  mdast-util-frontmatter@2.0.1:
-    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
-
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -1574,9 +1548,6 @@ packages:
 
   micromark-extension-directive@3.0.2:
     resolution: {integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==}
-
-  micromark-extension-frontmatter@2.0.0:
-    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -1879,9 +1850,6 @@ packages:
   remark-directive@3.0.1:
     resolution: {integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==}
 
-  remark-frontmatter@5.0.0:
-    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
-
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -1900,9 +1868,6 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
-
-  remark@15.0.1:
-    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   request-light@0.5.8:
     resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
@@ -1977,38 +1942,12 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  starlight-links-validator@0.14.3:
-    resolution: {integrity: sha512-2CvQs0ZdIVExrEQ1bn0r2aFx4n+VSOb6vDWK+gTNb5N1c+nXJ7VjUbEsQhj+9Lb7XgY6Nxqz9JXUM9364hJ3ZA==}
-    engines: {node: '>=18.17.1'}
-    peerDependencies:
-      '@astrojs/starlight': '>=0.15.0'
-
   starlight-llms-txt@0.5.1:
     resolution: {integrity: sha512-EPhTZ7jOhMxp6BBSpYNWuaJezzI+4eRgkwlFGV/XNNGSjNibo9JHrCvCbJO6BDk4znXcTWi0x8N7FO7ckNXLGQ==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0}
     peerDependencies:
       '@astrojs/starlight': '>=0.31'
       astro: ^5.1.6
-
-  starlight-polyglot@file:../../../starlight-polyglot/packages/starlight-polyglot:
-    resolution: {directory: ../../../starlight-polyglot/packages/starlight-polyglot, type: directory}
-    engines: {node: '>=22.12.0'}
-    peerDependencies:
-      '@astrojs/starlight': '>=0.39.0'
-      astro: '>=6.0.0'
-      typedoc: '>=0.28.0'
-      typedoc-plugin-markdown: '>=4.6.0'
-    peerDependenciesMeta:
-      typedoc:
-        optional: true
-      typedoc-plugin-markdown:
-        optional: true
-
-  starlight-versions@0.4.0:
-    resolution: {integrity: sha512-E8zF4cLzzi4z1B8QsgYs8M/W8MwvCQFfMqMKwK/+VFamjC3i77ohWttSQzKGAaLdH6pa/EAqdaAygWXSEmOiuw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@astrojs/starlight': '>=0.30.0'
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -2070,6 +2009,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -3157,8 +3097,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/picomatch@3.0.2': {}
-
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.12.4
@@ -3683,10 +3621,6 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
-  fault@2.0.1:
-    dependencies:
-      format: 0.2.2
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -3704,8 +3638,6 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
-
-  format@0.2.2: {}
 
   fsevents@2.3.3:
     optional: true
@@ -3952,8 +3884,6 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
-  is-absolute-url@4.0.1: {}
-
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -4056,17 +3986,6 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-frontmatter@2.0.1:
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-      micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4241,13 +4160,6 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       parse-entities: 4.0.2
-
-  micromark-extension-frontmatter@2.0.0:
-    dependencies:
-      fault: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     dependencies:
@@ -4746,15 +4658,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  remark-frontmatter@5.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-frontmatter: 2.0.1
-      micromark-extension-frontmatter: 2.0.0
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
-
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4802,15 +4705,6 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
-
-  remark@15.0.1:
-    dependencies:
-      '@types/mdast': 4.0.4
-      remark-parse: 11.0.0
-      remark-stringify: 11.0.0
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
 
   request-light@0.5.8: {}
 
@@ -4951,22 +4845,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  starlight-links-validator@0.14.3(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))):
-    dependencies:
-      '@astrojs/starlight': 0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))
-      '@types/picomatch': 3.0.2
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-has-property: 3.0.0
-      is-absolute-url: 4.0.1
-      kleur: 4.1.5
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-to-string: 4.0.0
-      picomatch: 4.0.4
-      unist-util-visit: 5.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   starlight-llms-txt@0.5.1(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)))(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)):
     dependencies:
       '@astrojs/mdx': 4.3.14(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))
@@ -4983,28 +4861,6 @@ snapshots:
       remark-stringify: 11.0.0
       unified: 11.0.5
       unist-util-remove: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  starlight-polyglot@file:../../../starlight-polyglot/packages/starlight-polyglot(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)))(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)):
-    dependencies:
-      '@astrojs/starlight': 0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))
-      astro: 5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)
-      github-slugger: 2.0.0
-
-  starlight-versions@0.4.0(@astrojs/starlight@0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))):
-    dependencies:
-      '@astrojs/starlight': 0.32.6(astro@5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0))
-      '@pagefind/default-ui': 1.5.2
-      github-slugger: 2.0.0
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
-      remark: 15.0.1
-      remark-frontmatter: 5.0.0
-      remark-mdx: 3.1.1
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-      yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 

--- a/docs/astro-site/src/content.config.ts
+++ b/docs/astro-site/src/content.config.ts
@@ -1,0 +1,6 @@
+import { defineCollection } from "astro:content";
+import { docsSchema } from "@astrojs/starlight/schema";
+
+export const collections = {
+  docs: defineCollection({ type: "content", schema: docsSchema() }),
+};

--- a/docs/astro-site/src/content/docs/api-reference/index.mdx
+++ b/docs/astro-site/src/content/docs/api-reference/index.mdx
@@ -5,8 +5,6 @@ sidebar:
   order: 1
 ---
 
-import PolyglotAPI from "starlight-polyglot/components/PolyglotAPI.astro";
-
 The API reference documentation is auto-generated from the voiage Python package source using `starlight-polyglot`. Below you'll find the generated API surface for each supported language.
 
-<PolyglotAPI />
+Use the generated API navigation entries for Python and TypeScript once the documentation build has completed.

--- a/docs/astro-site/src/content/docs/index.mdx
+++ b/docs/astro-site/src/content/docs/index.mdx
@@ -5,20 +5,14 @@ template: splash
 hero:
   title: "voiage"
   tagline: "Cross-domain Value of Information analysis for health economics, finance, engineering, and public policy"
-  image:
-    alt: voiage logo
-    file: ../../assets/voiage-logo.svg
   actions:
     - text: Get Started
       link: /getting-started/
-      icon: right-arrow
       variant: primary
     - text: Introduction
       link: /introduction/
-      icon: book-open
     - text: GitHub
       link: https://github.com/edithatogo/voiage
-      icon: external
 ---
 
 import { CardGrid, Card } from "@astrojs/starlight/components";


### PR DESCRIPTION
## Summary
- remove broken docs integrations that depended on local-only starlight-polyglot, invalid starlight-versions component paths, and failing absolute-link validation
- add explicit Starlight content collection config so docs pages are generated as content routes
- remove unsupported landing-page hero icon/image fields and replace the missing Polyglot API component with static API guidance

## Validation
- node -e "JSON.parse(require('fs').readFileSync('docs/astro-site/package.json','utf8')); console.log('package-json-ok')"
- CI=true npx pnpm@10.32.1 install --frozen-lockfile
- CI=true npx pnpm@10.32.1 run build (52 pages built)
