### PR TITLE
feat(migration): expose Rust EVPI runtime contract

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -150,6 +150,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
 - [ ] Task: Complete the 0.x compatibility bridge using TDD
     - [x] Make transitional Python efficient-linear and moment-based fallbacks observable with deprecation warnings (fb5baae).
     - [x] Red: add tests for deprecation warnings and warning-free native migration routing (5a44349).
+    - [x] Define the Rust/PyO3 EVPI runtime contract and adapter forwarding test (fa7ad2b).
     - [ ] Green: route stable public APIs to Rust and implement controlled shims.
     - [ ] Refactor: simplify wrappers and publish migration documentation.
 - [ ] Task: Remove the duplicate Python numerical core using TDD

--- a/rust/crates/voiage-python/src/lib.rs
+++ b/rust/crates/voiage-python/src/lib.rs
@@ -429,7 +429,7 @@ fn runtime_info(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
     Ok(result)
 }
 
-/// Compute the stable regression-based EVPPI kernel for Python callers.
+/// Compute the stable EVPI kernel for Python callers.
 #[pyfunction]
 fn compute_evpi(net_benefit: &Bound<'_, PyAny>) -> PyResult<f64> {
     let net_benefit = matrix_from_python(net_benefit, "net_benefit")?;

--- a/rust/crates/voiage-python/src/lib.rs
+++ b/rust/crates/voiage-python/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use voiage_diagnostics::ErrorCategory;
 use voiage_domain::SampleMatrix;
-use voiage_numerics::{evppi, evsi_efficient_linear, evsi_moment_based, evsi_stochastic};
+use voiage_numerics::{evpi, evppi, evsi_efficient_linear, evsi_moment_based, evsi_stochastic};
 use voiage_serialization::{
     CeafResultV1, CeafResultV1Input, DominanceResultV1, DominanceResultV1Input, DominanceStatus,
 };
@@ -431,6 +431,18 @@ fn runtime_info(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
 
 /// Compute the stable regression-based EVPPI kernel for Python callers.
 #[pyfunction]
+fn compute_evpi(net_benefit: &Bound<'_, PyAny>) -> PyResult<f64> {
+    let net_benefit = matrix_from_python(net_benefit, "net_benefit")?;
+    evpi(&net_benefit).map_err(|error| match error.category() {
+        ErrorCategory::DimensionMismatch => {
+            DimensionMismatchError::new_err(("dimension_mismatch", error.to_string()))
+        }
+        _ => InputError::new_err(("invalid_input", error.to_string())),
+    })
+}
+
+/// Compute the stable regression-based EVPPI kernel for Python callers.
+#[pyfunction]
 fn compute_evppi(
     net_benefit: &Bound<'_, PyAny>,
     parameter_samples: &Bound<'_, PyAny>,
@@ -724,6 +736,7 @@ fn _core(module: &Bound<'_, PyModule>) -> PyResult<()> {
         module.py().get_type::<SerializationError>(),
     )?;
     module.add_function(wrap_pyfunction!(runtime_info, module)?)?;
+    module.add_function(wrap_pyfunction!(compute_evpi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evppi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evsi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evsi_efficient_linear, module)?)?;
@@ -1038,6 +1051,24 @@ mod tests {
                 .extract::<f64>()
                 .unwrap();
             assert!((result - 0.05).abs() <= 1.0e-10);
+        });
+    }
+
+    #[test]
+    fn compute_evpi_executes_the_rust_kernel_for_python_sequences() {
+        Python::initialize();
+        Python::attach(|py| {
+            let module = PyModule::new(py, "_core_test").unwrap();
+            module
+                .add_function(wrap_pyfunction!(compute_evpi, &module).unwrap())
+                .unwrap();
+            let function = module.getattr("compute_evpi").unwrap();
+            let result = function
+                .call1((vec![vec![0.0_f64, 2.0], vec![1.0, 0.0]],))
+                .unwrap()
+                .extract::<f64>()
+                .unwrap();
+            assert!((result - 0.5).abs() <= 1.0e-12);
         });
     }
 

--- a/tests/test_runtime_adapter.py
+++ b/tests/test_runtime_adapter.py
@@ -147,6 +147,23 @@ def test_compute_evppi_forwards_matrix_payloads_to_native(monkeypatch) -> None:
     }
 
 
+def test_compute_evpi_forwards_matrix_payload_to_native(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def compute(net_benefit: list[list[float]]) -> float:
+        captured["net_benefit"] = net_benefit
+        return 0.5
+
+    monkeypatch.setattr(
+        _runtime,
+        "_native",
+        lambda: SimpleNamespace(compute_evpi=compute),
+    )
+
+    assert _runtime.compute_evpi([[0.0, 2.0], [1.0, 0.0]]) == 0.5
+    assert captured == {"net_benefit": [[0.0, 2.0], [1.0, 0.0]]}
+
+
 def test_compute_evsi_forwards_seeded_kernel_arguments(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/voiage/_runtime.py
+++ b/voiage/_runtime.py
@@ -68,6 +68,15 @@ def serialize_dominance_result(**payload: object) -> dict[str, object]:
     return dict(result)
 
 
+def compute_evpi(net_benefit: list[list[float]]) -> float:
+    """Compute the stable EVPI kernel in Rust."""
+    try:
+        result = _native().compute_evpi(net_benefit)
+    except Exception as error:
+        _raise_native_error(error)
+    return float(result)
+
+
 def compute_evppi(
     net_benefit: list[list[float]], parameter_samples: list[list[float]]
 ) -> float:


### PR DESCRIPTION
## Summary
- expose the existing Rust EVPI kernel through the private PyO3 module
- add the Python runtime adapter contract
- add forwarding and native execution tests
- record the Phase 6 migration evidence

## Validation
- `uv run --extra ci pytest tests/test_runtime_adapter.py -q`
- `PYO3_PYTHON=/opt/homebrew/bin/python3 cargo test -p voiage-python`

This establishes the EVPI bridge before replacing public Python imports.