### PR TITLE
conductor: record Python coverage gate

### DIFF
--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -164,7 +164,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
     - [ ] Refactor: reduce retained Python to a fully typed facade and rerun the suite.
 - [ ] Task: Validate the minimal Python distribution
     - [x] Prove stable operation without JAX, GPU, web, widget, distributed or experimental dependencies. (packaging probes validated 2026-07-20)
-    - [ ] Enforce at least 90 percent coverage for retained production Python.
+    - [x] Enforce at least 90 percent coverage for retained production Python. (validated by `tests/test_ci_cd_quality_gates.py` and hosted Coverage Report, 2026-07-20)
 - [ ] Task: Conductor - Automated Review and Checkpoint 'Python Legacy-Core Deprecation and Removal' (Protocol in workflow.md)
 
 ## Phase 7: Cross-Language Binding Consolidation


### PR DESCRIPTION
## Summary
- record the retained-Python 90% coverage gate as validated
- cite executable governance checks and the passing hosted Coverage Report

## Validation
- `tests/test_ci_cd_quality_gates.py` asserts `fail_under = 90` and tox `--cov-fail-under=90`
- hosted Coverage Report passed on the validated mainline

Generated Astro output remains untracked and is intentionally excluded.