### PR TITLE
🧪 Add test for create_parallel_config

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -331,6 +331,17 @@ def test_parallel_config() -> None:
         ParallelConfig(chunk_size=0)
 
 
+def test_create_parallel_config() -> None:
+    """Test create_parallel_config factory function."""
+    config = create_parallel_config()
+    assert isinstance(config, ParallelConfig)
+    assert config.n_workers is None
+    assert config.use_processes is True
+    assert config.max_workers is None
+    assert config.memory_limit_mb is None
+    assert config.chunk_size is None
+
+
 def test_factory_functions() -> None:
     """Test factory functions."""
     # Test create_default_config
@@ -385,5 +396,6 @@ if __name__ == "__main__":
     test_environmental_config()
     test_financial_config()
     test_parallel_config()
+    test_create_parallel_config()
     test_factory_functions()
     print("All configuration objects tests passed!")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `create_parallel_config` factory function was lacking a dedicated test to verify it returned a `ParallelConfig` object with the correct default properties.

📊 **Coverage:** What scenarios are now tested
The `test_create_parallel_config` function explicitly verifies that the returned instance is of type `ParallelConfig` and its attributes like `n_workers`, `use_processes`, `max_workers`, `memory_limit_mb`, and `chunk_size` are initialized to their expected default values.

✨ **Result:** The improvement in test coverage
Test coverage is improved in `tests/test_config_objects.py`, specifically ensuring regressions will not accidentally alter the behavior of `create_parallel_config`.

---
*PR created automatically by Jules for task [2399583899599815401](https://jules.google.com/task/2399583899599815401) started by @edithatogo*