### PR TITLE
fix(ci): isolate Scorecard scanning gate

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,12 +35,20 @@ jobs:
         with:
           sarif_file: scorecard-results.json
 
-      - name: Fail on blocking code-scanning alerts
-        uses: edithatogo/.github/.github/actions/code-scanning-gate@90b399a731a17b792352d0c049834a22dbd32523
-
       - name: Upload Scorecard results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: scorecard-results
           path: scorecard-results.json
           retention-days: 30
+
+  code-scanning-gate:
+    name: Scorecard code-scanning gate
+    needs: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: read
+      contents: read
+    steps:
+      - name: Fail on blocking code-scanning alerts
+        uses: edithatogo/.github/.github/actions/code-scanning-gate@90b399a731a17b792352d0c049834a22dbd32523

--- a/changelog.md
+++ b/changelog.md
@@ -459,6 +459,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Renovate configuration for automated dependency updates
 
 ### Fixed
+- Moved the blocking code-scanning gate into a separate least-privilege job so
+  OpenSSF can verify and publish Scorecard results without rejecting the custom
+  policy step in its privileged analysis job.
 - Removed tracked generated artifacts from version control, including pytest
   temp output, coverage reports, macOS metadata, legacy egg-info files, and R
   CMD check output, and added repo-local ignore rules for those generated

--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,10 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Restore OpenSSF Scorecard publication after the shared scanning rollout.
+    *   Isolated the custom blocking-alert gate in a dependent least-privilege
+        job that does not violate Scorecard workflow restrictions.
+
 *   [x] Remove the runtime-only `ValueArray` import from the basic VOI methods.
     *   Moved the annotation dependency behind `TYPE_CHECKING` and retained the
         existing public type contract without runtime import overhead.


### PR DESCRIPTION
## Summary
- move the custom code-scanning gate out of the privileged OpenSSF analysis job
- run it as a dependent least-privilege job
- preserve blocking-alert enforcement while satisfying Scorecard workflow restrictions

## Evidence
The default-branch Scorecard run failed with `workflow verification failed: job has unallowed step: ...code-scanning-gate`.

## Verification
- `uv run tox -e lint,harness`
- `git diff --check`