### PR TITLE
🧪 Add dedicated test for create_healthcare_config

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -331,15 +331,23 @@ def test_parallel_config() -> None:
         ParallelConfig(chunk_size=0)
 
 
+def test_create_healthcare_config() -> None:
+    """Test create_healthcare_config factory function."""
+    config = create_healthcare_config()
+    assert isinstance(config, HealthcareConfig)
+    assert config.qaly_discount_rate == 0.03
+    assert config.cost_discount_rate == 0.03
+    assert config.cycle_length == 1.0
+    assert config.max_cycles == 50
+    assert config.markov_cohort_size == 10000
+    assert config.markov_start_age == 25.0
+
+
 def test_factory_functions() -> None:
     """Test factory functions."""
     # Test create_default_config
     config = create_default_config()
     assert isinstance(config, VOIAnalysisConfig)
-
-    # Test create_healthcare_config
-    config = create_healthcare_config()
-    assert isinstance(config, HealthcareConfig)
 
     # Test create_environmental_config
     config = create_environmental_config()
@@ -385,5 +393,6 @@ if __name__ == "__main__":
     test_environmental_config()
     test_financial_config()
     test_parallel_config()
+    test_create_healthcare_config()
     test_factory_functions()
     print("All configuration objects tests passed!")


### PR DESCRIPTION
🎯 **What:** The `create_healthcare_config` was not specifically tested aside from a single type check nested inside a generic test method `test_factory_functions()`. 
📊 **Coverage:** A dedicated `test_create_healthcare_config` test now comprehensively validates both that the object is returned properly as an instance of `HealthcareConfig`, and that it contains the correct default values correctly.
✨ **Result:** A more explicit, thorough, and safer test coverage that effectively acts as regression testing for defaults and object instantiation for the healthcare config object.

---
*PR created automatically by Jules for task [5973387294568384584](https://jules.google.com/task/5973387294568384584) started by @edithatogo*