### PR TITLE
🧪 Add tests for FlaxMetamodel score and rmse methods

### DIFF
--- a/tests/test_metamodeling_comprehensive.py
+++ b/tests/test_metamodeling_comprehensive.py
@@ -332,7 +332,25 @@ def test_calculate_diagnostics_with_metamodels_without_methods(sample_data) -> N
     # Test with FlaxMetamodel if available
     try:
         model = FlaxMetamodel(learning_rate=0.01, n_epochs=10)
+
+        # Test error conditions before fitting
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.score(x, y)
+
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.rmse(x, y)
+
         model.fit(x, y)
+
+        # Test score and rmse methods
+        score = model.score(x, y)
+        assert isinstance(score, float)
+        assert score <= 1.0
+
+        rmse = model.rmse(x, y)
+        assert isinstance(rmse, float)
+        assert rmse >= 0.0
+
         # This should work even if FlaxMetamodel doesn't implement score/rmse
         # because calculate_diagnostics will compute them manually
         diagnostics = calculate_diagnostics(model, x, y)


### PR DESCRIPTION
🎯 **What:** Added tests to verify the behavior of `score` and `rmse` methods in `FlaxMetamodel`.
📊 **Coverage:** Ensures that `score` and `rmse` raise `RuntimeError` when called before fitting, and verifies that they return expected float values when called after fitting.
✨ **Result:** Improved test coverage and reliability for FlaxMetamodel.

---
*PR created automatically by Jules for task [11315815802300418293](https://jules.google.com/task/11315815802300418293) started by @edithatogo*