### PR TITLE
🧪 Add test for create_environmental_config

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -331,6 +331,19 @@ def test_parallel_config() -> None:
         ParallelConfig(chunk_size=0)
 
 
+def test_create_environmental_config() -> None:
+    """Test create_environmental_config factory function."""
+    config = create_environmental_config()
+    assert isinstance(config, EnvironmentalConfig)
+    # Check default properties
+    assert config.carbon_intensity == 0.5
+    assert config.energy_consumption == 10000
+    assert config.water_intensity == 0.1
+    assert config.water_cost == 0.002
+    assert config.biodiversity_impact_factor == 0.01
+    assert config.social_cost_of_carbon == 50
+
+
 def test_factory_functions() -> None:
     """Test factory functions."""
     # Test create_default_config


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for `create_environmental_config()`

📊 **Coverage:** What scenarios are now tested: Checks that `create_environmental_config()` successfully returns an instance of `EnvironmentalConfig` and verifies that all default configuration properties matching the `EnvironmentalConfig` definition are accurately maintained.

✨ **Result:** The improvement in test coverage: Improved test coverage on `voiage/config_objects.py`.

---
*PR created automatically by Jules for task [8629129192519004185](https://jules.google.com/task/8629129192519004185) started by @edithatogo*