### PR TITLE
feat(migration): expose Rust dominance runtime contract

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -152,6 +152,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [x] Red: add tests for deprecation warnings and warning-free native migration routing (5a44349).
     - [x] Define the Rust/PyO3 EVPI runtime contract and adapter forwarding test (fa7ad2b).
     - [x] Route the NumPy-backed public EVPI facade through Rust with a transitional fallback (c724c84).
+    - [x] Define the Rust/PyO3 dominance execution contract and adapter forwarding test (cc1172b).
     - [ ] Green: route stable public APIs to Rust and implement controlled shims.
     - [ ] Refactor: simplify wrappers and publish migration documentation.
 - [ ] Task: Remove the duplicate Python numerical core using TDD

--- a/rust/crates/voiage-python/src/lib.rs
+++ b/rust/crates/voiage-python/src/lib.rs
@@ -17,7 +17,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use voiage_diagnostics::ErrorCategory;
 use voiage_domain::SampleMatrix;
-use voiage_numerics::{evpi, evppi, evsi_efficient_linear, evsi_moment_based, evsi_stochastic};
+use voiage_numerics::{
+    dominance, evpi, evppi, evsi_efficient_linear, evsi_moment_based, evsi_stochastic,
+    DominanceStatus as KernelDominanceStatus,
+};
 use voiage_serialization::{
     CeafResultV1, CeafResultV1Input, DominanceResultV1, DominanceResultV1Input, DominanceStatus,
 };
@@ -302,6 +305,20 @@ fn matrix_from_python(values: &Bound<'_, PyAny>, field: &str) -> PyResult<Sample
     })
 }
 
+fn vector_from_python(values: &Bound<'_, PyAny>, field: &str) -> PyResult<Vec<f64>> {
+    let value = if values.hasattr("tolist")? {
+        values.call_method0("tolist")?
+    } else {
+        values.clone()
+    };
+    value.extract::<Vec<f64>>().map_err(|error| {
+        InputError::new_err((
+            "invalid_input",
+            format!("{field} must be a finite numeric vector: {error}"),
+        ))
+    })
+}
+
 fn validate_ceaf_alignment(lengths: &[usize]) -> Result<(), BoundaryError> {
     let Some((&expected, remaining)) = lengths.split_first() else {
         return Err(BoundaryError::Input(
@@ -439,6 +456,54 @@ fn compute_evpi(net_benefit: &Bound<'_, PyAny>) -> PyResult<f64> {
         }
         _ => InputError::new_err(("invalid_input", error.to_string())),
     })
+}
+
+/// Compute the stable dominance kernel for Python callers.
+#[pyfunction]
+fn compute_dominance<'py>(
+    py: Python<'py>,
+    costs: &Bound<'_, PyAny>,
+    effects: &Bound<'_, PyAny>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let costs = vector_from_python(costs, "costs")?;
+    let effects = vector_from_python(effects, "effects")?;
+    let costs_domain = voiage_domain::SampleVector::try_from(costs).map_err(|error| {
+        InputError::new_err(("invalid_input", format!("invalid costs vector: {error}")))
+    })?;
+    let effects_domain = voiage_domain::SampleVector::try_from(effects).map_err(|error| {
+        InputError::new_err(("invalid_input", format!("invalid effects vector: {error}")))
+    })?;
+    let result =
+        dominance(&costs_domain, &effects_domain).map_err(|error| match error.category() {
+            ErrorCategory::DimensionMismatch => {
+                DimensionMismatchError::new_err(("dimension_mismatch", error.to_string()))
+            }
+            _ => InputError::new_err(("invalid_input", error.to_string())),
+        })?;
+    let status = result
+        .status
+        .into_iter()
+        .map(|value| match value {
+            KernelDominanceStatus::Frontier => "frontier",
+            KernelDominanceStatus::StronglyDominated => "strongly_dominated",
+            KernelDominanceStatus::ExtendedDominated => "extended_dominated",
+        })
+        .collect::<Vec<_>>();
+    let output = PyDict::new(py);
+    output.set_item("frontier_indices", result.frontier_indices)?;
+    output.set_item(
+        "strongly_dominated_indices",
+        result.strongly_dominated_indices,
+    )?;
+    output.set_item(
+        "extended_dominated_indices",
+        result.extended_dominated_indices,
+    )?;
+    output.set_item("status", status)?;
+    output.set_item("incremental_costs", result.incremental_costs)?;
+    output.set_item("incremental_effects", result.incremental_effects)?;
+    output.set_item("icers", result.icers)?;
+    Ok(output)
 }
 
 /// Compute the stable regression-based EVPPI kernel for Python callers.
@@ -737,6 +802,7 @@ fn _core(module: &Bound<'_, PyModule>) -> PyResult<()> {
     )?;
     module.add_function(wrap_pyfunction!(runtime_info, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evpi, module)?)?;
+    module.add_function(wrap_pyfunction!(compute_dominance, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evppi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evsi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evsi_efficient_linear, module)?)?;
@@ -1069,6 +1135,30 @@ mod tests {
                 .extract::<f64>()
                 .unwrap();
             assert!((result - 0.5).abs() <= 1.0e-12);
+        });
+    }
+
+    #[test]
+    fn compute_dominance_executes_the_rust_kernel_for_python_sequences() {
+        Python::initialize();
+        Python::attach(|py| {
+            let module = PyModule::new(py, "_core_test").unwrap();
+            module
+                .add_function(wrap_pyfunction!(compute_dominance, &module).unwrap())
+                .unwrap();
+            let function = module.getattr("compute_dominance").unwrap();
+            let result = function
+                .call1((vec![1.0_f64, 2.0, 4.0], vec![1.0_f64, 2.0, 3.0]))
+                .unwrap()
+                .cast_into::<PyDict>()
+                .unwrap();
+            let frontier = result
+                .get_item("frontier_indices")
+                .unwrap()
+                .unwrap()
+                .extract::<Vec<usize>>()
+                .unwrap();
+            assert_eq!(frontier, vec![0, 1, 2]);
         });
     }
 

--- a/tests/test_runtime_adapter.py
+++ b/tests/test_runtime_adapter.py
@@ -164,6 +164,25 @@ def test_compute_evpi_forwards_matrix_payload_to_native(monkeypatch) -> None:
     assert captured == {"net_benefit": [[0.0, 2.0], [1.0, 0.0]]}
 
 
+def test_compute_dominance_forwards_vectors_to_native(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def compute(costs: list[float], effects: list[float]) -> dict[str, object]:
+        captured.update(costs=costs, effects=effects)
+        return {"frontier_indices": [0, 1]}
+
+    monkeypatch.setattr(
+        _runtime,
+        "_native",
+        lambda: SimpleNamespace(compute_dominance=compute),
+    )
+
+    assert _runtime.compute_dominance([1.0, 2.0], [1.0, 2.0]) == {
+        "frontier_indices": [0, 1]
+    }
+    assert captured == {"costs": [1.0, 2.0], "effects": [1.0, 2.0]}
+
+
 def test_compute_evsi_forwards_seeded_kernel_arguments(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/voiage/_runtime.py
+++ b/voiage/_runtime.py
@@ -77,6 +77,15 @@ def compute_evpi(net_benefit: list[list[float]]) -> float:
     return float(result)
 
 
+def compute_dominance(costs: list[float], effects: list[float]) -> dict[str, object]:
+    """Compute the stable dominance kernel in Rust."""
+    try:
+        result = _native().compute_dominance(costs, effects)
+    except Exception as error:
+        _raise_native_error(error)
+    return dict(result)
+
+
 def compute_evppi(
     net_benefit: list[list[float]], parameter_samples: list[list[float]]
 ) -> float:


### PR DESCRIPTION
## Summary
- expose the existing Rust dominance kernel through PyO3
- add a Python runtime adapter returning computed kernel fields
- add native and forwarding tests
- record Phase 6 Conductor evidence

## Validation
- `uv run --extra ci pytest tests/test_runtime_adapter.py -q`
- `PYO3_PYTHON=/opt/homebrew/bin/python3 cargo test -p voiage-python`
- Rust formatting check passed