### PR TITLE
test(migration): enforce Rust ownership of legacy kernels

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -146,6 +146,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [x] Enforce the inventory as an executable unclassified-module failure gate (e9eac92).
     - [x] Identify duplicate kernels, facade code, schemas, I/O, orchestration, CLI, plotting, reporting, wrappers and unrelated extensions (735948a).
     - [x] Produce an executable allowlist for Python code permitted at v1.0 (c818b8c).
+    - [x] Enforce Rust authority and compatibility-only Python role for transitional kernels (b4c23b3).
 - [ ] Task: Complete the 0.x compatibility bridge using TDD
     - [x] Make transitional Python efficient-linear and moment-based fallbacks observable with deprecation warnings (fb5baae).
     - [x] Red: add tests for deprecation warnings and warning-free native migration routing (5a44349).

--- a/scripts/validate_python_runtime_inventory.py
+++ b/scripts/validate_python_runtime_inventory.py
@@ -16,20 +16,22 @@ def validate(repo_root: Path) -> list[str]:
     categories = manifest["categories"]
     retained = set(manifest["v1_retained_categories"])
     transitional = manifest["transitional_kernel_modules"]
+    errors: list[str] = []
     if "transitional_numerical_core" in retained:
-        return ["transitional_numerical_core cannot be in v1_retained_categories"]
+        errors.append("transitional_numerical_core cannot be in v1_retained_categories")
     if transitional.get("authoritative_owner") != "rust":
-        return ["transitional numerical kernels must declare Rust as authoritative"]
+        errors.append(
+            "transitional numerical kernels must declare Rust as authoritative"
+        )
     if transitional.get("python_role") != "compatibility_fallback_only":
-        return [
+        errors.append(
             "transitional numerical kernels must declare Python as compatibility-only"
-        ]
+        )
     roots = [
         (root, category)
         for category, data in categories.items()
         for root in data["roots"]
     ]
-    errors: list[str] = []
     errors.extend(
         f"transitional kernel module is missing: {module}"
         for module in transitional["modules"]

--- a/scripts/validate_python_runtime_inventory.py
+++ b/scripts/validate_python_runtime_inventory.py
@@ -10,28 +10,49 @@ import sys
 
 
 def validate(repo_root: Path) -> list[str]:
+    """Return policy violations in the machine-readable runtime inventory."""
     manifest_path = repo_root / "specs/v1/python-runtime-inventory.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     categories = manifest["categories"]
     retained = set(manifest["v1_retained_categories"])
+    transitional = manifest["transitional_kernel_modules"]
     if "transitional_numerical_core" in retained:
         return ["transitional_numerical_core cannot be in v1_retained_categories"]
-    roots = [(root, category) for category, data in categories.items() for root in data["roots"]]
+    if transitional.get("authoritative_owner") != "rust":
+        return ["transitional numerical kernels must declare Rust as authoritative"]
+    if transitional.get("python_role") != "compatibility_fallback_only":
+        return [
+            "transitional numerical kernels must declare Python as compatibility-only"
+        ]
+    roots = [
+        (root, category)
+        for category, data in categories.items()
+        for root in data["roots"]
+    ]
     errors: list[str] = []
-    for module in manifest["transitional_kernel_modules"]["modules"]:
-        if not (repo_root / module).is_file():
-            errors.append(f"transitional kernel module is missing: {module}")
+    errors.extend(
+        f"transitional kernel module is missing: {module}"
+        for module in transitional["modules"]
+        if not (repo_root / module).is_file()
+    )
     for path in sorted((repo_root / "voiage").rglob("*.py")):
         relative = path.relative_to(repo_root).as_posix()
-        matches = [category for root, category in roots if relative == root or relative.startswith(root)]
+        matches = [
+            category
+            for root, category in roots
+            if relative == root or relative.startswith(root)
+        ]
         if len(matches) != 1:
-            errors.append(f"{relative}: expected exactly one inventory category, found {matches}")
+            errors.append(
+                f"{relative}: expected exactly one inventory category, found {matches}"
+            )
     if any(category not in categories for category in retained):
         errors.append("v1_retained_categories contains an unknown category")
     return errors
 
 
 def main() -> int:
+    """Validate the inventory at the requested repository root."""
     parser = argparse.ArgumentParser()
     parser.add_argument("repo", nargs="?", type=Path, default=Path.cwd())
     args = parser.parse_args()

--- a/specs/v1/python-runtime-inventory.json
+++ b/specs/v1/python-runtime-inventory.json
@@ -36,6 +36,8 @@
   ],
   "transitional_kernel_modules": {
     "status": "must_route_to_rust_or_be_removed_in_phase_6",
+    "authoritative_owner": "rust",
+    "python_role": "compatibility_fallback_only",
     "modules": [
       "voiage/methods/basic.py",
       "voiage/methods/ceaf.py",

--- a/tests/test_python_runtime_inventory.py
+++ b/tests/test_python_runtime_inventory.py
@@ -28,7 +28,10 @@ def test_transitional_kernel_inventory_is_explicit() -> None:
             / "specs/v1/python-runtime-inventory.json"
         ).read_text()
     )
-    assert set(manifest["transitional_kernel_modules"]["modules"]) == {
+    transitional = manifest["transitional_kernel_modules"]
+    assert transitional["authoritative_owner"] == "rust"
+    assert transitional["python_role"] == "compatibility_fallback_only"
+    assert set(transitional["modules"]) == {
         "voiage/methods/basic.py",
         "voiage/methods/ceaf.py",
         "voiage/methods/dominance.py",


### PR DESCRIPTION
## Summary
- declare Rust as authoritative for transitional numerical kernels
- declare Python role as compatibility-fallback-only
- enforce both fields in the runtime inventory validator and tests
- record Phase 6 evidence in the Conductor plan

## Validation
- `uv run ruff check scripts/validate_python_runtime_inventory.py tests/test_python_runtime_inventory.py`
- `uv run --extra ci pytest tests/test_python_runtime_inventory.py -q`
- `python scripts/validate_python_runtime_inventory.py`