### PR TITLE
feat(migration): expose Rust CEAF runtime contract

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -154,6 +154,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [x] Route the NumPy-backed public EVPI facade through Rust with a transitional fallback (c724c84).
     - [x] Define the Rust/PyO3 dominance execution contract and adapter forwarding test (cc1172b).
     - [x] Route the public dominance facade through Rust with a transitional fallback (211b41f).
+    - [x] Define the Rust/PyO3 CEAF execution contract and adapter forwarding test (0055bf0).
     - [ ] Green: route stable public APIs to Rust and implement controlled shims.
     - [ ] Refactor: simplify wrappers and publish migration documentation.
 - [ ] Task: Remove the duplicate Python numerical core using TDD

--- a/rust/crates/voiage-python/src/lib.rs
+++ b/rust/crates/voiage-python/src/lib.rs
@@ -16,9 +16,9 @@ use std::fmt::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use voiage_diagnostics::ErrorCategory;
-use voiage_domain::SampleMatrix;
+use voiage_domain::{SampleCube, SampleMatrix, SampleVector};
 use voiage_numerics::{
-    dominance, evpi, evppi, evsi_efficient_linear, evsi_moment_based, evsi_stochastic,
+    ceaf, dominance, evpi, evppi, evsi_efficient_linear, evsi_moment_based, evsi_stochastic,
     DominanceStatus as KernelDominanceStatus,
 };
 use voiage_serialization::{
@@ -305,6 +305,26 @@ fn matrix_from_python(values: &Bound<'_, PyAny>, field: &str) -> PyResult<Sample
     })
 }
 
+fn cube_from_python(values: &Bound<'_, PyAny>, field: &str) -> PyResult<SampleCube> {
+    let value = if values.hasattr("tolist")? {
+        values.call_method0("tolist")?
+    } else {
+        values.clone()
+    };
+    let values = value.extract::<Vec<Vec<Vec<f64>>>>().map_err(|error| {
+        InputError::new_err((
+            "invalid_input",
+            format!("{field} must be a finite rectangular numeric cube: {error}"),
+        ))
+    })?;
+    SampleCube::try_from(values).map_err(|error| {
+        InputError::new_err((
+            "invalid_input",
+            format!("{field} must be a finite rectangular numeric cube: {error}"),
+        ))
+    })
+}
+
 fn vector_from_python(values: &Bound<'_, PyAny>, field: &str) -> PyResult<Vec<f64>> {
     let value = if values.hasattr("tolist")? {
         values.call_method0("tolist")?
@@ -503,6 +523,40 @@ fn compute_dominance<'py>(
     output.set_item("incremental_costs", result.incremental_costs)?;
     output.set_item("incremental_effects", result.incremental_effects)?;
     output.set_item("icers", result.icers)?;
+    Ok(output)
+}
+
+/// Compute the stable CEAF kernel for Python callers.
+#[pyfunction]
+fn compute_ceaf<'py>(
+    py: Python<'py>,
+    net_benefit: &Bound<'_, PyAny>,
+    wtp_thresholds: &Bound<'_, PyAny>,
+    confidence_level: f64,
+) -> PyResult<Bound<'py, PyDict>> {
+    let net_benefit = cube_from_python(net_benefit, "net_benefit")?;
+    let wtp_thresholds =
+        SampleVector::try_from(vector_from_python(wtp_thresholds, "wtp_thresholds")?)
+            .map_err(|error| InputError::new_err(("invalid_input", error.to_string())))?;
+    let result =
+        ceaf(&net_benefit, &wtp_thresholds, confidence_level).map_err(|error| {
+            match error.category() {
+                ErrorCategory::DimensionMismatch => {
+                    DimensionMismatchError::new_err(("dimension_mismatch", error.to_string()))
+                }
+                _ => InputError::new_err(("invalid_input", error.to_string())),
+            }
+        })?;
+    let output = PyDict::new(py);
+    output.set_item("wtp_thresholds", result.wtp_thresholds)?;
+    output.set_item("optimal_strategy_indices", result.optimal_strategy_indices)?;
+    output.set_item(
+        "acceptability_probabilities",
+        result.acceptability_probabilities,
+    )?;
+    output.set_item("probability_lower", result.probability_lower)?;
+    output.set_item("probability_upper", result.probability_upper)?;
+    output.set_item("expected_net_benefit", result.expected_net_benefit)?;
     Ok(output)
 }
 
@@ -803,6 +857,7 @@ fn _core(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(runtime_info, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evpi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_dominance, module)?)?;
+    module.add_function(wrap_pyfunction!(compute_ceaf, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evppi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evsi, module)?)?;
     module.add_function(wrap_pyfunction!(compute_evsi_efficient_linear, module)?)?;
@@ -1159,6 +1214,37 @@ mod tests {
                 .extract::<Vec<usize>>()
                 .unwrap();
             assert_eq!(frontier, vec![0, 1, 2]);
+        });
+    }
+
+    #[test]
+    fn compute_ceaf_executes_the_rust_kernel_for_python_sequences() {
+        Python::initialize();
+        Python::attach(|py| {
+            let module = PyModule::new(py, "_core_test").unwrap();
+            module
+                .add_function(wrap_pyfunction!(compute_ceaf, &module).unwrap())
+                .unwrap();
+            let function = module.getattr("compute_ceaf").unwrap();
+            let result = function
+                .call1((
+                    vec![
+                        vec![vec![1.0_f64, 2.0], vec![2.0, 1.0]],
+                        vec![vec![2.0, 1.0], vec![1.0, 3.0]],
+                    ],
+                    vec![0.0_f64, 1.0],
+                    0.95_f64,
+                ))
+                .unwrap()
+                .cast_into::<PyDict>()
+                .unwrap();
+            let indices = result
+                .get_item("optimal_strategy_indices")
+                .unwrap()
+                .unwrap()
+                .extract::<Vec<usize>>()
+                .unwrap();
+            assert_eq!(indices, vec![0, 1]);
         });
     }
 

--- a/tests/test_runtime_adapter.py
+++ b/tests/test_runtime_adapter.py
@@ -183,6 +183,38 @@ def test_compute_dominance_forwards_vectors_to_native(monkeypatch) -> None:
     assert captured == {"costs": [1.0, 2.0], "effects": [1.0, 2.0]}
 
 
+def test_compute_ceaf_forwards_cube_arguments_to_native(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def compute(
+        net_benefit: list[list[list[float]]],
+        thresholds: list[float],
+        confidence: float,
+    ) -> dict[str, object]:
+        captured.update(
+            net_benefit=net_benefit,
+            thresholds=thresholds,
+            confidence=confidence,
+        )
+        return {"optimal_strategy_indices": [0, 1]}
+
+    monkeypatch.setattr(
+        _runtime,
+        "_native",
+        lambda: SimpleNamespace(compute_ceaf=compute),
+    )
+    cube = [[[1.0, 2.0], [2.0, 1.0]], [[2.0, 1.0], [1.0, 3.0]]]
+
+    assert _runtime.compute_ceaf(cube, [0.0, 1.0], 0.95) == {
+        "optimal_strategy_indices": [0, 1]
+    }
+    assert captured == {
+        "net_benefit": cube,
+        "thresholds": [0.0, 1.0],
+        "confidence": 0.95,
+    }
+
+
 def test_compute_evsi_forwards_seeded_kernel_arguments(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/voiage/_runtime.py
+++ b/voiage/_runtime.py
@@ -86,6 +86,23 @@ def compute_dominance(costs: list[float], effects: list[float]) -> dict[str, obj
     return dict(result)
 
 
+def compute_ceaf(
+    net_benefit: list[list[list[float]]],
+    wtp_thresholds: list[float],
+    confidence_level: float,
+) -> dict[str, object]:
+    """Compute the stable CEAF kernel in Rust."""
+    try:
+        result = _native().compute_ceaf(
+            net_benefit,
+            wtp_thresholds,
+            confidence_level,
+        )
+    except Exception as error:
+        _raise_native_error(error)
+    return dict(result)
+
+
 def compute_evppi(
     net_benefit: list[list[float]], parameter_samples: list[list[float]]
 ) -> float:


### PR DESCRIPTION
## Summary
- expose the existing Rust CEAF kernel through PyO3
- add cube extraction and computed result fields
- add Python runtime forwarding coverage
- record Phase 6 Conductor evidence

## Validation
- `uv run --extra ci pytest tests/test_runtime_adapter.py -q`
- `PYO3_PYTHON=/opt/homebrew/bin/python3 cargo test -p voiage-python`
- Rust formatting check passed