### PR TITLE
🧹 [Code Health] Remove unused `__future__` import and fix type hint in `voiage/versioning.py`

### DIFF
--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -5,15 +5,13 @@ the current release line. This module validates that the external binding
 manifests stay in lockstep with that repository version.
 """
 
-from __future__ import annotations
-
 import argparse
 from dataclasses import dataclass
 import json
 from pathlib import Path
 import re
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from defusedxml import ElementTree
 
@@ -22,8 +20,7 @@ try:  # Python 3.11+.
 except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10.
     import tomli as tomllib  # type: ignore[import-not-found]
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from collections.abc import Callable
 
 REPO_ROOT = Path.cwd()
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"


### PR DESCRIPTION
* 🎯 **What:** Removed `from __future__ import annotations` and resolved a resulting `NameError` by promoting the `Callable` type hint import from a `TYPE_CHECKING` block to a runtime import.
* 💡 **Why:** `from __future__ import annotations` deferred type hint evaluation, masking an issue where `Callable` was only imported conditionally, but needed to be evaluated as it was used in a dataclass field annotation. This improves code health, removing an unnecessary `__future__` import while ensuring proper runtime evaluation of type annotations, reducing the risk of errors when evaluating annotations directly.
* ✅ **Verification:** I confirmed the file imports successfully and `dataclasses.dataclass` can instantiate the `VersionTarget` class at runtime by running `python voiage/versioning.py`. I also ran `ruff check` and formatting checks to verify the code changes comply with the repository's styling conventions.
* ✨ **Result:** The unused `__future__` import has been cleanly removed, and the `Callable` type hint operates correctly at runtime.

---
*PR created automatically by Jules for task [14019311791101393210](https://jules.google.com/task/14019311791101393210) started by @edithatogo*