### PR TITLE
Fix reviewed release payload publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,6 +365,7 @@ jobs:
           cd dist
           sha256sum -- *.whl *.tar.gz | LC_ALL=C sort > SHA256SUMS
       - name: Create or refresh private draft release
+        if: github.event_name != 'workflow_dispatch' || !inputs.publish
         shell: bash
         run: |
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -403,11 +404,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.resolve-tag.outputs.tag_sha }}
           persist-credentials: false
-      - name: Download attested release set
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: voiage-attested-release
-          path: dist
+      - name: Download reviewed private draft payload
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          gh release download "$RELEASE_TAG" --dir dist --pattern '*.whl' --pattern '*.tar.gz'
       - name: Require reviewed artifact digests and private draft
         shell: bash
         env:
@@ -513,11 +516,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.resolve-tag.outputs.tag_sha }}
           persist-credentials: false
-      - name: Download attested release set
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: voiage-attested-release
-          path: dist
+      - name: Download reviewed private draft payload
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          gh release download "$RELEASE_TAG" --dir dist --pattern '*.whl' --pattern '*.tar.gz'
       - name: Revalidate remote tag binding immediately before PyPI
         shell: bash
         run: |

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made publication dispatches consume the already staged and reviewed draft
+  artifacts without rebuilding or clobbering them, so exact digest approval
+  remains valid even when a platform linker is not byte-reproducible.
+
 ## [1.0.0] - 2026-07-22
 
 ### Removed

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -174,6 +174,16 @@ def test_python_release_keeps_staging_separate_from_publication() -> None:
     assert "expected_sdist_sha256" in release_workflow
     assert "sha256sum" in release_workflow
     assert 'gh release view "$RELEASE_TAG" --json isDraft' in release_workflow
+    assert (
+        "if: github.event_name != 'workflow_dispatch' || !inputs.publish"
+        in release_workflow
+    )
+    assert (
+        release_workflow.count(
+            "gh release download \"$RELEASE_TAG\" --dir dist --pattern '*.whl' --pattern '*.tar.gz'"
+        )
+        == 2
+    )
     assert 'gh release edit "$RELEASE_TAG" --draft=false' in release_workflow
     assert "git cat-file -t" in release_workflow
     assert ".verification.verified == true" in release_workflow


### PR DESCRIPTION
## Summary
- prevent publish dispatches from clobbering the already staged private draft
- make TestPyPI and PyPI consume the exact reviewed draft wheels and sdist
- retain exact digest validation before any publication

This fixes the v1.0 publication gate exposed when separately rebuilt Windows wheels differed at the byte level.

## Validation
- focused release workflow contract tests
- `CI=true uv run tox -q -e lint,harness`
- workflow security audit: zero findings