### PR TITLE
chore(deps): consolidate compatible dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
         node-version: '22'
 
     - name: Install pnpm
-      uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       with:
         version: '10'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         node-version: '22'
 
     - name: Install pnpm
-      uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       with:
         version: '10'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dependencies = [
     "scipy>=1.16.3,<1.17; python_version>='3.11'",
     "pandas>=1.3,<3.0",
     "xarray>=0.19,<2025.0",
-    "scikit-learn>=1.0,<2.0",
-    "typing_extensions>=4.0",
+    "scikit-learn>=1.7.2,<2.0",
+    "typing_extensions>=4.16.0",
     "typer>=0.9,<1.0",
 ]
 
@@ -69,9 +69,9 @@ ci = [
     "maturin>=1.9,<2.0",
     "psutil>=5.9,<8.0",
     "pytest>=9.0.3,<10.0",
-    "pytest-benchmark>=4.0,<6.0",
+    "pytest-benchmark>=5.2.3,<6.0",
     "pytest-cov>=7.1.0,<8.0",
-    "pytest-integration>=0.2,<0.3",
+    "pytest-integration>=0.2.3,<0.3",
     "pytest-xdist>=3.0,<4.0",
     "PyYAML>=6.0,<7.0",
     "rfc8785>=0.1,<0.2",
@@ -81,8 +81,8 @@ dev = [
     "maturin>=1.9,<2.0",
     "mutmut>=2.0,<3.0",
     "scalene>=1.5,<2.0",
-    "ruff>=0.15.20,<1.0",
-    "bandit>=1.7,<2.0",
+    "ruff>=0.15.21,<1.0",
+    "bandit>=1.9.4,<2.0",
     "nox>=2026.4.10,<2027",
     "ty>=0.0.1,<1.0",
     "types-setuptools",
@@ -97,7 +97,7 @@ dev = [
 ]
 performance = ["psutil>=5.9,<8.0"]
 deep_learning = ["torch>=2.13.0,<3.0"]
-web = ["fastapi>=0.115,<1.0", "httpx>=0.27,<1.0", "uvicorn>=0.30,<1.0"]
+web = ["fastapi>=0.115,<1.0", "httpx>=0.27,<1.0", "uvicorn>=0.51.0,<1.0"]
 
 [project.urls]
 Homepage = "https://github.com/edithatogo/voiage"

--- a/uv.lock
+++ b/uv.lock
@@ -4145,11 +4145,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]
@@ -4301,7 +4301,7 @@ web = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
+    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4,<2.0" },
     { name = "defusedxml", marker = "extra == 'ci'", specifier = ">=0.7.1,<1.0" },
     { name = "defusedxml", marker = "extra == 'ecosystem'", specifier = ">=0.7.1,<1.0" },
     { name = "docutils", marker = "extra == 'ci'", specifier = ">=0.18,<0.22" },
@@ -4330,15 +4330,15 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'ci'", specifier = ">=5.9,<8.0" },
     { name = "psutil", marker = "extra == 'performance'", specifier = ">=5.9,<8.0" },
     { name = "pytest", marker = "extra == 'ci'", specifier = ">=9.0.3,<10.0" },
-    { name = "pytest-benchmark", marker = "extra == 'ci'", specifier = ">=4.0,<6.0" },
+    { name = "pytest-benchmark", marker = "extra == 'ci'", specifier = ">=5.2.3,<6.0" },
     { name = "pytest-cov", marker = "extra == 'ci'", specifier = ">=7.1.0,<8.0" },
-    { name = "pytest-integration", marker = "extra == 'ci'", specifier = ">=0.2,<0.3" },
+    { name = "pytest-integration", marker = "extra == 'ci'", specifier = ">=0.2.3,<0.3" },
     { name = "pytest-xdist", marker = "extra == 'ci'", specifier = ">=3.0,<4.0" },
     { name = "pyyaml", marker = "extra == 'ci'", specifier = ">=6.0,<7.0" },
     { name = "rfc8785", marker = "extra == 'ci'", specifier = ">=0.1,<0.2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.20,<1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.21,<1.0" },
     { name = "scalene", marker = "extra == 'dev'", specifier = ">=1.5,<2.0" },
-    { name = "scikit-learn", specifier = ">=1.0,<2.0" },
+    { name = "scikit-learn", specifier = ">=1.7.2,<2.0" },
     { name = "scipy", marker = "python_full_version < '3.11'", specifier = ">=1.7,<1.15" },
     { name = "scipy", marker = "python_full_version >= '3.11'", specifier = ">=1.16.3,<1.17" },
     { name = "taskipy", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
@@ -4350,8 +4350,8 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9,<1.0" },
     { name = "types-requests", marker = "extra == 'dev'" },
     { name = "types-setuptools", marker = "extra == 'dev'" },
-    { name = "typing-extensions", specifier = ">=4.0" },
-    { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.30,<1.0" },
+    { name = "typing-extensions", specifier = ">=4.16.0" },
+    { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.51.0,<1.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.0,<3.0" },
     { name = "xarray", specifier = ">=0.19,<2025.0" },
 ]


### PR DESCRIPTION
Consolidates the compatible portions of Dependabot PRs #257, #253, #252, #251, #250, #249, #247, plus the non-conflicting parts of the remaining dependency queue.

Changes:
- refresh Python runtime and CI dependency floors;
- update uv.lock;
- pin pnpm/action-setup consistently in CI and Astro docs workflows.

Validated locally with `uv lock` and the Rust/Python bridge workflow tests (14 passed). The unrelated setuptools PR was not copied because the project uses maturin as its active build backend.