### PR TITLE
fix(rust): support sha2 0.11 digest formatting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Made Rust provenance and payload digest encoding compatible with the `sha2`
+  0.11 digest representation, preserving deterministic lowercase hexadecimal
+  hashes during the dependency upgrade.
+
 ### Removed
 - Removed stale `conductor/tracks/dataset-registry-and-example-corpus_20260625/` and
   `conductor/tracks/voi-frontier-architecture-dependency-governance_20260625/`

--- a/changelog.md
+++ b/changelog.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Made Rust provenance and payload digest encoding compatible with the `sha2`
-  0.11 digest representation, preserving deterministic lowercase hexadecimal
-  hashes during the dependency upgrade.
-
 ### Removed
 - Removed stale `conductor/tracks/dataset-registry-and-example-corpus_20260625/` and
   `conductor/tracks/voi-frontier-architecture-dependency-governance_20260625/`
@@ -643,6 +638,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Renovate configuration for automated dependency updates
 
 ### Fixed
+- Made Rust provenance and payload digest encoding compatible with the `sha2`
+  0.11 digest representation, preserving deterministic lowercase hexadecimal
+  hashes during the dependency upgrade.
 - Prevented the TestPyPI and PyPI upload steps from attempting to create
   duplicate release attestations in the shared build directory.
 - Added a manual release-workflow trigger for safely retrying an existing tag

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -31,11 +31,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -45,31 +45,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -94,16 +100,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -133,6 +129,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "itoa"
@@ -431,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -498,12 +503,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voiage-diagnostics"

--- a/rust/crates/voiage-python/Cargo.toml
+++ b/rust/crates/voiage-python/Cargo.toml
@@ -17,14 +17,14 @@ pyo3 = { version = "0.29", features = ["abi3-py310"] }
 serde = "1"
 serde_json = "1"
 serde_json_canonicalizer = "0.3.2"
-sha2 = "0.10"
+sha2 = "0.11"
 voiage-diagnostics.workspace = true
 voiage-domain.workspace = true
 voiage-numerics.workspace = true
 voiage-serialization.workspace = true
 
 [build-dependencies]
-sha2 = "0.10"
+sha2 = "0.11"
 
 [lints]
 workspace = true

--- a/rust/crates/voiage-python/build.rs
+++ b/rust/crates/voiage-python/build.rs
@@ -13,13 +13,13 @@ const SOURCE_STATE_ALGORITHM: &str = "git-diff-and-untracked-sha256-v1";
 const EMBEDDED_PROVENANCE_FILE: &str = "source-provenance.txt";
 
 fn digest_hex<D: AsRef<[u8]>>(digest: D) -> String {
-    digest.as_ref().iter().fold(
-        String::with_capacity(digest.as_ref().len() * 2),
-        |mut hex, byte| {
-            write!(hex, "{byte:02x}").expect("writing to String is infallible");
-            hex
-        },
-    )
+    let bytes = digest.as_ref();
+    let mut hex = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        hex.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+        hex.push(char::from(b"0123456789abcdef"[(byte & 0xf) as usize]));
+    }
+    hex
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {

--- a/rust/crates/voiage-python/build.rs
+++ b/rust/crates/voiage-python/build.rs
@@ -12,8 +12,18 @@ const BUILD_ID_ALGORITHM: &str = "length-prefixed-sha256-v2";
 const SOURCE_STATE_ALGORITHM: &str = "git-diff-and-untracked-sha256-v1";
 const EMBEDDED_PROVENANCE_FILE: &str = "source-provenance.txt";
 
+fn digest_hex<D: AsRef<[u8]>>(digest: D) -> String {
+    digest.as_ref().iter().fold(
+        String::with_capacity(digest.as_ref().len() * 2),
+        |mut hex, byte| {
+            write!(hex, "{byte:02x}").expect("writing to String is infallible");
+            hex
+        },
+    )
+}
+
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    digest_hex(Sha256::digest(bytes))
 }
 
 fn command_output(program: &str, args: &[&str], directory: &Path) -> Option<String> {
@@ -104,7 +114,7 @@ pub(crate) fn source_state_sha256(
     append_field(&mut hasher, SOURCE_STATE_ALGORITHM.as_bytes());
     append_field(&mut hasher, tree_oid.as_bytes());
     if !dirty {
-        return Ok(format!("{:x}", hasher.finalize()));
+        return Ok(digest_hex(hasher.finalize()));
     }
 
     let tracked_diff = command_bytes(
@@ -174,7 +184,7 @@ pub(crate) fn source_state_sha256(
         append_field(&mut hasher, relative.to_string_lossy().as_bytes());
         append_field(&mut hasher, &contents);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(digest_hex(hasher.finalize()))
 }
 
 pub(crate) fn resolve_source_identity(

--- a/rust/crates/voiage-python/src/lib.rs
+++ b/rust/crates/voiage-python/src/lib.rs
@@ -11,6 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
+#[cfg(test)]
 use std::fmt::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -125,12 +126,12 @@ fn build_id_for_metadata(metadata: &BuildMetadata) -> String {
 
 fn sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
-    digest
-        .iter()
-        .fold(String::with_capacity(digest.len() * 2), |mut hex, byte| {
-            write!(hex, "{byte:02x}").expect("writing to String is infallible");
-            hex
-        })
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for &byte in &digest {
+        hex.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+        hex.push(char::from(b"0123456789abcdef"[(byte & 0xf) as usize]));
+    }
+    hex
 }
 
 fn canonical_payload_bytes<T: serde::Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {

--- a/rust/crates/voiage-python/src/lib.rs
+++ b/rust/crates/voiage-python/src/lib.rs
@@ -11,7 +11,6 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
-#[cfg(test)]
 use std::fmt::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -125,7 +124,13 @@ fn build_id_for_metadata(metadata: &BuildMetadata) -> String {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    let digest = Sha256::digest(bytes);
+    digest
+        .iter()
+        .fold(String::with_capacity(digest.len() * 2), |mut hex, byte| {
+            write!(hex, "{byte:02x}").expect("writing to String is infallible");
+            hex
+        })
 }
 
 fn canonical_payload_bytes<T: serde::Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {


### PR DESCRIPTION
## Summary
- update the voiage-python Rust crate to sha2 0.11
- replace removed LowerHex digest formatting with deterministic lowercase byte encoding
- retain provenance and payload hash contracts and document the fix

## Validation
- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo test --manifest-path rust/Cargo.toml -p voiage-python --test build_provenance
- cargo check --manifest-path rust/Cargo.toml -p voiage-python
- uv run python scripts/repo_harness.py
- uv run python scripts/validate_v1_programme.py

Closes the build failures in Dependabot PR #269.