### PR TITLE
feat(conductor): prepare HPSF curation handoff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -790,6 +790,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stack verification as external gates.
 - Archived the E4S follow-through track with curation, stack verification, and
   prerequisite upstream package gates retained as external.
+- Added an HPSF curation packet with current governance, security, release, CI,
+  and public-surface evidence while preserving submission and review as
+  external gates.
 
 - Added a machine-readable TPU production-scale evidence contract with CPU
   fallback, EVPI parity, compile/transfer overhead, deterministic indexing, and

--- a/conductor/tracks/hpsf-curation-submission-followthrough_20260625/handoff/hpsf-evidence.json
+++ b/conductor/tracks/hpsf-curation-submission-followthrough_20260625/handoff/hpsf-evidence.json
@@ -1,0 +1,53 @@
+{
+  "track_id": "hpsf-curation-submission-followthrough_20260625",
+  "channel": "HPSF",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "next_action": "Submit this packet through the HPSF curation/community route after maintainer review, pause for any account-bound submission step, then record curator requested changes or approval and verify any resulting listing.",
+  "external_gate": "HPSF has no repository-owned package API or confirmed voiage listing in the checked public surfaces; portal/community submission, curation review, and listing policy are external actions.",
+  "evidence_urls": [
+    "https://hpsf.io/",
+    "https://github.com/edithatogo/voiage/security/policy",
+    "https://github.com/edithatogo/voiage/releases/tag/v0.2.0",
+    "https://github.com/edithatogo/voiage/actions/runs/29546952487",
+    "https://github.com/edithatogo/voiage/actions/runs/29546952476"
+  ],
+  "commands": [
+    {
+      "command": "git ls-remote --tags https://github.com/edithatogo/voiage.git refs/tags/v0.2.0",
+      "runner": "networked Git audit",
+      "status": "passed",
+      "artifact": "v0.2.0 commit 653bd313af341cba65b84409b7abfb3af77f1407",
+      "details": "A reproducible release tag exists for the submission packet."
+    },
+    {
+      "command": "shasum -a 256 SECURITY.md CODE_OF_CONDUCT.md CONTRIBUTING.md LICENSE",
+      "runner": "local macOS audit",
+      "status": "passed",
+      "artifact": "SECURITY 6b09c05e441e32596414affd7d66ddb5404e7262cebbbb2bf90f79d810480f10; CODE_OF_CONDUCT a4f3df58bbd1d717819b55c16d48d6cef3a5a94866fe7b75ecd60dfbd5b1d869; CONTRIBUTING 7e824f58eef8eff8f34eeec046d533bc94afffbcf6a8da4f5ef8b4b762174d85; LICENSE ce8c23436cf2f3540f1148fe4202293f1612837c0a21951ba71591164b1c5dce",
+      "details": "Governance, security, contribution, and license artifacts are present and hashed."
+    },
+    {
+      "command": "gh api repos/edithatogo/voiage --jq '{visibility,archived,license:.license.spdx_id,default_branch}'",
+      "runner": "authenticated GitHub audit",
+      "status": "passed",
+      "artifact": "public, not archived, Apache-2.0, main",
+      "details": "The repository metadata supports a public curation handoff."
+    },
+    {
+      "command": "gh run list --repo edithatogo/voiage --workflow CI --branch main --status completed --limit 1",
+      "runner": "authenticated GitHub audit",
+      "status": "passed",
+      "artifact": "CI run 29546952487 success at 46791be",
+      "details": "The latest completed main CI run passed; the separate CodeQL run 29546952476 also passed."
+    },
+    {
+      "command": "curl -sS -o /tmp/hpsf-site -w '%{http_code}' https://hpsf.io/",
+      "runner": "networked HPSF audit",
+      "status": "passed",
+      "artifact": "HTTP 200",
+      "details": "The HPSF public site is reachable; reachability is not evidence of a voiage listing or approval."
+    }
+  ]
+}

--- a/conductor/tracks/hpsf-curation-submission-followthrough_20260625/plan.md
+++ b/conductor/tracks/hpsf-curation-submission-followthrough_20260625/plan.md
@@ -72,6 +72,15 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added `handoff/hpsf-evidence.json` with release, governance, security,
+  license, repository metadata, CI, CodeQL, and HPSF-site evidence.
+- Confirmed the public Apache-2.0 repository is not archived, the v0.2.0 tag
+  is reproducible, and the latest completed main CI and CodeQL runs passed.
+- HPSF curation, any portal/community submission, requested changes, approval,
+  and listing verification remain external; site reachability is not approval.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -128,7 +128,7 @@ The active follow-through tracks are:
 - `julia-general-registry-publication_20260625` (handoff: `conductor/archive/julia-general-registry-publication_20260625/handoff/julia-registry-evidence.json`)
 - `archive/spack-package-merge-followthrough_20260625` (handoff: `conductor/archive/spack-package-merge-followthrough_20260625/handoff/spack-evidence.json`)
 - `archive/easybuild-easyconfig-merge-followthrough_20260625` (handoff: `conductor/archive/easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json`)
-- `hpsf-curation-submission-followthrough_20260625`
+- `hpsf-curation-submission-followthrough_20260625` (handoff: `conductor/tracks/hpsf-curation-submission-followthrough_20260625/handoff/hpsf-evidence.json`)
 - `archive/e4s-inclusion-followthrough_20260625` (handoff: `conductor/archive/e4s-inclusion-followthrough_20260625/handoff/e4s-evidence.json`)
 
 These tracks must distinguish readiness, submitted, published, indexed,

--- a/docs/release/registry_audit_snapshot.json
+++ b/docs/release/registry_audit_snapshot.json
@@ -127,10 +127,10 @@
       "registry": "HPSF",
       "registry_url": "https://hpsf.io/",
       "status": "external_manual",
-      "details": "The E4S public site is reachable, but no voiage entry was found in the inspected E4S facility configuration repository; curation and package-stack verification remain external.",
+      "details": "The HPSF public site is reachable, but no repository-owned package API or confirmed voiage listing was found; curation and listing policy remain external.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "HPSF curation has no repo-owned package API check here; portal or curation review evidence must be attached by the follow-through track.",
-      "checked_at": "2026-06-25T10:08:22Z",
+      "checked_at": "2026-07-17T00:00:00Z",
       "evidence_confidence": "low"
     },
     "e4s": {
@@ -138,7 +138,7 @@
       "registry": "E4S",
       "registry_url": "https://e4s.io/",
       "status": "external_manual",
-      "details": "This target requires external curation or portal evidence and cannot be confirmed from a package API in this repository.",
+      "details": "The E4S public site is reachable, but no voiage entry was found in the inspected E4S facility configuration repository; curation and package-stack verification remain external.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "E4S inclusion depends on external curation and usually on upstream HPC packaging evidence such as Spack or EasyBuild.",
       "checked_at": "2026-07-17T00:00:00Z",

--- a/tests/test_hpsf_followthrough.py
+++ b/tests/test_hpsf_followthrough.py
@@ -1,0 +1,18 @@
+"""Tests for the HPSF external-gate handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = next(
+    root / "hpsf-curation-submission-followthrough_20260625/handoff/hpsf-evidence.json"
+    for root in (Path("conductor/tracks"), Path("conductor/archive"))
+    if (root / "hpsf-curation-submission-followthrough_20260625").is_dir()
+)
+
+
+def test_hpsf_handoff_preserves_governance_and_review_gate() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 5
+    assert summary["evidence_count"] == 5


### PR DESCRIPTION
## Summary
- add a machine-readable HPSF curation handoff
- capture governance, security, license, release, repository metadata, CI, CodeQL, and HPSF site evidence
- correct HPSF/E4S registry snapshot details and update the release checklist/changelog

## Verification
- uv run pytest tests/test_hpsf_followthrough.py tests/test_registry_audit.py tests/test_conductor_followthrough_tracks.py --no-cov
- uv run --with ruff ruff format tests/test_hpsf_followthrough.py tests/test_conductor_followthrough_tracks.py --check
- uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_hpsf_followthrough.py tests/test_conductor_followthrough_tracks.py
- git diff --check