### PR TITLE
🧪 Improve VOIAnalysisConfig.to_dict test coverage

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -67,6 +67,30 @@ def test_voi_analysis_config() -> None:
     assert isinstance(config_dict, dict)
     assert config_dict["population"] == 100000
     assert config_dict["time_horizon"] == 10
+    assert config_dict["discount_rate"] == 0.03
+    assert config_dict["chunk_size"] == 1000
+    assert config_dict["use_jit"] is True
+    assert config_dict["backend"] == "jax"
+    assert config_dict["enable_caching"] is True
+    assert config_dict["streaming_window_size"] == 5000
+    assert config_dict["n_regression_samples"] == 5000
+    assert config_dict["regression_model"] is None
+    assert config_dict["n_simulations"] == 2000
+
+    # Test to_dict method on default config
+    default_config = VOIAnalysisConfig()
+    default_dict = default_config.to_dict()
+    assert default_dict["population"] is None
+    assert default_dict["time_horizon"] is None
+    assert default_dict["discount_rate"] is None
+    assert default_dict["chunk_size"] is None
+    assert default_dict["use_jit"] is False
+    assert default_dict["backend"] == "numpy"
+    assert default_dict["enable_caching"] is False
+    assert default_dict["streaming_window_size"] is None
+    assert default_dict["n_regression_samples"] is None
+    assert default_dict["regression_model"] is None
+    assert default_dict["n_simulations"] == 1000
 
 
 def test_streaming_config() -> None:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `to_dict` method in `VOIAnalysisConfig` lacked comprehensive testing. The existing test only verified `population` and `time_horizon`, leaving 9 keys unverified. It also didn't cover default instantiation behavior.

📊 **Coverage:** What scenarios are now tested
1. Custom configuration dictionary mapping: verified serialization correctly translates all explicit parameter choices (e.g. `use_jit`, `streaming_window_size`, `backend`).
2. Default configuration serialization: verified that default instantiation yields a correct dictionary representation containing default parameter fallbacks.

✨ **Result:** The improvement in test coverage
`VOIAnalysisConfig.to_dict` logic is fully verified across default and custom instantiation paths, increasing testing robustness and catching missing/refactored parameter changes early.

---
*PR created automatically by Jules for task [10945822668789455012](https://jules.google.com/task/10945822668789455012) started by @edithatogo*