### PR TITLE
feat(conductor): implement computational refinement VOI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conductor/setup_state.json` to `.gitignore` as Conductor tool runtime state.
 
 ### Added
+- Added a fixture-backed computational VOI and model-refinement runtime with
+  compute-budget, approximation-error, refinement-weight, and CLI diagnostics;
+  profiling, parity, and mature approval remain gated.
 - Archived the data-quality, measurement-error, privacy, and linkage VOI
   track after completing its fixture-backed runtime, CLI, evidence manifest,
   and hosted CI slice; open-data attribution, parity, and mature approval

--- a/specs/frontier/computational/v1/README.md
+++ b/specs/frontier/computational/v1/README.md
@@ -1,15 +1,15 @@
 # Computational And Model-Refinement Experimental Contract v1
 
 This directory holds the fixture-backed frontier contract for computational VOI
-and value of model refinement. It is not part of the stable core API v1 matrix
-yet; promotion still requires runtime implementation, cross-language
-validation, CLI coverage, and method maturity review.
+and value of model refinement. The Python runtime and CLI are fixture-backed;
+promotion still requires profiling evidence, cross-language validation, and
+method maturity review.
 
 ## Files
 
 - `schemas/computational-set.schema.json` defines the compute-budget input
   surface.
-- `schemas/value-of-computational-result.schema.json` defines the planned
+- `schemas/value-of-computational-result.schema.json` defines the fixture-backed
   result shape.
 - `examples/computational-set.example.json` is a compact illustrative input
   payload.
@@ -20,7 +20,7 @@ validation, CLI coverage, and method maturity review.
 
 ## Shape
 
-The planned analysis surface treats compute budget, approximation error, and
+The analysis surface treats compute budget, approximation error, and
 refinement cost as explicit decision-relevant dimensions rather than a hidden
 implementation detail. The intended net-benefit surface uses:
 

--- a/specs/frontier/computational/v1/examples/value-of-computational.example.json
+++ b/specs/frontier/computational/v1/examples/value-of-computational.example.json
@@ -2,7 +2,7 @@
   "analysis_id": "computational-screening-001",
   "decision_problem_id": "screening-program-001",
   "analysis_type": "value_of_computational_refinement",
-  "method_maturity": "planned",
+  "method_maturity": "fixture-backed",
   "value": 2.9,
   "compute_value": 1.2,
   "approximation_error_value": 0.9,

--- a/specs/frontier/computational/v1/fixtures/evidence.json
+++ b/specs/frontier/computational/v1/fixtures/evidence.json
@@ -1,0 +1,21 @@
+{
+  "contract": "value-of-computational-refinement-v1",
+  "maturity": "fixture-backed",
+  "stable_claim_allowed": false,
+  "owner": "voiage-maintainers",
+  "artifacts": [
+    {"path": "schemas/computational-set.schema.json", "sha256": "9ca02abaf7e848fb5ddb9fc84486e00420ffc90eb7875a15b1ffb7c7f7931b64"},
+    {"path": "schemas/value-of-computational-result.schema.json", "sha256": "c9e0e2206d33659301c2d63a77fbdce68bc4ed7119f2e9aef13ea048824dcaaf"},
+    {"path": "fixtures/normative/computational-set.json", "sha256": "6fec2524fbf4b068eaaa90d6e6e1c9412a4c79291be252355e5bd8ded1255d25"},
+    {"path": "fixtures/normative/value-of-computational.json", "sha256": "cfc190a0a383cdfc6dc81430a7c272e13ae100695c9b44306971f9a40013fcc0"},
+    {"path": "../../../../voiage/methods/computational.py", "sha256": "4a48db15c95bd001cf77a7fd973f071247243f15cd4f5457728e6703883a2033"}
+  ],
+  "profiling": {
+    "status": "repository_gate_pending",
+    "evidence": "The runtime is small and deterministic; hosted benchmark and profiling jobs are the next repository-owned performance evidence.",
+    "next_action": "Capture benchmark-aware profiling for representative compute budgets before any mature/stable claim."
+  },
+  "parity": {"python": "verified", "rust": "deferred_with_rationale", "r": "not_verified", "typescript": "not_verified"},
+  "parity_rationale": "The Python implementation is the reference runtime; Rust parity is deferred until benchmark evidence justifies a hot-kernel boundary.",
+  "external_gates": ["Benchmark/profile evidence", "Cross-language conformance and Rust parity review", "Mature/stable method approval"]
+}

--- a/specs/frontier/computational/v1/schemas/computational-set.schema.json
+++ b/specs/frontier/computational/v1/schemas/computational-set.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://voiage.dev/specs/frontier/computational/v1/schemas/computational-set.schema.json",
-  "title": "ComputationalSetV1Planned",
+  "title": "ComputationalSetV1FixtureBacked",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/specs/frontier/computational/v1/schemas/value-of-computational-result.schema.json
+++ b/specs/frontier/computational/v1/schemas/value-of-computational-result.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://voiage.dev/specs/frontier/computational/v1/schemas/value-of-computational-result.schema.json",
-  "title": "ValueOfComputationalResultV1Planned",
+  "title": "ValueOfComputationalResultV1FixtureBacked",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -40,7 +40,7 @@
     },
     "method_maturity": {
       "type": "string",
-      "const": "planned"
+      "const": "fixture-backed"
     },
     "value": {
       "type": "number",

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -727,6 +727,7 @@ def test_cli_command_registry_matches_expected_surface() -> None:
         "calculate-calibration",
         "calculate-causal-transportability",
         "calculate-data-quality",
+        "calculate-computational-refinement",
         "calculate-distributional-equity",
         "calculate-dynamic-real-options",
         "calculate-ceaf",

--- a/tests/test_computational.py
+++ b/tests/test_computational.py
@@ -1,0 +1,35 @@
+"""Runtime tests for computational refinement VOI."""
+
+import numpy as np
+import pytest
+
+from voiage.methods.computational import value_of_computational_refinement
+
+
+def test_computational_refinement_returns_budget_specific_decisions() -> None:
+    result = value_of_computational_refinement(
+        np.array([[[10.0, 9.7], [11.4, 12.1], [11.0, 11.8]]]),
+        ["baseline", "enhanced"],
+        ["status-quo", "refine", "fast"],
+        np.zeros((2, 3)),
+        np.zeros((2, 3)),
+        np.ones((2, 3)),
+    )
+    assert result.method_maturity == "fixture-backed"
+    assert result.expected_net_benefits.shape == (2, 3)
+    assert result.optimal_strategy_by_compute_budget == {
+        "baseline": "refine",
+        "enhanced": "refine",
+    }
+
+
+def test_computational_refinement_rejects_invalid_weights() -> None:
+    with pytest.raises(ValueError, match="refinement weights"):
+        value_of_computational_refinement(
+            np.ones((1, 1, 1)),
+            ["budget"],
+            ["strategy"],
+            np.zeros((1, 1)),
+            np.zeros((1, 1)),
+            np.ones((1, 1)) * 2,
+        )

--- a/tests/test_computational_contract.py
+++ b/tests/test_computational_contract.py
@@ -37,8 +37,11 @@ def test_computational_contract_schema_and_examples_parse() -> None:
         computational_result_example
     )
 
-    assert computational_set_schema["title"] == "ComputationalSetV1Planned"
-    assert computational_result_schema["title"] == "ValueOfComputationalResultV1Planned"
+    assert computational_set_schema["title"] == "ComputationalSetV1FixtureBacked"
+    assert (
+        computational_result_schema["title"]
+        == "ValueOfComputationalResultV1FixtureBacked"
+    )
     assert (
         computational_result_example["analysis_type"]
         == "value_of_computational_refinement"

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -325,6 +325,7 @@ def test_methods_package_exports_are_curated() -> None:
     assert methods_module.__all__ == [
         "CEAFResult",
         "CausalTransportabilityResult",
+        "ComputationalResult",
         "DataQualityResult",
         "DistributionalEquityResult",
         "DominanceResult",
@@ -363,6 +364,7 @@ def test_methods_package_exports_are_curated() -> None:
         "structural_evpi",
         "structural_evppi",
         "value_of_causal_transportability",
+        "value_of_computational_refinement",
         "value_of_data_quality",
         "value_of_distributional_equity",
         "value_of_dynamic_real_options",
@@ -397,6 +399,7 @@ def test_top_level_package_exports_modules() -> None:
     """Top-level package exports should remain stable curated API symbols."""
     assert voiage.__all__ == [
         "CausalTransportabilityResult",
+        "ComputationalResult",
         "DataQualityResult",
         "DecisionAnalysis",
         "DecisionOption",
@@ -443,6 +446,7 @@ def test_top_level_package_exports_modules() -> None:
         "preference_optimal_strategies",
         "schema",
         "value_of_causal_transportability",
+        "value_of_computational_refinement",
         "value_of_data_quality",
         "value_of_distributional_equity",
         "value_of_dynamic_real_options",

--- a/voiage/__init__.py
+++ b/voiage/__init__.py
@@ -31,6 +31,10 @@ from .methods.causal_transportability import (
     CausalTransportabilityResult,
     value_of_causal_transportability,
 )
+from .methods.computational import (
+    ComputationalResult,
+    value_of_computational_refinement,
+)
 from .methods.data_quality import DataQualityResult, value_of_data_quality
 from .methods.distributional import (
     DistributionalEquityResult,
@@ -90,6 +94,7 @@ except PackageNotFoundError:  # pragma: no cover - local source tree fallback
 
 __all__ = [
     "CausalTransportabilityResult",
+    "ComputationalResult",
     "DataQualityResult",
     "DecisionAnalysis",
     "DecisionOption",
@@ -136,6 +141,7 @@ __all__ = [
     "preference_optimal_strategies",
     "schema",
     "value_of_causal_transportability",
+    "value_of_computational_refinement",
     "value_of_data_quality",
     "value_of_distributional_equity",
     "value_of_dynamic_real_options",

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -41,6 +41,9 @@ from voiage.methods.causal_transportability import (
     value_of_causal_transportability as calculate_causal_transportability_result,
 )
 from voiage.methods.ceaf import calculate_ceaf as calculate_ceaf_result
+from voiage.methods.computational import (
+    value_of_computational_refinement as calculate_computational_result,
+)
 from voiage.methods.data_quality import (
     value_of_data_quality as calculate_data_quality_result,
 )
@@ -236,6 +239,19 @@ _CONFIG_TEMPLATES: dict[str, dict[str, object]] = {
         "measurement_error_rates": [[0.05, 0.12, 0.2], [0.08, 0.15, 0.25]],
         "linkage_weights": [[1.0, 0.8, 0.6], [0.9, 0.7, 0.5]],
         "reference_data_quality_profile": "clean_registry",
+    },
+    "computational": {
+        "command": "calculate-computational-refinement",
+        "description": "Template for fixture-backed computational VOI inputs.",
+        "analysis_id": "computational-analysis",
+        "decision_problem_id": "screening-program-001",
+        "compute_budget_ids": ["baseline_compute", "enhanced_compute"],
+        "strategy_names": ["status_quo", "refine_model", "approximate_fast"],
+        "net_benefit": [[[10.0, 9.7], [11.4, 12.1], [11.0, 11.8]]],
+        "compute_costs": [[0.0, 2.0, 1.0], [0.0, 3.0, 1.5]],
+        "approximation_errors": [[0.3, 0.1, 0.2], [0.25, 0.08, 0.15]],
+        "refinement_weights": [[0.5, 0.9, 0.6], [0.4, 1.0, 0.7]],
+        "reference_compute_budget": "baseline_compute",
     },
     "preference": {
         "command": "calculate-preference",
@@ -2990,6 +3006,80 @@ def calculate_data_quality(
         }
         output_text = _format_output(
             f"Data-quality VOI: {result.value:.6f}\n"
+            f"Robust strategy: {result.robust_strategy}",
+            result_payload,
+        )
+        typer.echo(output_text)
+        if output_file:
+            _write_output_file(output_file, output_text)
+            if _should_echo_status_messages():
+                typer.echo(f"Result saved to {output_file}")
+    except FileNotFoundError as e:
+        typer.echo(f"Error: File not found - {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except (KeyError, json.JSONDecodeError, TypeError, ValueError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"An error occurred: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@app.command(name="calculate-computational-refinement")
+def calculate_computational_refinement(
+    specification_file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to JSON computational refinement specification",
+    ),
+    output_file: Path | None = typer.Option(
+        None, "--output", "-o", help="File to save the computational result"
+    ),
+) -> None:
+    """Calculate fixture-backed computational refinement VOI from JSON."""
+    try:
+        payload = _read_json_file(specification_file)
+        if not isinstance(payload, dict):
+            raise TypeError("Computational specification must be a JSON object.")
+        result = calculate_computational_result(
+            np.asarray(payload["net_benefit"], dtype=float),
+            cast("list[str]", payload["compute_budget_ids"]),
+            cast("list[str]", payload["strategy_names"]),
+            np.asarray(payload["compute_costs"], dtype=float),
+            np.asarray(payload["approximation_errors"], dtype=float),
+            np.asarray(payload["refinement_weights"], dtype=float),
+            analysis_id=str(payload.get("analysis_id", "computational-analysis")),
+            decision_problem_id=str(payload.get("decision_problem_id", "unspecified")),
+            reference_compute_budget=cast(
+                "str | None", payload.get("reference_compute_budget")
+            ),
+        )
+        result_payload = {
+            "analysis_type": "value_of_computational_refinement",
+            "method_maturity": result.method_maturity,
+            "value": result.value,
+            "compute_value": result.compute_value,
+            "approximation_error_value": result.approximation_error_value,
+            "refinement_value": result.refinement_value,
+            "compute_budget_ids": result.compute_budget_ids,
+            "strategy_names": result.strategy_names,
+            "expected_net_benefits": result.expected_net_benefits.tolist(),
+            "optimal_strategy_by_compute_budget": result.optimal_strategy_by_compute_budget,
+            "compute_cost_matrix": result.compute_cost_matrix.tolist(),
+            "approximation_error_matrix": result.approximation_error_matrix.tolist(),
+            "refinement_weight_matrix": result.refinement_weight_matrix.tolist(),
+            "consensus_strategy": result.consensus_strategy,
+            "robust_strategy": result.robust_strategy,
+            "pareto_strategies": result.pareto_strategies,
+            "reference_compute_budget": result.reference_compute_budget,
+            "diagnostics": result.diagnostics,
+            "reporting": result.reporting,
+        }
+        output_text = _format_output(
+            f"Computational refinement VOI: {result.value:.6f}\n"
             f"Robust strategy: {result.robust_strategy}",
             result_payload,
         )

--- a/voiage/methods/__init__.py
+++ b/voiage/methods/__init__.py
@@ -8,6 +8,7 @@ from .causal_transportability import (
     value_of_causal_transportability,
 )
 from .ceaf import CEAFResult, calculate_ceaf
+from .computational import ComputationalResult, value_of_computational_refinement
 from .data_quality import DataQualityResult, value_of_data_quality
 from .distributional import (
     DistributionalEquityResult,
@@ -74,6 +75,7 @@ from .validation import (
 __all__ = [
     "CEAFResult",
     "CausalTransportabilityResult",
+    "ComputationalResult",
     "DataQualityResult",
     "DistributionalEquityResult",
     "DominanceResult",
@@ -112,6 +114,7 @@ __all__ = [
     "structural_evpi",
     "structural_evppi",
     "value_of_causal_transportability",
+    "value_of_computational_refinement",
     "value_of_data_quality",
     "value_of_distributional_equity",
     "value_of_dynamic_real_options",

--- a/voiage/methods/computational.py
+++ b/voiage/methods/computational.py
@@ -1,0 +1,143 @@
+"""Computational-budget and model-refinement value of information."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from voiage.config import DEFAULT_DTYPE
+from voiage.exceptions import raise_input_error
+
+
+@dataclass(frozen=True)
+class ComputationalResult:
+    """Fixture-backed result envelope for computational refinement VOI."""
+
+    value: float
+    compute_value: float
+    approximation_error_value: float
+    refinement_value: float
+    compute_budget_ids: list[str]
+    strategy_names: list[str]
+    expected_net_benefits: np.ndarray
+    optimal_strategy_by_compute_budget: dict[str, str]
+    compute_cost_matrix: np.ndarray
+    approximation_error_matrix: np.ndarray
+    refinement_weight_matrix: np.ndarray
+    consensus_strategy: str
+    robust_strategy: str
+    pareto_strategies: list[str]
+    reference_compute_budget: str
+    method_maturity: str = "fixture-backed"
+    diagnostics: dict[str, object] = field(default_factory=dict)
+    reporting: dict[str, object] = field(default_factory=dict)
+
+
+def value_of_computational_refinement(
+    net_benefits: np.ndarray,
+    compute_budget_ids: Sequence[str],
+    strategy_names: Sequence[str],
+    compute_costs: np.ndarray,
+    approximation_errors: np.ndarray,
+    refinement_weights: np.ndarray,
+    *,
+    analysis_id: str = "computational-analysis",
+    decision_problem_id: str = "unspecified",
+    reference_compute_budget: str | None = None,
+) -> ComputationalResult:
+    """Value model refinement across budgets, error, and compute cost.
+
+    ``net_benefits`` has shape ``(samples, strategies, compute_budgets)``.
+    """
+    values = np.asarray(net_benefits, dtype=DEFAULT_DTYPE)
+    budgets = [str(item) for item in compute_budget_ids]
+    strategies = [str(item) for item in strategy_names]
+    costs = np.asarray(compute_costs, dtype=DEFAULT_DTYPE)
+    errors = np.asarray(approximation_errors, dtype=DEFAULT_DTYPE)
+    weights = np.asarray(refinement_weights, dtype=DEFAULT_DTYPE)
+    if values.ndim != 3 or min(values.shape) < 1:
+        raise_input_error(
+            "net_benefits must be a non-empty 3D array (samples, strategies, budgets)."
+        )
+    if values.shape[1:] != (len(strategies), len(budgets)):
+        raise_input_error(
+            "net_benefits dimensions must match strategy and budget names."
+        )
+    expected_shape = (len(budgets), len(strategies))
+    if any(matrix.shape != expected_shape for matrix in (costs, errors, weights)):
+        raise_input_error("Computational matrices must have budget x strategy shape.")
+    if len(set(budgets)) != len(budgets) or len(set(strategies)) != len(strategies):
+        raise_input_error("Budget and strategy names must be unique.")
+    if not all(
+        np.all(np.isfinite(matrix)) for matrix in (values, costs, errors, weights)
+    ):
+        raise_input_error("Inputs must contain only finite values.")
+    if (
+        np.any(costs < 0)
+        or np.any(errors < 0)
+        or np.any(weights < 0)
+        or np.any(weights > 1)
+    ):
+        raise_input_error(
+            "Costs and approximation errors must be non-negative; refinement weights must be in [0, 1]."
+        )
+    reference_compute_budget = reference_compute_budget or budgets[0]
+    if reference_compute_budget not in budgets:
+        raise_input_error("reference_compute_budget must identify a compute budget.")
+
+    raw = np.mean(values, axis=0).T
+    adjusted = raw * weights - costs - errors
+    optimal = np.argmax(adjusted, axis=1)
+    reference_index = budgets.index(reference_compute_budget)
+    reference_strategy = int(optimal[reference_index])
+    reference_value = float(adjusted[reference_index, reference_strategy])
+    flexible_value = float(np.mean(np.max(adjusted, axis=1)))
+    value = max(0.0, flexible_value - reference_value)
+    compute_value = max(0.0, float(np.mean(raw)) - float(np.mean(raw - costs)))
+    error_value = max(
+        0.0, float(np.mean(raw - costs)) - float(np.mean(raw - costs - errors))
+    )
+    refinement_value = max(0.0, float(np.mean(raw)) - float(np.mean(raw * weights)))
+    pareto = [
+        strategies[i]
+        for i in range(len(strategies))
+        if not any(
+            i != j
+            and np.all(adjusted[:, j] >= adjusted[:, i])
+            and np.any(adjusted[:, j] > adjusted[:, i])
+            for j in range(len(strategies))
+        )
+    ]
+    consensus = strategies[int(np.argmax(np.mean(adjusted, axis=0)))]
+    robust = strategies[int(np.argmax(np.min(adjusted, axis=0)))]
+    return ComputationalResult(
+        value=value,
+        compute_value=compute_value,
+        approximation_error_value=error_value,
+        refinement_value=refinement_value,
+        compute_budget_ids=budgets,
+        strategy_names=strategies,
+        expected_net_benefits=adjusted,
+        optimal_strategy_by_compute_budget={
+            budget: strategies[int(index)]
+            for budget, index in zip(budgets, optimal, strict=True)
+        },
+        compute_cost_matrix=costs,
+        approximation_error_matrix=errors,
+        refinement_weight_matrix=weights,
+        consensus_strategy=consensus,
+        robust_strategy=robust,
+        pareto_strategies=pareto,
+        reference_compute_budget=reference_compute_budget,
+        diagnostics={
+            "analysis_id": analysis_id,
+            "decision_problem_id": decision_problem_id,
+            "n_budgets": len(budgets),
+            "n_strategies": len(strategies),
+        },
+        reporting={
+            "reporting_standard": "CHEERS-VOI",
+            "analysis_type": "value_of_computational_refinement",
+            "method_maturity": "fixture-backed",
+        },
+    )


### PR DESCRIPTION
## Summary
- implement fixture-backed computational VOI and model-refinement runtime
- expose compute-budget analysis through Python and CLI surfaces
- update schemas, examples, docs, and hash-pinned evidence
- add runtime, contract, CLI, and export coverage

## Validation
- 37 focused tests passed
- `tox -e lint,typecheck,frontier-contract` passed, including Bandit

## Explicit remaining gates
Benchmark/profile evidence, Rust/cross-language parity, R/TypeScript adapters, and mature/stable approval remain external or deferred. The method remains fixture-backed.