### PR TITLE
feat(migration): route NumPy EVPI facade to Rust

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -151,6 +151,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [x] Make transitional Python efficient-linear and moment-based fallbacks observable with deprecation warnings (fb5baae).
     - [x] Red: add tests for deprecation warnings and warning-free native migration routing (5a44349).
     - [x] Define the Rust/PyO3 EVPI runtime contract and adapter forwarding test (fa7ad2b).
+    - [x] Route the NumPy-backed public EVPI facade through Rust with a transitional fallback (c724c84).
     - [ ] Green: route stable public APIs to Rust and implement controlled shims.
     - [ ] Refactor: simplify wrappers and publish migration documentation.
 - [ ] Task: Remove the duplicate Python numerical core using TDD

--- a/tests/test_analysis_comprehensive.py
+++ b/tests/test_analysis_comprehensive.py
@@ -132,6 +132,16 @@ class TestDecisionAnalysisComprehensive:
         result = analysis.evpi()
         assert result == 0.0
 
+    def test_numpy_evpi_facade_routes_to_rust_runtime(self) -> None:
+        """The stable NumPy facade delegates EVPI computation to Rust."""
+        nb_data = np.array([[1.0, 3.0], [4.0, 2.0]], dtype=np.float64)
+        analysis = DecisionAnalysis(nb_array=nb_data, backend="numpy")
+
+        with patch("voiage._runtime.compute_evpi", return_value=7.5) as compute:
+            assert analysis.evpi() == 7.5
+
+        compute.assert_called_once_with([[1.0, 3.0], [4.0, 2.0]])
+
     def test_evpi_empty_array(self) -> None:
         """Test EVPI calculation with empty array (should return 0)."""
         # Create empty test data

--- a/voiage/analysis.py
+++ b/voiage/analysis.py
@@ -5,6 +5,7 @@
 from collections import deque
 from collections.abc import Callable, Generator, Sequence
 from typing import Any, Protocol
+import warnings
 
 import numpy as np
 
@@ -666,6 +667,22 @@ class DecisionAnalysis:
             # Use incremental computation if chunk_size is specified
             if chunk_size is not None:
                 per_decision_evpi = self._incremental_evpi(nb_values, chunk_size)
+            elif type(self.backend).__name__ == "NumpyBackend" and not self.use_jit:
+                # The stable NumPy facade now delegates its canonical kernel to
+                # Rust.  Keep the backend fallback only for environments that
+                # intentionally lack the optional native extension.
+                try:
+                    from voiage import _runtime
+
+                    per_decision_evpi = _runtime.compute_evpi(nb_values.tolist())
+                except (ModuleNotFoundError, AttributeError):
+                    warnings.warn(
+                        "Python EVPI fallback is transitional; the Rust kernel is "
+                        "the v1 execution target.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    per_decision_evpi = self.backend.evpi(nb_values)
             # Use the selected backend for computation
             elif self.use_jit and hasattr(self.backend, "evpi_jit"):
                 # Use JIT compilation if available and requested


### PR DESCRIPTION
## Summary
- route NumPy-backed `DecisionAnalysis.evpi()` through the Rust EVPI kernel
- retain a deprecation-warning fallback only when the native extension is unavailable
- add facade routing coverage and record Conductor evidence

## Validation
- `uv run --extra ci pytest tests/test_analysis_comprehensive.py -k evpi tests/test_backend_consistency.py -q`
- Ruff check/format passed
- native EVPI bridge tests passed