### PR TITLE
feat(conductor): add Spack upstream handoff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -772,6 +772,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CRAN-style check, PDF manual, and explicit manual submission/indexing gates.
 - Added Julia General readiness evidence with passing `Pkg.test()`, Compat and
   TagBot/release workflow verification, and explicit registration/approval gates.
+- Added a draft Spack recipe and blocked upstream-PR handoff with reproducible
+  source-tag, syntax, concretization, and package-visibility evidence.
 - Archived the Julia registry follow-through track with General registration
   and maintainer approval retained as external gates.
 - Archived the R registry follow-through track with CRAN review and r-universe

--- a/conductor/tracks/spack-package-merge-followthrough_20260625/handoff/package.py
+++ b/conductor/tracks/spack-package-merge-followthrough_20260625/handoff/package.py
@@ -1,0 +1,16 @@
+from spack.package import PythonPackage
+
+
+class PyVoiage(PythonPackage):
+    """Draft Spack recipe for upstream review."""
+
+    homepage = "https://github.com/edithatogo/voiage"
+    git = "https://github.com/edithatogo/voiage.git"
+
+    version("0.2.0", commit="653bd313af341cba65b84409b7abfb3af77f1407")
+
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-numpy@1.20:2", type="run")
+    depends_on("py-scipy@1.7:", type="run")
+    depends_on("py-pandas@1.3:", type="run")
+    depends_on("py-xarray@0.19:", type="run")

--- a/conductor/tracks/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json
+++ b/conductor/tracks/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json
@@ -1,0 +1,16 @@
+{
+  "track_id": "spack-package-merge-followthrough_20260625",
+  "channel": "Spack",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "next_action": "Open the draft recipe as an upstream Spack PR, run upstream CI and spack spec/install validation, obtain maintainer merge, and verify package visibility before requesting E4S inclusion.",
+  "external_gate": "The upstream spack-packages repository does not contain py-voiage; maintainer review/merge and package index propagation are external actions.",
+  "evidence_urls": ["https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages/py-voiage", "https://packages.spack.io/package.html?name=py-voiage", "https://github.com/edithatogo/voiage/releases/tag/v0.2.0"],
+  "commands": [
+    {"command":"git ls-remote --tags https://github.com/edithatogo/voiage.git refs/tags/v0.2.0","runner":"networked Git audit","status":"passed","artifact":"v0.2.0 commit 653bd313af341cba65b84409b7abfb3af77f1407","details":"A reproducible source tag exists for the draft recipe."},
+    {"command":"python -m py_compile conductor/tracks/spack-package-merge-followthrough_20260625/handoff/package.py","runner":"local Python 3.14","status":"passed","artifact":"draft package.py","details":"The repository-owned draft Spack recipe is syntactically valid."},
+    {"command":"spack spec py-voiage","runner":"local Spack 1.2.1","status":"blocked","artifact":"concretization error: py-voiage does not exist","details":"Local Spack confirms no registered package is available to concretize."},
+    {"command":"curl -sS -o package.py -w '%{http_code}' https://raw.githubusercontent.com/spack/spack/develop/var/spack/repos/builtin/packages/py-voiage/package.py","runner":"networked upstream audit","status":"not_found","artifact":"HTTP 404","details":"The upstream recipe path is absent; no upstream PR or merge is evidenced."}
+  ]
+}

--- a/conductor/tracks/spack-package-merge-followthrough_20260625/plan.md
+++ b/conductor/tracks/spack-package-merge-followthrough_20260625/plan.md
@@ -72,6 +72,13 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added a syntactically valid draft `handoff/package.py` pinned to the reproducible `v0.2.0` commit.
+- Added `handoff/spack-evidence.json` using the shared external-track handoff schema.
+- Local Spack 1.2.1 reports that `py-voiage` does not exist; the upstream recipe URL returns HTTP 404.
+- Upstream package PR, maintainer merge, and package visibility remain external; the draft is not represented as upstream publication.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -126,7 +126,7 @@ The active follow-through tracks are:
 - `archive/conda-forge-feedstock-publication_20260625`
 - `r-cran-runiverse-publication_20260625` (handoff: `conductor/archive/r-cran-runiverse-publication_20260625/handoff/r-registry-evidence.json`)
 - `julia-general-registry-publication_20260625` (handoff: `conductor/archive/julia-general-registry-publication_20260625/handoff/julia-registry-evidence.json`)
-- `spack-package-merge-followthrough_20260625`
+- `spack-package-merge-followthrough_20260625` (handoff: `conductor/tracks/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json`)
 - `easybuild-easyconfig-merge-followthrough_20260625`
 - `hpsf-curation-submission-followthrough_20260625`
 - `e4s-inclusion-followthrough_20260625`

--- a/tests/test_spack_followthrough.py
+++ b/tests/test_spack_followthrough.py
@@ -1,0 +1,16 @@
+"""Tests for the Spack external-gate handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = Path(
+    "conductor/tracks/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json"
+)
+
+
+def test_spack_handoff_preserves_draft_recipe_and_upstream_gate() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 4
+    assert summary["evidence_count"] == 3


### PR DESCRIPTION
## Summary
- add a draft Spack `package.py` pinned to the reproducible v0.2.0 commit
- capture syntax, local concretization, upstream recipe, and package visibility evidence
- preserve upstream PR and maintainer merge gates

## Verification
- `python -m py_compile conductor/tracks/spack-package-merge-followthrough_20260625/handoff/package.py`
- `uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_spack_followthrough.py`
- `uv run pytest tests/test_spack_followthrough.py tests/test_registry_audit.py tests/test_conductor_followthrough_tracks.py --no-cov` (20 passed)
- `spack spec py-voiage` confirms the package is not currently registered
