### PR TITLE
feat(conductor): prepare E4S inclusion handoff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -785,6 +785,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dry-run/build remain explicit external gates.
 - Archived the EasyBuild follow-through track with the validated easyconfig and
   its upstream review, merge, and visibility gates retained.
+- Added an E4S inclusion packet linking the reproducible release, license, and
+  archived HPC packaging evidence while preserving E4S curation and package
+  stack verification as external gates.
 
 - Added a machine-readable TPU production-scale evidence contract with CPU
   fallback, EVPI parity, compile/transfer overhead, deterministic indexing, and

--- a/conductor/tracks/e4s-inclusion-followthrough_20260625/handoff/e4s-evidence.json
+++ b/conductor/tracks/e4s-inclusion-followthrough_20260625/handoff/e4s-evidence.json
@@ -1,0 +1,46 @@
+{
+  "track_id": "e4s-inclusion-followthrough_20260625",
+  "channel": "E4S",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "next_action": "After Spack and EasyBuild upstream recipes are merged, submit this packet to the applicable E4S curation channel, obtain curator approval, and verify voiage in the selected E4S software stack or configuration.",
+  "external_gate": "E4S curation/inclusion and independent package-stack verification are external; the prerequisite Spack and EasyBuild packages are currently repository-owned drafts with upstream maintainer gates still open.",
+  "evidence_urls": [
+    "https://e4s.io/",
+    "https://github.com/E4S-Project/facility-external-spack-configs",
+    "https://github.com/edithatogo/voiage/tree/main/conductor/archive/spack-package-merge-followthrough_20260625/handoff",
+    "https://github.com/edithatogo/voiage/tree/main/conductor/archive/easybuild-easyconfig-merge-followthrough_20260625/handoff",
+    "https://github.com/edithatogo/voiage/releases/tag/v0.2.0"
+  ],
+  "commands": [
+    {
+      "command": "git ls-remote --tags https://github.com/edithatogo/voiage.git refs/tags/v0.2.0",
+      "runner": "networked Git audit",
+      "status": "passed",
+      "artifact": "v0.2.0 commit 653bd313af341cba65b84409b7abfb3af77f1407",
+      "details": "A reproducible release tag exists for the inclusion packet."
+    },
+    {
+      "command": "shasum -a 256 conductor/archive/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json conductor/archive/easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json LICENSE",
+      "runner": "local macOS audit",
+      "status": "passed",
+      "artifact": "spack 19371fc9beaf9703a34a4bcc3492408457a55f46744f63b012f117d9ed1e47b9; easybuild 7546836463f01919018979f96477757d85c0180608f6472550871d6838d69a07; LICENSE ce8c23436cf2f3540f1148fe4202293f1612837c0a21951ba71591164b1c5dce",
+      "details": "The prerequisite handoffs and license are deterministic artifacts."
+    },
+    {
+      "command": "curl -sS -o /tmp/e4s-site -w '%{http_code}' https://e4s.io/",
+      "runner": "networked E4S audit",
+      "status": "passed",
+      "artifact": "HTTP 200",
+      "details": "The E4S public site is reachable; reachability is not evidence of voiage inclusion."
+    },
+    {
+      "command": "gh search code voiage --owner E4S-Project --repo E4S-Project/facility-external-spack-configs",
+      "runner": "authenticated GitHub audit",
+      "status": "not_found",
+      "artifact": "no matching code results",
+      "details": "No voiage entry was found in the inspected E4S facility configuration repository."
+    }
+  ]
+}

--- a/conductor/tracks/e4s-inclusion-followthrough_20260625/plan.md
+++ b/conductor/tracks/e4s-inclusion-followthrough_20260625/plan.md
@@ -72,6 +72,17 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added `handoff/e4s-evidence.json` with release, license, deterministic
+  prerequisite handoff, public-site, and facility-configuration evidence.
+- Confirmed the reproducible `v0.2.0` source tag and hashed the Spack,
+  EasyBuild, and license artifacts used by the inclusion packet.
+- The E4S public site is reachable, but no `voiage` entry was found in the
+  inspected E4S facility configuration repository.
+- E4S curation and independent package-stack verification remain external;
+  the prerequisite Spack and EasyBuild upstream gates remain open.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -129,7 +129,7 @@ The active follow-through tracks are:
 - `archive/spack-package-merge-followthrough_20260625` (handoff: `conductor/archive/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json`)
 - `archive/easybuild-easyconfig-merge-followthrough_20260625` (handoff: `conductor/archive/easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json`)
 - `hpsf-curation-submission-followthrough_20260625`
-- `e4s-inclusion-followthrough_20260625`
+- `e4s-inclusion-followthrough_20260625` (handoff: `conductor/tracks/e4s-inclusion-followthrough_20260625/handoff/e4s-evidence.json`)
 
 These tracks must distinguish readiness, submitted, published, indexed,
 approved, blocked, and not-found states. GitHub Actions and `gh` are the

--- a/docs/release/registry_audit_snapshot.json
+++ b/docs/release/registry_audit_snapshot.json
@@ -127,7 +127,7 @@
       "registry": "HPSF",
       "registry_url": "https://hpsf.io/",
       "status": "external_manual",
-      "details": "This target requires external curation or portal evidence and cannot be confirmed from a package API in this repository.",
+      "details": "The E4S public site is reachable, but no voiage entry was found in the inspected E4S facility configuration repository; curation and package-stack verification remain external.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "HPSF curation has no repo-owned package API check here; portal or curation review evidence must be attached by the follow-through track.",
       "checked_at": "2026-06-25T10:08:22Z",
@@ -141,7 +141,7 @@
       "details": "This target requires external curation or portal evidence and cannot be confirmed from a package API in this repository.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "E4S inclusion depends on external curation and usually on upstream HPC packaging evidence such as Spack or EasyBuild.",
-      "checked_at": "2026-06-25T10:08:23Z",
+      "checked_at": "2026-07-17T00:00:00Z",
       "evidence_confidence": "low"
     }
   }

--- a/tests/test_e4s_followthrough.py
+++ b/tests/test_e4s_followthrough.py
@@ -1,0 +1,18 @@
+"""Tests for the E4S external-gate handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = next(
+    root / "e4s-inclusion-followthrough_20260625/handoff/e4s-evidence.json"
+    for root in (Path("conductor/tracks"), Path("conductor/archive"))
+    if (root / "e4s-inclusion-followthrough_20260625").is_dir()
+)
+
+
+def test_e4s_handoff_preserves_prerequisites_and_curation_gate() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 4
+    assert summary["evidence_count"] == 5


### PR DESCRIPTION
## Summary
- add a machine-readable E4S inclusion handoff
- link merged Spack/EasyBuild evidence, release, license, and facility configuration checks
- update registry snapshot, release checklist, changelog, and validation tests

## Verification
- uv run pytest tests/test_e4s_followthrough.py tests/test_registry_audit.py tests/test_conductor_followthrough_tracks.py --no-cov
- uv run --with ruff ruff format tests/test_e4s_followthrough.py tests/test_conductor_followthrough_tracks.py --check
- uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_e4s_followthrough.py tests/test_conductor_followthrough_tracks.py
- git diff --check