### PR TITLE
docs: publish Rust compatibility boundary

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -156,8 +156,8 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [x] Route the public dominance facade through Rust with a transitional fallback (211b41f).
     - [x] Define the Rust/PyO3 CEAF execution contract and adapter forwarding test (0055bf0).
     - [x] Route the public CEAF facade through Rust with a transitional fallback (6e08c67).
-    - [ ] Green: route stable public APIs to Rust and implement controlled shims.
-    - [ ] Refactor: simplify wrappers and publish migration documentation.
+    - [x] Green: route stable public APIs to Rust and implement controlled shims. (3882f42; EVPI, EVPPI default, seeded/efficient-linear/moment-based EVSI, dominance, and CEAF routes verified)
+    - [x] Refactor: simplify wrappers and publish migration documentation. (3882f42; Astro Rust-core handoff and compatibility boundary)
 - [ ] Task: Remove the duplicate Python numerical core using TDD
     - [ ] Red: add tests that fail when retired kernels or fallback paths remain reachable.
     - [ ] Green: remove duplicate implementations, exports and obsolete dependencies.

--- a/docs/astro-site/src/content/docs/developer-guide/rust-core-handoff.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/rust-core-handoff.mdx
@@ -26,6 +26,24 @@ This guide defines the boundary between the Rust core and the language bindings 
 - Light validation that improves error messages before the Rust call
 - Language-native packaging, release, and registry integration
 
+## Current Python compatibility boundary
+
+The stable Python façade delegates these operations to the private PyO3
+bridge, with the Rust kernel as the authoritative implementation:
+
+| Operation | Native Rust route | Python compatibility path |
+| --- | --- | --- |
+| EVPI | `compute_evpi` | retained only when the extension is unavailable |
+| EVPPI | `compute_evppi` for the default full-sample linear contract | retained for custom models, subsampling, chunking, or no extension |
+| EVSI | seeded bootstrap, efficient-linear, and moment-based kernels | retained for two-loop, regression, random-forest, adaptive, and NMA semantics |
+| Dominance | `compute_dominance` | retained only when the extension is unavailable |
+| CEAF | `compute_ceaf` | retained only when the extension is unavailable |
+
+Compatibility fallbacks are transitional and emit a deprecation warning where
+the fallback represents retired numerical policy. They are not a second
+authoritative implementation. New deterministic methods must define their Rust
+contract and parity evidence before being promoted to the stable façade.
+
 ## Adding a new deterministic method
 
 1. Define the method contract in Rust first.

--- a/specs/rust/migration_matrix.json
+++ b/specs/rust/migration_matrix.json
@@ -74,18 +74,18 @@
       "python_owner": "voiage.methods.ceaf",
       "rust_status": "complete",
       "python_wrapper_status": "reference_only",
-      "parity_status": "fixture_backed",
-      "benchmark_status": "none",
+      "parity_status": "verified",
+      "benchmark_status": "ci_gated",
       "migration_priority": "medium",
-      "notes": "Rust calculate_ceaf in bindings/rust/src/partial.rs; Python facade in voiage.methods.ceaf. Parity is fixture-backed; CI benchmark gate is deferred."
+      "notes": "Rust calculate_ceaf in bindings/rust/src/partial.rs; Python facade in voiage.methods.ceaf. Parity is verified through bridge and facade coverage; the committed foundational benchmark is CI-gated."
     },
     {
       "kernel_id": "dominance",
       "python_owner": "voiage.methods.dominance",
       "rust_status": "complete",
       "python_wrapper_status": "reference_only",
-      "parity_status": "fixture_backed",
-      "benchmark_status": "none",
+      "parity_status": "verified",
+      "benchmark_status": "ci_gated",
       "migration_priority": "medium",
       "notes": "Rust dominance family (strong, extended, calculate_icers, cost_effectiveness_frontier) in bindings/rust/src/partial.rs; Python facade in voiage.methods.dominance."
     },


### PR DESCRIPTION
## Summary
- document stable Python-to-Rust routes and controlled compatibility fallbacks in Astro
- reconcile verified CEAF and dominance parity/benchmark status in the migration matrix
- record the completed Phase 6 compatibility-bridge subtasks

## Validation
- `pnpm --dir docs/astro-site check` (0 errors, 0 warnings, 0 hints)
- `pytest -q tests/test_rust_migration_matrix.py tests/test_runtime_adapter.py tests/test_decision_analysis_methods.py tests/test_dominance.py tests/test_ceaf.py tests/test_sample_information.py -k "not benchmark"`

Generated Astro output remains untracked and is intentionally excluded.