### PR TITLE
Fix conda-forge noarch dependency ranges

### DIFF
--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -29,7 +29,6 @@ To publish to conda-forge:
 ## Recipe Structure
 
 - `meta.yaml`: Main recipe file with package metadata and dependencies
-- `conda_build_config.yaml`: Configuration for building against multiple Python versions
 - `conda_build_config.yaml`: Python-version matrix used for local and staged builds
 
 ## Dependencies

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-python:
-  - 3.10.* *_cpython
-  - 3.11.* *_cpython
-  - 3.12.* *_cpython
-  - 3.13.* *_cpython
-  - 3.14.* *_cpython

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,16 +26,12 @@ requirements:
   run:
     - python >=3.10
     - defusedxml >=0.7.1
-    - numpy >=1.22,<2.0  # [py<311]
-    - numpy >=2.2.6,<3.0  # [py>=311]
-    - scipy >=1.7,<1.15  # [py<311]
-    - scipy >=1.16.3,<1.17  # [py>=311]
+    - numpy >=1.22,<3.0
+    - scipy >=1.7,<1.17
     - pandas >=1.3,<3.0
     - xarray >=0.19,<2025.0
-    - numpyro >=0.14,<0.20  # [py<311]
-    - numpyro >=0.21.0,<0.22  # [py>=311]
-    - jax >=0.4.33,<0.6  # [py<311]
-    - jax >=0.7.1,<0.8  # [py>=311]
+    - numpyro >=0.14,<0.22
+    - jax >=0.4.33,<0.8
     - scikit-learn >=1.0,<2.0
     - statsmodels >=0.13,<1.0
     - matplotlib >=3.4,<4.0


### PR DESCRIPTION
## Summary
- remove Python selectors and the redundant variant matrix from the noarch recipe
- use universal dependency ranges that let conda solve compatible releases per Python version

## Verification
- `conda render conda-recipe --channel conda-forge`
- `git diff --check`