### PR TITLE
fix(ci): isolate uv cache keys by job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
@@ -65,6 +66,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
@@ -92,6 +94,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
@@ -122,6 +125,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
@@ -149,6 +153,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
@@ -190,6 +195,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python ${{ matrix.python }}
@@ -236,6 +242,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
@@ -263,6 +270,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
@@ -296,6 +304,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -329,6 +338,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -363,6 +373,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -395,6 +406,7 @@ jobs:
       with:
         version: "latest"
         enable-cache: true
+        cache-suffix: ${{ github.job }}-${{ matrix.python || 'base' }}
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1


### PR DESCRIPTION
## Summary
- add job-specific `setup-uv` cache suffixes
- include the Python matrix value where present
- remove parallel cache-save contention annotations

## Verification
- `uv run python scripts/repo_harness.py` (0 findings)