### PR TITLE
refactor(types): avoid runtime ValueArray import

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -409,6 +409,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dictionary-to-NMA data conversion for ease of use
 
 ### Changed
+- Avoided importing `ValueArray` at runtime when it is used only for static
+  annotations in the basic VOI methods.
 - Updated the protected `main` ruleset for a single-maintainer repository:
   pull requests, signed commits, linear history, resolved review threads, and
   required CI/security checks remain enforced without an impossible

--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,10 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Remove the runtime-only `ValueArray` import from the basic VOI methods.
+    *   Moved the annotation dependency behind `TYPE_CHECKING` and retained the
+        existing public type contract without runtime import overhead.
+
 *   [x] Archive completed Conductor track records and repair their regression
     test and documentation references.
     *   Moved all completed registered tracks from `conductor/tracks/` to

--- a/voiage/methods/basic.py
+++ b/voiage/methods/basic.py
@@ -6,7 +6,7 @@
 - EVPPI (Expected Value of Partial Perfect Information)
 """
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 import warnings
 
 import numpy as np
@@ -17,7 +17,9 @@ from voiage.exceptions import (
     raise_input_error,
 )
 from voiage.schema import ParameterSet as PSASample
-from voiage.schema import ValueArray
+
+if TYPE_CHECKING:
+    from voiage.schema import ValueArray
 
 SKLEARN_AVAILABLE = False
 LinearRegression = None


### PR DESCRIPTION
## Summary
- move the annotation-only `ValueArray` import behind `TYPE_CHECKING`
- preserve the public type contract without runtime import overhead
- record the completed recommendation in the changelog and backlog

## Verification
- `uv run pytest tests/test_repo_cleanup.py::test_unreleased_changelog_sections_are_unique --no-cov -q`
- `uv run tox -e lint,typecheck,harness,docs`
- full tox reached 2,166 passing versioned tests before a stale pre-fix package snapshot caused the corrected changelog assertion to fail; the focused rebuilt assertion passes