### PR TITLE
feat(conductor): implement data quality VOI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conductor/setup_state.json` to `.gitignore` as Conductor tool runtime state.
 
 ### Added
+- Added a fixture-backed data-quality, measurement-error, privacy, and linkage
+  VOI runtime with CLI support and explicit parity/open-data gates.
 - Archived the causal transportability VOI track after completing its
   fixture-backed Python runtime, CLI, evidence manifest, and hosted CI slice;
   open-data attribution, parity, and mature approval remain gated.

--- a/specs/frontier/data-quality/v1/README.md
+++ b/specs/frontier/data-quality/v1/README.md
@@ -1,16 +1,15 @@
 # Data-Quality, Measurement-Error, Privacy, And Linkage Experimental Contract v1
 
 This directory holds the fixture-backed frontier contract for data-quality,
-measurement-error, data-acquisition, privacy, and linkage VOI. It is not part
-of the stable core API v1 matrix yet; promotion still requires runtime
-implementation, cross-language validation, CLI coverage, and method maturity
-review.
+measurement-error, data-acquisition, privacy, and linkage VOI. The Python
+runtime and CLI are fixture-backed; promotion still requires open-data
+attribution, cross-language validation, and method maturity review.
 
 ## Files
 
 - `schemas/data-quality-set.schema.json` defines the data-quality and privacy
   input surface.
-- `schemas/value-of-data-quality-result.schema.json` defines the planned
+- `schemas/value-of-data-quality-result.schema.json` defines the fixture-backed
   result shape.
 - `examples/data-quality-set.example.json` is a compact illustrative input
   payload.
@@ -21,7 +20,7 @@ review.
 
 ## Shape
 
-The planned analysis surface treats source quality, measurement error,
+The analysis surface treats source quality, measurement error,
 privacy, and linkage constraints as explicit decision-relevant dimensions
 rather than a hidden sensitivity analysis. The intended net-benefit surface
 uses:

--- a/specs/frontier/data-quality/v1/examples/value-of-data-quality.example.json
+++ b/specs/frontier/data-quality/v1/examples/value-of-data-quality.example.json
@@ -2,7 +2,7 @@
   "analysis_id": "data-quality-screening-001",
   "decision_problem_id": "screening-program-001",
   "analysis_type": "value_of_data_quality_privacy_linkage",
-  "method_maturity": "planned",
+  "method_maturity": "fixture-backed",
   "value": 3.8,
   "acquisition_cost_value": 1.1,
   "privacy_value": 0.9,

--- a/specs/frontier/data-quality/v1/fixtures/evidence.json
+++ b/specs/frontier/data-quality/v1/fixtures/evidence.json
@@ -1,0 +1,23 @@
+{
+  "contract": "value-of-data-quality-privacy-linkage-v1",
+  "maturity": "fixture-backed",
+  "stable_claim_allowed": false,
+  "owner": "voiage-maintainers",
+  "artifacts": [
+    {"path": "schemas/data-quality-set.schema.json", "sha256": "d5c267758e7abf2b27a1a1ec06e6b5494158d43839ad9313ba4845d196bcb4e0"},
+    {"path": "schemas/value-of-data-quality-result.schema.json", "sha256": "e5330d682ab9b58f798c2d88dcdc378b6d96f1b0e4aabc2c9a73351913bbc4fe"},
+    {"path": "fixtures/normative/data-quality-set.json", "sha256": "652e986931e7add102e530ea3ce1ff7f20ab79f9863ac1f49824f740fc442868"},
+    {"path": "fixtures/normative/value-of-data-quality.json", "sha256": "ebcb5cbef4961e938a89af9d5afec823300f682df762da09dcfb863af45e750f"},
+    {"path": "../../../../voiage/methods/data_quality.py", "sha256": "c9c24998db9fa4f2b1d15732568614c836868cbfdfb27ea705a545d405f17764"}
+  ],
+  "open_data": {
+    "status": "blocked_external",
+    "evidence": "No committed open-data snapshot currently combines licensed missingness, measurement-error, privacy, and linkage observations with a reproducible decision transform.",
+    "next_action": "Add a licensed data-quality or linkage benchmark snapshot with documented transform, privacy assumptions, and provenance.",
+    "source_candidates": ["https://databank.worldbank.org/", "https://ourworldindata.org/"],
+    "license_gate": "Confirm source license and permission for the privacy/linkage transform before committing a snapshot."
+  },
+  "parity": {"python": "verified", "rust": "deferred_with_rationale", "r": "not_verified", "typescript": "not_verified"},
+  "parity_rationale": "The Python implementation is the reference runtime; Rust parity is deferred until privacy and linkage semantics are reviewed for cross-language conformance.",
+  "external_gates": ["Open-data attribution and transform review", "Cross-language conformance and Rust parity review", "Mature/stable method approval"]
+}

--- a/specs/frontier/data-quality/v1/schemas/data-quality-set.schema.json
+++ b/specs/frontier/data-quality/v1/schemas/data-quality-set.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://voiage.dev/specs/frontier/data-quality/v1/schemas/data-quality-set.schema.json",
-  "title": "DataQualitySetV1Planned",
+  "title": "DataQualitySetV1FixtureBacked",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/specs/frontier/data-quality/v1/schemas/value-of-data-quality-result.schema.json
+++ b/specs/frontier/data-quality/v1/schemas/value-of-data-quality-result.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://voiage.dev/specs/frontier/data-quality/v1/schemas/value-of-data-quality-result.schema.json",
-  "title": "ValueOfDataQualityResultV1Planned",
+  "title": "ValueOfDataQualityResultV1FixtureBacked",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -42,7 +42,7 @@
     },
     "method_maturity": {
       "type": "string",
-      "const": "planned"
+      "const": "fixture-backed"
     },
     "value": {
       "type": "number",

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -726,6 +726,7 @@ def test_cli_command_registry_matches_expected_surface() -> None:
         "calculate-adaptive-evsi",
         "calculate-calibration",
         "calculate-causal-transportability",
+        "calculate-data-quality",
         "calculate-distributional-equity",
         "calculate-dynamic-real-options",
         "calculate-ceaf",

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -1,0 +1,38 @@
+"""Runtime tests for data-quality and privacy VOI."""
+
+import numpy as np
+import pytest
+
+from voiage.methods.data_quality import value_of_data_quality
+
+
+def test_data_quality_returns_profile_specific_decisions() -> None:
+    result = value_of_data_quality(
+        np.array([[[10.0, 9.0], [12.0, 11.4], [11.5, 12.1]]]),
+        ["clean", "noisy"],
+        ["status-quo", "collect", "link"],
+        np.zeros((2, 3)),
+        np.zeros((2, 3)),
+        np.zeros((2, 3)),
+        np.ones((2, 3)),
+    )
+    assert result.method_maturity == "fixture-backed"
+    assert result.expected_net_benefits.shape == (2, 3)
+    assert result.optimal_strategy_by_data_quality_profile == {
+        "clean": "collect",
+        "noisy": "link",
+    }
+    assert result.robust_strategy in result.strategy_names
+
+
+def test_data_quality_rejects_invalid_linkage_weights() -> None:
+    with pytest.raises(ValueError, match="Linkage weights"):
+        value_of_data_quality(
+            np.ones((1, 1, 1)),
+            ["profile"],
+            ["strategy"],
+            np.zeros((1, 1)),
+            np.zeros((1, 1)),
+            np.zeros((1, 1)),
+            np.ones((1, 1)) * 2,
+        )

--- a/tests/test_data_quality_contract.py
+++ b/tests/test_data_quality_contract.py
@@ -37,8 +37,10 @@ def test_data_quality_contract_schema_and_examples_parse() -> None:
         data_quality_result_example
     )
 
-    assert data_quality_set_schema["title"] == "DataQualitySetV1Planned"
-    assert data_quality_result_schema["title"] == "ValueOfDataQualityResultV1Planned"
+    assert data_quality_set_schema["title"] == "DataQualitySetV1FixtureBacked"
+    assert (
+        data_quality_result_schema["title"] == "ValueOfDataQualityResultV1FixtureBacked"
+    )
     assert (
         data_quality_result_example["analysis_type"]
         == "value_of_data_quality_privacy_linkage"

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -325,6 +325,7 @@ def test_methods_package_exports_are_curated() -> None:
     assert methods_module.__all__ == [
         "CEAFResult",
         "CausalTransportabilityResult",
+        "DataQualityResult",
         "DistributionalEquityResult",
         "DominanceResult",
         "DynamicRealOptionsResult",
@@ -362,6 +363,7 @@ def test_methods_package_exports_are_curated() -> None:
         "structural_evpi",
         "structural_evppi",
         "value_of_causal_transportability",
+        "value_of_data_quality",
         "value_of_distributional_equity",
         "value_of_dynamic_real_options",
         "value_of_heterogeneity",
@@ -395,6 +397,7 @@ def test_top_level_package_exports_modules() -> None:
     """Top-level package exports should remain stable curated API symbols."""
     assert voiage.__all__ == [
         "CausalTransportabilityResult",
+        "DataQualityResult",
         "DecisionAnalysis",
         "DecisionOption",
         "DistributionalEquityResult",
@@ -440,6 +443,7 @@ def test_top_level_package_exports_modules() -> None:
         "preference_optimal_strategies",
         "schema",
         "value_of_causal_transportability",
+        "value_of_data_quality",
         "value_of_distributional_equity",
         "value_of_dynamic_real_options",
         "value_of_implementation",

--- a/voiage/__init__.py
+++ b/voiage/__init__.py
@@ -31,6 +31,7 @@ from .methods.causal_transportability import (
     CausalTransportabilityResult,
     value_of_causal_transportability,
 )
+from .methods.data_quality import DataQualityResult, value_of_data_quality
 from .methods.distributional import (
     DistributionalEquityResult,
     value_of_distributional_equity,
@@ -89,6 +90,7 @@ except PackageNotFoundError:  # pragma: no cover - local source tree fallback
 
 __all__ = [
     "CausalTransportabilityResult",
+    "DataQualityResult",
     "DecisionAnalysis",
     "DecisionOption",
     "DistributionalEquityResult",
@@ -134,6 +136,7 @@ __all__ = [
     "preference_optimal_strategies",
     "schema",
     "value_of_causal_transportability",
+    "value_of_data_quality",
     "value_of_distributional_equity",
     "value_of_dynamic_real_options",
     "value_of_implementation",

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -41,6 +41,9 @@ from voiage.methods.causal_transportability import (
     value_of_causal_transportability as calculate_causal_transportability_result,
 )
 from voiage.methods.ceaf import calculate_ceaf as calculate_ceaf_result
+from voiage.methods.data_quality import (
+    value_of_data_quality as calculate_data_quality_result,
+)
 from voiage.methods.distributional import (
     DistributionalEquityResult,
     value_of_distributional_equity,
@@ -215,6 +218,24 @@ _CONFIG_TEMPLATES: dict[str, dict[str, object]] = {
         "transport_weights": [[1.0, 0.7], [0.8, 0.9]],
         "validity_penalties": [[0.0, 1.0], [0.5, 0.4]],
         "reference_target_population": "urban_target",
+    },
+    "data-quality": {
+        "command": "calculate-data-quality",
+        "description": "Template for fixture-backed data-quality, privacy, and linkage VOI inputs.",
+        "analysis_id": "data-quality-analysis",
+        "decision_problem_id": "screening-program-001",
+        "data_quality_profile_ids": ["clean_registry", "noisy_linked_records"],
+        "strategy_names": [
+            "status_quo",
+            "collect_more_data",
+            "privacy_preserving_linkage",
+        ],
+        "net_benefit": [[[10.0, 9.0], [12.0, 11.4], [11.5, 12.1]]],
+        "acquisition_costs": [[0.0, 1.5, 2.5], [0.0, 1.0, 2.0]],
+        "privacy_constraints": [[0.0, 0.4, 0.7], [0.1, 0.3, 0.5]],
+        "measurement_error_rates": [[0.05, 0.12, 0.2], [0.08, 0.15, 0.25]],
+        "linkage_weights": [[1.0, 0.8, 0.6], [0.9, 0.7, 0.5]],
+        "reference_data_quality_profile": "clean_registry",
     },
     "preference": {
         "command": "calculate-preference",
@@ -2892,6 +2913,83 @@ def calculate_causal_transportability(
         }
         output_text = _format_output(
             f"Causal transportability VOI: {result.value:.6f}\n"
+            f"Robust strategy: {result.robust_strategy}",
+            result_payload,
+        )
+        typer.echo(output_text)
+        if output_file:
+            _write_output_file(output_file, output_text)
+            if _should_echo_status_messages():
+                typer.echo(f"Result saved to {output_file}")
+    except FileNotFoundError as e:
+        typer.echo(f"Error: File not found - {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except (KeyError, json.JSONDecodeError, TypeError, ValueError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"An error occurred: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@app.command(name="calculate-data-quality")
+def calculate_data_quality(
+    specification_file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to JSON data-quality specification",
+    ),
+    output_file: Path | None = typer.Option(
+        None, "--output", "-o", help="File to save the data-quality result"
+    ),
+) -> None:
+    """Calculate fixture-backed data-quality and privacy VOI from JSON."""
+    try:
+        payload = _read_json_file(specification_file)
+        if not isinstance(payload, dict):
+            raise TypeError("Data-quality specification must be a JSON object.")
+        result = calculate_data_quality_result(
+            np.asarray(payload["net_benefit"], dtype=float),
+            cast("list[str]", payload["data_quality_profile_ids"]),
+            cast("list[str]", payload["strategy_names"]),
+            np.asarray(payload["acquisition_costs"], dtype=float),
+            np.asarray(payload["privacy_constraints"], dtype=float),
+            np.asarray(payload["measurement_error_rates"], dtype=float),
+            np.asarray(payload["linkage_weights"], dtype=float),
+            analysis_id=str(payload.get("analysis_id", "data-quality-analysis")),
+            decision_problem_id=str(payload.get("decision_problem_id", "unspecified")),
+            reference_data_quality_profile=cast(
+                "str | None", payload.get("reference_data_quality_profile")
+            ),
+        )
+        result_payload = {
+            "analysis_type": "value_of_data_quality_privacy_linkage",
+            "method_maturity": result.method_maturity,
+            "value": result.value,
+            "acquisition_cost_value": result.acquisition_cost_value,
+            "privacy_value": result.privacy_value,
+            "measurement_error_value": result.measurement_error_value,
+            "linkage_value": result.linkage_value,
+            "data_quality_profile_ids": result.data_quality_profile_ids,
+            "strategy_names": result.strategy_names,
+            "expected_net_benefits": result.expected_net_benefits.tolist(),
+            "optimal_strategy_by_data_quality_profile": result.optimal_strategy_by_data_quality_profile,
+            "acquisition_cost_matrix": result.acquisition_cost_matrix.tolist(),
+            "privacy_constraint_matrix": result.privacy_constraint_matrix.tolist(),
+            "measurement_error_matrix": result.measurement_error_matrix.tolist(),
+            "linkage_weight_matrix": result.linkage_weight_matrix.tolist(),
+            "consensus_strategy": result.consensus_strategy,
+            "robust_strategy": result.robust_strategy,
+            "pareto_strategies": result.pareto_strategies,
+            "reference_data_quality_profile": result.reference_data_quality_profile,
+            "diagnostics": result.diagnostics,
+            "reporting": result.reporting,
+        }
+        output_text = _format_output(
+            f"Data-quality VOI: {result.value:.6f}\n"
             f"Robust strategy: {result.robust_strategy}",
             result_payload,
         )

--- a/voiage/methods/__init__.py
+++ b/voiage/methods/__init__.py
@@ -8,6 +8,7 @@ from .causal_transportability import (
     value_of_causal_transportability,
 )
 from .ceaf import CEAFResult, calculate_ceaf
+from .data_quality import DataQualityResult, value_of_data_quality
 from .distributional import (
     DistributionalEquityResult,
     value_of_distributional_equity,
@@ -73,6 +74,7 @@ from .validation import (
 __all__ = [
     "CEAFResult",
     "CausalTransportabilityResult",
+    "DataQualityResult",
     "DistributionalEquityResult",
     "DominanceResult",
     "DynamicRealOptionsResult",
@@ -110,6 +112,7 @@ __all__ = [
     "structural_evpi",
     "structural_evppi",
     "value_of_causal_transportability",
+    "value_of_data_quality",
     "value_of_distributional_equity",
     "value_of_dynamic_real_options",
     "value_of_heterogeneity",

--- a/voiage/methods/data_quality.py
+++ b/voiage/methods/data_quality.py
@@ -1,0 +1,158 @@
+"""Data-quality, privacy, measurement-error, and linkage VOI."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from voiage.config import DEFAULT_DTYPE
+from voiage.exceptions import raise_input_error
+
+
+@dataclass(frozen=True)
+class DataQualityResult:
+    """Fixture-backed result envelope for data-quality decision analysis."""
+
+    value: float
+    acquisition_cost_value: float
+    privacy_value: float
+    measurement_error_value: float
+    linkage_value: float
+    data_quality_profile_ids: list[str]
+    strategy_names: list[str]
+    expected_net_benefits: np.ndarray
+    optimal_strategy_by_data_quality_profile: dict[str, str]
+    acquisition_cost_matrix: np.ndarray
+    privacy_constraint_matrix: np.ndarray
+    measurement_error_matrix: np.ndarray
+    linkage_weight_matrix: np.ndarray
+    consensus_strategy: str
+    robust_strategy: str
+    pareto_strategies: list[str]
+    reference_data_quality_profile: str
+    method_maturity: str = "fixture-backed"
+    diagnostics: dict[str, object] = field(default_factory=dict)
+    reporting: dict[str, object] = field(default_factory=dict)
+
+
+def value_of_data_quality(
+    net_benefits: np.ndarray,
+    data_quality_profile_ids: Sequence[str],
+    strategy_names: Sequence[str],
+    acquisition_costs: np.ndarray,
+    privacy_constraints: np.ndarray,
+    measurement_error_rates: np.ndarray,
+    linkage_weights: np.ndarray,
+    *,
+    analysis_id: str = "data-quality-analysis",
+    decision_problem_id: str = "unspecified",
+    reference_data_quality_profile: str | None = None,
+) -> DataQualityResult:
+    """Value improved data quality under cost, privacy, and linkage tradeoffs.
+
+    ``net_benefits`` has shape ``(samples, strategies, profiles)``. Quality
+    penalties are supplied as profile-by-strategy matrices.
+    """
+    values = np.asarray(net_benefits, dtype=DEFAULT_DTYPE)
+    profiles = [str(item) for item in data_quality_profile_ids]
+    strategies = [str(item) for item in strategy_names]
+    costs = np.asarray(acquisition_costs, dtype=DEFAULT_DTYPE)
+    privacy = np.asarray(privacy_constraints, dtype=DEFAULT_DTYPE)
+    error = np.asarray(measurement_error_rates, dtype=DEFAULT_DTYPE)
+    linkage = np.asarray(linkage_weights, dtype=DEFAULT_DTYPE)
+    if values.ndim != 3 or min(values.shape) < 1:
+        raise_input_error(
+            "net_benefits must be a non-empty 3D array (samples, strategies, profiles)."
+        )
+    if values.shape[1:] != (len(strategies), len(profiles)):
+        raise_input_error(
+            "net_benefits dimensions must match strategy and profile names."
+        )
+    expected_shape = (len(profiles), len(strategies))
+    if any(
+        matrix.shape != expected_shape for matrix in (costs, privacy, error, linkage)
+    ):
+        raise_input_error("Quality matrices must have profile x strategy shape.")
+    if len(set(profiles)) != len(profiles) or len(set(strategies)) != len(strategies):
+        raise_input_error("Profile and strategy names must be unique.")
+    if not all(
+        np.all(np.isfinite(matrix))
+        for matrix in (values, costs, privacy, error, linkage)
+    ):
+        raise_input_error("Inputs must contain only finite values.")
+    if (
+        np.any(costs < 0)
+        or np.any(privacy < 0)
+        or np.any(error < 0)
+        or np.any(error > 1)
+    ):
+        raise_input_error(
+            "Costs, privacy constraints, and measurement error must be non-negative; error must be <= 1."
+        )
+    if np.any(linkage < 0) or np.any(linkage > 1):
+        raise_input_error("Linkage weights must be in [0, 1].")
+    reference_data_quality_profile = reference_data_quality_profile or profiles[0]
+    if reference_data_quality_profile not in profiles:
+        raise_input_error("reference_data_quality_profile must identify a profile.")
+
+    raw = np.mean(values, axis=0).T
+    adjusted = raw * linkage - costs - privacy - error
+    optimal = np.argmax(adjusted, axis=1)
+    reference_index = profiles.index(reference_data_quality_profile)
+    reference_strategy = int(optimal[reference_index])
+    reference_value = float(adjusted[reference_index, reference_strategy])
+    flexible_value = float(np.mean(np.max(adjusted, axis=1)))
+    value = max(0.0, flexible_value - reference_value)
+    acquisition_value = max(0.0, float(np.mean(raw)) - float(np.mean(raw - costs)))
+    privacy_value = max(
+        0.0, float(np.mean(raw - costs)) - float(np.mean(raw - costs - privacy))
+    )
+    error_value = max(
+        0.0, float(np.mean(raw - costs - privacy)) - float(np.mean(adjusted))
+    )
+    linkage_value = max(0.0, float(np.mean(raw)) - float(np.mean(raw * linkage)))
+    pareto = [
+        strategies[i]
+        for i in range(len(strategies))
+        if not any(
+            i != j
+            and np.all(adjusted[:, j] >= adjusted[:, i])
+            and np.any(adjusted[:, j] > adjusted[:, i])
+            for j in range(len(strategies))
+        )
+    ]
+    consensus = strategies[int(np.argmax(np.mean(adjusted, axis=0)))]
+    robust = strategies[int(np.argmax(np.min(adjusted, axis=0)))]
+    return DataQualityResult(
+        value=value,
+        acquisition_cost_value=acquisition_value,
+        privacy_value=privacy_value,
+        measurement_error_value=error_value,
+        linkage_value=linkage_value,
+        data_quality_profile_ids=profiles,
+        strategy_names=strategies,
+        expected_net_benefits=adjusted,
+        optimal_strategy_by_data_quality_profile={
+            profile: strategies[int(index)]
+            for profile, index in zip(profiles, optimal, strict=True)
+        },
+        acquisition_cost_matrix=costs,
+        privacy_constraint_matrix=privacy,
+        measurement_error_matrix=error,
+        linkage_weight_matrix=linkage,
+        consensus_strategy=consensus,
+        robust_strategy=robust,
+        pareto_strategies=pareto,
+        reference_data_quality_profile=reference_data_quality_profile,
+        diagnostics={
+            "analysis_id": analysis_id,
+            "decision_problem_id": decision_problem_id,
+            "n_profiles": len(profiles),
+            "n_strategies": len(strategies),
+        },
+        reporting={
+            "reporting_standard": "CHEERS-VOI",
+            "analysis_type": "value_of_data_quality_privacy_linkage",
+            "method_maturity": "fixture-backed",
+        },
+    )


### PR DESCRIPTION
## Summary
- implement fixture-backed data-quality, measurement-error, privacy, and linkage VOI runtime
- expose the method through Python and CLI surfaces
- update schemas, examples, docs, and hash-pinned maturity evidence
- add runtime, contract, CLI, and export coverage

## Validation
- 37 focused tests passed
- `tox -e lint,typecheck,frontier-contract` passed, including Bandit

## Explicit remaining gates
Licensed open-data attribution, Rust/cross-language parity, R/TypeScript adapters, and mature/stable approval remain external or deferred. The method remains fixture-backed.