### PR TITLE
🧹 Remove unused multiprocessing import

### DIFF
--- a/voiage/parallel/monte_carlo.py
+++ b/voiage/parallel/monte_carlo.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from functools import partial
-import multiprocessing as mp
+import os
 from typing import TypeVar
 
 import numpy as np
@@ -223,7 +223,7 @@ def parallel_monte_carlo_simulation(
         float: Expected maximum net benefit from posterior analysis
     """
     if n_workers is None:
-        n_workers = mp.cpu_count()
+        n_workers = os.cpu_count() or 1
 
     # Distribute simulations across workers
     simulations_per_worker = [n_simulations // n_workers] * n_workers
@@ -400,7 +400,7 @@ def parallel_bootstrap_sampling(
         Dict with bootstrap statistics (mean, std, percentiles)
     """
     if n_workers is None:
-        n_workers = mp.cpu_count()
+        n_workers = os.cpu_count() or 1
 
     # Distribute bootstrap samples across workers
     samples_per_worker = [n_bootstrap_samples // n_workers] * n_workers


### PR DESCRIPTION
🎯 **What:** The `multiprocessing` standard library was being imported and aliased as `mp`, but only used for `mp.cpu_count()`. It has been removed and replaced with `os.cpu_count()`.
💡 **Why:** Reduces unused imports and uses the more direct `os` module for fetching the CPU count, making the intent clearer and avoiding loading an unnecessary heavy module. `os.cpu_count() or 1` also correctly handles the rare case where the CPU count can't be determined and returns None.
✅ **Verification:** Verified by running `tox -e lint`, the full test suite (`tox -e py312`), and typechecking (`tox -e typecheck`). All checks passed successfully.
✨ **Result:** A cleaner import block with correct default CPU counting behavior preserved.

---
*PR created automatically by Jules for task [16306940645988196870](https://jules.google.com/task/16306940645988196870) started by @edithatogo*