### PR TITLE
feat(conductor): add Julia registry handoff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -770,6 +770,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indexing retained as explicit external gates.
 - Added R CRAN/r-universe readiness evidence with reproducible package build,
   CRAN-style check, PDF manual, and explicit manual submission/indexing gates.
+- Added Julia General readiness evidence with passing `Pkg.test()`, Compat and
+  TagBot/release workflow verification, and explicit registration/approval gates.
 - Archived the R registry follow-through track with CRAN review and r-universe
   indexing retained as external gates.
 

--- a/conductor/tracks/julia-general-registry-publication_20260625/handoff/julia-registry-evidence.json
+++ b/conductor/tracks/julia-general-registry-publication_20260625/handoff/julia-registry-evidence.json
@@ -1,0 +1,17 @@
+{
+  "track_id": "julia-general-registry-publication_20260625",
+  "channel": "Julia General",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "next_action": "Submit the package registration through Registrator or the Julia General contribution path, obtain maintainer review/merge, and verify General registry visibility.",
+  "external_gate": "Julia General registration and review are upstream maintainer actions; TagBot can synchronize releases only after registry approval and required repository secrets remain configured externally.",
+  "evidence_urls": ["https://github.com/JuliaRegistries/General", "https://github.com/edithatogo/voiage/blob/main/bindings/julia/Project.toml", "https://github.com/edithatogo/voiage/blob/main/.github/workflows/julia-tagbot.yml", "https://github.com/edithatogo/voiage/blob/main/.github/workflows/bindings-release.yml"],
+  "commands": [
+    {"command":"julia --project=bindings/julia -e 'using Pkg; Pkg.test()'","runner":"local Julia 1.12.6","status":"passed","artifact":"Julia test summary: EVPI 2 passed, total 2 passed","details":"The binding test suite passes locally against the shared contract."},
+    {"command":"sha256sum bindings/julia/Project.toml bindings/julia/src/Voiage.jl bindings/julia/test/runtests.jl","runner":"local Git worktree","status":"passed","artifact":"Project 56ddcd7bd03668d57030f250bbaf75af24866e381d85941568cc067d4b1f2a1b; source 3f949e9d9722b09944cbb08887ee652028f8b6091dec52a38130f48e08b1ff04; tests a08a044627ab8791cae557775e4ef65629aa57659b2e0a94ab92f357d49e8db2","details":"Compat bound julia=1.10 and version 0.2.0 are recorded from Project.toml."},
+    {"command":"git show HEAD:.github/workflows/julia-tagbot.yml && git show HEAD:.github/workflows/bindings-release.yml","runner":"local Git worktree","status":"passed","artifact":"TagBot workflow and julia-v* release workflow","details":"TagBot synchronization, verify-tag behavior, Pkg.test, and release archive steps are repository-owned and configured."},
+    {"command":"curl -sS -o Package.toml -w '%{http_code}' https://raw.githubusercontent.com/JuliaRegistries/General/master/V/Voiage/Package.toml","runner":"networked Julia General audit","status":"not_found","artifact":"HTTP 404","details":"General registry has no active Voiage Package.toml entry."},
+    {"command":"curl -sS -o Versions.toml -w '%{http_code}' https://raw.githubusercontent.com/JuliaRegistries/General/master/V/Voiage/Versions.toml","runner":"networked Julia General audit","status":"not_found","artifact":"HTTP 404","details":"No General registry version entry is visible."}
+  ]
+}

--- a/conductor/tracks/julia-general-registry-publication_20260625/plan.md
+++ b/conductor/tracks/julia-general-registry-publication_20260625/plan.md
@@ -72,6 +72,13 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added `handoff/julia-registry-evidence.json` using the shared external-track handoff schema.
+- `julia --project=bindings/julia -e 'using Pkg; Pkg.test()'` passed 2/2 EVPI tests under Julia 1.12.6.
+- Project, source, test, TagBot, and release workflow evidence is hashed and linked.
+- Julia General `V/Voiage/Package.toml` and `Versions.toml` both returned HTTP 404; registration and maintainer approval remain external gates.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -125,7 +125,7 @@ The active follow-through tracks are:
 - `external-registry-publication-program_20260625`
 - `archive/conda-forge-feedstock-publication_20260625`
 - `r-cran-runiverse-publication_20260625` (handoff: `conductor/archive/r-cran-runiverse-publication_20260625/handoff/r-registry-evidence.json`)
-- `julia-general-registry-publication_20260625`
+- `julia-general-registry-publication_20260625` (handoff: `conductor/tracks/julia-general-registry-publication_20260625/handoff/julia-registry-evidence.json`)
 - `spack-package-merge-followthrough_20260625`
 - `easybuild-easyconfig-merge-followthrough_20260625`
 - `hpsf-curation-submission-followthrough_20260625`

--- a/tests/test_julia_registry_followthrough.py
+++ b/tests/test_julia_registry_followthrough.py
@@ -1,0 +1,16 @@
+"""Tests for the Julia General external-gate handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = Path(
+    "conductor/tracks/julia-general-registry-publication_20260625/handoff/julia-registry-evidence.json"
+)
+
+
+def test_julia_registry_handoff_preserves_local_tests_and_external_approval() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 5
+    assert summary["evidence_count"] == 4


### PR DESCRIPTION
## Summary
- add Julia General registration evidence with Compat, TagBot, release, and test checks
- capture package metadata hashes and registry 404 results
- preserve external registration and maintainer approval gates

## Verification
- `julia --project=bindings/julia -e 'using Pkg; Pkg.test()'` (2/2 passed)
- `uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_julia_registry_followthrough.py`
- `uv run pytest tests/test_julia_registry_followthrough.py tests/test_julia_release_workflow.py tests/test_registry_audit.py tests/test_conductor_followthrough_tracks.py --no-cov` (21 passed)
