### PR TITLE
🧹 Remove unused Figure import in plotting modules

### DIFF
--- a/voiage/plot/ceac.py
+++ b/voiage/plot/ceac.py
@@ -5,13 +5,11 @@ import numpy as np
 # Attempt to import Matplotlib, but make it optional
 try:
     from matplotlib.axes import Axes
-    from matplotlib.figure import Figure
     import matplotlib.pyplot as plt
 
     MATPLOTLIB_AVAILABLE = True
 except ImportError:  # pragma: no cover
     MATPLOTLIB_AVAILABLE = False
-    Figure = None  # type: ignore
     Axes = None  # type: ignore
 
 from voiage.config import DEFAULT_DTYPE

--- a/voiage/plot/voi_curves.py
+++ b/voiage/plot/voi_curves.py
@@ -7,14 +7,12 @@ import numpy as np
 # Attempt to import Matplotlib, but make it optional
 try:
     from matplotlib.axes import Axes
-    from matplotlib.figure import Figure
     import matplotlib.pyplot as plt
     from mpl_toolkits.mplot3d import Axes3D
 
     MATPLOTLIB_AVAILABLE = True
 except ImportError:  # pragma: no cover
     MATPLOTLIB_AVAILABLE = False
-    Figure = None  # type: ignore
     Axes = None  # type: ignore
     Axes3D = None  # type: ignore
 


### PR DESCRIPTION
🎯 **What:** Removed unused `Figure` import from `matplotlib.figure` and its corresponding fallback assignment in `voiage/plot/ceac.py` and `voiage/plot/voi_curves.py`.
💡 **Why:** Static analysis indicated these imports were unused, removing dead code helps improve readability and code health.
✅ **Verification:** Verified safe by running `uv run ruff check voiage/plot/` and `uv run pytest tests/test_plotting.py` with passing results.
✨ **Result:** A slightly cleaner and more maintainable codebase without dead imports.

---
*PR created automatically by Jules for task [6872328752907857604](https://jules.google.com/task/6872328752907857604) started by @edithatogo*