### PR TITLE
🧪 [testing improvement] Add tests for FlaxMetamodel.rmse

### DIFF
--- a/tests/test_metamodeling_comprehensive.py
+++ b/tests/test_metamodeling_comprehensive.py
@@ -230,6 +230,32 @@ def test_flax_metamodel_dependency_handling(sample_data) -> None:
         pass
 
 
+def test_flax_metamodel_rmse(sample_data) -> None:
+    """Test the rmse method of FlaxMetamodel."""
+    try:
+        from voiage.metamodels import FlaxMetamodel
+    except ImportError:
+        pytest.skip("FlaxMetamodel not available")
+
+    x, y = sample_data
+
+    try:
+        model = FlaxMetamodel(learning_rate=0.01, n_epochs=10)
+
+        # Test rmse before fitting raises error
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
+            model.rmse(x, y)
+
+        model.fit(x, y)
+
+        # Test rmse after fitting
+        rmse_val = model.rmse(x, y)
+        assert isinstance(rmse_val, float)
+        assert rmse_val >= 0
+    except ImportError:
+        pass
+
+
 def test_tinygp_metamodel_dependency_handling(sample_data) -> None:
     """Test that TinyGPMetamodel properly handles missing dependencies."""
     try:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `FlaxMetamodel`'s `rmse` functionality was untested.

📊 **Coverage:** This adds a comprehensive unit test (`test_flax_metamodel_rmse`) within `tests/test_metamodeling_comprehensive.py`. It includes logic testing successful `rmse` generation mapping after the model has been fitted, returning the required float value > 0 constraint, while also including a test to assert that `rmse` rightfully raises a `RuntimeError` regarding an unfitted state if it is queried prior to `.fit()`. It appropriately skips handling where testing deps are unavailable.

✨ **Result:** The test suite now safely and directly exercises the `FlaxMetamodel.rmse` implementation against multiple failure modes and happy paths.

---
*PR created automatically by Jules for task [13995045978266871334](https://jules.google.com/task/13995045978266871334) started by @edithatogo*