### PR TITLE
Bind release broker repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,7 +401,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p dist
-          gh release download "$RELEASE_TAG" --dir dist --pattern '*.whl' --pattern '*.tar.gz'
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --dir dist --pattern '*.whl' --pattern '*.tar.gz'
       - name: Require reviewed artifact digests and private draft
         shell: bash
         env:
@@ -418,7 +418,7 @@ jobs:
           actual_wheels="$(for wheel in "${wheels[@]}"; do sha256sum "$wheel" | cut -d ' ' -f1; done | paste -sd, -)"
           test "$actual_wheels" = "$EXPECTED_WHEEL_SHA256"
           test "$(sha256sum "${sdists[0]}" | cut -d ' ' -f1)" = "$EXPECTED_SDIST_SHA256"
-          test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = true
+          test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = true
       - name: Upload reviewed release payload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remains valid even when a platform linker is not byte-reproducible.
 - Isolated private-draft retrieval and digest validation in a short-lived
   broker job, keeping registry OIDC publication jobs read-only for contents.
+- Bound draft-broker GitHub CLI calls to the explicit repository context so
+  they work without an unnecessary source checkout.
 
 ## [1.0.0] - 2026-07-22
 

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -181,7 +181,7 @@ def test_python_release_keeps_staging_separate_from_publication() -> None:
     )
     assert (
         release_workflow.count(
-            "gh release download \"$RELEASE_TAG\" --dir dist --pattern '*.whl' --pattern '*.tar.gz'"
+            "gh release download \"$RELEASE_TAG\" --repo \"$GITHUB_REPOSITORY\" --dir dist --pattern '*.whl' --pattern '*.tar.gz'"
         )
         == 1
     )
@@ -190,6 +190,10 @@ def test_python_release_keeps_staging_separate_from_publication() -> None:
         in release_workflow
     )
     assert release_workflow.count("name: reviewed-release-payload") == 3
+    assert (
+        'gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft'
+        in release_workflow
+    )
     assert 'gh release edit "$RELEASE_TAG" --draft=false' in release_workflow
     assert "git cat-file -t" in release_workflow
     assert ".verification.verified == true" in release_workflow


### PR DESCRIPTION
Explicitly supplies the repository to GitHub CLI calls in the no-checkout draft broker job. Focused release contracts plus lint/security harness pass.