### PR TITLE
feat(conductor): record custom circuit no-go decision

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -802,6 +802,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime as external gates.
 - Archived the ASIC MPW/silicon follow-through track with shuttle, fabrication,
   bring-up, and runtime evidence retained as external gates.
+- Recorded a no-go decision for production FPGA/ASIC acceleration until direct
+  board/silicon runtime, parity, throughput, cost, maintenance, and review
+  evidence is available.
 - Archived the HPSF curation follow-through track with portal submission,
   curation review, approval, and listing retained as external gates.
 

--- a/conductor/tracks/custom-circuit-production-acceleration-review_20260625/handoff/production-acceleration-decision.json
+++ b/conductor/tracks/custom-circuit-production-acceleration-review_20260625/handoff/production-acceleration-decision.json
@@ -1,0 +1,47 @@
+{
+  "track_id": "custom-circuit-production-acceleration-review_20260625",
+  "channel": "FPGA/ASIC production acceleration review",
+  "status": "blocked",
+  "owner": "voiage-maintainers",
+  "checked_at": "2026-07-17T00:00:00Z",
+  "decision": "no_go",
+  "decision_summary": "Do not make a production FPGA or ASIC acceleration claim. Keep the supported CPU path and explicit FPGA/ASIC placeholders as the public boundary until independently reviewed hardware runtime, parity, throughput, deployment-cost, and maintenance evidence exists.",
+  "next_action": "Reopen the decision only after the archived FPGA and ASIC external gates produce board/silicon runtime packets with CPU comparison, reproducibility, deployment cost, maintenance burden, and reviewer sign-off.",
+  "external_gate": "Physical FPGA board runtime and fabricated ASIC runtime are absent; shuttle/board access, hardware toolchains, silicon, production measurements, and independent review remain external.",
+  "evidence_urls": [
+    "https://github.com/edithatogo/voiage/blob/main/conductor/archive/fpga-physical-board-runtime-evidence_20260625/handoff/fpga-runtime-evidence.json",
+    "https://github.com/edithatogo/voiage/blob/main/conductor/archive/asic-mpw-shuttle-and-silicon-evidence_20260625/handoff/asic-silicon-evidence.json",
+    "https://github.com/edithatogo/voiage/blob/main/conductor/archive/hpc-production-speedup-evidence-program_20260625/handoff/production-speedup-manifest.json",
+    "https://github.com/edithatogo/voiage/blob/main/docs/developer_guide/hpc_native_roadmap.rst"
+  ],
+  "commands": [
+    {
+      "command": "shasum -a 256 conductor/archive/fpga-physical-board-runtime-evidence_20260625/handoff/fpga-runtime-evidence.json conductor/archive/asic-mpw-shuttle-and-silicon-evidence_20260625/handoff/asic-silicon-evidence.json conductor/archive/hpc-production-speedup-evidence-program_20260625/handoff/production-speedup-manifest.json conductor/archive/hpc-production-speedup-evidence-program_20260625/handoff/production-speedup-index.json",
+      "runner": "local macOS audit",
+      "status": "passed",
+      "artifact": "FPGA 807dafe6951efe8e8ef56115c115e3842430e5846ee5613310de02c3c1e50541; ASIC ad2360bb0173af409c62fb4922c6ee835a959d261740f13fca11af2155a11cd0; manifest 47bf77acb1f28591550277336c521709d5dd1799cc901aef5390e57b791dd8cb; index 9831074afcc17755efec55c2bdb89e5e5e1d61b2c3199c3d620df392f4ffac77",
+      "details": "The review packet inputs are deterministic and traceable."
+    },
+    {
+      "command": "inspect production-speedup manifest and FPGA/ASIC unavailable packets",
+      "runner": "repository evidence audit",
+      "status": "blocked",
+      "artifact": "CPU fallback true; FPGA device no physical board; ASIC device no fabricated silicon",
+      "details": "The shared benchmark contract preserves CPU fallback and records no hardware timing, throughput, or speedup."
+    },
+    {
+      "command": "review archived FPGA and ASIC handoff claim boundaries",
+      "runner": "Conductor decision review",
+      "status": "blocked",
+      "artifact": "no board runtime; no GDS/DEF or silicon runtime",
+      "details": "Neither track supplies the direct hardware evidence required for a production claim."
+    },
+    {
+      "command": "rg -n 'CPU fallback|production acceleration|FPGA|ASIC' docs/developer_guide/hpc_native_roadmap.rst",
+      "runner": "documentation audit",
+      "status": "passed",
+      "artifact": "roadmap preserves CPU-first and external-gate wording",
+      "details": "The public documentation distinguishes pre-silicon/placeholder progress from production acceleration."
+    }
+  ]
+}

--- a/conductor/tracks/custom-circuit-production-acceleration-review_20260625/plan.md
+++ b/conductor/tracks/custom-circuit-production-acceleration-review_20260625/plan.md
@@ -72,6 +72,19 @@
 
 ## Verification Commands
 
+## Execution Evidence
+
+- Added `handoff/production-acceleration-decision.json` consolidating the
+  archived FPGA/ASIC packets, shared production-speedup manifest, CPU fallback,
+  and documentation boundary.
+- Decision: **no-go** for production FPGA/ASIC acceleration claims at the
+  current evidence level.
+- The decision is based on absent board/silicon runtime, throughput, parity,
+  deployment-cost, maintenance, and independent-review evidence; placeholders
+  and pre-silicon artifacts remain the supported boundary.
+- Reopen only when external hardware evidence supplies the required measured
+  comparison and review packet.
+
 - [ ] `uv run pytest tests/test_conductor_followthrough_tracks.py --no-cov`
 - [ ] `uv run pytest tests/test_hpc_evidence_docs.py tests/test_registry_audit.py --no-cov` where relevant
 - [ ] `uv run --with tox tox -e lint,typecheck,docs,py314,coverage_report,frontier-contract,version-sync` before final archive when code/docs changes warrant it

--- a/docs/developer_guide/hpc_native_roadmap.rst
+++ b/docs/developer_guide/hpc_native_roadmap.rst
@@ -131,6 +131,12 @@ speedup or hardware outcomes. The active production-evidence tracks are:
 * ``custom-circuit-production-acceleration-review_20260625`` for the final
   go/no-go decision on FPGA/ASIC production acceleration claims.
 
+The current custom-circuit review is a repository-owned **no-go** for
+production FPGA/ASIC acceleration claims. The CPU path remains authoritative
+and FPGA/ASIC remain explicit placeholders or pre-silicon evidence lanes until
+external board/silicon runtime, parity, throughput, deployment-cost,
+maintenance, and independent-review evidence is available.
+
 Until those tracks produce production-sized benchmark packets, the correct
 status remains setup/visibility/parity evidence rather than HPC-native speedup.
 

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -132,6 +132,7 @@ The active follow-through tracks are:
 - `archive/e4s-inclusion-followthrough_20260625` (handoff: `conductor/archive/e4s-inclusion-followthrough_20260625/handoff/e4s-evidence.json`)
 - `archive/fpga-physical-board-runtime-evidence_20260625` (handoff: `conductor/archive/fpga-physical-board-runtime-evidence_20260625/handoff/fpga-runtime-evidence.json`)
 - `archive/asic-mpw-shuttle-and-silicon-evidence_20260625` (handoff: `conductor/archive/asic-mpw-shuttle-and-silicon-evidence_20260625/handoff/asic-silicon-evidence.json`)
+- `custom-circuit-production-acceleration-review_20260625` (handoff: `conductor/tracks/custom-circuit-production-acceleration-review_20260625/handoff/production-acceleration-decision.json`)
 
 These tracks must distinguish readiness, submitted, published, indexed,
 approved, blocked, and not-found states. GitHub Actions and `gh` are the

--- a/tests/test_custom_circuit_review.py
+++ b/tests/test_custom_circuit_review.py
@@ -1,0 +1,23 @@
+"""Tests for the custom-circuit production decision handoff."""
+
+from pathlib import Path
+
+from scripts.validate_external_track_handoff import validate_handoff
+
+HANDOFF = next(
+    root
+    / "custom-circuit-production-acceleration-review_20260625/handoff/production-acceleration-decision.json"
+    for root in (Path("conductor/tracks"), Path("conductor/archive"))
+    if (root / "custom-circuit-production-acceleration-review_20260625").is_dir()
+)
+
+
+def test_custom_circuit_review_records_no_go_boundary() -> None:
+    summary = validate_handoff(HANDOFF)
+    assert summary["status"] == "blocked"
+    assert summary["command_count"] == 4
+    assert summary["evidence_count"] == 4
+
+    payload = HANDOFF.read_text(encoding="utf-8")
+    assert '"decision": "no_go"' in payload
+    assert "CPU path" in payload


### PR DESCRIPTION
## Summary
- add a machine-readable custom-circuit production acceleration decision
- record an evidence-backed no-go for FPGA/ASIC production claims
- preserve CPU fallback and explicit external hardware gates in the roadmap and release checklist

## Verification
- uv run pytest tests/test_custom_circuit_review.py tests/test_registry_audit.py tests/test_conductor_followthrough_tracks.py tests/test_hpc_evidence_docs.py --no-cov
- uv run --with ruff ruff format tests/test_custom_circuit_review.py tests/test_conductor_followthrough_tracks.py --check
- uv run --with ruff ruff check scripts/validate_external_track_handoff.py tests/test_custom_circuit_review.py tests/test_conductor_followthrough_tracks.py
- git diff --check