### PR TITLE
Apply conda-forge noarch recipe guidance

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "voiage" %}
 {% set version = "0.2.1" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -18,13 +19,13 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=69
     - setuptools_scm >=8
     - wheel
   run:
-    - python >=3.10
+    - python >= {{ python_min }}
     - defusedxml >=0.7.1
     - numpy >=1.22,<3.0
     - scipy >=1.7,<1.17
@@ -34,7 +35,7 @@ requirements:
     - jax >=0.4.33,<0.8
     - scikit-learn >=1.0,<2.0
     - statsmodels >=0.13,<1.0
-    - matplotlib >=3.4,<4.0
+    - matplotlib-base >=3.4,<4.0
     - seaborn >=0.13.2,<1.0
     - psutil >=5.9,<8.0
     - typing_extensions >=4.0
@@ -49,6 +50,7 @@ test:
     - pip check
     - voiage --help
   requires:
+    - python {{ python_min }}
     - pip
 
 about:


### PR DESCRIPTION
## Summary
- add explicit `python_min` pins for the noarch recipe
- use `matplotlib-base` instead of the metapackage

## Verification
- local conda-build package tests passed for 0.2.1
- `git diff --check`