### PR TITLE
🧹 Remove unused NetBenefitArray import alias

### DIFF
--- a/voiage/methods/basic.py
+++ b/voiage/methods/basic.py
@@ -17,7 +17,7 @@ from voiage.exceptions import (
     raise_input_error,
 )
 from voiage.schema import ParameterSet as PSASample
-from voiage.schema import ValueArray as NetBenefitArray
+from voiage.schema import ValueArray
 
 SKLEARN_AVAILABLE = False
 LinearRegression = None
@@ -87,7 +87,7 @@ def check_parameter_samples(parameter_samples: object, n_samples: int) -> np.nda
 
 
 def evpi(
-    nb_array: Union[np.ndarray, "NetBenefitArray"],
+    nb_array: Union[np.ndarray, "ValueArray"],
     population: float | None = None,
     time_horizon: float | None = None,
     discount_rate: float | None = None,
@@ -146,7 +146,7 @@ def evpi(
 
 
 def evppi(
-    nb_array: Union[np.ndarray, "NetBenefitArray"],
+    nb_array: Union[np.ndarray, "ValueArray"],
     parameter_samples: Union[np.ndarray, "PSASample", dict[str, np.ndarray]],
     parameters_of_interest: list[str],
     population: float | None = None,


### PR DESCRIPTION
🎯 **What:** Removed the unused import alias `NetBenefitArray` and updated the corresponding type annotations in `voiage/methods/basic.py`.
💡 **Why:** The imported type `NetBenefitArray` was never used as a runtime object in the file and only existed as a string reference in type annotations. The original symbol `ValueArray` is imported directly and clarifies the intended type hint.
✅ **Verification:** Ran `uv run pytest tests/` which passed. Checked formatting and linting via `ruff`.
✨ **Result:** Cleaner imports and code health improvement.

---
*PR created automatically by Jules for task [6637270471602024227](https://jules.google.com/task/6637270471602024227) started by @edithatogo*