### PR TITLE
🧪 Add test for evaluate_multiple_frameworks edge case

### DIFF
--- a/tests/test_hta_integration.py
+++ b/tests/test_hta_integration.py
@@ -1,5 +1,7 @@
 """Focused regression tests for NICE HTA threshold logic."""
 
+from unittest.mock import patch
+
 import pytest
 
 from voiage.hta_integration import (
@@ -323,3 +325,19 @@ def test_hta_utility_functions_create_evaluate_compare_and_report() -> None:
     assert default_strategy["target_frameworks"] == ["nice", "cadth", "icer"]
     assert "Technology: ExampleTx" in report
     assert "DECISION: approval" in report
+
+
+def test_evaluate_multiple_frameworks_skips_none_evaluation() -> None:
+    """Multi-framework evaluation should skip evaluations that return None due to exceptions."""
+    framework = HTAIntegrationFramework()
+    submission = HTASubmission()
+
+    with patch.object(
+        framework, "evaluate_for_framework", side_effect=Exception("Simulated failure")
+    ):
+        with pytest.warns(UserWarning, match="Error evaluating"):
+            evaluations = framework.evaluate_multiple_frameworks(
+                submission, [HTAFramework.NICE, HTAFramework.CADTH]
+            )
+
+    assert evaluations == {}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed in `evaluate_multiple_frameworks` when a simulated evaluation causes `_evaluate_framework` to return `None`.
📊 **Coverage:** The scenario where a mock exception forces the fallback logic inside `_evaluate_framework` to return `None` and correctly verifies it is skipped by `evaluate_multiple_frameworks`.
✨ **Result:** Enhanced test coverage and validation of error fallback skipping without relying exclusively on warning emissions for verification.

---
*PR created automatically by Jules for task [11862665103563426294](https://jules.google.com/task/11862665103563426294) started by @edithatogo*