### PR TITLE
ci(security): complete shared scanning gate rollout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,5 +46,3 @@ jobs:
 
     - name: Fail on blocking code-scanning alerts
       uses: edithatogo/.github/.github/actions/code-scanning-gate@90b399a731a17b792352d0c049834a22dbd32523
-      with:
-        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           sarif_file: scorecard-results.json
 
+      - name: Fail on blocking code-scanning alerts
+        uses: edithatogo/.github/.github/actions/code-scanning-gate@90b399a731a17b792352d0c049834a22dbd32523
+
       - name: Upload Scorecard results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Completed the shared code-scanning rollout by enforcing the pinned organization gate after both CodeQL and OpenSSF Scorecard SARIF uploads.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,5 @@
 # Changelog
 
-- Completed the shared code-scanning rollout by enforcing the pinned organization gate after both CodeQL and OpenSSF Scorecard SARIF uploads.
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -10,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Completed the shared code-scanning rollout by enforcing the pinned
+  organization gate after both CodeQL and OpenSSF Scorecard SARIF uploads.
 - Archived all completed Conductor track records under `conductor/archive/` and
   updated the regression tests and integration documentation to read those
   historical records from their canonical archived locations.


### PR DESCRIPTION
Closes #43.\n\n- invokes the SHA-pinned organization code-scanning gate after Scorecard SARIF upload\n- removes an unsupported `category` input from the CodeQL gate invocation\n- records the completed rollout in the changelog\n\nValidation: `uv run tox -e lint,harness`; `uvx zizmor .github/workflows`; `git diff --check`