### PR TITLE
🧹 Remove commented out function autodoc_skip_member

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,15 +178,6 @@ epub_exclude_files = ["search.html"]
 #     '.md': 'markdown',
 # }
 
-# This function can be used to dynamically skip members during autodoc
-# def autodoc_skip_member(app, what, name, obj, skip, options):
-#     # Example: skip private members not starting with an underscore (if any)
-#     # if what == "method" and not name.startswith("_") and name.startswith("__"):
-#     #     return True
-#     return skip
-
-# def setup(app):
-#     app.connect("autodoc-skip-member", autodoc_skip_member)
 
 # Add path for custom Sphinx extensions if any
 # sys.path.append(os.path.abspath('_extensions'))


### PR DESCRIPTION
🎯 What: Removed the commented-out autodoc_skip_member function and the commented-out setup function that references it in docs/conf.py.
💡 Why: The code was entirely commented out and can be safely removed without affecting functionality, improving maintainability and readability.
✅ Verification: Ran tox -e lint and tox -e typecheck to ensure no functionality is broken.
✨ Result: Codebase is cleaner.

---
*PR created automatically by Jules for task [16148560787884380332](https://jules.google.com/task/16148560787884380332) started by @edithatogo*