### PR TITLE
🧹 Refactor SKLEARN_AVAILABLE to avoid unused import

### DIFF
--- a/voiage/methods/sample_information.py
+++ b/voiage/methods/sample_information.py
@@ -6,6 +6,7 @@ Implementation of Value of Information methods related to sample information.
 """
 
 from collections.abc import Callable, Sequence
+import importlib.util
 from typing import Any
 
 import numpy as np
@@ -17,12 +18,7 @@ from voiage.exceptions import (
 from voiage.schema import ParameterSet, TrialDesign, ValueArray
 from voiage.stats import normal_normal_update
 
-try:
-    import sklearn  # noqa: F401
-
-    SKLEARN_AVAILABLE = True
-except ImportError:
-    SKLEARN_AVAILABLE = False
+SKLEARN_AVAILABLE = importlib.util.find_spec("sklearn") is not None
 
 EconomicModelFunctionType = Callable[[ParameterSet], ValueArray]
 MetamodelName = str


### PR DESCRIPTION
🎯 What: Replaced the 'try...except ImportError' block that imports 'sklearn' with 'importlib.util.find_spec'.
💡 Why: The 'sklearn' import was flagged as unused by static analysis. Using 'importlib.util' allows us to check for the package's existence without unnecessarily importing it into the namespace.
✅ Verification: Ran 'ruff check' to verify linting and executed the full test suite ('pytest tests/') to ensure all tests passed (1066 passed).
✨ Result: The code health issue is resolved, maintaining the identical runtime behavior without leaving an unused module in the namespace.

---
*PR created automatically by Jules for task [6822468857151610246](https://jules.google.com/task/6822468857151610246) started by @edithatogo*