### PR TITLE
🧹 Remove aliased DecisionOption import in network_nma.py

### DIFF
--- a/voiage/methods/network_nma.py
+++ b/voiage/methods/network_nma.py
@@ -633,13 +633,10 @@ if __name__ == "__main__":  # pragma: no cover
     # Add local imports for classes used in this test block
     import numpy as np  # np is used by NetBenefitArray and PSASample
 
-    from voiage.schema import (
-        DecisionOption as TrialArm,
-    )
+    from voiage.schema import DecisionOption, TrialDesign
     from voiage.schema import (
         ParameterSet as PSASample,
     )
-    from voiage.schema import TrialDesign
     from voiage.schema import (
         ValueArray as NetBenefitArray,
     )
@@ -654,8 +651,8 @@ if __name__ == "__main__":  # pragma: no cover
     }
     trial_design = TrialDesign(
         [
-            TrialArm(name="Treatment A", sample_size=50),
-            TrialArm(name="Treatment B", sample_size=50),
+            DecisionOption(name="Treatment A", sample_size=50),
+            DecisionOption(name="Treatment B", sample_size=50),
         ]
     )
 


### PR DESCRIPTION
🎯 **What:** The `DecisionOption` import in `voiage/methods/network_nma.py` was aliased as `TrialArm`, which creates unnecessary indirection. I replaced the alias usage with the direct `DecisionOption` class and updated the import.

💡 **Why:** Using aliases unnecessarily can obscure code readability and make it harder to trace the origin of a class, particularly when the class name (`DecisionOption`) already clearly conveys its purpose. Removing the alias improves code health and maintainability.

✅ **Verification:** Ran `uv run ruff check` and `uv run pytest tests/` (excluding unrelated existing errors). Confirmed formatting, linting, and tests pass.

✨ **Result:** The code now imports and uses `DecisionOption` directly instead of aliasing it, reducing complexity and adhering to clean code principles.

---
*PR created automatically by Jules for task [1236889744387140307](https://jules.google.com/task/1236889744387140307) started by @edithatogo*