### PR TITLE
Release voiage v1.0.0

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -30,7 +30,7 @@ authoritative if this document drifts.
 - [ ] Run `CI=true uv run tox -q`.
 - [ ] In `docs/astro-site`, run
   `pnpm install --frozen-lockfile`, `pnpm run check`, and
-  `pnpm run build` with the minimum-release-age policy enabled.
+  `pnpm run build` with the repository's explicit zero-delay release policy.
 - [ ] Run the Rust workspace, MSRV, Clippy, formatting, tests, coverage,
   benchmarks, Miri, sanitizer, and dependency-policy gates.
 - [ ] Run Python/PyO3, R, and Julia conformance, lifecycle, error, packaging,

--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["voiage Contributors <voiage@users.noreply.github.com>"]
-version = "0.2.1"
+version = "1.0.0"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/changelog.md
+++ b/changelog.md
@@ -708,6 +708,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Renovate configuration for automated dependency updates
 
 ### Fixed
+- Patched the Astro validation toolchain's transitive `fast-uri` dependency to
+  3.1.4, resolving CVE-2026-16221 before the v1.0 release.
 - Added a directly linked private-vulnerability reporting path and continuous
   bounded `cargo-fuzz` coverage for stable Rust EVPI input handling, enforced
   by the repository harness and workflow-contract tests.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+## [1.0.0] - 2026-07-22
+
 ### Removed
 - Removed the conflicting pure-Python Conda recipe; the canonical
   `conda-recipe/` now builds the native Maturin/Rust distribution.

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -26,7 +26,7 @@ To publish to conda-forge:
 1. Fork the [conda-forge/staged-recipes](https://github.com/conda-forge/staged-recipes) repository
 2. Copy this recipe directory to `recipes/voiage` in the forked repository
 3. Submit a pull request to `conda-forge/staged-recipes`; the recipe is pinned
-   to the published `voiage 0.2.1` sdist and its verified SHA256 hash.
+   to the published `voiage 1.0.0` sdist and its verified SHA256 hash.
 
 ## Recipe Structure
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "voiage" %}
-{% set version = "0.2.1" %}
+{% set version = "1.0.0" %}
 {% set python_min = "3.12" %}
 
 package:

--- a/docs/astro-site/pnpm-lock.yaml
+++ b/docs/astro-site/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: 0.28.1
+  fast-uri: 3.1.4
 
 importers:
 
@@ -1354,8 +1355,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3484,7 +3485,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3867,7 +3868,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/docs/astro-site/pnpm-workspace.yaml
+++ b/docs/astro-site/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ allowBuilds:
   sharp: true
 overrides:
   esbuild: 0.28.1
+  fast-uri: 3.1.4

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 0.2.1
+Version: 1.0.0
 Author: voiage Development Team
 Maintainer: voiage Development Team <voiage@users.noreply.github.com>
 Description: An R interface to the Rust-backed voiage core for Value of Information analysis,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "proptest",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-ffi"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "proptest",
  "voiage-diagnostics",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-python"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "pyo3",
  "serde",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-serialization"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-test-support"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/edithatogo/voiage"
 
 [workspace.dependencies]
-voiage-diagnostics = { version = "=0.2.1", path = "crates/voiage-diagnostics" }
-voiage-domain = { version = "=0.2.1", path = "crates/voiage-domain" }
-voiage-numerics = { version = "=0.2.1", path = "crates/voiage-numerics" }
-voiage-serialization = { version = "=0.2.1", path = "crates/voiage-serialization" }
+voiage-diagnostics = { version = "=1.0.0", path = "crates/voiage-diagnostics" }
+voiage-domain = { version = "=1.0.0", path = "crates/voiage-domain" }
+voiage-numerics = { version = "=1.0.0", path = "crates/voiage-numerics" }
+voiage-serialization = { version = "=1.0.0", path = "crates/voiage-serialization" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/rust/fuzz/Cargo.lock
+++ b/rust/fuzz/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "serde",
  "voiage-domain",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "serde",
 ]
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "0.2.1"
+version = "1.0.0"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",


### PR DESCRIPTION
## Summary
- set the authoritative Rust workspace and retained Julia/R/Conda package versions to 1.0.0
- regenerate Rust and fuzz lockfiles
- preserve an empty Unreleased changelog scaffold and open the dated 1.0.0 release section
- align the operator checklist with the approved zero-delay Astro release policy

## Validation
- `uv run python -m voiage.versioning --release-tag v1.0.0`
- `CI=true uv run tox -q` (all 12 environments green)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

Raw local `cargo test --workspace --locked` passed the Rust kernel suites and then encountered the host-only missing `libpython3.13.dylib` linkage boundary in the PyO3 crate; hosted native-wheel checks are the authoritative cross-platform PyO3 evidence.