### PR TITLE
Prepare conda-forge 0.2.1 recipe

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conductor/setup_state.json` to `.gitignore` as Conductor tool runtime state.
 
 ### Added
+- Added a conda-forge-ready `0.2.1` recipe pinned to the published source
+  distribution hash, current runtime constraints, and Python 3.10–3.14 build
+  variants; the recipe passes a local conda-build package test.
+
 - Added explicit agent context-loading order, a repository context map, and a
   solo-maintainer merge policy; the fail-closed harness now protects these
   governance surfaces from disappearing.

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -8,10 +8,10 @@ To build the conda package locally:
 
 ```bash
 # Install conda-build
-conda install conda-build
+conda install -n base conda-build
 
 # Build the package
-conda build .
+conda build conda-recipe
 
 # Install the built package
 conda install -c local voiage
@@ -23,37 +23,32 @@ To publish to conda-forge:
 
 1. Fork the [conda-forge/staged-recipes](https://github.com/conda-forge/staged-recipes) repository
 2. Copy this recipe directory to `recipes/voiage` in the forked repository
-3. Update the SHA256 hash in `meta.yaml` with the actual hash of the PyPI release
-4. Submit a pull request to conda-forge/staged-recipes
+3. Submit a pull request to `conda-forge/staged-recipes`; the recipe is pinned
+   to the published `voiage 0.2.1` sdist and its verified SHA256 hash.
 
 ## Recipe Structure
 
 - `meta.yaml`: Main recipe file with package metadata and dependencies
 - `conda_build_config.yaml`: Configuration for building against multiple Python versions
-- `build.sh`: Build script for Unix-like systems (automatically generated)
-- `bld.bat`: Build script for Windows (automatically generated)
+- `conda_build_config.yaml`: Python-version matrix used for local and staged builds
 
 ## Dependencies
 
 The recipe specifies the following dependencies:
 
 ### Host Dependencies
-- python >=3.8
+- python >=3.10
 - pip
-- setuptools >=45
+- setuptools >=69
+- setuptools_scm >=8
 - wheel
 
 ### Run Dependencies
-- python >=3.8
-- numpy >=1.20.0
-- scipy >=1.7.0
-- pandas >=1.3.0
-- xarray >=0.18.0
-- matplotlib >=3.4.0
-- seaborn >=0.11.0
-- scikit-learn >=1.0.0
-- jax >=0.2.0
-- jaxlib >=0.1.65
+- python >=3.10
+- defusedxml >=0.7.1
+- numpy, scipy, pandas, xarray, numpyro, jax
+- scikit-learn, statsmodels, matplotlib, seaborn
+- psutil, typing_extensions, typer
 
 ## Testing
 

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,25 +1,6 @@
 python:
-  - 3.8.* *_cpython
-  - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
-
-numpy:
-  - 1.20
-  - 1.21
-  - 1.22
-  - 1.23
-
-scipy:
-  - 1.7
-  - 1.8
-  - 1.9
-  - 1.10
-
-pin_run_as_build:
-  numpy:
-    min_pin: x.x
-    max_pin: x.x
-  scipy:
-    min_pin: x.x
-    max_pin: x.x
+  - 3.12.* *_cpython
+  - 3.13.* *_cpython
+  - 3.14.* *_cpython

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,38 +1,48 @@
 {% set name = "voiage" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: placeholder_sha256_hash
+  url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: eedf952ffd1b0eae1e7aef8d17983f7da7f4dbf5d290796453c5e8e22b8dac5e
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - voiage = voiage.cli:main
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.10
     - pip
-    - setuptools >=45
+    - setuptools >=69
+    - setuptools_scm >=8
     - wheel
   run:
-    - python >=3.8
-    - numpy >=1.20.0
-    - scipy >=1.7.0
-    - pandas >=1.3.0
-    - xarray >=0.18.0
-    - matplotlib >=3.4.0
-    - seaborn >=0.11.0
-    - scikit-learn >=1.0.0
-    - jax >=0.2.0
-    - jaxlib >=0.1.65
+    - python >=3.10
+    - defusedxml >=0.7.1
+    - numpy >=1.22,<2.0  # [py<311]
+    - numpy >=2.2.6,<3.0  # [py>=311]
+    - scipy >=1.7,<1.15  # [py<311]
+    - scipy >=1.16.3,<1.17  # [py>=311]
+    - pandas >=1.3,<3.0
+    - xarray >=0.19,<2025.0
+    - numpyro >=0.14,<0.20  # [py<311]
+    - numpyro >=0.21.0,<0.22  # [py>=311]
+    - jax >=0.4.33,<0.6  # [py<311]
+    - jax >=0.7.1,<0.8  # [py>=311]
+    - scikit-learn >=1.0,<2.0
+    - statsmodels >=0.13,<1.0
+    - matplotlib >=3.4,<4.0
+    - seaborn >=0.13.2,<1.0
+    - psutil >=5.9,<8.0
+    - typing_extensions >=4.0
+    - typer >=0.9,<1.0
 
 test:
   imports:
@@ -46,7 +56,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/doughnut/voiage
+  home: https://github.com/edithatogo/voiage
   summary: A Python library for Value of Information analysis
   description: |
     voiage is a Python library for Value of Information (VOI) analysis, 
@@ -54,11 +64,11 @@ about:
     and decision-makers. It implements core VOI methods including EVPI, EVPPI, 
     and EVSI, as well as advanced methods for adaptive trial designs, network 
     meta-analyses, and structural uncertainty.
-  dev_url: https://github.com/doughnut/voiage
-  doc_url: https://voiage.readthedocs.io
-  license: MIT
+  dev_url: https://github.com/edithatogo/voiage
+  doc_url: https://edithatogo.github.io/voiage
+  license: Apache-2.0
   license_file: LICENSE
-  license_family: MIT
+  license_family: Apache
 
 extra:
   recipe-maintainers:

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,10 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Prepare the pinned `0.2.1` conda-forge recipe and verify it with a
+    local conda-build package/test cycle; staged-recipes submission remains a
+    hosted conda-forge gate.
+
 *   [x] Strengthen context and harness engineering for the solo-maintainer
     workflow while retaining pull-request traceability and automated review
     gates.


### PR DESCRIPTION
## Summary
- refresh the conda recipe for the published 0.2.1 sdist and verified SHA256
- align Python and runtime dependency constraints with the package metadata
- add Python 3.10-3.14 build variants and document the staged-recipes submission path

## Verification
- `conda build conda-recipe --no-anaconda-upload`
- package tests: imports, `voiage --help`, and `pip check`
- `conda render conda-recipe`
- `git diff --check`