### PR TITLE
fix(release): avoid duplicate upload attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         verbose: true
         print-hash: true
         skip-existing: true
+        attestations: false
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
@@ -62,6 +63,7 @@ jobs:
         packages-dir: dist/
         verbose: true
         print-hash: true
+        attestations: false
 
     - name: Create GitHub Release
       run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --verify-tag

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevented the TestPyPI and PyPI upload steps from attempting to create
+  duplicate release attestations in the shared build directory.
+
 ### Removed
 - Removed stale `conductor/tracks/dataset-registry-and-example-corpus_20260625/` and
   `conductor/tracks/voi-frontier-architecture-dependency-governance_20260625/`

--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Prevented the TestPyPI and PyPI upload steps from attempting to create
-  duplicate release attestations in the shared build directory.
-
 ### Removed
 - Removed stale `conductor/tracks/dataset-registry-and-example-corpus_20260625/` and
   `conductor/tracks/voi-frontier-architecture-dependency-governance_20260625/`
@@ -571,6 +567,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Renovate configuration for automated dependency updates
 
 ### Fixed
+- Prevented the TestPyPI and PyPI upload steps from attempting to create
+  duplicate release attestations in the shared build directory.
 - Moved the blocking code-scanning gate into a separate least-privilege job so
   OpenSSF can verify and publish Scorecard results without rejecting the custom
   policy step in its privileged analysis job.

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Prevent duplicate release-attestation generation across the TestPyPI
+    and PyPI upload steps so the tag-driven publication workflow completes.
+
 *   [x] Prepare the synchronized `0.2.1` release metadata and verify the
     tag-driven PyPI publication path.
     *   Updated the canonical Python version and all binding manifests in


### PR DESCRIPTION
The release workflow creates build provenance attestations once. Disable the upload action's duplicate attestation generation so TestPyPI and PyPI can both consume the shared dist directory.

Checks: version-sync validation and diff check passed locally.