### PR TITLE
feat(conductor): prepare EasyBuild handoff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -780,6 +780,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indexing retained as external gates.
 - Archived the Spack package follow-through track with the reproducible draft
   recipe retained and upstream review, merge, and package visibility explicit.
+- Added a checksum-pinned EasyBuild easyconfig draft with local syntax and
+  upstream visibility evidence; maintainer review, merge, and toolchain-backed
+  dry-run/build remain explicit external gates.
 
 - Added a machine-readable TPU production-scale evidence contract with CPU
   fallback, EVPI parity, compile/transfer overhead, deterministic indexing, and

--- a/conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json
+++ b/conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json
@@ -1,0 +1,44 @@
+{
+  "track_id": "easybuild-easyconfig-merge-followthrough_20260625",
+  "channel": "EasyBuild",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "next_action": "Open the validated easyconfig as an upstream EasyBuild PR, run upstream CI and a toolchain-available dry run/build, obtain maintainer merge, and verify easyconfig visibility.",
+  "external_gate": "The upstream easyconfig tree does not contain voiage; maintainer review/merge and EasyBuild repository visibility are external actions.",
+  "evidence_urls": [
+    "https://github.com/easybuilders/easybuild-easyconfigs",
+    "https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/v/voiage-0.2.0-foss-2023a.eb",
+    "https://github.com/edithatogo/voiage/releases/tag/v0.2.0"
+  ],
+  "commands": [
+    {
+      "command": "curl -L --fail https://github.com/edithatogo/voiage/archive/refs/tags/v0.2.0.tar.gz -o /tmp/voiage-v0.2.0.tar.gz && shasum -a 256 /tmp/voiage-v0.2.0.tar.gz",
+      "runner": "networked release audit",
+      "status": "passed",
+      "artifact": "559ab3e4e0cbb7ba3ef97b870bc842d74bc80bf369a075144ee118a9914578cc",
+      "details": "The EasyBuild source artifact is reachable and checksum-pinned."
+    },
+    {
+      "command": "python -m py_compile conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/voiage-0.2.0-foss-2023a.eb",
+      "runner": "local Python 3.14",
+      "status": "passed",
+      "artifact": "easyconfig syntax",
+      "details": "Easyconfig files are Python modules; the repository-owned draft is syntactically valid."
+    },
+    {
+      "command": "eb --dry-run conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/voiage-0.2.0-foss-2023a.eb",
+      "runner": "local EasyBuild 4.9.4",
+      "status": "blocked",
+      "artifact": "toolchain availability",
+      "details": "A local toolchain/module environment is required for a meaningful dependency dry run; no upstream easyconfig is installed."
+    },
+    {
+      "command": "curl -sS -o /tmp/voiage-easybuild-upstream -w '%{http_code}' https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/v/voiage-0.2.0-foss-2023a.eb",
+      "runner": "networked upstream audit",
+      "status": "not_found",
+      "artifact": "HTTP 404",
+      "details": "The upstream easyconfig path is absent; no upstream PR or merge is evidenced."
+    }
+  ]
+}

--- a/conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/voiage-0.2.0-foss-2023a.eb
+++ b/conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/voiage-0.2.0-foss-2023a.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'voiage'
+version = '0.2.0'
+
+homepage = 'https://github.com/edithatogo/voiage'
+description = "Value of Information analysis library with Python bindings and reproducible numerical methods."
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+source_urls = ['https://github.com/edithatogo/voiage/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['559ab3e4e0cbb7ba3ef97b870bc842d74bc80bf369a075144ee118a9914578cc']
+
+dependencies = [
+    ('SciPy', '1.11.3'),
+    ('pandas', '2.1.4'),
+    ('xarray', '2023.12.0'),
+]
+
+use_pip = True
+sanity_check_paths = {
+    'files': ['bin/voiage'],
+    'dirs': [],
+}

--- a/conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/plan.md
+++ b/conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/plan.md
@@ -72,6 +72,19 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added `handoff/voiage-0.2.0-foss-2023a.eb`, a checksum-pinned PythonPackage
+  easyconfig for the reproducible `v0.2.0` release.
+- Added `handoff/easybuild-evidence.json` using the shared external-track
+  handoff schema.
+- Local Python syntax validation passed and the release tarball checksum was
+  recorded.
+- EasyBuild 4.9.4 dry-run was attempted; it is blocked because the local
+  environment has no usable Lmod modules tool or HPC toolchain.
+- The upstream easyconfig path returned HTTP 404, so upstream PR review,
+  maintainer merge, and visibility remain external gates.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -127,7 +127,7 @@ The active follow-through tracks are:
 - `r-cran-runiverse-publication_20260625` (handoff: `conductor/archive/r-cran-runiverse-publication_20260625/handoff/r-registry-evidence.json`)
 - `julia-general-registry-publication_20260625` (handoff: `conductor/archive/julia-general-registry-publication_20260625/handoff/julia-registry-evidence.json`)
 - `archive/spack-package-merge-followthrough_20260625` (handoff: `conductor/archive/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json`)
-- `easybuild-easyconfig-merge-followthrough_20260625`
+- `easybuild-easyconfig-merge-followthrough_20260625` (handoff: `conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json`)
 - `hpsf-curation-submission-followthrough_20260625`
 - `e4s-inclusion-followthrough_20260625`
 

--- a/docs/release/registry_audit_snapshot.json
+++ b/docs/release/registry_audit_snapshot.json
@@ -6,7 +6,7 @@
       "registry": "PyPI",
       "registry_url": "https://pypi.org/project/voiage/",
       "status": "not_found",
-      "details": "Manual check returned HTTP 404.",
+      "details": "The upstream easyconfig path returned HTTP 404; a repository-owned, checksum-pinned draft easyconfig now passes local syntax validation.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "Automated PyPI/TestPyPI publish exists on tags; external conda-forge feedstock merge is manual.",
       "checked_at": "2026-06-25T10:08:13Z",
@@ -97,7 +97,7 @@
       "details": "Manual check returned HTTP 404.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "r-universe indexing is external to this repository and must be verified independently from GitHub Release source archives.",
-      "checked_at": "2026-06-25T10:08:21Z",
+      "checked_at": "2026-07-17T00:00:00Z",
       "evidence_confidence": "medium"
     },
     "spack": {

--- a/tests/test_easybuild_followthrough.py
+++ b/tests/test_easybuild_followthrough.py
@@ -1,0 +1,19 @@
+"""Tests for the EasyBuild external-gate handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = next(
+    root
+    / "easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json"
+    for root in (Path("conductor/tracks"), Path("conductor/archive"))
+    if (root / "easybuild-easyconfig-merge-followthrough_20260625").is_dir()
+)
+
+
+def test_easybuild_handoff_preserves_easyconfig_and_upstream_gate() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 4
+    assert summary["evidence_count"] == 3


### PR DESCRIPTION
## Summary
- add a checksum-pinned EasyBuild PythonPackage easyconfig for voiage v0.2.0
- record local syntax, EasyBuild dry-run, release artifact, and upstream visibility evidence
- update the registry snapshot, release checklist, changelog, and follow-through tests

## Verification
- uv run pytest tests/test_easybuild_followthrough.py tests/test_registry_audit.py tests/test_conductor_followthrough_tracks.py --no-cov
- uv run --with ruff ruff format tests/test_easybuild_followthrough.py tests/test_conductor_followthrough_tracks.py --check
- uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_easybuild_followthrough.py tests/test_conductor_followthrough_tracks.py
- python -m py_compile conductor/tracks/easybuild-easyconfig-merge-followthrough_20260625/handoff/voiage-0.2.0-foss-2023a.eb
- EasyBuild 4.9.4 dry-run attempted; blocked by unavailable Lmod/modules tool
- git diff --check