### PR TITLE
🧹 Remove unused 'DecisionOption as TrialArm' import in portfolio.py

### DIFF
--- a/voiage/methods/portfolio.py
+++ b/voiage/methods/portfolio.py
@@ -325,8 +325,8 @@ def portfolio_voi(
 if __name__ == "__main__":  # pragma: no cover
     # Add local imports for classes used in this test block
 
-    from voiage.schema import DecisionOption as TrialArm
     from voiage.schema import (
+        DecisionOption,
         PortfolioSpec,
         PortfolioStudy,
         TrialDesign,
@@ -348,10 +348,10 @@ if __name__ == "__main__":  # pragma: no cover
         return 0.0
 
     # Create dummy portfolio studies
-    study_a_design = TrialDesign([TrialArm("T1", 10)])
-    study_b_design = TrialDesign([TrialArm("T2", 20)])
-    study_c_design = TrialDesign([TrialArm("T3", 15)])
-    study_d_design = TrialDesign([TrialArm("T4", 30)])
+    study_a_design = TrialDesign([DecisionOption("T1", 10)])
+    study_b_design = TrialDesign([DecisionOption("T2", 20)])
+    study_c_design = TrialDesign([DecisionOption("T3", 15)])
+    study_d_design = TrialDesign([DecisionOption("T4", 30)])
 
     studies = [
         PortfolioStudy(


### PR DESCRIPTION
🎯 **What:** Removed unused alias `TrialArm` for `DecisionOption` in `voiage/methods/portfolio.py`.
💡 **Why:** To improve code health by removing an unnecessary alias and directly using the true class `DecisionOption`.
✅ **Verification:** Verified that lint checks pass, script execution passes, and the unit tests are unbroken.
✨ **Result:** Cleaned up code that is more direct and easier to maintain.

---
*PR created automatically by Jules for task [10022575433615052746](https://jules.google.com/task/10022575433615052746) started by @edithatogo*