### PR TITLE
🧹 Fix unused jax.numpy import in analysis.py

### DIFF
--- a/voiage/analysis.py
+++ b/voiage/analysis.py
@@ -22,11 +22,11 @@ from voiage.schema import ParameterSet, PortfolioSpec, PortfolioStudy, ValueArra
 # Check for JAX availability
 JAX_AVAILABLE = False
 try:
-    import jax.numpy as jnp
+    import jax.numpy  # noqa: F401
 
     JAX_AVAILABLE = True
 except ImportError:
-    jnp = None
+    pass
 
 SKLEARN_AVAILABLE = False
 LinearRegression = None


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused `jnp` import alias in `voiage/analysis.py` by replacing it with a direct import and suppressing the `F401` unused import warning. Also replaced the `jnp = None` in the `except` block with a `pass` statement, as it was no longer needed.

💡 **Why:** How this improves maintainability
This eliminates unused variables that trigger linters or cause confusion for developers reading the code, while keeping the essential availability check intact.

✅ **Verification:** How you confirmed the change is safe
Ran `uv run ruff check` which passed and confirmed the import alias warning is gone. Ran `uv run pytest tests/` which completed successfully with all relevant tests passing, ensuring no functional changes occurred.

✨ **Result:** The improvement achieved
A cleaner codebase with less dead code and unused variables, maintaining 100% of the intended functionality.

---
*PR created automatically by Jules for task [15552058841205127353](https://jules.google.com/task/15552058841205127353) started by @edithatogo*