### PR TITLE
feat(release): derive Python version from tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       with:
+        fetch-depth: 0
         persist-credentials: false
 
     - name: Install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       with:
         fetch-depth: 0
+        ref: ${{ inputs.release_tag || github.ref }}
         persist-credentials: false
 
     - name: Install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to publish"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,6 +19,8 @@ jobs:
   release:
     name: Build and Publish
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     permissions:
       contents: write
       id-token: write
@@ -66,6 +74,6 @@ jobs:
         attestations: false
 
     - name: Create GitHub Release
-      run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --verify-tag
+      run: gh release create "$RELEASE_TAG" dist/* --generate-notes --verify-tag
       env:
         GH_TOKEN: ${{ github.token }}

--- a/changelog.md
+++ b/changelog.md
@@ -503,6 +503,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dictionary-to-NMA data conversion for ease of use
 
 ### Changed
+- Python package versions are now derived from release tags with
+  `setuptools-scm`; binding manifests continue to track the latest released
+  version.
 - Registered the 32 genuine Conductor tracks in an explicit dependency-aware
   execution order, separated 10 externally blocked tracks from automatic
   selection, and archived two superseded umbrella/duplicate tracks.

--- a/changelog.md
+++ b/changelog.md
@@ -569,6 +569,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Prevented the TestPyPI and PyPI upload steps from attempting to create
   duplicate release attestations in the shared build directory.
+- Added a manual release-workflow trigger for safely retrying an existing tag
+  when a hosted publication step fails after artifact creation.
 - Moved the blocking code-scanning gate into a separate least-privilege job so
   OpenSSF can verify and publish Scorecard results without rejecting the custom
   policy step in its privileged analysis job.

--- a/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
@@ -3,11 +3,19 @@ title: Versioning & Release Policy
 description: Semantic versioning and release flow for voiage
 ---
 
-`voiage` uses semantic versioning and tag-driven releases. The repository needs one canonical version source so manifests and release automation stay in lockstep.
+`voiage` uses semantic versioning and tag-driven releases. Python package
+metadata is derived from release tags with `setuptools-scm`, while the
+polyglot manifests remain explicit and synchronized to the latest released
+version.
 
 ## Canonical version source
 
-The current release line treats `pyproject.toml` as the canonical source of truth for the repository version. That version drives Python package metadata, release tag checks, and validation of binding manifests.
+The Python package declares a dynamic version in `pyproject.toml` and
+`setuptools-scm` derives it from the nearest `v*` tag. A checkout at a release
+tag builds the exact release version; an untagged development checkout builds
+an identifiable development version. The version-sync validator resolves the
+latest reachable release tag and compares the external binding manifests to
+that released version.
 
 Binding manifests are expected to match the canonical version exactly:
 
@@ -28,7 +36,9 @@ The repository keeps ecosystem-specific tag and registry conventions:
 - .NET publishes from `dotnet-v*` tags
 - R publishes from `r-v*` tags
 
-The version numbers in package manifests must align with the canonical repository version. Tag prefixes and registry targets remain ecosystem-specific; only the version value is shared.
+The version numbers in package manifests must align with the latest released
+Python tag. Tag prefixes and registry targets remain ecosystem-specific; only
+the version value is shared.
 
 ## Validation
 
@@ -46,7 +56,7 @@ uv run python scripts/validate_version_sync.py
 
 ## Release flow
 
-1. Update the canonical version in `pyproject.toml`
-2. Update the binding manifests to the same version
-3. Run the version-sync validator
-4. Cut the matching tag and let ecosystem-specific release workflows run
+1. Update the binding manifests to the next release version
+2. Run the version-sync validator against the current release tag
+3. Cut the matching `v<version>` tag
+4. Let the tag-specific release workflows build the Python package and publish it

--- a/docs/developer_guide/versioning_and_release_policy.rst
+++ b/docs/developer_guide/versioning_and_release_policy.rst
@@ -1,16 +1,20 @@
 Versioning and Release Policy
 =============================
 
-``voiage`` uses semantic versioning and tag-driven releases, but the
-repository needs one canonical version source so manifests and release
-automation stay in lockstep.
+``voiage`` uses semantic versioning and tag-driven releases. Python package
+metadata is derived from release tags with ``setuptools-scm``, while the
+polyglot manifests remain explicit and synchronized to the latest released
+version.
 
 Canonical version source
 ------------------------
 
-The current release line treats ``pyproject.toml`` as the canonical source of
-truth for the repository version. That version drives the Python package
-metadata, the release tag checks, and the validation of the binding manifests.
+The Python package declares a dynamic version in ``pyproject.toml`` and
+``setuptools-scm`` derives it from the nearest ``v*`` tag. A checkout at a
+release tag builds the exact release version; an untagged development checkout
+builds an identifiable development version. The version-sync validator
+resolves the latest reachable release tag and compares the external binding
+manifests to that released version.
 
 Binding manifests are expected to match the canonical version exactly:
 
@@ -33,7 +37,7 @@ The repository keeps ecosystem-specific tag and registry conventions:
 * R publishes from ``r-v*`` tags.
 
 The version numbers in those package manifests still need to line up with the
-canonical repository version. The tag prefixes and registry targets remain
+latest released Python tag. The tag prefixes and registry targets remain
 ecosystem-specific; only the version value is shared.
 
 Validation
@@ -55,11 +59,11 @@ or, equivalently:
 Release flow
 ------------
 
-When changing versions:
+When preparing a release:
 
-1. Update the canonical version in ``pyproject.toml``.
-2. Update the binding manifests to the same version.
-3. Run the version-sync validator.
-4. Cut the matching tag and let the ecosystem-specific release workflows run.
+1. Update the binding manifests to the next release version.
+2. Run the version-sync validator against the current release tag.
+3. Cut the matching ``v<version>`` tag.
+4. Let the tag-specific release workflows build and publish the Python package.
 
 The validator keeps the repo honest before release automation starts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 # pyproject.toml for voiage
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=69.0", "setuptools-scm>=8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "voiage"
-version = "0.2.1"
+dynamic = ["version"]
 description = "A Python library for Value of Information analysis."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -110,6 +110,11 @@ voiage = "voiage.cli:app"
 where = ["."]
 include = ["voiage*"]
 exclude = ["tests*"]
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0.dev0"
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
 
 [tool.ruff]
 target-version = "py310"
@@ -219,7 +224,6 @@ runner = "pytest -x --no-cov"
 fail_under = 90
 
 [tool.semantic_release]
-version_variables = ["pyproject.toml:project.version"]
 version_source = "tag"
 upload_to_pypi = true
 upload_to_release = true

--- a/roadmap.md
+++ b/roadmap.md
@@ -122,7 +122,10 @@ evidence-obsolescence/refresh VOI, and strategic behavior/game-theoretic VOI.
     *   **Status: `✅ Done`**
     *   TestPyPI → PyPI publishing on `v*` tags, plus conda-forge feedstock recipe updates with the external feedstock merge remaining outside this repository.
     *   Polyglot release workflows now publish npm, crates.io, and NuGet packages and attach GitHub release artifacts for Go, Julia, and R bindings. The R package currently ships source archives on GitHub Releases, while CRAN remains the maturity target and r-universe remains an optional external indexing path; registry-side indexing or approval still depends on the external ecosystem for conda-forge, CRAN/r-universe, and the Julia General registry.
-    *   Repository versioning is now explicit policy: `pyproject.toml` is the canonical source of truth for the current release line, the external binding manifests must stay in lockstep, and the version-sync validator is enforced in CI and local tox automation.
+    *   Repository versioning is now tag-derived for Python through
+        `setuptools-scm`; external binding manifests stay synchronized to the
+        latest released tag, and the version-sync validator is enforced in CI
+        and local tox automation.
 2.  **Dependency Management:**
     *   **Status: `✅ Done`**
     *   uv for package management, Renovate for automated updates.

--- a/tests/test_ci_cd_quality_gates.py
+++ b/tests/test_ci_cd_quality_gates.py
@@ -295,6 +295,10 @@ class TestCICDQualityGatesConfiguration:
         assert "version-sync" in ci_config["jobs"], (
             "Version sync validation job not found"
         )
+        checkout = ci_config["jobs"]["version-sync"]["steps"][0]
+        assert checkout["with"]["fetch-depth"] == 0, (
+            "Version sync requires release tags from a full checkout"
+        )
 
 
 class TestQualityGatePolicyCompliance:

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -16,7 +16,10 @@ def test_python_release_workflow_matches_documented_tag_flow() -> None:
         "Publish to PyPI"
     )
     assert "uv build" in release_workflow
-    assert 'gh release create "$GITHUB_REF_NAME"' in release_workflow
+    assert "workflow_dispatch:" in release_workflow
+    assert 'description: "Existing release tag to publish"' in release_workflow
+    assert 'RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}' in release_workflow
+    assert 'gh release create "$RELEASE_TAG"' in release_workflow
     assert "--generate-notes --verify-tag" in release_workflow
     assert "GH_TOKEN: ${{ github.token }}" in release_workflow
 

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -18,7 +18,7 @@ def test_python_release_workflow_matches_documented_tag_flow() -> None:
     assert "uv build" in release_workflow
     assert "workflow_dispatch:" in release_workflow
     assert 'description: "Existing release tag to publish"' in release_workflow
-    assert 'RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}' in release_workflow
+    assert "RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}" in release_workflow
     assert 'gh release create "$RELEASE_TAG"' in release_workflow
     assert "--generate-notes --verify-tag" in release_workflow
     assert "GH_TOKEN: ${{ github.token }}" in release_workflow

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -18,7 +18,9 @@ def test_python_release_workflow_matches_documented_tag_flow() -> None:
     assert "uv build" in release_workflow
     assert "workflow_dispatch:" in release_workflow
     assert 'description: "Existing release tag to publish"' in release_workflow
-    assert "RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}" in release_workflow
+    assert (
+        "RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}" in release_workflow
+    )
     assert 'gh release create "$RELEASE_TAG"' in release_workflow
     assert "--generate-notes --verify-tag" in release_workflow
     assert "GH_TOKEN: ${{ github.token }}" in release_workflow

--- a/tests/test_versioning_and_gpu_edge_cases.py
+++ b/tests/test_versioning_and_gpu_edge_cases.py
@@ -58,6 +58,20 @@ def test_versioning_helpers_cover_error_paths(tmp_path: Path) -> None:
     assert "1.2.3" in formatted
 
 
+def test_dynamic_canonical_version_comes_from_release_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\ndynamic = ['version']\n", encoding="utf-8")
+    monkeypatch.setattr(
+        versioning.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="v0.2.1\n"),
+    )
+
+    assert versioning._read_canonical_version(pyproject) == "0.2.1"
+
+
 def test_versioning_load_helpers_and_version_extractors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,11 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Enable tag-derived Python package versioning with `setuptools-scm`.
+    *   Release tags now build exact Python versions; development checkouts
+        produce identifiable development versions, while binding manifests
+        remain synchronized to the latest reachable release tag.
+
 *   [x] Prevent duplicate release-attestation generation across the TestPyPI
     and PyPI upload steps so the tag-driven publication workflow completes.
 

--- a/uv.lock
+++ b/uv.lock
@@ -4324,7 +4324,6 @@ wheels = [
 
 [[package]]
 name = "voiage"
-version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },

--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -1,8 +1,8 @@
 """Version synchronization helpers for release automation.
 
-The repository treats ``pyproject.toml`` as the canonical version source for
-the current release line. This module validates that the external binding
-manifests stay in lockstep with that repository version.
+The Python package derives its version from release tags. This module resolves
+the latest reachable release tag and validates that external binding manifests
+stay in lockstep with that released version.
 """
 
 import argparse
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import json
 from pathlib import Path
 import re
+import subprocess  # nosec B404 - fixed git executable is used for tag discovery.
 import sys
 from typing import Any
 
@@ -65,14 +66,46 @@ def _load_json(path: Path) -> dict[str, Any]:
     return data
 
 
+def _read_release_tag_version(repo_root: Path) -> str | None:
+    """Return the newest release tag version, or ``None`` when unavailable."""
+    result = subprocess.run(  # nosec B603 B607 - fixed argv, no shell, repo-local cwd.
+        [  # noqa: S607 - git is the fixed executable used for tag discovery.
+            "git",
+            "describe",
+            "--tags",
+            "--match",
+            "v[0-9]*",
+            "--abbrev=0",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    tag = result.stdout.strip()
+    if not tag.startswith("v") or len(tag) == 1:
+        return None
+    return tag[1:]
+
+
 def _read_canonical_version(pyproject_path: Path) -> str:
     project = _load_toml(pyproject_path).get("project")
     if not isinstance(project, dict):
         raise VersionSyncError(f"{pyproject_path}: missing [project] table")
     version = project.get("version")
-    if not isinstance(version, str) or not version.strip():
-        raise VersionSyncError(f"{pyproject_path}: missing project.version")
-    return version
+    if isinstance(version, str) and version.strip():
+        return version
+    dynamic = project.get("dynamic", [])
+    if isinstance(dynamic, list) and "version" in dynamic:
+        release_version = _read_release_tag_version(pyproject_path.parent)
+        if release_version:
+            return release_version
+        raise VersionSyncError(
+            f"{pyproject_path}: dynamic version requires a reachable v* release tag"
+        )
+    raise VersionSyncError(f"{pyproject_path}: missing project.version")
 
 
 def _read_json_version(path: Path) -> str:


### PR DESCRIPTION
## Summary
- derive the Python package version from `v*` release tags with `setuptools-scm`
- keep external binding manifests synchronized against the latest reachable release tag
- make release workflow manual retries check out and build the selected tag exactly
- document the versioning and release policy in Astro and legacy docs

## Verification
- `uvx tox -e lint,py312`
- full tox run passed on Python 3.13 and 3.14; remaining matrix setup initially exhausted local disk, then Python 3.12 and lint were rerun successfully
- `uv run pytest tests/test_version_sync.py tests/test_versioning_and_gpu_edge_cases.py tests/test_python_release_workflow.py -q`
- `uv build` and `twine check`
