### PR TITLE
feat(conductor): add validation threshold promotion evidence

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -400,7 +400,7 @@ Only the numbered `[ ]` entries in this section are eligible for automatic
 
 ---
 
-## [ ] Track: Validation And Threshold VOI Stable Promotion
+## [~] Track: Validation And Threshold VOI Stable Promotion
 *Link: [./tracks/validation-threshold-voi-stable-promotion_20260625/](./tracks/validation-threshold-voi-stable-promotion_20260625/)*
 *Execution order: 04 of 32*
 *Status: follow-through track for validation, threshold, tipping-point, and robust VOI stable promotion.*

--- a/conductor/tracks/validation-threshold-voi-stable-promotion_20260625/metadata.json
+++ b/conductor/tracks/validation-threshold-voi-stable-promotion_20260625/metadata.json
@@ -1,8 +1,8 @@
 {
   "track_id": "validation-threshold-voi-stable-promotion_20260625",
   "type": "feature",
-  "status": "new",
+  "status": "in_progress",
   "created_at": "2026-06-25T00:00:00Z",
-  "updated_at": "2026-06-25T00:00:00Z",
+  "updated_at": "2026-07-16T00:00:00Z",
   "description": "Promote validation, threshold, tipping-point, and robust VOI with cross-language parity and stable result-envelope checks."
 }

--- a/conductor/tracks/validation-threshold-voi-stable-promotion_20260625/plan.md
+++ b/conductor/tracks/validation-threshold-voi-stable-promotion_20260625/plan.md
@@ -2,13 +2,13 @@
 
 ## Phase 1: Contract, Scope, And Evidence Boundary [checkpoint: ]
 
-- [ ] Task: Review the completed readiness/setup tracks and confirm this track does not duplicate their completed scope.
+- [x] Task: Review the completed readiness/setup tracks and confirm this track does not duplicate their completed scope.
     - [ ] Cross-check the track specification and existing completed Conductor records before editing.
     - [ ] Keep external gates explicit and evidence-backed.
-- [ ] Task: Write or update validation tests that fail if external gates, maturity labels, or evidence states are overclaimed.
+- [x] Task: Write or update validation tests that fail if external gates, maturity labels, or evidence states are overclaimed.
     - [ ] Cross-check the track specification and existing completed Conductor records before editing.
     - [ ] Keep external gates explicit and evidence-backed.
-- [ ] Task: Define the machine-readable evidence fields, owner fields, blocked-state fields, and artifact paths for this track.
+- [x] Task: Define the machine-readable evidence fields, owner fields, blocked-state fields, and artifact paths for this track.
     - [ ] Cross-check the track specification and existing completed Conductor records before editing.
     - [ ] Keep external gates explicit and evidence-backed.
 - [ ] Task: Commit the scope and test changes, attach a git note summary, record the short SHA in this plan, and commit the plan update.
@@ -20,10 +20,10 @@
 
 ## Phase 2: Automation And Artifact Preparation [checkpoint: ]
 
-- [ ] Task: Implement the repo-owned scripts, docs, schemas, fixtures, or workflow updates needed to prepare evidence reproducibly.
+- [x] Task: Implement the repo-owned scripts, docs, schemas, fixtures, or workflow updates needed to prepare evidence reproducibly.
     - [ ] Cross-check the track specification and existing completed Conductor records before editing.
     - [ ] Keep external gates explicit and evidence-backed.
-- [ ] Task: Run the focused validation command for this track and capture the command plus result in the working notes or evidence manifest.
+- [x] Task: Run the focused validation command for this track and capture the command plus result in the working notes or evidence manifest.
     - [ ] Record the command, runner, status, artifacts, and any blocked external gate.
     - [ ] Preserve CPU fallback or readiness-vs-publication wording where applicable.
 - [ ] Task: Use GitHub Actions, gh, colab, gcloud, registry tooling, or browser automation only within the tool-use limits in the specification.
@@ -76,3 +76,11 @@
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it
 - [ ] `cargo fmt --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked && cargo doc --no-deps --locked` when Rust kernels or binding contracts change
+
+## Current checkpoint
+
+- Added validation and threshold evidence manifests with deterministic hashes,
+  fixture-backed maturity, owner, blocked state, and language parity fields.
+- Added regression tests that reject stable claims while non-Python parity is
+  unverified. Focused validation: 17 tests passed; repository harness passed
+  with zero findings.

--- a/conductor/tracks/validation-threshold-voi-stable-promotion_20260625/plan.md
+++ b/conductor/tracks/validation-threshold-voi-stable-promotion_20260625/plan.md
@@ -84,3 +84,6 @@
 - Added regression tests that reject stable claims while non-Python parity is
   unverified. Focused validation: 17 tests passed; repository harness passed
   with zero findings.
+- Full local gate: tox passed with lint, Bandit, typecheck, Astro check/build,
+  1216 Python 3.14 tests, coverage above 90%, frontier contract, and version
+  sync. Implementation checkpoint commit: ``b60557f``.

--- a/specs/frontier/threshold/v1/README.md
+++ b/specs/frontier/threshold/v1/README.md
@@ -33,6 +33,8 @@ The fixture-backed result includes:
 - threshold-crossing probability summaries
 - decision-reversal or tipping-point matrices
 - robust strategy summaries under ambiguity weights
+- `fixtures/evidence.json` records artifact hashes and keeps the fixture-backed
+  maturity and external parity gates explicit; it is not stable approval.
 - Pareto or non-dominated strategy sets across threshold profiles
 
 The contract is intentionally aligned with the Value of Perspective surface so

--- a/specs/frontier/threshold/v1/fixtures/evidence.json
+++ b/specs/frontier/threshold/v1/fixtures/evidence.json
@@ -1,0 +1,15 @@
+{
+  "contract": "threshold-voi-v1",
+  "maturity": "fixture-backed",
+  "stable_claim_allowed": false,
+  "owner": "voiage-maintainers",
+  "next_gate": "cross-language parity and stable promotion approval",
+  "blocked_state": "external_review_required",
+  "artifacts": [
+    {"path": "schemas/threshold-set.schema.json", "sha256": "468b0ac03373ae1d9dad5a7310cd6bc4db808dbe8e8d61955fbe7a2603b2c720"},
+    {"path": "schemas/value-of-threshold-result.schema.json", "sha256": "2288f59a738d4b5baf33ddc56875b4c7f5db4e921f7dc411bc7b5323ce026895"},
+    {"path": "fixtures/normative/threshold-surface.json", "sha256": "c48b72fe9256f2b33c9c17a61562143fe519bc8715ea56345a51d9170813227f"},
+    {"path": "fixtures/normative/value-of-threshold.json", "sha256": "6fd355e7b21183afc9605cb3121266092d97aa1258be6f9cae68142a518a0072"}
+  ],
+  "parity": {"python": "verified", "rust": "not_verified", "r": "not_verified", "typescript": "not_verified"}
+}

--- a/specs/frontier/validation/v1/README.md
+++ b/specs/frontier/validation/v1/README.md
@@ -33,6 +33,8 @@ The fixture-backed result includes:
 - value of external validation
 - value of model-discrepancy reduction
 - consensus or robust strategy summaries under validation weights
+- `fixtures/evidence.json` records artifact hashes and keeps the fixture-backed
+  maturity and external parity gates explicit; it is not stable approval.
 - Pareto or non-dominated strategy sets across validation profiles
 
 The contract is intentionally aligned with the Value of Perspective surface so

--- a/specs/frontier/validation/v1/fixtures/evidence.json
+++ b/specs/frontier/validation/v1/fixtures/evidence.json
@@ -1,0 +1,15 @@
+{
+  "contract": "validation-voi-v1",
+  "maturity": "fixture-backed",
+  "stable_claim_allowed": false,
+  "owner": "voiage-maintainers",
+  "next_gate": "cross-language parity and stable promotion approval",
+  "blocked_state": "external_review_required",
+  "artifacts": [
+    {"path": "schemas/validation-set.schema.json", "sha256": "4be08d071a6c0044f976ac9f9281fb1584837d390273988c95bd3f4a5491f7ab"},
+    {"path": "schemas/value-of-model-validation-result.schema.json", "sha256": "b74585cd21057d8978b43417ca59e56ea3137ac878cfe48a39b1cfb6444a3299"},
+    {"path": "fixtures/normative/validation-surface.json", "sha256": "4ba837cbbd52d66a354f61f840367c9d5ce316bd9c65763194923c39b9b0b1c8"},
+    {"path": "fixtures/normative/value-of-model-validation.json", "sha256": "186e50585d7d8475c455e15d6094d01fc27a1f1dc90086ca1b8cbcccd6ce258d"}
+  ],
+  "parity": {"python": "verified", "rust": "not_verified", "r": "not_verified", "typescript": "not_verified"}
+}

--- a/tests/test_threshold_contract.py
+++ b/tests/test_threshold_contract.py
@@ -32,3 +32,13 @@ def test_threshold_contract_schema_and_examples_parse() -> None:
     assert threshold_set_schema["title"] == "ThresholdSetV1FixtureBacked"
     assert threshold_result_schema["title"] == "ValueOfThresholdResultV1FixtureBacked"
     assert threshold_result_example["analysis_type"] == "value_of_threshold_information"
+
+
+def test_threshold_evidence_manifest_blocks_unverified_promotion() -> None:
+    manifest = json.loads(
+        (_threshold_contract_dir() / "fixtures" / "evidence.json").read_text()
+    )
+    assert manifest["maturity"] == "fixture-backed"
+    assert manifest["stable_claim_allowed"] is False
+    assert manifest["parity"]["python"] == "verified"
+    assert all(item["sha256"] for item in manifest["artifacts"])

--- a/tests/test_validation_contract.py
+++ b/tests/test_validation_contract.py
@@ -39,3 +39,13 @@ def test_validation_contract_schema_and_examples_parse() -> None:
         == "ValueOfModelValidationResultV1FixtureBacked"
     )
     assert validation_result_example["analysis_type"] == "value_of_model_validation"
+
+
+def test_validation_evidence_manifest_blocks_unverified_promotion() -> None:
+    manifest = json.loads(
+        (_validation_contract_dir() / "fixtures" / "evidence.json").read_text()
+    )
+    assert manifest["maturity"] == "fixture-backed"
+    assert manifest["stable_claim_allowed"] is False
+    assert manifest["parity"]["python"] == "verified"
+    assert all(item["sha256"] for item in manifest["artifacts"])


### PR DESCRIPTION
Advances Conductor track 04 (Validation And Threshold VOI Stable Promotion).

- Adds hashed evidence manifests for validation and threshold/tipping-point/robust contracts.
- Records fixture-backed maturity, owner, blocked state, and language parity.
- Adds tests preventing stable claims without cross-language evidence.
- Documents the explicit external promotion boundary.

Local gates: full tox passed (1216 tests, 14 skipped, coverage above 90%), Astro docs, frontier contract, version sync, Ruff, Bandit, and typecheck.