### PR TITLE
feat(conductor): add Conda-Forge feedstock handoff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -764,6 +764,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unified accelerator evidence packet validation and deterministic indexing for passed GPU and blocked TPU/Metal runs, preserving CPU fallback and external-gate reasons.
 ## Unreleased
 
+- Added a reproducible Conda-Forge feedstock handoff recording release,
+  workflow, recipe, credential, maintainer-merge, and package-index evidence.
+
 - Added a machine-readable TPU production-scale evidence contract with CPU
   fallback, EVPI parity, compile/transfer overhead, deterministic indexing, and
   an explicit Colab/gcloud availability gate.

--- a/conductor/tracks/conda-forge-feedstock-publication_20260625/handoff/conda-forge-evidence.json
+++ b/conductor/tracks/conda-forge-feedstock-publication_20260625/handoff/conda-forge-evidence.json
@@ -1,0 +1,16 @@
+{
+  "track_id": "conda-forge-feedstock-publication_20260625",
+  "channel": "conda-forge",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "next_action": "Publish a non-prerelease version, run the release workflow with CONDA_FORGE_TOKEN, then obtain feedstock maintainer review and verify Anaconda indexing.",
+  "external_gate": "A conda-forge feedstock PR requires the repository secret CONDA_FORGE_TOKEN and external conda-forge maintainer merge; package visibility requires channel indexing after merge.",
+  "evidence_urls": ["https://github.com/edithatogo/voiage/releases/tag/v0.2.0", "https://github.com/edithatogo/voiage/blob/main/.github/workflows/conda-update.yml", "https://github.com/edithatogo/voiage/blob/main/conda/meta.yaml", "https://anaconda.org/conda-forge/voiage"],
+  "commands": [
+    {"command":"gh release view v0.2.0 --json tagName,publishedAt,isPrerelease,isDraft","runner":"authenticated GitHub CLI","status":"passed","artifact":"release v0.2.0 metadata","details":"Release exists but is prerelease; no stable release-triggered feedstock update is evidenced."},
+    {"command":"curl -sS -o package.json -w '%{http_code}' https://api.anaconda.org/package/conda-forge/voiage","runner":"networked repository audit","status":"passed","artifact":"HTTP 404; package not found","details":"The package is not currently indexed in conda-forge."},
+    {"command":"git hash-object .github/workflows/conda-update.yml && git hash-object conda/meta.yaml","runner":"local Git worktree","status":"passed","artifact":"workflow 5dfd6ff4aa373aa9402f267d4166ae3de0fa6f85; recipe 737de25b628ea5e3db857e2452431a41c5d53ac0","details":"Repository-owned workflow and recipe are present; recipe retains UPDATE_ON_RELEASE until a stable release is available."},
+    {"command":"gh secret list --repo edithatogo/voiage","runner":"authenticated GitHub CLI","status":"not_run","artifact":"no secret value inspected","details":"Secret presence/value is not exposed or changed; feedstock token availability remains an external repository administration gate."}
+  ]
+}

--- a/conductor/tracks/conda-forge-feedstock-publication_20260625/plan.md
+++ b/conductor/tracks/conda-forge-feedstock-publication_20260625/plan.md
@@ -72,6 +72,13 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added `handoff/conda-forge-evidence.json` using the shared external-track handoff schema.
+- Verified `gh release view v0.2.0 --json tagName,publishedAt,isPrerelease,isDraft`: the only current release is prerelease.
+- Queried `https://api.anaconda.org/package/conda-forge/voiage`: HTTP 404, package not indexed.
+- Verified the release workflow and recipe hashes; feedstock PR creation remains gated by `CONDA_FORGE_TOKEN` and external conda-forge maintainer merge.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/scripts/validate_external_track_handoff.py
+++ b/scripts/validate_external_track_handoff.py
@@ -1,0 +1,89 @@
+"""Validate a Conductor external-gate handoff packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+STATUSES = {
+    "ready",
+    "submitted",
+    "published",
+    "indexed",
+    "approved",
+    "blocked",
+    "not_found",
+}
+REQUIRED = {
+    "track_id",
+    "channel",
+    "status",
+    "owner",
+    "checked_at",
+    "next_action",
+    "external_gate",
+    "evidence_urls",
+    "commands",
+}
+
+
+def validate_handoff(path: Path) -> dict[str, Any]:
+    """Validate a handoff and return its stable summary."""
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError("handoff must be a JSON object")
+    missing = sorted(REQUIRED - value.keys())
+    if missing:
+        raise ValueError(f"handoff missing fields {missing}")
+    if value["status"] not in STATUSES:
+        raise ValueError(f"unsupported handoff status: {value['status']}")
+    for field in (
+        "track_id",
+        "channel",
+        "owner",
+        "checked_at",
+        "next_action",
+        "external_gate",
+    ):
+        if not isinstance(value[field], str) or not value[field].strip():
+            raise ValueError(f"{field} must be non-empty")
+    if not isinstance(value["evidence_urls"], list) or not all(
+        isinstance(url, str) and url.startswith(("https://", "http://"))
+        for url in value["evidence_urls"]
+    ):
+        raise ValueError("evidence_urls must contain HTTP(S) URLs")
+    commands = value["commands"]
+    if not isinstance(commands, list) or not commands:
+        raise ValueError("commands must be a non-empty list")
+    for command in commands:
+        if not isinstance(command, dict):
+            raise TypeError("command entries must be objects")
+        for field in ("command", "runner", "status", "artifact", "details"):
+            if not isinstance(command.get(field), str) or not command[field].strip():
+                raise ValueError(f"command.{field} must be non-empty")
+    if value["status"] in {"blocked", "not_found"} and value[
+        "external_gate"
+    ].strip().lower() in {"none", "n/a"}:
+        raise ValueError("blocked handoffs require an external gate")
+    return {
+        "track_id": value["track_id"],
+        "channel": value["channel"],
+        "status": value["status"],
+        "command_count": len(commands),
+        "evidence_count": len(value["evidence_urls"]),
+    }
+
+
+def main() -> int:
+    """Validate a handoff packet from the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("handoff", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(validate_handoff(args.handoff), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/external-track-handoff/v1/schema.json
+++ b/specs/external-track-handoff/v1/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "voiage Conductor external track handoff",
+  "type": "object",
+  "required": ["track_id", "channel", "status", "owner", "checked_at", "next_action", "external_gate", "evidence_urls", "commands"],
+  "properties": {
+    "status": {"enum": ["ready", "submitted", "published", "indexed", "approved", "blocked", "not_found"]},
+    "evidence_urls": {"type": "array", "items": {"type": "string", "format": "uri"}},
+    "commands": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["command", "runner", "status", "artifact", "details"]}}
+  }
+}

--- a/tests/test_conda_forge_followthrough.py
+++ b/tests/test_conda_forge_followthrough.py
@@ -1,0 +1,16 @@
+"""Tests for the Conda-Forge external-gate handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = Path(
+    "conductor/tracks/conda-forge-feedstock-publication_20260625/handoff/conda-forge-evidence.json"
+)
+
+
+def test_conda_forge_handoff_preserves_feedstock_gate() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 4
+    assert summary["evidence_count"] == 4

--- a/todo.md
+++ b/todo.md
@@ -7,6 +7,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## In Progress
 
+*   [ ] Complete the Conda-Forge feedstock handoff and archive the track while
+    retaining external token, maintainer-merge, and indexing gates.
 
 ## Done
 


### PR DESCRIPTION
## Summary
- add a reusable external-track handoff schema and validator
- record Conda-Forge release, workflow, recipe, credential, maintainer, and indexing evidence
- preserve the external token/merge/indexing boundary without claiming publication

## Verification
- `uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_conda_forge_followthrough.py`
- `uv run pytest tests/test_conda_forge_followthrough.py tests/test_registry_audit.py tests/test_python_release_workflow.py tests/test_conductor_followthrough_tracks.py --no-cov` (22 passed)
- `uv run python scripts/validate_external_track_handoff.py conductor/tracks/conda-forge-feedstock-publication_20260625/handoff/conda-forge-evidence.json`
