### PR TITLE
chore(release): prepare 0.2.1 metadata

### DIFF
--- a/bindings/dotnet/src/Voiage.Core/Voiage.Core.csproj
+++ b/bindings/dotnet/src/Voiage.Core/Voiage.Core.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>true</IsPackable>
     <PackageId>Voiage.Core</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>voiage Contributors</Authors>
     <Company>voiage</Company>
     <Description>.NET 11 bindings for the voiage core API contract.</Description>

--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["voiage Contributors <voiage@users.noreply.github.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
  "serde",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voiage-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Canonical Rust core engine and domain-model crate for voiage."

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voiage/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript bindings for the voiage core API contract.",
   "license": "Apache-2.0",
   "type": "module",

--- a/changelog.md
+++ b/changelog.md
@@ -503,6 +503,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dictionary-to-NMA data conversion for ease of use
 
 ### Changed
+- Prepared synchronized package metadata for the upcoming `0.2.1` release.
 - Registered the 32 genuine Conductor tracks in an explicit dependency-aware
   execution order, separated 10 externally blocked tracks from automatic
   selection, and archived two superseded umbrella/duplicate tracks.

--- a/changelog.md
+++ b/changelog.md
@@ -503,7 +503,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dictionary-to-NMA data conversion for ease of use
 
 ### Changed
-- Prepared synchronized package metadata for the upcoming `0.2.1` release.
 - Registered the 32 genuine Conductor tracks in an explicit dependency-aware
   execution order, separated 10 externally blocked tracks from automatic
   selection, and archived two superseded umbrella/duplicate tracks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "voiage"
-version = "0.2.0" # Target version for this phase
+version = "0.2.1"
 description = "A Python library for Value of Information analysis."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 0.2.0
+Version: 0.2.1
 Author: voiage Development Team
 Maintainer: voiage Development Team <voiage@users.noreply.github.com>
 Description: An R interface to the voiage Python library for Value of Information analysis,

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,12 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Prepare the synchronized `0.2.1` release metadata and verify the
+    tag-driven PyPI publication path.
+    *   Updated the canonical Python version and all binding manifests in
+        lockstep; release tagging and publication remain a separate hosted
+        action.
+
 *   [x] Archive the dynamic real-options VOI track after implementing the
     staged runtime and CLI; retain longitudinal-data, parity, and mature
     approval as explicit external gates.

--- a/uv.lock
+++ b/uv.lock
@@ -4324,7 +4324,7 @@ wheels = [
 
 [[package]]
 name = "voiage"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary
- synchronize the canonical 0.2.1 version across all binding manifests
- update the changelog and release task ledger
- validate the tag-driven PyPI artifact path

## Verification
- uv run python scripts/validate_version_sync.py
- uvx tox -e py314 --recreate
- uv build
- uvx twine check