### PR TITLE
fix(security): raise vulnerable dependency floors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
     - --ignore=unused-type-ignore-comment
     - --ignore=redundant-cast
     additional_dependencies:
-    - numpy>=1.20
+    - numpy>=1.22
     - pandas>=1.3
     - xarray>=0.19
     - scikit-learn>=1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 
 dependencies = [
     "defusedxml>=0.7.1",
-    "numpy>=1.20,<2.0; python_version<'3.11'",
+    "numpy>=1.22,<2.0; python_version<'3.11'",
     "numpy>=2.2.6,<3.0; python_version>='3.11'",
     "scipy>=1.7,<1.15; python_version<'3.11'",
     "scipy>=1.16.3,<1.17; python_version>='3.11'",

--- a/uv.lock
+++ b/uv.lock
@@ -4562,7 +4562,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'plotting'", specifier = ">=3.4" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=2.0,<3.0" },
     { name = "nox", marker = "extra == 'dev'", specifier = ">=2026.4.10,<2027" },
-    { name = "numpy", marker = "python_full_version < '3.11'", specifier = ">=1.20,<2.0" },
+    { name = "numpy", marker = "python_full_version < '3.11'", specifier = ">=1.22,<2.0" },
     { name = "numpy", marker = "python_full_version >= '3.11'", specifier = ">=2.2.6,<3.0" },
     { name = "numpyro", marker = "python_full_version < '3.11'", specifier = ">=0.14,<0.20" },
     { name = "numpyro", marker = "python_full_version >= '3.11'", specifier = ">=0.21.0,<0.22" },

--- a/voiage/web/requirements.txt
+++ b/voiage/web/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.68.0
+fastapi>=0.115.0
 uvicorn>=0.15.0
-pydantic>=1.8.0
-numpy>=1.20.0
+pydantic>=1.10.13
+numpy>=1.22.0


### PR DESCRIPTION
Raises legacy minimum versions for NumPy, FastAPI, and Pydantic so declared dependency ranges no longer permit the vulnerabilities reported by the post-merge OpenSSF Scorecard gate. Repository harness and version synchronization checks pass locally.