### PR TITLE
feat(release): support manual tag republishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to publish"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,6 +19,8 @@ jobs:
   release:
     name: Build and Publish
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     permissions:
       contents: write
       id-token: write
@@ -66,6 +74,6 @@ jobs:
         attestations: false
 
     - name: Create GitHub Release
-      run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --verify-tag
+      run: gh release create "$RELEASE_TAG" dist/* --generate-notes --verify-tag
       env:
         GH_TOKEN: ${{ github.token }}

--- a/changelog.md
+++ b/changelog.md
@@ -569,6 +569,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Prevented the TestPyPI and PyPI upload steps from attempting to create
   duplicate release attestations in the shared build directory.
+- Added a manual release-workflow trigger for safely retrying an existing tag
+  when a hosted publication step fails after artifact creation.
 - Moved the blocking code-scanning gate into a separate least-privilege job so
   OpenSSF can verify and publish Scorecard results without rejecting the custom
   policy step in its privileged analysis job.

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -16,7 +16,10 @@ def test_python_release_workflow_matches_documented_tag_flow() -> None:
         "Publish to PyPI"
     )
     assert "uv build" in release_workflow
-    assert 'gh release create "$GITHUB_REF_NAME"' in release_workflow
+    assert "workflow_dispatch:" in release_workflow
+    assert 'description: "Existing release tag to publish"' in release_workflow
+    assert 'RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}' in release_workflow
+    assert 'gh release create "$RELEASE_TAG"' in release_workflow
     assert "--generate-notes --verify-tag" in release_workflow
     assert "GH_TOKEN: ${{ github.token }}" in release_workflow
 

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -18,7 +18,7 @@ def test_python_release_workflow_matches_documented_tag_flow() -> None:
     assert "uv build" in release_workflow
     assert "workflow_dispatch:" in release_workflow
     assert 'description: "Existing release tag to publish"' in release_workflow
-    assert 'RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}' in release_workflow
+    assert "RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}" in release_workflow
     assert 'gh release create "$RELEASE_TAG"' in release_workflow
     assert "--generate-notes --verify-tag" in release_workflow
     assert "GH_TOKEN: ${{ github.token }}" in release_workflow

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -18,7 +18,9 @@ def test_python_release_workflow_matches_documented_tag_flow() -> None:
     assert "uv build" in release_workflow
     assert "workflow_dispatch:" in release_workflow
     assert 'description: "Existing release tag to publish"' in release_workflow
-    assert "RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}" in release_workflow
+    assert (
+        "RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}" in release_workflow
+    )
     assert 'gh release create "$RELEASE_TAG"' in release_workflow
     assert "--generate-notes --verify-tag" in release_workflow
     assert "GH_TOKEN: ${{ github.token }}" in release_workflow


### PR DESCRIPTION
Add a manual release trigger accepting an existing tag, while preserving normal tag pushes. This provides a safe retry path after a hosted publication failure.

The release workflow also uses the corrected non-duplicating attestation settings from the merged release fix.