### PR TITLE
Plan registry and archival roadmap

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -1,5 +1,9 @@
 # Project Tracks
 
+## [ ] Track: research_software_registry_readiness_20260721
+
+[Specification and plan](./tracks/research_software_registry_readiness_20260721/)
+
 ## [x] Track: Domain Abstraction Excellence [completed: 2026-07-20]
 *Link: [./archive/abstraction-excellence_20260719/index.md](./archive/abstraction-excellence_20260719/index.md)*
 *Status: strict domain contracts, capability-aware kernels, machine-readable

--- a/conductor/tracks/research_software_registry_readiness_20260721/index.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/index.md
@@ -1,0 +1,10 @@
+# research_software_registry_readiness_20260721
+
+Status: planned
+
+Parent issue: [#296](https://github.com/edithatogo/voiage/issues/296)
+
+- [Specification](./spec.md)
+- [Implementation plan](./plan.md)
+- [Metadata](./metadata.json)
+

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -1,0 +1,17 @@
+{
+  "track_id": "research_software_registry_readiness_20260721",
+  "version": "1.0.0",
+  "type": "chore",
+  "status": "planned",
+  "created_at": "2026-07-21T00:00:00Z",
+  "updated_at": "2026-07-21T00:00:00Z",
+  "owner_repo": "edithatogo/voiage",
+  "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
+  "github_subissues": [
+    "https://github.com/edithatogo/voiage/issues/297",
+    "https://github.com/edithatogo/voiage/issues/298",
+    "https://github.com/edithatogo/voiage/issues/299"
+  ],
+  "external_evidence_required": true
+}
+

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan
+
+## Phase 1: Readiness and prerequisites
+
+- [ ] Confirm scope, rights, licensing, metadata, release, and persistence prerequisites in the parent issue.
+- [ ] Capture repository-specific validation commands and baseline results.
+
+## Phase 2: Registry deliverables
+
+- [ ] [Issue #297](https://github.com/edithatogo/voiage/issues/297)
+- [ ] [Issue #298](https://github.com/edithatogo/voiage/issues/298)
+- [ ] [Issue #299](https://github.com/edithatogo/voiage/issues/299)
+
+## Phase 3: Reconciliation and closeout
+
+- [ ] Reconcile Conductor status, issue state, project state, and external evidence.
+- [ ] Run the repository's documented validation workflow.
+- [ ] Archive this track only after all automatable work is complete and every remaining external gate is explicit.
+

--- a/conductor/tracks/research_software_registry_readiness_20260721/spec.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/spec.md
@@ -1,0 +1,26 @@
+# Specification
+
+## Objective
+
+Make voiage's appropriate registry, archival, identifier, or research-software destinations explicit, executable, and evidence-gated.
+
+## Requirements
+
+- Maintain one GitHub parent issue and native registry-specific subissues.
+- Record eligibility and prerequisite evidence before submission.
+- Record authoritative submission, acceptance, publication, archival, or identifier evidence when available.
+- Do not claim external completion from local preparation or a successful workflow alone.
+- Preserve existing repository contracts and rights constraints.
+
+## GitHub hierarchy
+
+Parent: [#296](https://github.com/edithatogo/voiage/issues/296)
+
+- [#297](https://github.com/edithatogo/voiage/issues/297)
+- [#298](https://github.com/edithatogo/voiage/issues/298)
+- [#299](https://github.com/edithatogo/voiage/issues/299)
+
+## Acceptance
+
+The planning structure is complete when all subissues are linked, project-visible, and traceable from this track. Individual registry deliverables close only with authoritative evidence or a documented ineligibility decision.
+


### PR DESCRIPTION
## Summary

- add or extend the Conductor registry roadmap
- link the parent issue and native registry-specific subissues
- preserve external submission and acceptance as evidence-gated states

## Validation

- track files present
- metadata JSON parsed
- staged scope restricted to conductor/