### PR TITLE
feat(conductor): prepare FPGA runtime handoff

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -793,6 +793,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an HPSF curation packet with current governance, security, release, CI,
   and public-surface evidence while preserving submission and review as
   external gates.
+- Added an FPGA runtime handoff linking reproducible pre-silicon evidence and
+  the explicit no-board CPU-fallback boundary; board runtime remains external.
 
 - Added a machine-readable TPU production-scale evidence contract with CPU
   fallback, EVPI parity, compile/transfer overhead, deterministic indexing, and

--- a/conductor/tracks/fpga-physical-board-runtime-evidence_20260625/handoff/fpga-runtime-evidence.json
+++ b/conductor/tracks/fpga-physical-board-runtime-evidence_20260625/handoff/fpga-runtime-evidence.json
@@ -1,0 +1,45 @@
+{
+  "track_id": "fpga-physical-board-runtime-evidence_20260625",
+  "channel": "FPGA physical runtime",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "next_action": "Provide an identified physical FPGA board, licensed or open toolchain, bitstream runner, and board access; then capture bitstream hash, runtime timing/throughput, CPU parity, workload hash, and reviewer sign-off.",
+  "external_gate": "No physical FPGA board, board runner, bitstream, or hardware toolchain is available in this repository-only execution context; pre-silicon evidence and CPU fallback remain the authoritative boundary.",
+  "evidence_urls": [
+    "https://github.com/edithatogo/voiage/blob/main/.github/workflows/pre-silicon-evidence.yml",
+    "https://github.com/edithatogo/voiage/blob/main/scripts/pre_silicon_evidence.py",
+    "https://github.com/edithatogo/voiage/blob/main/conductor/archive/fpga-implementation_20260511/working-notes.md",
+    "https://github.com/edithatogo/voiage/blob/main/conductor/archive/hpc-production-speedup-evidence-program_20260625/handoff/packets/fpga-not-available.json"
+  ],
+  "commands": [
+    {
+      "command": "python scripts/pre_silicon_evidence.py fpga --output-root /tmp/voiage-fpga-pre-silicon",
+      "runner": "local Python 3.14",
+      "status": "passed",
+      "artifact": "pre_silicon_evidence_manifest.json sha256 df9ac14cbd4fd16c634c6cbfeed759dd3f2e0af09c6d5e9c50fc1b4d380f4b3d",
+      "details": "The repository-owned FPGA pre-silicon manifest is reproducibly generated."
+    },
+    {
+      "command": "shasum -a 256 conductor/archive/hpc-production-speedup-evidence-program_20260625/handoff/packets/fpga-not-available.json conductor/archive/fpga-implementation_20260511/working-notes.md scripts/pre_silicon_evidence.py .github/workflows/pre-silicon-evidence.yml",
+      "runner": "local macOS audit",
+      "status": "passed",
+      "artifact": "packet d22b9a1378525920795e28dcec88197c0bf4a9609d20cac74cd46d577db387c0; notes e95b6680c7c5fec631697384cb099bf5ca97ff9dc9f952b3af851415459bf70e",
+      "details": "Pre-silicon and unavailable-runtime evidence inputs are deterministic."
+    },
+    {
+      "command": "gh run list --repo edithatogo/voiage --workflow pre-silicon-evidence.yml --branch main --status completed --limit 1",
+      "runner": "authenticated GitHub audit",
+      "status": "not_found",
+      "artifact": "no completed main workflow run returned",
+      "details": "No hosted pre-silicon run is currently available as additional live evidence."
+    },
+    {
+      "command": "inspect archived fpga-not-available packet and explicit fpga placeholder adapter",
+      "runner": "repository evidence audit",
+      "status": "blocked",
+      "artifact": "device: no physical board; cpu_fallback: true",
+      "details": "The existing packet explicitly records physical board, bitstream, and toolchain gates; no board runtime claim is made."
+    }
+  ]
+}

--- a/conductor/tracks/fpga-physical-board-runtime-evidence_20260625/plan.md
+++ b/conductor/tracks/fpga-physical-board-runtime-evidence_20260625/plan.md
@@ -72,6 +72,17 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added `handoff/fpga-runtime-evidence.json` linking the pre-silicon workflow,
+  generator, archived implementation notes, and unavailable-runtime packet.
+- Re-generated the repository-owned FPGA pre-silicon manifest and recorded
+  hashes for the deterministic evidence inputs.
+- No completed hosted pre-silicon run or physical board runtime is available;
+  the existing CPU fallback and explicit no-board packet remain authoritative.
+- Board, bitstream, toolchain/runner, timing, throughput, parity, and reviewer
+  evidence remain external hardware gates.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -130,6 +130,7 @@ The active follow-through tracks are:
 - `archive/easybuild-easyconfig-merge-followthrough_20260625` (handoff: `conductor/archive/easybuild-easyconfig-merge-followthrough_20260625/handoff/easybuild-evidence.json`)
 - `hpsf-curation-submission-followthrough_20260625` (handoff: `conductor/tracks/hpsf-curation-submission-followthrough_20260625/handoff/hpsf-evidence.json`)
 - `archive/e4s-inclusion-followthrough_20260625` (handoff: `conductor/archive/e4s-inclusion-followthrough_20260625/handoff/e4s-evidence.json`)
+- `fpga-physical-board-runtime-evidence_20260625` (handoff: `conductor/tracks/fpga-physical-board-runtime-evidence_20260625/handoff/fpga-runtime-evidence.json`)
 
 These tracks must distinguish readiness, submitted, published, indexed,
 approved, blocked, and not-found states. GitHub Actions and `gh` are the

--- a/tests/test_fpga_followthrough.py
+++ b/tests/test_fpga_followthrough.py
@@ -1,0 +1,19 @@
+"""Tests for the FPGA physical-runtime external-gate handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = next(
+    root
+    / "fpga-physical-board-runtime-evidence_20260625/handoff/fpga-runtime-evidence.json"
+    for root in (Path("conductor/tracks"), Path("conductor/archive"))
+    if (root / "fpga-physical-board-runtime-evidence_20260625").is_dir()
+)
+
+
+def test_fpga_handoff_preserves_pre_silicon_and_board_gate() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 4
+    assert summary["evidence_count"] == 4


### PR DESCRIPTION
## Summary
- add a machine-readable FPGA physical-runtime handoff
- link reproducible pre-silicon evidence, CPU fallback, and the no-board packet
- record exact board, bitstream, toolchain, runner, and runtime evidence gates

## Verification
- uv run pytest tests/test_fpga_followthrough.py tests/test_registry_audit.py tests/test_conductor_followthrough_tracks.py tests/test_pre_silicon_evidence_tracks.py --no-cov
- uv run --with ruff ruff format tests/test_fpga_followthrough.py tests/test_conductor_followthrough_tracks.py --check
- uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_fpga_followthrough.py tests/test_conductor_followthrough_tracks.py
- python scripts/pre_silicon_evidence.py fpga --output-root /tmp/voiage-fpga-pre-silicon
- git diff --check