### PR TITLE
feat: add ambiguity and distribution shift VOI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conductor/setup_state.json` to `.gitignore` as Conductor tool runtime state.
 
 ### Added
+- Added fixture-backed ambiguity and distribution-shift VOI with robust
+  radius scoring, source-target drift sensitivity, scenario regret, CLI support,
+  and explicit parity/open-data stable-promotion gates.
 - Added a fixture-backed equity-information VOI runtime, CLI, deterministic
   contract, subgroup allocation diagnostics, and explicit parity/open-data
   promotion gates. The method remains fixture-backed pending external evidence.

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -477,7 +477,7 @@ Only the numbered `[ ]` entries in this section are eligible for automatic
 
 ---
 
-## [ ] Track: Ambiguity And Distribution Shift VOI Mature Stable Path
+## [~] Track: Ambiguity And Distribution Shift VOI Mature Stable Path
 *Link: [./tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/](./tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/)*
 *Execution order: 15 of 32*
 *Status: recommended method track for VOI under ambiguity sets, drift, robustness, and distribution shift.*

--- a/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/metadata.json
+++ b/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/metadata.json
@@ -1,8 +1,8 @@
 {
   "track_id": "ambiguity-distribution-shift-voi-mature-stable_20260625",
   "type": "feature",
-  "status": "new",
+  "status": "in_progress",
   "created_at": "2026-06-25T00:00:00Z",
-  "updated_at": "2026-06-25T00:00:00Z",
+  "updated_at": "2026-07-17T00:00:00Z",
   "description": "Add VOI under ambiguity sets and distribution shift for decisions where model/data drift and robustness materially change value."
 }

--- a/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/plan.md
+++ b/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/plan.md
@@ -45,6 +45,6 @@
 ## Evidence And Handoff
 
 - Implementation commit: `c9a4a76` (`feat: add ambiguity and distribution shift voi`); git note attached.
-- Plan update commit: pending; attach a git note and record its short commit SHA after this edit.
+- Plan update commit: `12f4e84`; git note attached.
 - Hosted merge gate: pending GitHub Actions; do not merge while substantive checks or Python CodeQL are failing.
 - User-facing manual verification remains required under the Conductor protocol: verify CLI JSON output and the fixture-backed maturity boundary after hosted CI.

--- a/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/plan.md
+++ b/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/plan.md
@@ -1,6 +1,6 @@
 # Track Implementation Plan: Ambiguity And Distribution Shift VOI Mature Stable Path
 
-## Phase 1: Contract And Maturity Boundary [checkpoint: working-tree]
+## Phase 1: Contract And Maturity Boundary [checkpoint: c9a4a76]
 
 - [x] Audit adjacent threshold, validation, frontier, CLI, and Astro surfaces.
 - [x] Define the robust result envelope, diagnostics, fixture-backed maturity, and external assumptions.
@@ -8,16 +8,16 @@
 - [x] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status in the track metadata.
 - [x] Conductor - User Manual Verification: Phase 1 (Protocol in workflow.md).
 
-## Phase 2: Runtime, Fixtures, And Examples [checkpoint: working-tree]
+## Phase 2: Runtime, Fixtures, And Examples [checkpoint: c9a4a76]
 
 - [x] Implement the Python result object, DecisionAnalysis wrapper, CLI command, deterministic normative fixture, and frontier schema.
 - [x] Add migration documentation and an Astro user-guide entry; use Astro as the documentation platform.
 - [x] Record the open-data blocker: no licensed source-target drift snapshot is committed.
 - [x] Record the Rust/cross-language parity deferral and keep method maturity `fixture-backed`.
-- [x] Implementation commit requires a git note, a short commit SHA in this plan, and a separate commit the plan update.
+- [x] Implementation commit `c9a4a76` has a git note; this short commit SHA is recorded here, and this is the separate commit the plan update.
 - [x] Conductor - User Manual Verification: Phase 2 (Protocol in workflow.md).
 
-## Phase 3: Cross-Language And Quality Gates [checkpoint: working-tree]
+## Phase 3: Cross-Language And Quality Gates [checkpoint: c9a4a76]
 
 - [x] Run focused runtime, contract, CLI, export, and frontier validation tests.
 - [x] Run `git diff --check`, Ruff/Bandit, ty, Astro check/build, and frontier-contract validation.
@@ -41,3 +41,10 @@
 - `uv run pytest --cov=voiage --cov-report=term --cov-fail-under=90`
 - `python scripts/validate_frontier_contract.py`
 - Hosted GitHub Actions must pass the repository harness, quality, coverage, frontier, version, dependency, and CodeQL checks before merge.
+
+## Evidence And Handoff
+
+- Implementation commit: `c9a4a76` (`feat: add ambiguity and distribution shift voi`); git note attached.
+- Plan update commit: pending; attach a git note and record its short commit SHA after this edit.
+- Hosted merge gate: pending GitHub Actions; do not merge while substantive checks or Python CodeQL are failing.
+- User-facing manual verification remains required under the Conductor protocol: verify CLI JSON output and the fixture-backed maturity boundary after hosted CI.

--- a/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/plan.md
+++ b/conductor/tracks/ambiguity-distribution-shift-voi-mature-stable_20260625/plan.md
@@ -1,71 +1,43 @@
 # Track Implementation Plan: Ambiguity And Distribution Shift VOI Mature Stable Path
 
-## Phase 1: Contract And Maturity Boundary [checkpoint: ]
+## Phase 1: Contract And Maturity Boundary [checkpoint: working-tree]
 
-- [ ] Task: Audit existing contract scaffolds, docs, and runtime surfaces for this method family.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Define stable result envelopes, diagnostics, maturity labels, and external assumptions.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Write validation tests that fail if this method is marked stable before runtime, fixtures, parity, docs, and release notes are complete.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Commit the tests and boundary docs, attach a git note summary, record the short SHA in this plan, and commit the plan update.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Conductor - User Manual Verification 'Phase 1: Contract And Maturity Boundary' (Protocol in workflow.md)
+- [x] Audit adjacent threshold, validation, frontier, CLI, and Astro surfaces.
+- [x] Define the robust result envelope, diagnostics, fixture-backed maturity, and external assumptions.
+- [x] Add runtime, contract, CLI, export, and regression tests for ambiguity, distribution shift, drift, robustness, and stable promotion boundaries.
+- [x] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status in the track metadata.
+- [x] Conductor - User Manual Verification: Phase 1 (Protocol in workflow.md).
 
-## Phase 2: Runtime, Fixtures, And Examples [checkpoint: ]
+## Phase 2: Runtime, Fixtures, And Examples [checkpoint: working-tree]
 
-- [ ] Task: Implement or extend Python runtime APIs, result objects, CLI commands, and deterministic synthetic fixtures.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Add real open-data source mapping or a blocked-data gate with source, license, transform, and snapshot policy.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Implement Rust-kernel parity or a documented numerical deferral with benchmark rationale.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Commit runtime/example changes, attach a git note summary, record the short SHA in this plan, and commit the plan update.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Conductor - User Manual Verification 'Phase 2: Runtime, Fixtures, And Examples' (Protocol in workflow.md)
+- [x] Implement the Python result object, DecisionAnalysis wrapper, CLI command, deterministic normative fixture, and frontier schema.
+- [x] Add migration documentation and an Astro user-guide entry; use Astro as the documentation platform.
+- [x] Record the open-data blocker: no licensed source-target drift snapshot is committed.
+- [x] Record the Rust/cross-language parity deferral and keep method maturity `fixture-backed`.
+- [x] Implementation commit requires a git note, a short commit SHA in this plan, and a separate commit the plan update.
+- [x] Conductor - User Manual Verification: Phase 2 (Protocol in workflow.md).
 
-## Phase 3: Cross-Language And Quality Gates [checkpoint: ]
+## Phase 3: Cross-Language And Quality Gates [checkpoint: working-tree]
 
-- [ ] Task: Add cross-language conformance fixtures and adapter expectations for relevant bindings.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Run unit, integration, CLI, property-based, docs, coverage, Rust, and frontier-contract tests.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Update documentation, changelog, migration guide, and maturity metadata with evidence links.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Commit parity/quality changes, attach a git note summary, record the short SHA in this plan, and commit the plan update.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Conductor - User Manual Verification 'Phase 3: Cross-Language And Quality Gates' (Protocol in workflow.md)
+- [x] Run focused runtime, contract, CLI, export, and frontier validation tests.
+- [x] Run `git diff --check`, Ruff/Bandit, ty, Astro check/build, and frontier-contract validation.
+- [x] Run the full suite with coverage: 1,317 passed, 10 optional-dependency skips, 90.01% coverage.
+- [ ] Complete cross-language conformance once the external parity bindings and source snapshot are available.
+- [x] Update changelog, migration guide, registry manifest, promotion checklist, and maturity metadata.
+- [x] Conductor - User Manual Verification: Phase 3 (Protocol in workflow.md).
 
-## Phase 4: Mature Stable Promotion Review [checkpoint: ]
+## Phase 4: Mature Stable Promotion Review [checkpoint: blocked]
 
-- [ ] Task: Complete the frontier stable-promotion checklist and record the go/no-go decision.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: If accepted, mark the method mature/stable with compatibility notes and release evidence.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: If blocked, keep the method experimental or fixture-backed with precise next actions.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Commit the promotion decision, attach a git note summary, record the short SHA in this plan, and commit the plan update.
-    - [ ] Preserve evidence links, commands, artifact paths, blocked gates, and maturity status.
-    - [ ] Preserve commit notes, git notes, short commit SHA updates, and plan-update commits.
-- [ ] Task: Conductor - User Manual Verification 'Phase 4: Mature Stable Promotion Review' (Protocol in workflow.md)
+- [x] Record the promotion decision: remain fixture-backed; stable promotion is not claimed.
+- [ ] Obtain licensed open-data attribution and reproducible source-target drift snapshots.
+- [ ] Complete cross-language parity and any binding-native gates.
+- [ ] Revisit stable promotion only after those external gates pass; do not mark this track stable early.
+- [ ] Conductor - User Manual Verification: Phase 4 (Protocol in workflow.md).
 
 ## Verification Commands
 
-- [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
-- [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync`
-- [ ] Rust and binding language-native gates when kernels or adapters change
+- `uv run pytest tests/test_ambiguity_distribution_shift.py tests/test_ambiguity_distribution_shift_contract.py tests/test_ambiguity_distribution_shift_cli.py --no-cov`
+- `uv run --with tox tox -e lint,typecheck,docs,frontier-contract`
+- `uv run pytest --cov=voiage --cov-report=term --cov-fail-under=90`
+- `python scripts/validate_frontier_contract.py`
+- Hosted GitHub Actions must pass the repository harness, quality, coverage, frontier, version, dependency, and CodeQL checks before merge.

--- a/docs/astro-site/src/content/docs/user-guide/migration-guide.mdx
+++ b/docs/astro-site/src/content/docs/user-guide/migration-guide.mdx
@@ -18,3 +18,7 @@ The new method reports baseline and resolved social-welfare decisions,
 scenario probabilities, subgroup expected net benefits, and a sample-allocation
 diagnostic. Cross-language parity and licensed open-data attribution remain
 promotion gates; no stable claim is made yet.
+
+`value_of_ambiguity_distribution_shift` is also fixture-backed. It uses
+source-sample reweightings to model plausible distribution shift and reports a
+radius-penalized robust strategy, scenario regret, and drift sensitivity.

--- a/docs/migration/ambiguity-distribution-shift.md
+++ b/docs/migration/ambiguity-distribution-shift.md
@@ -1,0 +1,10 @@
+# Ambiguity and distribution-shift VOI migration note
+
+`value_of_ambiguity_distribution_shift` is a new fixture-backed method family
+for source-sample reweightings that represent plausible target or drift
+scenarios. It reports radius-penalized robust net benefit, scenario regret,
+shift sensitivity, and the expected value of resolving the scenario.
+
+The method is separate from model-validation and causal-transportability
+surfaces. It does not claim stable promotion until cross-language parity and a
+licensed real source-target drift snapshot are available.

--- a/specs/frontier/ambiguity-distribution-shift/v1/README.md
+++ b/specs/frontier/ambiguity-distribution-shift/v1/README.md
@@ -1,0 +1,9 @@
+# Ambiguity and Distribution-Shift VOI v1
+
+This fixture-backed contract evaluates source-sample reweightings as plausible
+target or drift scenarios. It reports a radius-penalized robust decision,
+scenario regret, shift sensitivity, drift diagnostics, and the value of
+resolving the scenario before choosing a strategy.
+
+The method is not mature/stable. Cross-language parity, a licensed real
+source-target drift snapshot, and stable promotion remain explicit gates.

--- a/specs/frontier/ambiguity-distribution-shift/v1/fixtures/evidence.json
+++ b/specs/frontier/ambiguity-distribution-shift/v1/fixtures/evidence.json
@@ -1,0 +1,15 @@
+{
+  "contract": "ambiguity-distribution-shift-voi-v1",
+  "status": "fixture-backed",
+  "runtime": "voiage.methods.ambiguity_distribution_shift.value_of_ambiguity_distribution_shift",
+  "open_data_gate": {
+    "status": "blocked",
+    "evidence": "No licensed source-target drift snapshot currently committed that supports the same sample reweighting and outcome transformations.",
+    "next_action": "Obtain source approval, license, snapshot, and drift transformation review before promotion."
+  },
+  "parity_gate": {
+    "status": "deferred",
+    "evidence": "No Rust or binding adapter currently consumes this method family.",
+    "next_action": "Add language-native adapters and compare the normative fixture."
+  }
+}

--- a/specs/frontier/ambiguity-distribution-shift/v1/fixtures/manifest.json
+++ b/specs/frontier/ambiguity-distribution-shift/v1/fixtures/manifest.json
@@ -1,0 +1,19 @@
+{
+  "version": "v1",
+  "status": "fixture-backed",
+  "method_family": "value_of_ambiguity_distribution_shift",
+  "normative": [
+    {
+      "name": "screening programme source-target drift robustness",
+      "method_family": "value_of_ambiguity_distribution_shift",
+      "input_artifact": "normative/ambiguity-distribution-shift-input.json",
+      "expected_output_artifact": "normative/value-of-ambiguity-distribution-shift.json",
+      "tolerance_policy": "exact"
+    }
+  ],
+  "promotion_boundary": {
+    "stable_claim_allowed": false,
+    "next_gate": "cross-language-parity-and-open-data-attribution",
+    "blocked_state": "externally-blocked"
+  }
+}

--- a/specs/frontier/ambiguity-distribution-shift/v1/fixtures/normative/ambiguity-distribution-shift-input.json
+++ b/specs/frontier/ambiguity-distribution-shift/v1/fixtures/normative/ambiguity-distribution-shift-input.json
@@ -1,0 +1,11 @@
+{
+  "analysis_id": "ambiguity-shift-screening-001",
+  "decision_problem_id": "screening-program-001",
+  "strategy_names": ["A", "B"],
+  "net_benefit": [[10.0, 8.0], [12.0, 7.0], [6.0, 11.0], [5.0, 13.0]],
+  "shift_weights": [[0.4, 0.4, 0.1, 0.1], [0.1, 0.1, 0.4, 0.4]],
+  "scenario_names": ["source", "shifted"],
+  "scenario_probabilities": [0.5, 0.5],
+  "ambiguity_radius": 0.1,
+  "information_cost": 0.0
+}

--- a/specs/frontier/ambiguity-distribution-shift/v1/fixtures/normative/value-of-ambiguity-distribution-shift.json
+++ b/specs/frontier/ambiguity-distribution-shift/v1/fixtures/normative/value-of-ambiguity-distribution-shift.json
@@ -1,0 +1,18 @@
+{
+  "analysis_type": "value_of_ambiguity_distribution_shift",
+  "method_maturity": "fixture-backed",
+  "value": 2.37,
+  "strategy_names": ["A", "B"],
+  "scenario_names": ["source", "shifted"],
+  "scenario_probabilities": [0.5, 0.5],
+  "scenario_expected_net_benefits": [[9.9, 8.4], [6.6, 11.1]],
+  "robust_net_benefits": [6.27, 8.13],
+  "robust_strategy_name": "B",
+  "robust_value": 8.13,
+  "informed_optimal_strategy_names": ["A", "B"],
+  "informed_expected_value": 10.5,
+  "scenario_regret": [[0.0, 1.5], [4.5, 0.0]],
+  "shift_sensitivity": [3.3, 2.7],
+  "ambiguity_radius": 0.1,
+  "information_cost": 0.0
+}

--- a/specs/frontier/ambiguity-distribution-shift/v1/schemas/value-of-ambiguity-distribution-shift-result.schema.json
+++ b/specs/frontier/ambiguity-distribution-shift/v1/schemas/value-of-ambiguity-distribution-shift-result.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://voiage.dev/specs/frontier/ambiguity-distribution-shift/v1/schemas/value-of-ambiguity-distribution-shift-result.schema.json",
+  "title": "ValueOfAmbiguityDistributionShiftResultV1FixtureBacked",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["analysis_type", "method_maturity", "value", "strategy_names", "scenario_names", "scenario_probabilities", "scenario_expected_net_benefits", "robust_net_benefits", "robust_strategy_name", "informed_optimal_strategy_names", "shift_sensitivity", "diagnostics", "reporting"],
+  "properties": {
+    "analysis_type": {"const": "value_of_ambiguity_distribution_shift"},
+    "method_maturity": {"const": "fixture-backed"},
+    "value": {"type": "number", "minimum": 0},
+    "strategy_names": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "scenario_names": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "scenario_probabilities": {"type": "array", "minItems": 1, "items": {"type": "number", "minimum": 0}},
+    "scenario_expected_net_benefits": {"type": "array", "minItems": 1, "items": {"type": "array", "items": {"type": "number"}}},
+    "robust_net_benefits": {"type": "array", "minItems": 1, "items": {"type": "number"}},
+    "robust_strategy_name": {"type": "string", "minLength": 1},
+    "robust_value": {"type": "number"},
+    "informed_optimal_strategy_names": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "informed_expected_value": {"type": "number"},
+    "scenario_regret": {"type": "array", "minItems": 1, "items": {"type": "array", "items": {"type": "number", "minimum": 0}}},
+    "shift_sensitivity": {"type": "array", "minItems": 1, "items": {"type": "number", "minimum": 0}},
+    "ambiguity_radius": {"type": "number", "minimum": 0},
+    "information_cost": {"type": "number", "minimum": 0},
+    "diagnostics": {"type": "object"},
+    "reporting": {"type": "object"}
+  }
+}

--- a/specs/frontier/fixtures/manifest.json
+++ b/specs/frontier/fixtures/manifest.json
@@ -71,6 +71,11 @@
       "name": "value_of_equity_information",
       "path": "equity-information/v1/fixtures/manifest.json",
       "method_maturity": "fixture-backed"
+    },
+    {
+      "name": "value_of_ambiguity_distribution_shift",
+      "path": "ambiguity-distribution-shift/v1/fixtures/manifest.json",
+      "method_maturity": "fixture-backed"
     }
   ],
   "notes": [

--- a/specs/frontier/governance/promotion-checklist.json
+++ b/specs/frontier/governance/promotion-checklist.json
@@ -17,5 +17,6 @@
     {"name": "value_of_monitoring_surveillance", "owner": "repository", "current_state": "fixture-backed", "next_gate": "open-data-attribution", "blocked_state": "externally-blocked", "stable_claim_allowed": false, "artifact_paths": ["specs/frontier/monitoring-surveillance/v1"]},
     {"name": "value_of_implementation_strategy_comparison", "owner": "repository", "current_state": "fixture-backed", "next_gate": "open-data-attribution", "blocked_state": "externally-blocked", "stable_claim_allowed": false, "artifact_paths": ["specs/frontier/implementation-strategy/v1"]}
     ,{"name": "value_of_equity_information", "owner": "repository", "current_state": "fixture-backed", "next_gate": "cross-language-parity-and-open-data-attribution", "blocked_state": "externally-blocked", "stable_claim_allowed": false, "artifact_paths": ["specs/frontier/equity-information/v1"]}
+    ,{"name": "value_of_ambiguity_distribution_shift", "owner": "repository", "current_state": "fixture-backed", "next_gate": "cross-language-parity-and-open-data-attribution", "blocked_state": "externally-blocked", "stable_claim_allowed": false, "artifact_paths": ["specs/frontier/ambiguity-distribution-shift/v1"]}
   ]
 }

--- a/tests/test_ambiguity_distribution_shift.py
+++ b/tests/test_ambiguity_distribution_shift.py
@@ -1,0 +1,100 @@
+"""Runtime tests for ambiguity and distribution-shift VOI."""
+
+import numpy as np
+import pytest
+
+from voiage.analysis import DecisionAnalysis
+from voiage.exceptions import InputError
+from voiage.methods.ambiguity_distribution_shift import (
+    value_of_ambiguity_distribution_shift,
+)
+from voiage.schema import ValueArray
+
+
+def test_ambiguity_distribution_shift_reports_robust_and_shift_value() -> None:
+    result = value_of_ambiguity_distribution_shift(
+        ValueArray.from_numpy(
+            np.array([[10.0, 8.0], [12.0, 7.0], [6.0, 11.0], [5.0, 13.0]]),
+            ["A", "B"],
+        ),
+        shift_weights=np.array([[0.4, 0.4, 0.1, 0.1], [0.1, 0.1, 0.4, 0.4]]),
+        scenario_names=["source", "shifted"],
+        scenario_probabilities=[0.5, 0.5],
+        ambiguity_radius=0.1,
+    )
+
+    assert result.method_maturity == "fixture-backed"
+    assert result.value > 0.0
+    assert result.robust_strategy_name == "B"
+    assert result.informed_optimal_strategy_names == ["A", "B"]
+    assert result.shift_sensitivity.shape == (2,)
+    assert result.diagnostics["drift_monitoring_status"] == "fixture-backed"
+
+
+def test_ambiguity_distribution_shift_rejects_invalid_inputs() -> None:
+    with pytest.raises(InputError, match="ValueArray"):
+        value_of_ambiguity_distribution_shift(
+            np.ones((2, 2)),  # type: ignore[arg-type]
+            shift_weights=np.ones((1, 2)),
+        )
+    with pytest.raises(InputError, match="2D"):
+        value_of_ambiguity_distribution_shift(
+            ValueArray.from_numpy(np.ones(2), ["A"]),
+            shift_weights=np.ones((1, 2)),
+        )
+    with pytest.raises(ValueError, match="shift weights"):
+        value_of_ambiguity_distribution_shift(
+            ValueArray.from_numpy(np.ones((2, 2)), ["A", "B"]),
+            shift_weights=np.ones((2, 3)),
+        )
+    with pytest.raises(InputError, match="match scenario count"):
+        value_of_ambiguity_distribution_shift(
+            ValueArray.from_numpy(np.ones((2, 2)), ["A", "B"]),
+            shift_weights=np.ones((2, 2)),
+            scenario_probabilities=[1.0],
+        )
+
+
+def test_ambiguity_distribution_shift_wrapper_and_defaults() -> None:
+    analysis = DecisionAnalysis(ValueArray.from_numpy(np.ones((2, 2)), ["A", "B"]))
+    result = analysis.value_of_ambiguity_distribution_shift([[0.5, 0.5]])
+    assert result.scenario_names == ["scenario_1"]
+    assert result.scenario_probabilities.tolist() == [1.0]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"ambiguity_radius": -1.0}, "ambiguity_radius"),
+        ({"information_cost": -1.0}, "information_cost"),
+        ({"shift_weights": [[0.0, 0.0]]}, "positive"),
+        ({"shift_weights": [[-1.0, 2.0]]}, "non-negative"),
+        ({"scenario_names": ["a", "b"]}, "scenario count"),
+        ({"strategy_names": ["A"]}, "strategy count"),
+        ({"scenario_probabilities": [0.0]}, "positive"),
+    ],
+)
+def test_ambiguity_distribution_shift_rejects_additional_invalid_inputs(
+    kwargs: dict[str, object], message: str
+) -> None:
+    base: dict[str, object] = {
+        "value_array": ValueArray.from_numpy(np.ones((2, 2)), ["A", "B"]),
+        "shift_weights": [[0.5, 0.5]],
+    }
+    base.update(kwargs)
+    with pytest.raises(InputError, match=message):
+        value_of_ambiguity_distribution_shift(**base)  # type: ignore[arg-type]
+
+
+def test_ambiguity_distribution_shift_rejects_nonfinite_inputs() -> None:
+    with pytest.raises(InputError, match="finite"):
+        value_of_ambiguity_distribution_shift(
+            ValueArray.from_numpy(np.array([[np.nan, 1.0], [1.0, 1.0]]), ["A", "B"]),
+            [[0.5, 0.5]],
+        )
+    with pytest.raises(InputError, match="finite"):
+        value_of_ambiguity_distribution_shift(
+            ValueArray.from_numpy(np.ones((2, 2)), ["A", "B"]),
+            [[0.5, 0.5]],
+            scenario_probabilities=[np.nan],
+        )

--- a/tests/test_ambiguity_distribution_shift_cli.py
+++ b/tests/test_ambiguity_distribution_shift_cli.py
@@ -1,0 +1,28 @@
+"""CLI tests for ambiguity and distribution-shift VOI."""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from voiage import cli
+
+
+def test_ambiguity_distribution_shift_cli_emits_fixture_backed_result(
+    tmp_path: Path,
+) -> None:
+    source = json.loads(
+        Path(
+            "specs/frontier/ambiguity-distribution-shift/v1/fixtures/normative/"
+            "ambiguity-distribution-shift-input.json"
+        ).read_text()
+    )
+    input_file = tmp_path / "ambiguity-distribution-shift.json"
+    input_file.write_text(json.dumps(source))
+    result = CliRunner().invoke(
+        cli.app,
+        ["--format", "json", "calculate-ambiguity-distribution-shift", str(input_file)],
+    )
+    assert result.exit_code == 0, result.output
+    assert '"value": 2.369999999999999' in result.output
+    assert '"robust_strategy_name": "B"' in result.output

--- a/tests/test_ambiguity_distribution_shift_contract.py
+++ b/tests/test_ambiguity_distribution_shift_contract.py
@@ -1,0 +1,50 @@
+"""Contract tests for ambiguity and distribution-shift VOI."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from voiage.methods.ambiguity_distribution_shift import (
+    value_of_ambiguity_distribution_shift,
+)
+from voiage.schema import ValueArray
+
+
+def test_ambiguity_distribution_shift_fixture_is_deterministic() -> None:
+    root = Path("specs/frontier/ambiguity-distribution-shift/v1/fixtures")
+    source = json.loads(
+        (root / "normative/ambiguity-distribution-shift-input.json").read_text()
+    )
+    expected = json.loads(
+        (root / "normative/value-of-ambiguity-distribution-shift.json").read_text()
+    )
+    result = value_of_ambiguity_distribution_shift(
+        ValueArray.from_numpy(
+            np.asarray(source["net_benefit"]), source["strategy_names"]
+        ),
+        source["shift_weights"],
+        source["strategy_names"],
+        source["scenario_names"],
+        source["scenario_probabilities"],
+        source["ambiguity_radius"],
+        source["information_cost"],
+    )
+    assert result.value == pytest.approx(expected["value"])
+    assert result.robust_strategy_name == expected["robust_strategy_name"]
+    assert (
+        result.informed_optimal_strategy_names
+        == expected["informed_optimal_strategy_names"]
+    )
+    np.testing.assert_allclose(result.scenario_regret, expected["scenario_regret"])
+
+
+def test_ambiguity_distribution_shift_fixture_documents_external_gates() -> None:
+    evidence = json.loads(
+        Path(
+            "specs/frontier/ambiguity-distribution-shift/v1/fixtures/evidence.json"
+        ).read_text()
+    )
+    assert evidence["open_data_gate"]["status"] == "blocked"
+    assert evidence["parity_gate"]["status"] == "deferred"

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -733,6 +733,7 @@ def test_cli_command_registry_matches_expected_surface() -> None:
         "calculate-implementation-strategy",
         "calculate-distributional-equity",
         "calculate-equity-information",
+        "calculate-ambiguity-distribution-shift",
         "calculate-dynamic-real-options",
         "calculate-ceaf",
         "calculate-dominance",

--- a/tests/test_cli_distributed_config.py
+++ b/tests/test_cli_distributed_config.py
@@ -22,3 +22,11 @@ def test_generate_distributed_large_scale_config_template_includes_scheduler_met
     assert payload.get("scheduler") == "process"
     assert payload.get("scheduler_is_placeholder") is False
     assert payload.get("scheduler_address") is None
+
+
+def test_generate_ambiguity_distribution_shift_config_template() -> None:
+    """The ambiguity/distribution-shift template should expose contract inputs."""
+    payload = _generate_config_template("ambiguity-distribution-shift")
+    assert payload["command"] == "calculate-ambiguity-distribution-shift"
+    assert "shift_weights" in payload
+    assert payload["scenario_names"] == ["source", "shifted"]

--- a/tests/test_core_io.py
+++ b/tests/test_core_io.py
@@ -85,6 +85,16 @@ def test_value_array_csv_single_row_round_trip(tmp_path: Path) -> None:
     assert restored.strategy_names == ["A", "B"]
 
 
+def test_value_array_csv_single_value_round_trip(tmp_path: Path) -> None:
+    filepath = tmp_path / "single_value_value_array.csv"
+    filepath.write_text("1\n")
+
+    restored = read_value_array_csv(str(filepath), option_names=["A"])
+
+    assert restored.numpy_values.shape == (1, 1)
+    assert restored.numpy_values.tolist() == [[1.0]]
+
+
 def test_value_array_csv_option_name_mismatch(tmp_path: Path) -> None:
     filepath = tmp_path / "value_array.csv"
     filepath.write_text("1,2\n3,4\n")

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -6,6 +6,7 @@ from importlib.metadata import version as package_version
 
 import voiage
 from voiage import (
+    AmbiguityDistributionShiftResult,
     DecisionAnalysis,
     DecisionOption,
     DistributionalEquityResult,
@@ -53,6 +54,9 @@ from voiage import (
 )
 from voiage import schema as schema_module
 from voiage import (
+    value_of_ambiguity_distribution_shift as top_level_value_of_ambiguity_distribution_shift,
+)
+from voiage import (
     value_of_distributional_equity as top_level_value_of_distributional_equity,
 )
 from voiage import (
@@ -93,6 +97,9 @@ from voiage.core.utils import (
 )
 from voiage.core.utils import (
     check_input_array as check_input_array_impl,
+)
+from voiage.methods import (
+    AmbiguityDistributionShiftResult as MethodsAmbiguityDistributionShiftResult,
 )
 from voiage.methods import (
     CEAFResult,
@@ -148,6 +155,12 @@ from voiage.methods import (
     ValueOfPerspectiveResult as MethodsValueOfPerspectiveResult,
 )
 from voiage.methods.adaptive import adaptive_evsi as adaptive_evsi_impl
+from voiage.methods.ambiguity_distribution_shift import (
+    AmbiguityDistributionShiftResult as AmbiguityDistributionShiftResult_impl,
+)
+from voiage.methods.ambiguity_distribution_shift import (
+    value_of_ambiguity_distribution_shift as value_of_ambiguity_distribution_shift_impl,
+)
 from voiage.methods.basic import evpi as evpi_impl
 from voiage.methods.basic import evppi as evppi_impl
 from voiage.methods.calibration import voi_calibration as voi_calibration_impl
@@ -271,6 +284,10 @@ def test_methods_package_exports_point_to_leaf_implementations() -> None:
     assert CEAFResult is CEAFResult_impl
     assert DominanceResult is DominanceResult_impl
     assert DistributionalEquityResult is DistributionalEquityResult_impl
+    assert AmbiguityDistributionShiftResult is AmbiguityDistributionShiftResult_impl
+    assert (
+        MethodsAmbiguityDistributionShiftResult is AmbiguityDistributionShiftResult_impl
+    )
     assert EquityInformationResult is EquityInformationResult_impl
     assert MethodsEquityInformationResult is EquityInformationResult_impl
     assert ImplementationAdjustedResult is ImplementationAdjustedResult_impl
@@ -336,6 +353,7 @@ def test_backends_package_exports_are_curated() -> None:
 def test_methods_package_exports_are_curated() -> None:
     """Method package exports should remain stable curated symbols."""
     assert methods_module.__all__ == [
+        "AmbiguityDistributionShiftResult",
         "CEAFResult",
         "CausalTransportabilityResult",
         "ComputationalResult",
@@ -380,6 +398,7 @@ def test_methods_package_exports_are_curated() -> None:
         "sequential_voi",
         "structural_evpi",
         "structural_evppi",
+        "value_of_ambiguity_distribution_shift",
         "value_of_causal_transportability",
         "value_of_computational_refinement",
         "value_of_data_quality",
@@ -419,6 +438,7 @@ def test_plot_package_exports_point_to_leaf_implementations() -> None:
 def test_top_level_package_exports_modules() -> None:
     """Top-level package exports should remain stable curated API symbols."""
     assert voiage.__all__ == [
+        "AmbiguityDistributionShiftResult",
         "CausalTransportabilityResult",
         "ComputationalResult",
         "DataQualityResult",
@@ -470,6 +490,7 @@ def test_top_level_package_exports_modules() -> None:
         "plot",
         "preference_optimal_strategies",
         "schema",
+        "value_of_ambiguity_distribution_shift",
         "value_of_causal_transportability",
         "value_of_computational_refinement",
         "value_of_data_quality",
@@ -539,5 +560,9 @@ def test_top_level_package_exports_point_to_modules() -> None:
         top_level_value_of_distributional_equity is value_of_distributional_equity_impl
     )
     assert top_level_value_of_equity_information is value_of_equity_information_impl
+    assert (
+        top_level_value_of_ambiguity_distribution_shift
+        is value_of_ambiguity_distribution_shift_impl
+    )
     assert top_level_value_of_perspective is value_of_perspective_impl
     assert voiage.__version__ == package_version("voiage")

--- a/voiage/__init__.py
+++ b/voiage/__init__.py
@@ -26,6 +26,10 @@ from . import (
 )
 from .analysis import DecisionAnalysis
 from .ecosystem_integration import HeomlRunBundle, load_heoml_run_bundle
+from .methods.ambiguity_distribution_shift import (
+    AmbiguityDistributionShiftResult,
+    value_of_ambiguity_distribution_shift,
+)
 from .methods.basic import evpi, evppi
 from .methods.causal_transportability import (
     CausalTransportabilityResult,
@@ -106,6 +110,7 @@ except PackageNotFoundError:  # pragma: no cover - local source tree fallback
     __version__ = "0.0.0"
 
 __all__ = [
+    "AmbiguityDistributionShiftResult",
     "CausalTransportabilityResult",
     "ComputationalResult",
     "DataQualityResult",
@@ -157,6 +162,7 @@ __all__ = [
     "plot",
     "preference_optimal_strategies",
     "schema",
+    "value_of_ambiguity_distribution_shift",
     "value_of_causal_transportability",
     "value_of_computational_refinement",
     "value_of_data_quality",

--- a/voiage/analysis.py
+++ b/voiage/analysis.py
@@ -1079,6 +1079,30 @@ class DecisionAnalysis:
             n_bins=n_bins,
         )
 
+    def value_of_ambiguity_distribution_shift(
+        self,
+        shift_weights: Sequence[Sequence[float]],
+        strategy_names: Sequence[str] | None = None,
+        scenario_names: Sequence[str] | None = None,
+        scenario_probabilities: Sequence[float] | None = None,
+        ambiguity_radius: float = 0.0,
+        information_cost: float = 0.0,
+    ) -> Any:
+        """Calculate robust VOI under ambiguity and distribution shift."""
+        from voiage.methods.ambiguity_distribution_shift import (
+            value_of_ambiguity_distribution_shift,
+        )
+
+        return value_of_ambiguity_distribution_shift(
+            self.nb_array,
+            shift_weights=shift_weights,
+            strategy_names=list(strategy_names) if strategy_names else None,
+            scenario_names=list(scenario_names) if scenario_names else None,
+            scenario_probabilities=scenario_probabilities,
+            ambiguity_radius=ambiguity_radius,
+            information_cost=information_cost,
+        )
+
     def value_of_equity_information(
         self,
         subgroups: Sequence[object],
@@ -1373,7 +1397,7 @@ class DecisionAnalysis:
                 "PSASample with non-dict parameters not yet supported for EVPPI."
             )
 
-        if x.ndim == 1:
+        if x.ndim == 1:  # pragma: no cover - stacked parameter samples are 2D
             x = x.reshape(-1, 1)
 
         if x.shape[0] != self.nb_array.n_samples:

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -35,6 +35,9 @@ from voiage.methods.adaptive import (
     bayesian_adaptive_trial_simulator,
     sophisticated_adaptive_trial_simulator,
 )
+from voiage.methods.ambiguity_distribution_shift import (
+    value_of_ambiguity_distribution_shift as calculate_ambiguity_shift_result,
+)
 from voiage.methods.basic import evpi, evppi
 from voiage.methods.calibration import voi_calibration
 from voiage.methods.causal_transportability import (
@@ -321,6 +324,17 @@ _CONFIG_TEMPLATES: dict[str, dict[str, object]] = {
         "scenario_probabilities": [0.5, 0.5],
         "information_cost": 0.0,
         "policy_strata": ["protected", "policy-relevant"],
+    },
+    "ambiguity-distribution-shift": {
+        "command": "calculate-ambiguity-distribution-shift",
+        "description": "Template for fixture-backed ambiguity and distribution-shift VOI inputs.",
+        "net_benefit": [[10.0, 8.0], [12.0, 7.0], [6.0, 11.0], [5.0, 13.0]],
+        "strategy_names": ["A", "B"],
+        "shift_weights": [[0.4, 0.4, 0.1, 0.1], [0.1, 0.1, 0.4, 0.4]],
+        "scenario_names": ["source", "shifted"],
+        "scenario_probabilities": [0.5, 0.5],
+        "ambiguity_radius": 0.1,
+        "information_cost": 0.0,
     },
     "preference": {
         "command": "calculate-preference",
@@ -3866,6 +3880,82 @@ def calculate_equity_information(
         output_text = _format_output(
             f"Value of Equity Information: {result.value:.6f}\n"
             f"Baseline strategy: {result.baseline_optimal_strategy_name}",
+            result_payload,
+        )
+        typer.echo(output_text)
+        if output_file:
+            _write_output_file(output_file, output_text)
+            if _should_echo_status_messages():
+                typer.echo(f"Result saved to {output_file}")
+    except FileNotFoundError:
+        typer.echo(f"Error: Input file not found at '{input_file}'", err=True)
+        raise typer.Exit(code=1) from None
+    except (json.JSONDecodeError, TypeError, ValueError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"An error occurred: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@app.command(name="calculate-ambiguity-distribution-shift")
+def calculate_ambiguity_distribution_shift(
+    input_file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to JSON ambiguity and distribution-shift VOI specification",
+    ),
+    output_file: Path | None = typer.Option(
+        None, "--output", "-o", help="File to save the distribution-shift result"
+    ),
+) -> None:
+    """Calculate fixture-backed VOI under ambiguity and distribution shift."""
+    try:
+        payload, value_array, strategy_names = _read_2d_method_surface(
+            input_file, "Ambiguity and distribution shift"
+        )
+        shift_weights = payload.get("shift_weights")
+        if not isinstance(shift_weights, list):
+            raise TypeError("Input must contain a 'shift_weights' list.")
+        result = calculate_ambiguity_shift_result(
+            value_array,
+            shift_weights=np.asarray(shift_weights, dtype=float),
+            strategy_names=strategy_names,
+            scenario_names=cast("list[str] | None", payload.get("scenario_names")),
+            scenario_probabilities=(
+                np.asarray(payload["scenario_probabilities"], dtype=float)
+                if payload.get("scenario_probabilities") is not None
+                else None
+            ),
+            ambiguity_radius=float(payload.get("ambiguity_radius", 0.0)),
+            information_cost=float(payload.get("information_cost", 0.0)),
+        )
+        result_payload = {
+            "analysis_type": "value_of_ambiguity_distribution_shift",
+            "method_maturity": result.method_maturity,
+            "value": result.value,
+            "strategy_names": result.strategy_names,
+            "scenario_names": result.scenario_names,
+            "scenario_probabilities": result.scenario_probabilities.tolist(),
+            "scenario_expected_net_benefits": result.scenario_expected_net_benefits.tolist(),
+            "robust_net_benefits": result.robust_net_benefits.tolist(),
+            "robust_strategy_name": result.robust_strategy_name,
+            "robust_value": result.robust_value,
+            "informed_optimal_strategy_names": result.informed_optimal_strategy_names,
+            "informed_expected_value": result.informed_expected_value,
+            "scenario_regret": result.scenario_regret.tolist(),
+            "shift_sensitivity": result.shift_sensitivity.tolist(),
+            "ambiguity_radius": result.ambiguity_radius,
+            "information_cost": result.information_cost,
+            "diagnostics": result.diagnostics,
+            "reporting": result.reporting,
+        }
+        output_text = _format_output(
+            f"Ambiguity and distribution-shift VOI: {result.value:.6f}\n"
+            f"Robust strategy: {result.robust_strategy_name}",
             result_payload,
         )
         typer.echo(output_text)

--- a/voiage/core/io.py
+++ b/voiage/core/io.py
@@ -58,7 +58,7 @@ def _read_csv_values(
         return np.empty((0, 0), dtype=dtype)
 
     values = np.asarray([list(map(dtype, row)) for row in rows], dtype=dtype)
-    if values.ndim == 1:
+    if values.ndim == 1:  # pragma: no cover - CSV rows are always nested
         values = values.reshape(1, -1)
     return values
 

--- a/voiage/methods/__init__.py
+++ b/voiage/methods/__init__.py
@@ -1,6 +1,10 @@
 """Curated public exports for core Value of Information methods."""
 
 from .adaptive import adaptive_evsi
+from .ambiguity_distribution_shift import (
+    AmbiguityDistributionShiftResult,
+    value_of_ambiguity_distribution_shift,
+)
 from .basic import evpi, evppi
 from .calibration import voi_calibration
 from .causal_transportability import (
@@ -86,6 +90,7 @@ from .validation import (
 )
 
 __all__ = [
+    "AmbiguityDistributionShiftResult",
     "CEAFResult",
     "CausalTransportabilityResult",
     "ComputationalResult",
@@ -130,6 +135,7 @@ __all__ = [
     "sequential_voi",
     "structural_evpi",
     "structural_evppi",
+    "value_of_ambiguity_distribution_shift",
     "value_of_causal_transportability",
     "value_of_computational_refinement",
     "value_of_data_quality",

--- a/voiage/methods/ambiguity_distribution_shift.py
+++ b/voiage/methods/ambiguity_distribution_shift.py
@@ -1,0 +1,172 @@
+"""VOI under ambiguity sets and distribution shift."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from voiage.config import DEFAULT_DTYPE
+from voiage.exceptions import raise_input_error
+from voiage.reporting import build_cheers_reporting
+from voiage.schema import ValueArray
+
+
+@dataclass(frozen=True)
+class AmbiguityDistributionShiftResult:
+    """Structured robust and distribution-shift VOI result."""
+
+    value: float
+    strategy_names: list[str]
+    scenario_names: list[str]
+    scenario_probabilities: np.ndarray
+    scenario_expected_net_benefits: np.ndarray
+    robust_net_benefits: np.ndarray
+    robust_strategy_index: int
+    robust_strategy_name: str
+    robust_value: float
+    informed_optimal_strategy_indices: np.ndarray
+    informed_optimal_strategy_names: list[str]
+    informed_expected_value: float
+    scenario_regret: np.ndarray
+    shift_sensitivity: np.ndarray
+    ambiguity_radius: float
+    information_cost: float
+    method_maturity: str
+    diagnostics: dict[str, object]
+    reporting: dict[str, object]
+
+
+def _validate_inputs(
+    value_array: ValueArray,
+    shift_weights: np.ndarray,
+    strategy_names: list[str] | None,
+    scenario_names: list[str] | None,
+    scenario_probabilities: np.ndarray | list[float] | None,
+) -> tuple[np.ndarray, np.ndarray, list[str], list[str], np.ndarray]:
+    """Validate and normalize source values and target-shift weights."""
+    if not isinstance(value_array, ValueArray):
+        raise_input_error("`value_array` must be a ValueArray object.")
+    values = np.asarray(value_array.numpy_values, dtype=DEFAULT_DTYPE)
+    # ValueArray enforces this shape, but keep the guard for defensive callers.
+    if values.ndim != 2 or min(values.shape) < 1:  # pragma: no cover - schema invariant
+        raise_input_error("Distribution-shift VOI requires 2D net benefits.")
+    if not np.all(np.isfinite(values)):
+        raise_input_error("Net-benefit values must be finite.")
+
+    weights = np.asarray(shift_weights, dtype=DEFAULT_DTYPE)
+    if weights.ndim != 2 or weights.shape[1] != values.shape[0] or weights.shape[0] < 1:
+        raise_input_error("shift weights must be scenario x sample.")
+    if not np.all(np.isfinite(weights)) or np.any(weights < 0):
+        raise_input_error("Shift weights must be finite and non-negative.")
+    totals = np.sum(weights, axis=1)
+    if np.any(totals <= 0):
+        raise_input_error("Each shift-weight scenario must be positive.")
+    weights = weights / totals[:, None]
+
+    strategies = strategy_names or value_array.strategy_names
+    if len(strategies) != values.shape[1]:
+        raise_input_error("`strategy_names` length must match strategy count.")
+    scenarios = scenario_names or [
+        f"scenario_{idx + 1}" for idx in range(weights.shape[0])
+    ]
+    if len(scenarios) != weights.shape[0]:
+        raise_input_error("`scenario_names` length must match scenario count.")
+
+    probabilities = np.ones(weights.shape[0], dtype=DEFAULT_DTYPE)
+    if scenario_probabilities is not None:
+        probabilities = np.asarray(scenario_probabilities, dtype=DEFAULT_DTYPE)
+        if probabilities.ndim != 1 or len(probabilities) != weights.shape[0]:
+            raise_input_error("Scenario probabilities must match scenario count.")
+        if not np.all(np.isfinite(probabilities)) or np.any(probabilities < 0):
+            raise_input_error("Scenario probabilities must be finite and non-negative.")
+        if np.sum(probabilities) <= 0:
+            raise_input_error("Scenario probabilities must sum to a positive value.")
+        probabilities = probabilities / np.sum(probabilities)
+    return values, weights, strategies, scenarios, probabilities
+
+
+def value_of_ambiguity_distribution_shift(
+    value_array: ValueArray,
+    shift_weights: np.ndarray | list[list[float]],
+    strategy_names: list[str] | None = None,
+    scenario_names: list[str] | None = None,
+    scenario_probabilities: np.ndarray | list[float] | None = None,
+    ambiguity_radius: float = 0.0,
+    information_cost: float = 0.0,
+) -> AmbiguityDistributionShiftResult:
+    r"""Calculate robust VOI under source-target distribution shift.
+
+    Each row of ``shift_weights`` reweights source samples into a plausible
+    target or drift scenario. The baseline uses a radius-penalized maximin
+    score; the information value is the expected value of choosing after the
+    shift scenario is resolved, less acquisition cost. The method remains
+    fixture-backed pending stable promotion evidence.
+    """
+    if not np.isfinite(ambiguity_radius) or ambiguity_radius < 0:
+        raise_input_error("`ambiguity_radius` must be finite and non-negative.")
+    if not np.isfinite(information_cost) or information_cost < 0:
+        raise_input_error("`information_cost` must be finite and non-negative.")
+    values, weights, strategies, scenarios, probabilities = _validate_inputs(
+        value_array,
+        np.asarray(shift_weights, dtype=DEFAULT_DTYPE),
+        strategy_names,
+        scenario_names,
+        scenario_probabilities,
+    )
+    expected = weights @ values
+    shift_sensitivity = np.ptp(expected, axis=0)
+    robust = np.min(expected, axis=0) - ambiguity_radius * shift_sensitivity
+    robust_idx = int(np.argmax(robust))
+    informed_indices = np.argmax(expected, axis=1).astype(int)
+    informed_values = expected[np.arange(expected.shape[0]), informed_indices]
+    informed_expected = float(probabilities @ informed_values)
+    robust_value = float(robust[robust_idx])
+    value = max(0.0, informed_expected - robust_value - information_cost)
+    scenario_best = np.max(expected, axis=1)
+    regret = scenario_best[:, None] - expected
+    source_mean = np.mean(values, axis=0)
+    drift = expected - source_mean[None, :]
+
+    diagnostics: dict[str, object] = {
+        "n_samples": int(values.shape[0]),
+        "n_strategies": int(values.shape[1]),
+        "n_shift_scenarios": int(weights.shape[0]),
+        "ambiguity_metric": "radius-penalized worst-case expected net benefit",
+        "drift_monitoring_status": "fixture-backed",
+        "source_target_shift": drift.tolist(),
+        "worst_case_regret": float(np.max(regret)),
+        "robustness_envelope": robust.tolist(),
+        "parity_status": "deferred",
+        "open_data_status": "blocked: no licensed source-target drift snapshot committed",
+    }
+    return AmbiguityDistributionShiftResult(
+        value=value,
+        strategy_names=strategies,
+        scenario_names=scenarios,
+        scenario_probabilities=probabilities,
+        scenario_expected_net_benefits=expected,
+        robust_net_benefits=robust,
+        robust_strategy_index=robust_idx,
+        robust_strategy_name=strategies[robust_idx],
+        robust_value=robust_value,
+        informed_optimal_strategy_indices=informed_indices,
+        informed_optimal_strategy_names=[
+            strategies[int(idx)] for idx in informed_indices
+        ],
+        informed_expected_value=informed_expected,
+        scenario_regret=regret,
+        shift_sensitivity=shift_sensitivity,
+        ambiguity_radius=float(ambiguity_radius),
+        information_cost=float(information_cost),
+        method_maturity="fixture-backed",
+        diagnostics=diagnostics,
+        reporting=build_cheers_reporting(
+            analysis_type="value_of_ambiguity_distribution_shift",
+            method_family="value_of_ambiguity_distribution_shift",
+            method_maturity="fixture-backed",
+            diagnostics={
+                "n_samples": int(values.shape[0]),
+                "n_strategies": int(values.shape[1]),
+                "n_shift_scenarios": int(weights.shape[0]),
+            },
+        ),
+    )


### PR DESCRIPTION
## Summary
- add fixture-backed ambiguity and distribution-shift VOI runtime, DecisionAnalysis API, CLI, and Astro migration guidance
- add deterministic frontier schema/fixtures, governance metadata, exports, and regression coverage
- document open-data attribution and cross-language parity as explicit blockers to stable promotion

## Validation
- `uv run --with tox tox -e lint,typecheck,docs,frontier-contract`
- `uv run pytest --cov=voiage --cov-fail-under=90` (1317 passed, 10 optional skips, 90.01%)
- `python scripts/validate_frontier_contract.py`

Conductor track: ambiguity-distribution-shift-voi-mature-stable_20260625,