### PR TITLE
chore(governance): harden solo-maintainer harness

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,16 +3,8 @@ name: GitHub Actions Audit
 on:
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - ".github/dependabot.yml"
-      - "renovate.json"
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - ".github/dependabot.yml"
-      - "renovate.json"
   schedule:
     - cron: "31 4 * * 1"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,44 @@ This document outlines the standard operating procedure for AI agents contributi
 
 The primary objective is to advance the `voiage` library by implementing features, fixing bugs, and improving the codebase, guided by the `roadmap.md` and `todo.md` files. The ultimate vision is to establish `voiage` as the premier, cross-domain, high-performance library for Value of Information analysis.
 
+## Context Loading Order
+
+Before making a change, load context in this order:
+
+1. `AGENTS.md` for agent protocol and repository boundaries.
+2. `roadmap.md` and `todo.md` for current priorities and completed work.
+3. `CONTRIBUTING.md` and `docs/developer_guide/quality_and_security.rst` for
+   implementation and verification rules.
+4. The relevant package, test, workflow, Conductor track, and binding files.
+
+When sources disagree, prefer executable tests and active workflow/configuration
+over narrative status documents, then update the stale narrative in the same
+change. Treat `voiage/` as the Python runtime, `tests/` as behavioral evidence,
+`specs/` and `conductor/` as contract/roadmap evidence, `docs/astro-site/` as
+the documentation source, and `.github/` plus `tox.ini` as the automation
+contract.
+
+## Repository Context Map
+
+* `voiage/`: public Python API, methods, schemas, CLI, and backend boundaries.
+* `tests/`: unit, integration, property, workflow, registry, and evidence tests.
+* `specs/`: canonical API, ecosystem, frontier, and binding contracts.
+* `bindings/` and `r-package/`: polyglot surfaces whose manifests must remain
+  synchronized with the Python release policy.
+* `conductor/tracks/`: active execution tracks; `conductor/archive/`: completed
+  or externally gated records.
+* `docs/astro-site/`: Astro/Starlight source and build output contract.
+* `.github/workflows/`: hosted quality, security, release, and evidence gates.
+
+## Solo-Maintainer Merge Policy
+
+The repository is operated by a single maintainer. Pull requests remain the
+auditable change boundary, but no independent reviewer approval is required:
+the protected `main` ruleset uses zero required approvals and does not require
+code-owner review. The maintainer must still self-review the diff and wait for
+all required automated checks, security gates, resolved threads, linear-history
+and signed-commit controls before merging.
+
 ## Agent Operating Procedure
 
 Agents must follow this sequence for every contribution:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,11 @@ We welcome contributions from the community, whether from humans or AI agents. T
 
 ## Development Workflow
 
+This is currently a solo-maintainer repository. Pull requests are retained for
+traceability and automated quality gates, but an additional human approval is
+not required. The maintainer should self-review every diff and merge only after
+the required CI, security, coverage, documentation, and contract checks pass.
+
 1.  **Create a Branch:**
     *   Create a new branch for your feature or bugfix:
         ```bash

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conductor/setup_state.json` to `.gitignore` as Conductor tool runtime state.
 
 ### Added
+- Added explicit agent context-loading order, a repository context map, and a
+  solo-maintainer merge policy; the fail-closed harness now protects these
+  governance surfaces from disappearing.
+
 - Added discrete GPU/CUDA benchmark packet validation for CPU comparison,
   transfer and compile overhead, result parity, CPU fallback, and explicit
   Colab/cloud runner blocks; T4 visibility alone does not prove speedup.

--- a/scripts/repo_harness.py
+++ b/scripts/repo_harness.py
@@ -19,12 +19,22 @@ REQUIRED_FILES = (
     "pyproject.toml",
     "tox.ini",
     ".github/CODEOWNERS",
+    ".github/PULL_REQUEST_TEMPLATE/default.md",
+    ".pre-commit-config.yaml",
+    "roadmap.md",
+    "todo.md",
+    "changelog.md",
 )
 REQUIRED_WORKFLOWS = (
     "ci.yml",
     "codeql.yml",
     "dependency-review.yml",
     "scorecard.yml",
+)
+REQUIRED_CONTEXT_MARKERS = (
+    "## Context Loading Order",
+    "## Repository Context Map",
+    "## Solo-Maintainer Merge Policy",
 )
 
 
@@ -52,6 +62,19 @@ def check_required_files(root: Path) -> list[Finding]:
         Finding(relative_path, "required file is missing")
         for relative_path in REQUIRED_FILES
         if not (root / relative_path).is_file()
+    ]
+
+
+def check_context_contract(root: Path) -> list[Finding]:
+    """Ensure agent-facing repository context remains explicit and discoverable."""
+    path = root / "AGENTS.md"
+    if not path.is_file():
+        return []
+    text = path.read_text(encoding="utf-8")
+    return [
+        Finding("AGENTS.md", f"required context section is missing: {marker}")
+        for marker in REQUIRED_CONTEXT_MARKERS
+        if marker not in text
     ]
 
 
@@ -162,6 +185,7 @@ def collect_findings(root: Path) -> list[Finding]:
     """Run all deterministic harness checks."""
     return (
         check_required_files(root)
+        + check_context_contract(root)
         + check_workflows(root)
         + check_docs_platform(root)
         + check_conflict_markers(root)

--- a/tests/test_repo_harness.py
+++ b/tests/test_repo_harness.py
@@ -2,7 +2,12 @@
 
 from pathlib import Path
 
-from scripts.repo_harness import check_docs_platform, check_workflows, collect_findings
+from scripts.repo_harness import (
+    check_context_contract,
+    check_docs_platform,
+    check_workflows,
+    collect_findings,
+)
 
 ROOT = Path(__file__).parents[1]
 
@@ -32,3 +37,12 @@ def test_sphinx_build_configuration_is_rejected(tmp_path: Path) -> None:
     (tmp_path / "docs" / "conf.py").write_text("project = 'legacy'\n", encoding="utf-8")
     findings = check_docs_platform(tmp_path)
     assert any("Sphinx" in finding.message for finding in findings)
+
+
+def test_missing_agent_context_section_is_rejected(tmp_path: Path) -> None:
+    """The harness keeps agent-facing repository context explicit."""
+    (tmp_path / "AGENTS.md").write_text(
+        "# Agent Protocol\n\n## Context Loading Order\n", encoding="utf-8"
+    )
+    findings = check_context_contract(tmp_path)
+    assert any("Repository Context Map" in finding.message for finding in findings)

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,13 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Strengthen context and harness engineering for the solo-maintainer
+    workflow while retaining pull-request traceability and automated review
+    gates.
+    *   Added explicit agent context loading order and repository map, expanded
+        fail-closed governance checks, and documented that independent review
+        approval is intentionally not required.
+
 *   [x] Enable tag-derived Python package versioning with `setuptools-scm`.
     *   Release tags now build exact Python versions; development checkouts
         produce identifiable development versions, while binding manifests


### PR DESCRIPTION
## Summary
- make agent context-loading order and repository ownership boundaries explicit
- document the solo-maintainer policy: PR traceability and automated gates remain, independent approval is not required
- extend the fail-closed harness to protect governance/context files and sections

Hosted policy updates applied separately:
- squash-only merges, zero required approvals, no code-owner approval
- active required signed commits
- 90% ruleset coverage floor aligned with CI
- all stable PR quality/security checks required
- active CodeQL, dependency review, secret scanning push protection, and Dependabot updates

## Verification
- `uv run pytest tests/test_repo_harness.py tests/test_ci_cd_quality_gates.py -q`
- `uv run python scripts/repo_harness.py`
- Ruff check and format check
- `git diff --check`
