### PR TITLE
🧹 Remove unused Axes3D import

### DIFF
--- a/voiage/plot/voi_curves.py
+++ b/voiage/plot/voi_curves.py
@@ -9,14 +9,12 @@ try:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
     import matplotlib.pyplot as plt
-    from mpl_toolkits.mplot3d import Axes3D
 
     MATPLOTLIB_AVAILABLE = True
 except ImportError:  # pragma: no cover
     MATPLOTLIB_AVAILABLE = False
     Figure = None  # type: ignore
     Axes = None  # type: ignore
-    Axes3D = None  # type: ignore
 
 from voiage.config import DEFAULT_DTYPE
 from voiage.exceptions import raise_input_error, raise_plotting_error


### PR DESCRIPTION
🎯 **What:** Removed unused `Axes3D` import and its fallback in `voiage/plot/voi_curves.py`.
💡 **Why:** To improve code health, maintainability, and readability by eliminating dead code.
✅ **Verification:** Verified by checking that `Axes3D` is not used anywhere in the file and ensuring tests still pass.
✨ **Result:** Cleaned up code without altering behavior.

---
*PR created automatically by Jules for task [7230513175802929920](https://jules.google.com/task/7230513175802929920) started by @edithatogo*