### PR TITLE
feat(migration): route dominance facade to Rust

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -153,6 +153,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [x] Define the Rust/PyO3 EVPI runtime contract and adapter forwarding test (fa7ad2b).
     - [x] Route the NumPy-backed public EVPI facade through Rust with a transitional fallback (c724c84).
     - [x] Define the Rust/PyO3 dominance execution contract and adapter forwarding test (cc1172b).
+    - [x] Route the public dominance facade through Rust with a transitional fallback (211b41f).
     - [ ] Green: route stable public APIs to Rust and implement controlled shims.
     - [ ] Refactor: simplify wrappers and publish migration documentation.
 - [ ] Task: Remove the duplicate Python numerical core using TDD

--- a/voiage/methods/dominance.py
+++ b/voiage/methods/dominance.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from itertools import pairwise
+import warnings
 
 import numpy as np
 
@@ -166,22 +167,40 @@ def calculate_dominance(
         effects,
         strategy_names,
     )
-    strong = calculate_strong_dominance(cost_arr, effect_arr)
-    frontier = cost_effectiveness_frontier(cost_arr, effect_arr)
-    extended = [
-        idx for idx in range(len(cost_arr)) if idx not in strong and idx not in frontier
-    ]
-    incremental_costs, incremental_effects, icers = calculate_icers(
-        cost_arr,
-        effect_arr,
-        frontier,
-    )
-
-    status = ["frontier"] * len(cost_arr)
-    for idx in strong:
-        status[idx] = "strongly_dominated"
-    for idx in extended:
-        status[idx] = "extended_dominated"
+    try:
+        native = _runtime.compute_dominance(cost_arr.tolist(), effect_arr.tolist())
+    except (ModuleNotFoundError, AttributeError):
+        warnings.warn(
+            "Python dominance fallback is transitional; the Rust kernel is the "
+            "v1 execution target.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        strong = calculate_strong_dominance(cost_arr, effect_arr)
+        frontier = cost_effectiveness_frontier(cost_arr, effect_arr)
+        extended = [
+            idx
+            for idx in range(len(cost_arr))
+            if idx not in strong and idx not in frontier
+        ]
+        incremental_costs, incremental_effects, icers = calculate_icers(
+            cost_arr, effect_arr, frontier
+        )
+        status = ["frontier"] * len(cost_arr)
+        for idx in strong:
+            status[idx] = "strongly_dominated"
+        for idx in extended:
+            status[idx] = "extended_dominated"
+    else:
+        frontier = list(native["frontier_indices"])
+        strong = list(native["strongly_dominated_indices"])
+        extended = list(native["extended_dominated_indices"])
+        status = list(native["status"])
+        incremental_costs = np.asarray(native["incremental_costs"], dtype=DEFAULT_DTYPE)
+        incremental_effects = np.asarray(
+            native["incremental_effects"], dtype=DEFAULT_DTYPE
+        )
+        icers = np.asarray(native["icers"], dtype=DEFAULT_DTYPE)
 
     return DominanceResult(
         strategy_names=final_names,


### PR DESCRIPTION
## Summary
- route public dominance computation through the Rust kernel
- preserve the existing Python result and reporting shape
- retain a deprecation-warning fallback only without the native extension
- record Phase 6 migration evidence

## Validation
- `uv run --extra ci pytest tests/test_dominance.py tests/test_runtime_adapter.py -q`
- Ruff check/format passed
- Rust/PyO3 dominance contract tests passed in the preceding bridge PR