### PR TITLE
Broker reviewed draft assets for publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,26 +384,17 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  test-pypi:
-    name: Publish Reviewed Draft to TestPyPI
+  reviewed-payload:
+    name: Validate Reviewed Private Draft
     needs: [resolve-tag, stage]
     if: github.event_name == 'workflow_dispatch' && inputs.publish
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    environment: testpypi
     permissions:
-      contents: read
-      id-token: write
+      contents: write
     env:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
-      TAG_SHA: ${{ needs.resolve-tag.outputs.tag_sha }}
     steps:
-      - name: Check out immutable release commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.resolve-tag.outputs.tag_sha }}
-          persist-credentials: false
       - name: Download reviewed private draft payload
         shell: bash
         env:
@@ -428,6 +419,39 @@ jobs:
           test "$actual_wheels" = "$EXPECTED_WHEEL_SHA256"
           test "$(sha256sum "${sdists[0]}" | cut -d ' ' -f1)" = "$EXPECTED_SDIST_SHA256"
           test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = true
+      - name: Upload reviewed release payload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: reviewed-release-payload
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  test-pypi:
+    name: Publish Reviewed Draft to TestPyPI
+    needs: [resolve-tag, reviewed-payload]
+    if: github.event_name == 'workflow_dispatch' && inputs.publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+      TAG_SHA: ${{ needs.resolve-tag.outputs.tag_sha }}
+    steps:
+      - name: Check out immutable release commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve-tag.outputs.tag_sha }}
+          persist-credentials: false
+      - name: Download reviewed release payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: reviewed-release-payload
+          path: dist
       - name: Revalidate remote tag binding immediately before TestPyPI
         shell: bash
         run: |
@@ -516,13 +540,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.resolve-tag.outputs.tag_sha }}
           persist-credentials: false
-      - name: Download reviewed private draft payload
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p dist
-          gh release download "$RELEASE_TAG" --dir dist --pattern '*.whl' --pattern '*.tar.gz'
+      - name: Download reviewed release payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: reviewed-release-payload
+          path: dist
       - name: Revalidate remote tag binding immediately before PyPI
         shell: bash
         run: |

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made publication dispatches consume the already staged and reviewed draft
   artifacts without rebuilding or clobbering them, so exact digest approval
   remains valid even when a platform linker is not byte-reproducible.
+- Isolated private-draft retrieval and digest validation in a short-lived
+  broker job, keeping registry OIDC publication jobs read-only for contents.
 
 ## [1.0.0] - 2026-07-22
 

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -144,6 +144,7 @@ def test_python_release_publish_job_is_exact_tag_and_least_privilege() -> None:
     assert "pypi:" in release_workflow
     assert "github-release:" in release_workflow
     assert "needs: [resolve-tag, stage]" in release_workflow
+    assert "needs: [resolve-tag, reviewed-payload]" in release_workflow
     assert "needs: [resolve-tag, test-pypi]" in release_workflow
     assert "needs: [resolve-tag, test-pypi-smoke]" in release_workflow
     assert "needs: [resolve-tag, pypi]" in release_workflow
@@ -182,8 +183,13 @@ def test_python_release_keeps_staging_separate_from_publication() -> None:
         release_workflow.count(
             "gh release download \"$RELEASE_TAG\" --dir dist --pattern '*.whl' --pattern '*.tar.gz'"
         )
-        == 2
+        == 1
     )
+    assert (
+        "reviewed-payload:\n    name: Validate Reviewed Private Draft"
+        in release_workflow
+    )
+    assert release_workflow.count("name: reviewed-release-payload") == 3
     assert 'gh release edit "$RELEASE_TAG" --draft=false' in release_workflow
     assert "git cat-file -t" in release_workflow
     assert ".verification.verified == true" in release_workflow


### PR DESCRIPTION
## Summary
- retrieve the private draft in a dedicated short-lived contents-write job
- validate the approved hashes there and upload an internal reviewed payload
- keep TestPyPI and PyPI OIDC jobs contents-read-only

This addresses GitHub draft-release visibility without weakening exact digest approval.

## Validation
- focused release workflow and changelog contracts
- `CI=true uv run tox -q -e lint,harness`
- workflow audit: zero findings