### PR TITLE
feat(conductor): define perspective promotion evidence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conductor/setup_state.json` to `.gitignore` as Conductor tool runtime state.
 
 ### Added
+- Added a seven-perspective Value of Perspective catalog covering payer,
+  societal, patient, provider, regulator, equity-weighted, and custom views,
+  with hash-pinned maturity evidence and an explicit real-data attribution
+  gate. The method remains fixture-backed pending parity and review.
 - Archived the distributional and implementation VOI promotion track after
   adding open-data evidence with provenance and passing hosted CI; retained
   cross-language parity and stable approval as explicit external gates.

--- a/conductor/tracks/perspective-uncertainty-voi-mature-stable_20260625/plan.md
+++ b/conductor/tracks/perspective-uncertainty-voi-mature-stable_20260625/plan.md
@@ -1,6 +1,6 @@
 # Track Implementation Plan: Perspective Uncertainty VOI Mature Stable Path
 
-## Phase 1: Contract And Maturity Boundary [checkpoint: ]
+## Phase 1: Contract And Maturity Boundary [checkpoint: in progress]
 
 - [ ] Task: Audit existing contract scaffolds, docs, and runtime surfaces for this method family.
     - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
@@ -16,7 +16,7 @@
     - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
 - [ ] Task: Conductor - User Manual Verification 'Phase 1: Contract And Maturity Boundary' (Protocol in workflow.md)
 
-## Phase 2: Runtime, Fixtures, And Examples [checkpoint: ]
+## Phase 2: Runtime, Fixtures, And Examples [checkpoint: in progress]
 
 - [ ] Task: Implement or extend Python runtime APIs, result objects, CLI commands, and deterministic synthetic fixtures.
     - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
@@ -69,3 +69,15 @@
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync`
 - [ ] Rust and binding language-native gates when kernels or adapters change
+
+## Evidence update 2026-07-16
+
+- Existing runtime, result envelope, CLI, docs, and two-perspective deterministic
+  fixture were audited as repository-owned implementation.
+- Added the seven-perspective stakeholder catalog and hash-pinned evidence
+  manifest in ``specs/frontier/perspective/v1/fixtures``.
+- The real-data gate remains explicit: no committed dataset currently supports
+  defensible payer, societal, patient, provider, regulator, and equity-weighted
+  transforms from the same outcome/cost basis.
+- Cross-language parity, Rust parity review, real-data attribution, and mature
+  approval remain open; the method stays fixture-backed.

--- a/conductor/tracks/perspective-uncertainty-voi-mature-stable_20260625/plan.md
+++ b/conductor/tracks/perspective-uncertainty-voi-mature-stable_20260625/plan.md
@@ -76,6 +76,8 @@
   fixture were audited as repository-owned implementation.
 - Added the seven-perspective stakeholder catalog and hash-pinned evidence
   manifest in ``specs/frontier/perspective/v1/fixtures``.
+- Commit ``4fc614d`` records this contract-boundary checkpoint and its review
+  note.
 - The real-data gate remains explicit: no committed dataset currently supports
   defensible payer, societal, patient, provider, regulator, and equity-weighted
   transforms from the same outcome/cost basis.

--- a/specs/frontier/perspective/v1/README.md
+++ b/specs/frontier/perspective/v1/README.md
@@ -12,6 +12,10 @@ yet; promotion still requires cross-language validation and maturity review.
 - `examples/value-of-perspective.example.json` is a compact illustrative result.
 - `fixtures/` contains the deterministic screening-program conformance
   fixture set used to anchor the CLI contract.
+- `fixtures/perspective-catalog.json` records the payer, societal, patient,
+  provider, regulator, equity-weighted, and custom stakeholder definitions.
+- `fixtures/evidence.json` records the fixture hashes, explicit real-data
+  gate, parity state, and stable-promotion boundary.
 
 ## Shape
 

--- a/specs/frontier/perspective/v1/fixtures/README.md
+++ b/specs/frontier/perspective/v1/fixtures/README.md
@@ -7,6 +7,10 @@ Value of Perspective contract.
 
 - `normative/`: deterministic fixtures that anchor the CLI contract and serve
   as the first conformance target for future language bindings.
+- `perspective-catalog.json`: the required stakeholder perspective catalog and
+  explicit objective-uncertainty assumptions.
+- `evidence.json`: machine-readable maturity, hash, real-data, and parity
+  evidence. The contract remains fixture-backed until those gates pass.
 
 The committed fixture is intentionally small and uses the screening-program
 comparison surface already documented in the v1 example files. The top-level

--- a/specs/frontier/perspective/v1/fixtures/evidence.json
+++ b/specs/frontier/perspective/v1/fixtures/evidence.json
@@ -1,0 +1,29 @@
+{
+  "contract": "value-of-perspective-v1",
+  "maturity": "fixture-backed",
+  "stable_claim_allowed": false,
+  "owner": "voiage-maintainers",
+  "artifacts": [
+    {"path": "schemas/perspective-set.schema.json", "sha256": "be7af0c3e2a1b31aa68354331387481e3d491d09a8be531a0c7a5f81d9b38df3"},
+    {"path": "schemas/value-of-perspective-result.schema.json", "sha256": "7bbd475b3d7bb6aa7ebfee6570026ab50293d6ded7cdd0479a4e05cb73e05f8b"},
+    {"path": "fixtures/normative/perspective-surface.json", "sha256": "f6ca8bb41abc36a19190abc3625127e82c03c455504ed8c948bfc3d050288245"},
+    {"path": "fixtures/normative/value-of-perspective.json", "sha256": "f41dbb68f354f80a36333dba5379be35c5625f447df5afa893730821a1e914b2"},
+    {"path": "fixtures/perspective-catalog.json", "sha256": "c06e38d46049b1eeeee223c94f318b5b76a36237131c662655e8e669da1499fd"}
+  ],
+  "open_data": {
+    "status": "blocked_external",
+    "evidence": "No committed dataset currently identifies the same outcome and cost transformations for payer, societal, patient, provider, regulator, and equity-weighted perspectives.",
+    "next_action": "Add a licensed health-economic dataset with a documented perspective-specific cost/effect transform and reproducible snapshot.",
+    "source_candidates": [
+      "https://databank.worldbank.org/",
+      "https://ourworldindata.org/"
+    ],
+    "license_gate": "Confirm source license and permission for the perspective-specific transform before committing a snapshot."
+  },
+  "parity": {"python": "verified", "rust": "not_verified", "r": "not_verified", "typescript": "not_verified"},
+  "external_gates": [
+    "Cross-language conformance and Rust parity review",
+    "Perspective-specific real-data attribution",
+    "Mature/stable method approval"
+  ]
+}

--- a/specs/frontier/perspective/v1/fixtures/perspective-catalog.json
+++ b/specs/frontier/perspective/v1/fixtures/perspective-catalog.json
@@ -1,0 +1,19 @@
+{
+  "contract": "value-of-perspective-v1",
+  "method_maturity": "fixture-backed",
+  "stable_claim_allowed": false,
+  "perspectives": [
+    {"id": "payer", "label": "Payer", "objective": "payer costs and payer-valued outcomes"},
+    {"id": "societal", "label": "Societal", "objective": "all specified costs and outcomes from a societal view"},
+    {"id": "patient", "label": "Patient", "objective": "patient costs, burden, and patient-valued outcomes"},
+    {"id": "provider", "label": "Provider", "objective": "provider resource use and provider-valued outcomes"},
+    {"id": "regulator", "label": "Regulator", "objective": "regulatory outcomes, safety, and budget impact"},
+    {"id": "equity-weighted", "label": "Equity-weighted", "objective": "distributionally weighted outcomes and burdens"},
+    {"id": "custom", "label": "Custom stakeholder", "objective": "user-specified objective and stakeholder weights"}
+  ],
+  "assumptions": {
+    "perspective_weights": "Weights represent uncertainty over which perspective should govern the decision and are normalized before aggregation.",
+    "objective_uncertainty": "Each perspective supplies its own net-benefit surface; the method values resolving which surface should govern the choice.",
+    "real_data_boundary": "Real observations must be mapped to a named perspective with a documented cost/effect transform; no such mapping is claimed by this catalog."
+  }
+}

--- a/tests/test_perspective_promotion_evidence.py
+++ b/tests/test_perspective_promotion_evidence.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "specs" / "frontier" / "perspective" / "v1"
+
+
+def test_perspective_catalog_and_promotion_gates_are_explicit() -> None:
+    catalog = json.loads((ROOT / "fixtures" / "perspective-catalog.json").read_text())
+    evidence = json.loads((ROOT / "fixtures" / "evidence.json").read_text())
+
+    assert catalog["method_maturity"] == "fixture-backed"
+    assert catalog["stable_claim_allowed"] is False
+    assert [item["id"] for item in catalog["perspectives"]] == [
+        "payer",
+        "societal",
+        "patient",
+        "provider",
+        "regulator",
+        "equity-weighted",
+        "custom",
+    ]
+    assert catalog["assumptions"]["objective_uncertainty"]
+    assert evidence["open_data"]["status"] == "blocked_external"
+    assert evidence["open_data"]["next_action"]
+    assert evidence["parity"]["python"] == "verified"
+    assert evidence["stable_claim_allowed"] is False
+
+    for artifact in evidence["artifacts"]:
+        path = ROOT / artifact["path"]
+        assert path.is_file()
+        if artifact["sha256"] != "pending":
+            assert hashlib.sha256(path.read_bytes()).hexdigest() == artifact["sha256"]


### PR DESCRIPTION
## Summary
- add the seven required stakeholder perspective definitions
- add hash-pinned fixture evidence and regression validation
- keep real-data attribution, cross-language/Rust parity, and mature approval explicit gates

## Validation
- uv run pytest tests/test_perspective.py tests/test_perspective_promotion_evidence.py tests/test_conductor_followthrough_tracks.py --no-cov
- python scripts/validate_frontier_contract.py
- python scripts/repo_harness.py

26 focused tests passed; repository harness finding_count 0.