### PR TITLE
🧹 Remove unused SklearnLinearRegression import in main_backends.py

### DIFF
--- a/voiage/main_backends.py
+++ b/voiage/main_backends.py
@@ -137,11 +137,11 @@ try:
     # Try to import optional dependencies
     SKLEARN_AVAILABLE = False
     try:
-        from sklearn.linear_model import LinearRegression as SklearnLinearRegression
+        import sklearn  # noqa: F401
 
         SKLEARN_AVAILABLE = True
     except ImportError:
-        SklearnLinearRegression = None
+        pass
 
     class _JaxBackendImpl(Backend):
         """JAX-based computational backend."""


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the unused import of `SklearnLinearRegression` in `voiage/main_backends.py:140`. The assignment inside the except block `SklearnLinearRegression = None` was also unused.
💡 **Why:** Having unused imports and assignments pollutes the module namespace and confuses readers of the code (since static analyzers flag them). By using a simpler `import sklearn  # noqa: F401` to check for module presence, we achieve the same goal cleanly.
✅ **Verification:** I ran `uv run ruff check` which confirmed there are no linting errors anymore. I also ran `uv run pytest` targeting `test_backends.py` and `test_apple_metal_backend.py` which completed successfully, ensuring the `evpi` logic remains intact.
✨ **Result:** A safer, cleaner module that successfully drops a dead variable and an unnecessary from-import, passing all linting and test coverage.

---
*PR created automatically by Jules for task [6443953371540845718](https://jules.google.com/task/6443953371540845718) started by @edithatogo*