### PR TITLE
feat(conductor): implement causal transportability VOI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conductor/setup_state.json` to `.gitignore` as Conductor tool runtime state.
 
 ### Added
+- Added a fixture-backed causal-identification, transportability, and
+  external-validity VOI runtime with CLI support and explicit open-data and
+  cross-language parity gates.
 - Archived the dynamic real-options VOI track after implementing its staged
   runtime and CLI and passing hosted CI; retained longitudinal-data, parity,
   and mature approval as explicit gates.
@@ -686,3 +689,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Hardened the Rust benchmark baselines so they no longer depend on timing assertions, versioned the Rust core `Cargo.lock` so locked CI builds work reliably, split the CI test stack into a lighter `ci` extra to avoid disk exhaustion, and improved the benchmark workflow to print captured Cargo output when a baseline fails in CI.
+* Add a fixture-backed causal-identification and transportability VOI runtime.

--- a/specs/frontier/causal-transportability/v1/README.md
+++ b/specs/frontier/causal-transportability/v1/README.md
@@ -1,17 +1,16 @@
 # Causal Identification, Transportability, And External-Validity Experimental Contract v1
 
 This directory holds the fixture-backed frontier contract for
-causal-identification, transportability, and external-validity VOI. It is not
-part of the stable core API v1 matrix yet; promotion still requires runtime
-implementation, cross-language validation, CLI coverage, and method maturity
-review.
+causal-identification, transportability, and external-validity VOI. The Python
+runtime and CLI are fixture-backed; promotion still requires open-data
+attribution, cross-language validation, and method maturity review.
 
 ## Files
 
 - `schemas/causal-transportability-set.schema.json` defines the causal and
   transport-context input surface.
 - `schemas/value-of-causal-transportability-result.schema.json` defines the
-  planned result shape.
+  fixture-backed result shape.
 - `examples/causal-transportability-set.example.json` is a compact
   illustrative input payload.
 - `examples/value-of-causal-transportability.example.json` is a compact
@@ -21,7 +20,7 @@ review.
 
 ## Shape
 
-The planned analysis surface treats source-to-target population shifts as an
+The analysis surface treats source-to-target population shifts as an
 explicit decision-relevant dimension rather than a hidden modelling
 assumption. The intended net-benefit surface uses:
 

--- a/specs/frontier/causal-transportability/v1/examples/value-of-causal-transportability.example.json
+++ b/specs/frontier/causal-transportability/v1/examples/value-of-causal-transportability.example.json
@@ -2,7 +2,7 @@
   "analysis_id": "causal-transportability-screening-001",
   "decision_problem_id": "screening-program-001",
   "analysis_type": "value_of_causal_transportability",
-  "method_maturity": "planned",
+  "method_maturity": "fixture-backed",
   "value": 4.2,
   "causal_identification_value": 1.3,
   "transportability_value": 1.8,

--- a/specs/frontier/causal-transportability/v1/fixtures/evidence.json
+++ b/specs/frontier/causal-transportability/v1/fixtures/evidence.json
@@ -1,0 +1,23 @@
+{
+  "contract": "value-of-causal-transportability-v1",
+  "maturity": "fixture-backed",
+  "stable_claim_allowed": false,
+  "owner": "voiage-maintainers",
+  "artifacts": [
+    {"path": "schemas/causal-transportability-set.schema.json", "sha256": "e2c13fda44e9acd8ba6e12d7ecf22c73892a55cd575ae35f0fc317be3c46b249"},
+    {"path": "schemas/value-of-causal-transportability-result.schema.json", "sha256": "0f94902d7ddcbe29b37842c908100079d91a74addac9989bdf30168ffdb0735f"},
+    {"path": "fixtures/normative/causal-transportability-set.json", "sha256": "bc56c67f9ef9c43f052a2d113dce746ba8f87bcc8b035b50109a04846a9089c7"},
+    {"path": "fixtures/normative/value-of-causal-transportability.json", "sha256": "00bd47fb7f067b6243ec4c8328b5e13eadf5e11e4f06b032850e7684cd185db0"},
+    {"path": "../../../../voiage/methods/causal_transportability.py", "sha256": "c342058a87dda4262bf0d2c9c2dcce7c616aced2535fb781a6035e020e0d312f"}
+  ],
+  "open_data": {
+    "status": "blocked_external",
+    "evidence": "No committed open-data source currently provides licensed causal effects, transport weights, and target-population validity measures in one reproducible decision-ready snapshot.",
+    "next_action": "Add a licensed causal or health-outcomes dataset with documented source-to-target transform and snapshot policy.",
+    "source_candidates": ["https://databank.worldbank.org/", "https://ourworldindata.org/"],
+    "license_gate": "Confirm source license and permission for the causal transform before committing a snapshot."
+  },
+  "parity": {"python": "verified", "rust": "deferred_with_rationale", "r": "not_verified", "typescript": "not_verified"},
+  "parity_rationale": "The Python implementation is the reference runtime; Rust parity is deferred until causal estimand semantics and cross-language fixture conventions are reviewed.",
+  "external_gates": ["Open-data attribution and transform review", "Cross-language conformance and Rust parity review", "Mature/stable method approval"]
+}

--- a/specs/frontier/causal-transportability/v1/fixtures/evidence.json
+++ b/specs/frontier/causal-transportability/v1/fixtures/evidence.json
@@ -8,7 +8,7 @@
     {"path": "schemas/value-of-causal-transportability-result.schema.json", "sha256": "0f94902d7ddcbe29b37842c908100079d91a74addac9989bdf30168ffdb0735f"},
     {"path": "fixtures/normative/causal-transportability-set.json", "sha256": "bc56c67f9ef9c43f052a2d113dce746ba8f87bcc8b035b50109a04846a9089c7"},
     {"path": "fixtures/normative/value-of-causal-transportability.json", "sha256": "00bd47fb7f067b6243ec4c8328b5e13eadf5e11e4f06b032850e7684cd185db0"},
-    {"path": "../../../../voiage/methods/causal_transportability.py", "sha256": "c342058a87dda4262bf0d2c9c2dcce7c616aced2535fb781a6035e020e0d312f"}
+    {"path": "../../../../voiage/methods/causal_transportability.py", "sha256": "47b413afd6b94ce73dc6e26f3a014dc700b6e13c0b9bc1aae03ffb95154347cf"}
   ],
   "open_data": {
     "status": "blocked_external",

--- a/specs/frontier/causal-transportability/v1/schemas/causal-transportability-set.schema.json
+++ b/specs/frontier/causal-transportability/v1/schemas/causal-transportability-set.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://voiage.dev/specs/frontier/causal-transportability/v1/schemas/causal-transportability-set.schema.json",
-  "title": "CausalTransportabilitySetV1Planned",
+  "title": "CausalTransportabilitySetV1FixtureBacked",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/specs/frontier/causal-transportability/v1/schemas/value-of-causal-transportability-result.schema.json
+++ b/specs/frontier/causal-transportability/v1/schemas/value-of-causal-transportability-result.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://voiage.dev/specs/frontier/causal-transportability/v1/schemas/value-of-causal-transportability-result.schema.json",
-  "title": "ValueOfCausalTransportabilityResultV1Planned",
+  "title": "ValueOfCausalTransportabilityResultV1FixtureBacked",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -40,7 +40,7 @@
     },
     "method_maturity": {
       "type": "string",
-      "const": "planned"
+      "const": "fixture-backed"
     },
     "value": {
       "type": "number",

--- a/tests/test_causal_transportability.py
+++ b/tests/test_causal_transportability.py
@@ -1,0 +1,30 @@
+"""Runtime tests for causal transportability VOI."""
+
+import numpy as np
+import pytest
+
+from voiage.methods.causal_transportability import value_of_causal_transportability
+
+
+def test_causal_transportability_returns_target_specific_decisions() -> None:
+    result = value_of_causal_transportability(
+        np.array([[[10.0, 12.0], [9.0, 11.0]], [[11.0, 13.0], [8.0, 12.0]]]),
+        ["trial", "registry"],
+        ["urban", "rural"],
+        ["usual-care", "adapted"],
+        np.array([[1.0, 0.6], [0.8, 1.0]]),
+        np.array([[0.0, 1.0], [0.5, 0.2]]),
+    )
+    assert result.method_maturity == "fixture-backed"
+    assert result.expected_net_benefits.shape == (2, 2)
+    assert result.optimal_strategy_by_target_population["urban"] == "adapted"
+    assert result.robust_strategy in result.strategy_names
+    assert result.value >= 0
+
+
+def test_causal_transportability_rejects_missing_target_weight() -> None:
+    with pytest.raises(ValueError, match="positive transport weight"):
+        value_of_causal_transportability(
+            np.ones((1, 1, 1)), ["source"], ["target"], ["strategy"],
+            np.zeros((1, 1)), np.zeros((1, 1)),
+        )

--- a/tests/test_causal_transportability.py
+++ b/tests/test_causal_transportability.py
@@ -25,6 +25,10 @@ def test_causal_transportability_returns_target_specific_decisions() -> None:
 def test_causal_transportability_rejects_missing_target_weight() -> None:
     with pytest.raises(ValueError, match="positive transport weight"):
         value_of_causal_transportability(
-            np.ones((1, 1, 1)), ["source"], ["target"], ["strategy"],
-            np.zeros((1, 1)), np.zeros((1, 1)),
+            np.ones((1, 1, 1)),
+            ["source"],
+            ["target"],
+            ["strategy"],
+            np.zeros((1, 1)),
+            np.zeros((1, 1)),
         )

--- a/tests/test_causal_transportability_contract.py
+++ b/tests/test_causal_transportability_contract.py
@@ -43,6 +43,7 @@ def test_causal_transportability_contract_schema_and_examples_parse() -> None:
 
     assert causal_set_schema["title"] == "CausalTransportabilitySetV1FixtureBacked"
     assert (
-        causal_result_schema["title"] == "ValueOfCausalTransportabilityResultV1FixtureBacked"
+        causal_result_schema["title"]
+        == "ValueOfCausalTransportabilityResultV1FixtureBacked"
     )
     assert causal_result_example["analysis_type"] == "value_of_causal_transportability"

--- a/tests/test_causal_transportability_contract.py
+++ b/tests/test_causal_transportability_contract.py
@@ -41,8 +41,8 @@ def test_causal_transportability_contract_schema_and_examples_parse() -> None:
     Draft202012Validator(causal_set_schema).validate(causal_set_example)
     Draft202012Validator(causal_result_schema).validate(causal_result_example)
 
-    assert causal_set_schema["title"] == "CausalTransportabilitySetV1Planned"
+    assert causal_set_schema["title"] == "CausalTransportabilitySetV1FixtureBacked"
     assert (
-        causal_result_schema["title"] == "ValueOfCausalTransportabilityResultV1Planned"
+        causal_result_schema["title"] == "ValueOfCausalTransportabilityResultV1FixtureBacked"
     )
     assert causal_result_example["analysis_type"] == "value_of_causal_transportability"

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -724,8 +724,8 @@ def test_cli_command_registry_matches_expected_surface() -> None:
 
     assert set(command.commands) == {
         "calculate-adaptive-evsi",
-            "calculate-calibration",
-            "calculate-causal-transportability",
+        "calculate-calibration",
+        "calculate-causal-transportability",
         "calculate-distributional-equity",
         "calculate-dynamic-real-options",
         "calculate-ceaf",

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -724,7 +724,8 @@ def test_cli_command_registry_matches_expected_surface() -> None:
 
     assert set(command.commands) == {
         "calculate-adaptive-evsi",
-        "calculate-calibration",
+            "calculate-calibration",
+            "calculate-causal-transportability",
         "calculate-distributional-equity",
         "calculate-dynamic-real-options",
         "calculate-ceaf",

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -324,6 +324,7 @@ def test_methods_package_exports_are_curated() -> None:
     """Method package exports should remain stable curated symbols."""
     assert methods_module.__all__ == [
         "CEAFResult",
+        "CausalTransportabilityResult",
         "DistributionalEquityResult",
         "DominanceResult",
         "DynamicRealOptionsResult",
@@ -360,6 +361,7 @@ def test_methods_package_exports_are_curated() -> None:
         "sequential_voi",
         "structural_evpi",
         "structural_evppi",
+        "value_of_causal_transportability",
         "value_of_distributional_equity",
         "value_of_dynamic_real_options",
         "value_of_heterogeneity",
@@ -392,6 +394,7 @@ def test_plot_package_exports_point_to_leaf_implementations() -> None:
 def test_top_level_package_exports_modules() -> None:
     """Top-level package exports should remain stable curated API symbols."""
     assert voiage.__all__ == [
+        "CausalTransportabilityResult",
         "DecisionAnalysis",
         "DecisionOption",
         "DistributionalEquityResult",
@@ -436,6 +439,7 @@ def test_top_level_package_exports_modules() -> None:
         "plot",
         "preference_optimal_strategies",
         "schema",
+        "value_of_causal_transportability",
         "value_of_distributional_equity",
         "value_of_dynamic_real_options",
         "value_of_implementation",

--- a/voiage/__init__.py
+++ b/voiage/__init__.py
@@ -27,6 +27,10 @@ from . import (
 from .analysis import DecisionAnalysis
 from .ecosystem_integration import HeomlRunBundle, load_heoml_run_bundle
 from .methods.basic import evpi, evppi
+from .methods.causal_transportability import (
+    CausalTransportabilityResult,
+    value_of_causal_transportability,
+)
 from .methods.distributional import (
     DistributionalEquityResult,
     value_of_distributional_equity,
@@ -84,6 +88,7 @@ except PackageNotFoundError:  # pragma: no cover - local source tree fallback
     __version__ = "0.0.0"
 
 __all__ = [
+    "CausalTransportabilityResult",
     "DecisionAnalysis",
     "DecisionOption",
     "DistributionalEquityResult",
@@ -128,6 +133,7 @@ __all__ = [
     "plot",
     "preference_optimal_strategies",
     "schema",
+    "value_of_causal_transportability",
     "value_of_distributional_equity",
     "value_of_dynamic_real_options",
     "value_of_implementation",

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -2852,7 +2852,9 @@ def calculate_causal_transportability(
     try:
         payload = _read_json_file(specification_file)
         if not isinstance(payload, dict):
-            raise TypeError("Causal transportability specification must be a JSON object.")
+            raise TypeError(
+                "Causal transportability specification must be a JSON object."
+            )
         result = calculate_causal_transportability_result(
             np.asarray(payload["net_benefit"], dtype=float),
             cast("list[str]", payload["source_population_ids"]),
@@ -2860,9 +2862,13 @@ def calculate_causal_transportability(
             cast("list[str]", payload["strategy_names"]),
             np.asarray(payload["transport_weights"], dtype=float),
             np.asarray(payload["validity_penalties"], dtype=float),
-            analysis_id=str(payload.get("analysis_id", "causal-transportability-analysis")),
+            analysis_id=str(
+                payload.get("analysis_id", "causal-transportability-analysis")
+            ),
             decision_problem_id=str(payload.get("decision_problem_id", "unspecified")),
-            reference_target_population=cast("str | None", payload.get("reference_target_population")),
+            reference_target_population=cast(
+                "str | None", payload.get("reference_target_population")
+            ),
         )
         result_payload = {
             "analysis_type": "value_of_causal_transportability",

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -37,6 +37,9 @@ from voiage.methods.adaptive import (
 )
 from voiage.methods.basic import evpi, evppi
 from voiage.methods.calibration import voi_calibration
+from voiage.methods.causal_transportability import (
+    value_of_causal_transportability as calculate_causal_transportability_result,
+)
 from voiage.methods.ceaf import calculate_ceaf as calculate_ceaf_result
 from voiage.methods.distributional import (
     DistributionalEquityResult,
@@ -199,6 +202,19 @@ _CONFIG_TEMPLATES: dict[str, dict[str, object]] = {
         "lock_in_penalty": 0.25,
         "evidence_arrival_times": {"after_phase_1": 1.0, "after_phase_2": 2.0},
         "exercise_rules": {"now": "exercise_immediately"},
+    },
+    "causal-transportability": {
+        "command": "calculate-causal-transportability",
+        "description": "Template for fixture-backed causal transportability VOI inputs.",
+        "analysis_id": "causal-transportability-analysis",
+        "decision_problem_id": "screening-program-001",
+        "source_population_ids": ["trial_population", "real_world_population"],
+        "target_population_ids": ["urban_target", "rural_target"],
+        "strategy_names": ["status_quo", "adapted_policy"],
+        "net_benefit": [[[10.0, 12.0], [9.0, 11.0]]],
+        "transport_weights": [[1.0, 0.7], [0.8, 0.9]],
+        "validity_penalties": [[0.0, 1.0], [0.5, 0.4]],
+        "reference_target_population": "urban_target",
     },
     "preference": {
         "command": "calculate-preference",
@@ -2806,6 +2822,71 @@ def calculate_dynamic_real_options(
         output_text = _format_output(
             f"Dynamic real-options VOI: {result.option_value:.6f}\n"
             f"Robust strategy: {result.robust_strategy_name}",
+            result_payload,
+        )
+        typer.echo(output_text)
+        if output_file:
+            _write_output_file(output_file, output_text)
+            if _should_echo_status_messages():
+                typer.echo(f"Result saved to {output_file}")
+    except FileNotFoundError as e:
+        typer.echo(f"Error: File not found - {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@app.command(name="calculate-causal-transportability")
+def calculate_causal_transportability(
+    specification_file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to JSON causal transportability specification",
+    ),
+    output_file: Path | None = typer.Option(
+        None, "--output", "-o", help="File to save the causal transportability result"
+    ),
+) -> None:
+    """Calculate fixture-backed causal transportability VOI from JSON."""
+    try:
+        payload = _read_json_file(specification_file)
+        if not isinstance(payload, dict):
+            raise TypeError("Causal transportability specification must be a JSON object.")
+        result = calculate_causal_transportability_result(
+            np.asarray(payload["net_benefit"], dtype=float),
+            cast("list[str]", payload["source_population_ids"]),
+            cast("list[str]", payload["target_population_ids"]),
+            cast("list[str]", payload["strategy_names"]),
+            np.asarray(payload["transport_weights"], dtype=float),
+            np.asarray(payload["validity_penalties"], dtype=float),
+            analysis_id=str(payload.get("analysis_id", "causal-transportability-analysis")),
+            decision_problem_id=str(payload.get("decision_problem_id", "unspecified")),
+            reference_target_population=cast("str | None", payload.get("reference_target_population")),
+        )
+        result_payload = {
+            "analysis_type": "value_of_causal_transportability",
+            "method_maturity": result.method_maturity,
+            "value": result.value,
+            "causal_identification_value": result.causal_identification_value,
+            "transportability_value": result.transportability_value,
+            "external_validity_value": result.external_validity_value,
+            "source_population_ids": result.source_population_ids,
+            "target_population_ids": result.target_population_ids,
+            "strategy_names": result.strategy_names,
+            "expected_net_benefits": result.expected_net_benefits.tolist(),
+            "optimal_strategy_by_target_population": result.optimal_strategy_by_target_population,
+            "transport_weight_matrix": result.transport_weight_matrix.tolist(),
+            "validity_penalty_matrix": result.validity_penalty_matrix.tolist(),
+            "robust_strategy": result.robust_strategy,
+            "pareto_strategies": result.pareto_strategies,
+            "reference_target_population": result.reference_target_population,
+            "diagnostics": result.diagnostics,
+            "reporting": result.reporting,
+        }
+        output_text = _format_output(
+            f"Causal transportability VOI: {result.value:.6f}\n"
+            f"Robust strategy: {result.robust_strategy}",
             result_payload,
         )
         typer.echo(output_text)

--- a/voiage/methods/__init__.py
+++ b/voiage/methods/__init__.py
@@ -3,6 +3,10 @@
 from .adaptive import adaptive_evsi
 from .basic import evpi, evppi
 from .calibration import voi_calibration
+from .causal_transportability import (
+    CausalTransportabilityResult,
+    value_of_causal_transportability,
+)
 from .ceaf import CEAFResult, calculate_ceaf
 from .distributional import (
     DistributionalEquityResult,
@@ -68,6 +72,7 @@ from .validation import (
 
 __all__ = [
     "CEAFResult",
+    "CausalTransportabilityResult",
     "DistributionalEquityResult",
     "DominanceResult",
     "DynamicRealOptionsResult",
@@ -104,6 +109,7 @@ __all__ = [
     "sequential_voi",
     "structural_evpi",
     "structural_evppi",
+    "value_of_causal_transportability",
     "value_of_distributional_equity",
     "value_of_dynamic_real_options",
     "value_of_heterogeneity",

--- a/voiage/methods/causal_transportability.py
+++ b/voiage/methods/causal_transportability.py
@@ -58,28 +58,47 @@ def value_of_causal_transportability(
     weights = np.asarray(transport_weights, dtype=DEFAULT_DTYPE)
     penalties = np.asarray(validity_penalties, dtype=DEFAULT_DTYPE)
     if values.ndim != 3 or min(values.shape) < 1:
-        raise_input_error("net_benefits must be a non-empty 3D array (samples, sources, strategies).")
+        raise_input_error(
+            "net_benefits must be a non-empty 3D array (samples, sources, strategies)."
+        )
     if values.shape[1:] != (len(sources), len(strategies)):
-        raise_input_error("net_benefits dimensions must match source and strategy names.")
+        raise_input_error(
+            "net_benefits dimensions must match source and strategy names."
+        )
     if len(set(sources)) != len(sources) or len(set(targets)) != len(targets):
         raise_input_error("Population identifiers must be unique.")
     if len(set(strategies)) != len(strategies):
         raise_input_error("Strategy names must be unique.")
-    if weights.shape != (len(sources), len(targets)) or penalties.shape != weights.shape:
-        raise_input_error("Transport weights and validity penalties must be source x target matrices.")
-    if not np.all(np.isfinite(values)) or not np.all(np.isfinite(weights)) or not np.all(np.isfinite(penalties)):
+    if (
+        weights.shape != (len(sources), len(targets))
+        or penalties.shape != weights.shape
+    ):
+        raise_input_error(
+            "Transport weights and validity penalties must be source x target matrices."
+        )
+    if (
+        not np.all(np.isfinite(values))
+        or not np.all(np.isfinite(weights))
+        or not np.all(np.isfinite(penalties))
+    ):
         raise_input_error("Inputs must contain only finite values.")
     if np.any(weights < 0) or np.any(penalties < 0) or np.any(weights > 1):
-        raise_input_error("Transport weights must be in [0, 1] and penalties non-negative.")
+        raise_input_error(
+            "Transport weights must be in [0, 1] and penalties non-negative."
+        )
     if reference_target_population is None:
         reference_target_population = targets[0]
     if reference_target_population not in targets:
-        raise_input_error("reference_target_population must identify a target population.")
+        raise_input_error(
+            "reference_target_population must identify a target population."
+        )
 
     source_means = np.mean(values, axis=0)
     denominator = np.sum(weights, axis=0)
     if np.any(denominator <= 0):
-        raise_input_error("Every target population must have positive transport weight.")
+        raise_input_error(
+            "Every target population must have positive transport weight."
+        )
     expected = (weights.T @ source_means) / denominator[:, None] - penalties.T
     optimum = np.argmax(expected, axis=1)
     reference_index = targets.index(reference_target_population)
@@ -87,13 +106,35 @@ def value_of_causal_transportability(
     reference_value = float(expected[reference_index, reference_strategy])
     target_specific_value = float(np.mean(np.max(expected, axis=1)))
     value = max(0.0, target_specific_value - reference_value)
-    causal_value = max(0.0, float(np.mean(np.max(source_means, axis=1)) - np.max(source_means[:, reference_strategy])))
-    transport_value = max(0.0, target_specific_value - float(np.mean(np.max(source_means, axis=1))))
-    external_value = max(0.0, float(np.mean(np.max(expected, axis=1) - np.max(expected[:, reference_strategy][:, None], axis=1))))
-    pareto = [strategies[i] for i in range(len(strategies)) if not any(
-        i != j and np.all(expected[:, j] >= expected[:, i]) and np.any(expected[:, j] > expected[:, i])
-        for j in range(len(strategies))
-    )]
+    causal_value = max(
+        0.0,
+        float(
+            np.mean(np.max(source_means, axis=1))
+            - np.max(source_means[:, reference_strategy])
+        ),
+    )
+    transport_value = max(
+        0.0, target_specific_value - float(np.mean(np.max(source_means, axis=1)))
+    )
+    external_value = max(
+        0.0,
+        float(
+            np.mean(
+                np.max(expected, axis=1)
+                - np.max(expected[:, reference_strategy][:, None], axis=1)
+            )
+        ),
+    )
+    pareto = [
+        strategies[i]
+        for i in range(len(strategies))
+        if not any(
+            i != j
+            and np.all(expected[:, j] >= expected[:, i])
+            and np.any(expected[:, j] > expected[:, i])
+            for j in range(len(strategies))
+        )
+    ]
     robust = strategies[int(np.argmax(np.min(expected, axis=0)))]
     return CausalTransportabilityResult(
         value=value,
@@ -104,12 +145,25 @@ def value_of_causal_transportability(
         target_population_ids=targets,
         strategy_names=strategies,
         expected_net_benefits=expected,
-        optimal_strategy_by_target_population={target: strategies[int(index)] for target, index in zip(targets, optimum, strict=True)},
+        optimal_strategy_by_target_population={
+            target: strategies[int(index)]
+            for target, index in zip(targets, optimum, strict=True)
+        },
         transport_weight_matrix=weights,
         validity_penalty_matrix=penalties,
         robust_strategy=robust,
         pareto_strategies=pareto,
         reference_target_population=reference_target_population,
-        diagnostics={"analysis_id": analysis_id, "decision_problem_id": decision_problem_id, "n_sources": len(sources), "n_targets": len(targets), "n_strategies": len(strategies)},
-        reporting={"reporting_standard": "CHEERS-VOI", "analysis_type": "value_of_causal_transportability", "method_maturity": "fixture-backed"},
+        diagnostics={
+            "analysis_id": analysis_id,
+            "decision_problem_id": decision_problem_id,
+            "n_sources": len(sources),
+            "n_targets": len(targets),
+            "n_strategies": len(strategies),
+        },
+        reporting={
+            "reporting_standard": "CHEERS-VOI",
+            "analysis_type": "value_of_causal_transportability",
+            "method_maturity": "fixture-backed",
+        },
     )

--- a/voiage/methods/causal_transportability.py
+++ b/voiage/methods/causal_transportability.py
@@ -1,0 +1,115 @@
+"""Causal-identification and transportability value of information."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from voiage.config import DEFAULT_DTYPE
+from voiage.exceptions import raise_input_error
+
+
+@dataclass(frozen=True)
+class CausalTransportabilityResult:
+    """Fixture-backed result for source-to-target causal evidence analysis."""
+
+    value: float
+    causal_identification_value: float
+    transportability_value: float
+    external_validity_value: float
+    source_population_ids: list[str]
+    target_population_ids: list[str]
+    strategy_names: list[str]
+    expected_net_benefits: np.ndarray
+    optimal_strategy_by_target_population: dict[str, str]
+    transport_weight_matrix: np.ndarray
+    validity_penalty_matrix: np.ndarray
+    robust_strategy: str
+    pareto_strategies: list[str]
+    reference_target_population: str
+    method_maturity: str = "fixture-backed"
+    diagnostics: dict[str, object] = field(default_factory=dict)
+    reporting: dict[str, object] = field(default_factory=dict)
+
+
+def value_of_causal_transportability(
+    net_benefits: np.ndarray,
+    source_population_ids: Sequence[str],
+    target_population_ids: Sequence[str],
+    strategy_names: Sequence[str],
+    transport_weights: np.ndarray,
+    validity_penalties: np.ndarray,
+    *,
+    analysis_id: str = "causal-transportability-analysis",
+    decision_problem_id: str = "unspecified",
+    reference_target_population: str | None = None,
+) -> CausalTransportabilityResult:
+    """Value causal evidence transported from source to target populations.
+
+    ``net_benefits`` has shape ``(samples, sources, strategies)``.  Each
+    target receives a weighted source estimate, reduced by its validity
+    penalty; the returned value is the gain from target-specific decisions
+    over the reference target's decision rule.
+    """
+    values = np.asarray(net_benefits, dtype=DEFAULT_DTYPE)
+    sources = [str(item) for item in source_population_ids]
+    targets = [str(item) for item in target_population_ids]
+    strategies = [str(item) for item in strategy_names]
+    weights = np.asarray(transport_weights, dtype=DEFAULT_DTYPE)
+    penalties = np.asarray(validity_penalties, dtype=DEFAULT_DTYPE)
+    if values.ndim != 3 or min(values.shape) < 1:
+        raise_input_error("net_benefits must be a non-empty 3D array (samples, sources, strategies).")
+    if values.shape[1:] != (len(sources), len(strategies)):
+        raise_input_error("net_benefits dimensions must match source and strategy names.")
+    if len(set(sources)) != len(sources) or len(set(targets)) != len(targets):
+        raise_input_error("Population identifiers must be unique.")
+    if len(set(strategies)) != len(strategies):
+        raise_input_error("Strategy names must be unique.")
+    if weights.shape != (len(sources), len(targets)) or penalties.shape != weights.shape:
+        raise_input_error("Transport weights and validity penalties must be source x target matrices.")
+    if not np.all(np.isfinite(values)) or not np.all(np.isfinite(weights)) or not np.all(np.isfinite(penalties)):
+        raise_input_error("Inputs must contain only finite values.")
+    if np.any(weights < 0) or np.any(penalties < 0) or np.any(weights > 1):
+        raise_input_error("Transport weights must be in [0, 1] and penalties non-negative.")
+    if reference_target_population is None:
+        reference_target_population = targets[0]
+    if reference_target_population not in targets:
+        raise_input_error("reference_target_population must identify a target population.")
+
+    source_means = np.mean(values, axis=0)
+    denominator = np.sum(weights, axis=0)
+    if np.any(denominator <= 0):
+        raise_input_error("Every target population must have positive transport weight.")
+    expected = (weights.T @ source_means) / denominator[:, None] - penalties.T
+    optimum = np.argmax(expected, axis=1)
+    reference_index = targets.index(reference_target_population)
+    reference_strategy = int(optimum[reference_index])
+    reference_value = float(expected[reference_index, reference_strategy])
+    target_specific_value = float(np.mean(np.max(expected, axis=1)))
+    value = max(0.0, target_specific_value - reference_value)
+    causal_value = max(0.0, float(np.mean(np.max(source_means, axis=1)) - np.max(source_means[:, reference_strategy])))
+    transport_value = max(0.0, target_specific_value - float(np.mean(np.max(source_means, axis=1))))
+    external_value = max(0.0, float(np.mean(np.max(expected, axis=1) - np.max(expected[:, reference_strategy][:, None], axis=1))))
+    pareto = [strategies[i] for i in range(len(strategies)) if not any(
+        i != j and np.all(expected[:, j] >= expected[:, i]) and np.any(expected[:, j] > expected[:, i])
+        for j in range(len(strategies))
+    )]
+    robust = strategies[int(np.argmax(np.min(expected, axis=0)))]
+    return CausalTransportabilityResult(
+        value=value,
+        causal_identification_value=causal_value,
+        transportability_value=transport_value,
+        external_validity_value=external_value,
+        source_population_ids=sources,
+        target_population_ids=targets,
+        strategy_names=strategies,
+        expected_net_benefits=expected,
+        optimal_strategy_by_target_population={target: strategies[int(index)] for target, index in zip(targets, optimum, strict=True)},
+        transport_weight_matrix=weights,
+        validity_penalty_matrix=penalties,
+        robust_strategy=robust,
+        pareto_strategies=pareto,
+        reference_target_population=reference_target_population,
+        diagnostics={"analysis_id": analysis_id, "decision_problem_id": decision_problem_id, "n_sources": len(sources), "n_targets": len(targets), "n_strategies": len(strategies)},
+        reporting={"reporting_standard": "CHEERS-VOI", "analysis_type": "value_of_causal_transportability", "method_maturity": "fixture-backed"},
+    )


### PR DESCRIPTION
## Summary
- implement fixture-backed causal-identification, transportability, and external-validity VOI runtime
- expose the method through Python and CLI surfaces
- update the frontier schemas, examples, docs, and hash-pinned evidence manifest
- add runtime, contract, and CLI coverage

## Validation
- `uv run pytest tests/test_causal_transportability.py tests/test_causal_transportability_contract.py tests/test_cli_comprehensive.py --no-cov` (30 passed)
- `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov` (13 passed)
- `uv run python scripts/validate_frontier_contract.py`

## Explicit remaining gates
Open-data attribution/transform review, Rust and cross-language parity, R/TypeScript adapters, and mature/stable approval remain external or deferred. The method remains fixture-backed.