### PR TITLE
🧹 Code health: Remove unused arviz import from metamodels

### DIFF
--- a/voiage/metamodels.py
+++ b/voiage/metamodels.py
@@ -95,7 +95,6 @@ except ImportError:
     gam_spline = None
 
 try:
-    import arviz as az
     import pymc as pm
     import pymc_bart as pmb
 
@@ -103,7 +102,6 @@ try:
 except ImportError:
     PYMC_AVAILABLE = False
     pm = None
-    az = None
     pmb = None
 
 from voiage.exceptions import (


### PR DESCRIPTION
🎯 **What:** Removed `import arviz as az` and its fallback `az = None` in `voiage/metamodels.py`.
💡 **Why:** The `az` variable is never referenced or used in the `metamodels.py` file or externally. Removing it cleans up dead code and removes unnecessary dependencies, improving maintainability.
✅ **Verification:** Ran pytest tests successfully and verified with ruff check that linting passed.
✨ **Result:** Improved code cleanliness.

---
*PR created automatically by Jules for task [4162640855835416986](https://jules.google.com/task/4162640855835416986) started by @edithatogo*