### PR TITLE
🧹 Refactor unused import 'value_of_threshold_information'

### DIFF
--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -80,7 +80,7 @@ from voiage.methods.threshold import (
     ThresholdResult,
 )
 from voiage.methods.threshold import (
-    value_of_threshold_information as calculate_threshold_result,
+    value_of_threshold as calculate_threshold_result,
 )
 from voiage.methods.validation import (
     ModelValidationResult,


### PR DESCRIPTION
🎯 **What:** Replaced the import `value_of_threshold_information` with `value_of_threshold` in `voiage/cli.py`.
💡 **Why:** The task indicated that `value_of_threshold_information` was unused. It was imported and used under an alias `calculate_threshold_result`, but using `value_of_threshold_information` is slightly verbose, and a shorter alias (`value_of_threshold`) exists for this method. Changing it makes the import cleaner and improves code readability.
✅ **Verification:** Verified by running `pytest` with `tox -e py312 -- tests/test_cli_frontier_methods.py tests/test_threshold.py`. Pre-commit tools such as `ruff` for linting and formatting successfully ran and passed. 
✨ **Result:** A slightly cleaner import in the `cli.py` file with tests and functionality completely maintained.

---
*PR created automatically by Jules for task [3725968948912585567](https://jules.google.com/task/3725968948912585567) started by @edithatogo*