### PR TITLE
ci: reanchor operational assurance after squash merge

### DIFF
--- a/.github/workflows/operational-assurance.yml
+++ b/.github/workflows/operational-assurance.yml
@@ -51,7 +51,7 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
         PR_BASE: ${{ github.event.pull_request.base.sha }}
         PUSH_BASE: ${{ github.event.before }}
-        C15_PROVENANCE_FLOOR: 4017aac3b5803f2d68b09d74e57ebd6c55e933d0
+        C15_PROVENANCE_FLOOR: f05231ce21a81ffb4029493927e5572d114fad67
       run: |
         candidate="${PUSH_BASE}"
         if [ "${EVENT_NAME}" = pull_request ]; then candidate="${PR_BASE}"; fi

--- a/scripts/repo_harness.py
+++ b/scripts/repo_harness.py
@@ -74,7 +74,7 @@ OPERATIONAL_ASSURANCE_MARKERS = {
         "scripts/check_consumer_matrix.py",
         "scripts/check_coverage_policy.py",
         "--cov-fail-under=90",
-        "4017aac3b5803f2d68b09d74e57ebd6c55e933d0",
+        "f05231ce21a81ffb4029493927e5572d114fad67",
         "include-hidden-files: true",
         "if-no-files-found: error",
     ),

--- a/tests/test_coverage_policy.py
+++ b/tests/test_coverage_policy.py
@@ -102,7 +102,7 @@ def test_workflow_uses_full_suite_provenance_floor_and_hidden_evidence() -> None
     )
     assert "pytest tests/ --cov=voiage" in workflow
     assert '-m "not integration' not in workflow
-    assert "4017aac3b5803f2d68b09d74e57ebd6c55e933d0" in workflow
+    assert "f05231ce21a81ffb4029493927e5572d114fad67" in workflow
     assert (
         'merge-base --is-ancestor "${C15_PROVENANCE_FLOOR}" "${merge_base}"' in workflow
     )


### PR DESCRIPTION
## Summary
- reanchor the C15 provenance floor to the GitHub-verified squash commit now present on main
- update the repository harness and its focused coverage-policy test
- preserve the fail-closed 100% changed-branch coverage threshold

## Why
The post-merge Operational Assurance run correctly failed because its provenance floor referenced the pre-squash branch commit, which is not an ancestor of main. This change anchors the policy to the signed squash commit without weakening any assurance control.

## Validation
- uvx ruff check scripts/repo_harness.py tests/test_coverage_policy.py
- uvx ruff format --check scripts/repo_harness.py tests/test_coverage_policy.py
- actionlint .github/workflows/operational-assurance.yml
- git diff --check