### PR TITLE
feat(migration): route CEAF facade to Rust

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -155,6 +155,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [x] Define the Rust/PyO3 dominance execution contract and adapter forwarding test (cc1172b).
     - [x] Route the public dominance facade through Rust with a transitional fallback (211b41f).
     - [x] Define the Rust/PyO3 CEAF execution contract and adapter forwarding test (0055bf0).
+    - [x] Route the public CEAF facade through Rust with a transitional fallback (6e08c67).
     - [ ] Green: route stable public APIs to Rust and implement controlled shims.
     - [ ] Refactor: simplify wrappers and publish migration documentation.
 - [ ] Task: Remove the duplicate Python numerical core using TDD

--- a/voiage/methods/ceaf.py
+++ b/voiage/methods/ceaf.py
@@ -1,6 +1,7 @@
 """Cost-effectiveness acceptability frontier calculations."""
 
 from dataclasses import dataclass
+import warnings
 
 import numpy as np
 from scipy.stats import norm
@@ -202,31 +203,56 @@ def calculate_ceaf(
         strategy_names,
     )
     n_samples = nb_values.shape[0]
-
-    mean_nb = np.mean(nb_values, axis=0)
-    optimal_strategy_indices = np.argmax(mean_nb, axis=0)
-    sample_optimal_indices = np.argmax(nb_values, axis=1)
-    wtp_indices = np.arange(nb_values.shape[2])
-    acceptability_probabilities = np.mean(
-        sample_optimal_indices == optimal_strategy_indices[np.newaxis, :],
-        axis=0,
-    )
-    expected_net_benefit = mean_nb[optimal_strategy_indices, wtp_indices]
-
-    z_value = float(norm.ppf(0.5 + confidence_level / 2.0))
-    standard_error = np.sqrt(
-        acceptability_probabilities * (1.0 - acceptability_probabilities) / n_samples
-    )
-    probability_lower = np.clip(
-        acceptability_probabilities - z_value * standard_error,
-        0.0,
-        1.0,
-    )
-    probability_upper = np.clip(
-        acceptability_probabilities + z_value * standard_error,
-        0.0,
-        1.0,
-    )
+    try:
+        native = _runtime.compute_ceaf(
+            nb_values.tolist(),
+            wtp_arr.tolist(),
+            confidence_level,
+        )
+    except (ModuleNotFoundError, AttributeError):
+        warnings.warn(
+            "Python CEAF fallback is transitional; the Rust kernel is the v1 "
+            "execution target.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        mean_nb = np.mean(nb_values, axis=0)
+        optimal_strategy_indices = np.argmax(mean_nb, axis=0)
+        sample_optimal_indices = np.argmax(nb_values, axis=1)
+        wtp_indices = np.arange(nb_values.shape[2])
+        acceptability_probabilities = np.mean(
+            sample_optimal_indices == optimal_strategy_indices[np.newaxis, :],
+            axis=0,
+        )
+        expected_net_benefit = mean_nb[optimal_strategy_indices, wtp_indices]
+        z_value = float(norm.ppf(0.5 + confidence_level / 2.0))
+        standard_error = np.sqrt(
+            acceptability_probabilities
+            * (1.0 - acceptability_probabilities)
+            / n_samples
+        )
+        probability_lower = np.clip(
+            acceptability_probabilities - z_value * standard_error,
+            0.0,
+            1.0,
+        )
+        probability_upper = np.clip(
+            acceptability_probabilities + z_value * standard_error,
+            0.0,
+            1.0,
+        )
+    else:
+        optimal_strategy_indices = np.asarray(
+            native["optimal_strategy_indices"], dtype=int
+        )
+        acceptability_probabilities = np.asarray(
+            native["acceptability_probabilities"], dtype=DEFAULT_DTYPE
+        )
+        probability_lower = np.asarray(native["probability_lower"], dtype=DEFAULT_DTYPE)
+        probability_upper = np.asarray(native["probability_upper"], dtype=DEFAULT_DTYPE)
+        expected_net_benefit = np.asarray(
+            native["expected_net_benefit"], dtype=DEFAULT_DTYPE
+        )
 
     return CEAFResult(
         wtp_thresholds=wtp_arr,


### PR DESCRIPTION
## Summary
- route public CEAF computation through the Rust kernel
- preserve CEAF result/reporting compatibility
- retain a deprecation-warning fallback only without native Rust
- record Phase 6 Conductor evidence

## Validation
- `uv run --extra ci pytest tests/test_ceaf.py tests/test_runtime_adapter.py -q`
- Ruff check/format passed
- CEAF PyO3 contract tests passed in #282