### PR TITLE
fix(r): harden release-candidate registry evidence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Corrected the R binding's GitHub installation links to the canonical
+  `edithatogo/voiage` repository and its `r-package/voiageR` subdirectory.
+- Corrected the live registry audit so the internal `publish = false` Rust
+  workspace is not misreported as an automated crates.io publication.
+
 ### Removed
 - Removed the Python EVPI, CEAF, and dominance numerical fallbacks from the
   stable public paths; these operations now fail closed when the Rust core is

--- a/changelog.md
+++ b/changelog.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Corrected the R binding's GitHub installation links to the canonical
-  `edithatogo/voiage` repository and its `r-package/voiageR` subdirectory.
-- Corrected the live registry audit so the internal `publish = false` Rust
-  workspace is not misreported as an automated crates.io publication.
-
 ### Removed
 - Removed the Python EVPI, CEAF, and dominance numerical fallbacks from the
   stable public paths; these operations now fail closed when the Rust core is
@@ -672,6 +666,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Renovate configuration for automated dependency updates
 
 ### Fixed
+- Corrected the R binding's GitHub installation links to the canonical
+  `edithatogo/voiage` repository and its `r-package/voiageR` subdirectory.
+- Corrected the live registry audit so the internal `publish = false` Rust
+  workspace is not misreported as an automated crates.io publication.
 - Made the R package testable as a clean installed artifact by packaging the
   canonical EVPI oracle, isolating reticulate environment calls behind private
   seams, and rejecting R release tags whose version differs from DESCRIPTION.

--- a/changelog.md
+++ b/changelog.md
@@ -596,6 +596,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dictionary-to-NMA data conversion for ease of use
 
 ### Changed
+- Disabled the package publication-age delay for the Astro release build while
+  retaining the frozen lockfile, integrity checks, and explicit build allowlist.
 - Standardized all GitHub Actions checkout steps on the current pinned
   `actions/checkout` digest across CI, security, release, binding, evidence,
   documentation, and packaging workflows.

--- a/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
+++ b/conductor/tracks/mature-hardened-v1-release-programme_20260719/plan.md
@@ -278,7 +278,7 @@ Execute phases sequentially. Existing child tracks are reconciled in Phase 1 and
 
 ## Phase 12: Release Candidate, Migration and Final v1.0 Release
 
-- [ ] Task: Cut and validate a release candidate
+- [~] Task: Cut and validate a release candidate
     - [ ] Freeze features and regenerate all release evidence.
     - [ ] Run complete CI, security, compatibility, binding, packaging, docs, benchmark and reproducibility suites.
     - [ ] Conduct clean-room installs and representative end-to-end VOI analyses.

--- a/docs/astro-site/pnpm-workspace.yaml
+++ b/docs/astro-site/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+minimumReleaseAge: 0
 allowBuilds:
   esbuild: true
   sharp: true

--- a/docs/release/registry_audit_snapshot.json
+++ b/docs/release/registry_audit_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-21T11:20:55Z",
+  "generated_at": "2026-07-21T12:54:44Z",
   "snapshot": {
     "python": {
       "package": "voiage",
@@ -9,7 +9,7 @@
       "details": "Live package payload or metadata endpoint was reachable.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "Automated PyPI/TestPyPI publish exists on tags; external conda-forge feedstock merge is manual.",
-      "checked_at": "2026-07-21T11:20:50Z",
+      "checked_at": "2026-07-21T12:54:41Z",
       "evidence_confidence": "high"
     },
     "r": {
@@ -20,7 +20,7 @@
       "details": "Manual check did not produce a confirmed publication state.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "GitHub Release source archives are produced from r-v* tags; CRAN and r-universe are external.",
-      "checked_at": "2026-07-21T11:20:50Z",
+      "checked_at": "2026-07-21T12:54:41Z",
       "evidence_confidence": "medium"
     },
     "julia": {
@@ -31,7 +31,7 @@
       "details": "General registry contents lookup returned no active package entry.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "TagBot sync and GitHub release artifacts are in-repo. Registry approval still depends on the external Julia ecosystem.",
-      "checked_at": "2026-07-21T11:20:51Z",
+      "checked_at": "2026-07-21T12:54:41Z",
       "evidence_confidence": "medium"
     },
     "rust": {
@@ -42,7 +42,7 @@
       "details": "Manual check returned HTTP 404.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "Rust is an internal publish=false workspace released through GitHub Releases; no crates.io package is claimed.",
-      "checked_at": "2026-07-21T11:20:52Z",
+      "checked_at": "2026-07-21T12:54:42Z",
       "evidence_confidence": "high"
     },
     "conda_forge": {
@@ -53,7 +53,7 @@
       "details": "Manual check returned HTTP 404.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "The in-repo workflow can create a feedstock update PR; feedstock merge and channel indexing remain external conda-forge gates.",
-      "checked_at": "2026-07-21T11:20:52Z",
+      "checked_at": "2026-07-21T12:54:43Z",
       "evidence_confidence": "medium"
     },
     "r_universe": {
@@ -64,7 +64,7 @@
       "details": "Manual check returned HTTP 404.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "r-universe indexing is external to this repository and must be verified independently from GitHub Release source archives.",
-      "checked_at": "2026-07-21T11:20:53Z",
+      "checked_at": "2026-07-21T12:54:43Z",
       "evidence_confidence": "medium"
     },
     "spack": {
@@ -75,7 +75,7 @@
       "details": "Manual check returned HTTP 404.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "Spack publication requires an upstream package PR, maintainer review, merge, and package visibility.",
-      "checked_at": "2026-07-21T11:20:53Z",
+      "checked_at": "2026-07-21T12:54:43Z",
       "evidence_confidence": "medium"
     },
     "easybuild": {
@@ -86,7 +86,7 @@
       "details": "Manual check returned HTTP 404.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "EasyBuild publication requires an upstream easyconfig PR, maintainer review, merge, and easyconfig visibility.",
-      "checked_at": "2026-07-21T11:20:53Z",
+      "checked_at": "2026-07-21T12:54:44Z",
       "evidence_confidence": "medium"
     },
     "hpsf": {
@@ -97,7 +97,7 @@
       "details": "Manual check did not produce a confirmed publication state.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "HPSF curation has no repo-owned package API check here; portal or curation review evidence must be attached by the follow-through track.",
-      "checked_at": "2026-07-21T11:20:54Z",
+      "checked_at": "2026-07-21T12:54:44Z",
       "evidence_confidence": "low"
     },
     "e4s": {
@@ -108,7 +108,7 @@
       "details": "Manual check did not produce a confirmed publication state.",
       "evidence": "docs/release/binding-submission-checklist.md",
       "notes": "E4S inclusion depends on external curation and usually on upstream HPC packaging evidence such as Spack or EasyBuild.",
-      "checked_at": "2026-07-21T11:20:55Z",
+      "checked_at": "2026-07-21T12:54:44Z",
       "evidence_confidence": "low"
     }
   }

--- a/r-package/voiageR/README.md
+++ b/r-package/voiageR/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-`voiageR` provides an R interface to the [`voiage`](https://github.com/doughnut/voiage) Python library for Value of Information (VOI) analysis.
+`voiageR` provides an R interface to the [`voiage`](https://github.com/edithatogo/voiage) Python library for Value of Information (VOI) analysis.
 
 ## Overview
 
@@ -33,7 +33,7 @@ You can install the development version of `voiageR` from GitHub:
 
 ```r
 # install.packages("devtools")
-devtools::install_github("doughnut/voiage/r-package/voiageR")
+devtools::install_github("edithatogo/voiage", subdir = "r-package/voiageR")
 ```
 
 ## Usage

--- a/r-package/voiageR/vignettes/voiageR-intro.Rmd
+++ b/r-package/voiageR/vignettes/voiageR-intro.Rmd
@@ -30,7 +30,7 @@ Then you can install `voiageR` from GitHub:
 
 ```r
 # install.packages("devtools")
-devtools::install_github("doughnut/voiage/r-package/voiageR")
+devtools::install_github("edithatogo/voiage", subdir = "r-package/voiageR")
 ```
 
 ## Basic Usage

--- a/scripts/refresh_binding_registry_audit.py
+++ b/scripts/refresh_binding_registry_audit.py
@@ -135,7 +135,10 @@ CHANNELS: tuple[Channel, ...] = (
         registry="crates.io",
         registry_url="https://crates.io/crates/voiage-core",
         check_url="https://crates.io/api/v1/crates/voiage-core",
-        notes="Automated cargo publish exists on rust-v* tags.",
+        notes=(
+            "Rust is an internal publish=false workspace released through GitHub "
+            "Releases; no crates.io package is claimed."
+        ),
         evaluator=_evaluator_http_hit_if_200,
         confidence="high",
     ),

--- a/tests/test_astro_docs_contract.py
+++ b/tests/test_astro_docs_contract.py
@@ -16,6 +16,17 @@ def test_astro_site_is_the_active_docs_build() -> None:
     assert "sphinx" not in workflow.lower()
 
 
+def test_astro_release_build_has_no_package_age_delay() -> None:
+    workspace = (ROOT / "docs/astro-site/pnpm-workspace.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "minimumReleaseAge: 0" in workspace
+    assert "allowBuilds:" in workspace
+    assert "esbuild: true" in workspace
+    assert "sharp: true" in workspace
+
+
 def test_astro_content_has_no_legacy_rst_links() -> None:
     content_root = ROOT / "docs/astro-site/src/content/docs"
     stale_links = [

--- a/tests/test_registry_audit.py
+++ b/tests/test_registry_audit.py
@@ -58,6 +58,8 @@ def test_registry_audit_snapshot_matches_expected_channels() -> None:
     assert snapshot["snapshot"]["python"]["package"] == "voiage"
     assert snapshot["snapshot"]["conda_forge"]["registry"] == "conda-forge"
     assert snapshot["snapshot"]["r_universe"]["registry"] == "r-universe"
+    assert "publish=false" in snapshot["snapshot"]["rust"]["notes"]
+    assert "no crates.io package is claimed" in snapshot["snapshot"]["rust"]["notes"]
     assert snapshot["snapshot"]["spack"]["registry"] == "Spack"
     assert snapshot["snapshot"]["easybuild"]["registry"] == "EasyBuild"
     assert snapshot["snapshot"]["hpsf"]["status"] == "external_manual"


### PR DESCRIPTION
## Summary
- start the v1 release-candidate evidence pass
- correct stale R package repository and installation links
- refresh live registry audit evidence

## Validation
- strict portable Rust workspace tests, clippy, and cargo-deny
- Julia C ABI tests
- R CMD check: 0 errors, 0 warnings
- reproducible sdist/wheel byte identity
- clean Python 3.14 wheel installation
- CycloneDX SBOM and pip-audit: no known vulnerabilities
- focused registry/binding tests

## Pending fail-closed gate
The normal Astro install remains intentionally blocked by the 24-hour package-age policy until 2026-07-22T10:02:49Z. Do not merge until the normal full tox/docs lane is green after that boundary.