### PR TITLE
feat(registry): publish Rust core crates and record archival

### DIFF
--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -6,6 +6,7 @@ on:
       - "rust-v*"
       - "julia-v*"
       - "r-v*"
+      # R source releases are published from r-v* tags.
 
 permissions: {}
 

--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -35,6 +35,7 @@ jobs:
       # published by rust-crates-release.yml in dependency order.
       - run: cargo package --manifest-path crates/voiage-ffi/Cargo.toml --locked --allow-dirty
       - name: Create GitHub release
+        # Contract marker: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag
         run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -30,11 +30,8 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --locked -- -D warnings
       - run: cargo test --workspace --all-features --locked
-      # The Rust workspace is the in-repository execution core. Its crates are
-      # intentionally publish=false because the FFI crate depends on sibling
-      # workspace crates that are not independently published. Keep the tag
-      # gate honest: validate/package the workspace and publish the GitHub
-      # release, while any future crates.io facade gets its own contract.
+      # The FFI adapter remains private. Binding-independent core crates are
+      # published by rust-crates-release.yml in dependency order.
       - run: cargo package --manifest-path crates/voiage-ffi/Cargo.toml --locked --allow-dirty
       - name: Create GitHub release
         run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag

--- a/.github/workflows/rust-crates-release.yml
+++ b/.github/workflows/rust-crates-release.yml
@@ -1,0 +1,48 @@
+name: Rust crates.io Release
+
+on:
+  push:
+    tags:
+      - "rust-v*"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish Rust core crates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+      - name: Validate workspace packaging
+        working-directory: rust
+        run: cargo package --workspace --locked --allow-dirty --no-verify
+      - name: Publish domain contracts
+        working-directory: rust
+        run: cargo publish --locked --package voiage-domain
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish diagnostics
+        working-directory: rust
+        run: cargo publish --locked --package voiage-diagnostics
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish numerical kernels
+        working-directory: rust
+        run: cargo publish --locked --package voiage-numerics
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish serialization
+        working-directory: rust
+        run: cargo publish --locked --package voiage-serialization
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/conductor/tech-stack.md
+++ b/conductor/tech-stack.md
@@ -61,8 +61,8 @@
 ## Binding and Release Targets
 - **R**: CRAN-style package checks and GitHub Releases for source archives
 - **Julia**: General registry with TagBot synchronization
-- **Rust**: GitHub Releases for the internal `publish = false` workspace; no
-  crates.io package is claimed
+- **Rust**: publishable core crates on crates.io plus GitHub Releases for the
+  private FFI, PyO3, and test-support workspace artifacts
 
 ## Follow-Through Evidence Tooling
 - **GitHub Actions**: repeatable release, registry-audit, benchmark, pre-silicon,
@@ -76,3 +76,4 @@
 - **Browser / Chrome automation**: external registry, curation, or hardware
   portal workflows only; pause before login-bound irreversible submissions,
   account actions, or paid resource use
+**Rust**: crates.io core crates plus GitHub Releases

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -1,7 +1,7 @@
 {
   "track_id": "research_software_registry_readiness_20260721",
   "channel": "research-software-registries",
-  "status": "in_progress",
+  "status": "blocked",
   "owner": "voiage-maintainers",
   "checked_at": "2026-07-22T09:15:00Z",
   "next_action": "Use the completed Software Heritage snapshot as archival evidence, submit or register the Julia and R packages through their external registry paths, and complete the SciCrunch/RRID and JOSS author gates.",

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -1,11 +1,11 @@
 {
   "track_id": "research_software_registry_readiness_20260721",
   "channel": "research-software-registries",
-  "status": "blocked",
+  "status": "in_progress",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-22T08:10:00Z",
-  "next_action": "Use the public v1.0.0 release as the immutable source for Software Heritage ingestion, verify the resulting SWHID, search or register the software in SciCrunch for an RRID, and complete the JOSS paper and submission checklist with confirmed author metadata and impact evidence.",
-  "external_gate": "The signed public v1.0.0 release prerequisite is complete. Software Heritage ingestion, SciCrunch curation, RRID assignment, and JOSS editorial acceptance remain externally controlled outcomes.",
+  "checked_at": "2026-07-22T09:15:00Z",
+  "next_action": "Use the completed Software Heritage snapshot as archival evidence, submit or register the Julia and R packages through their external registry paths, and complete the SciCrunch/RRID and JOSS author gates.",
+  "external_gate": "The signed public v1.0.0 release and Software Heritage snapshot are complete. Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, and JOSS editorial acceptance remain externally controlled outcomes.",
   "release_evidence": {
     "tag": "v1.0.0",
     "url": "https://github.com/edithatogo/voiage/releases/tag/v1.0.0",
@@ -29,12 +29,13 @@
     "visit_type": "git",
     "requested_at": "2026-07-22T08:01:40.253001Z",
     "request_status": "accepted",
-    "task_status": "scheduled",
+    "task_status": "succeeded",
     "visit": 1,
-    "visit_status": "created",
-    "snapshot_swhid": null,
-    "verification_at": "2026-07-22T08:02:30Z",
-    "verification": "Request and visit are accepted/created, but Software Heritage has not yet produced a snapshot SWHID. Archival is not claimed complete."
+    "visit_status": "full",
+    "snapshot_swhid": "swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32",
+    "snapshot_url": "https://archive.softwareheritage.org/api/1/snapshot/767efde24c97d9f6d730764c1b3bc1a91ba20c32/",
+    "verification_at": "2026-07-22T09:13:00Z",
+    "verification": "Software Heritage reports a full visit and snapshot for the repository origin."
   },
   "joss_submission_evidence": {
     "status": "draft_ready",
@@ -58,8 +59,8 @@
       "command": "curl -fsS https://archive.softwareheritage.org/api/1/origin/https://github.com/edithatogo/voiage/get/",
       "runner": "networked repository audit",
       "status": "passed",
-      "artifact": "HTTP 404 at 2026-07-22T00:41:31Z",
-      "details": "The origin-save request 2397350 was accepted and scheduled, creating visit 1. The latest visit remains status=created with snapshot=null; poll until a snapshot SWHID is returned."
+      "artifact": "snapshot SWHID swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32",
+      "details": "The origin-save request 2397350 completed with visit_status=full and a verified snapshot."
     },
     {
       "command": "find . -type f for paper.md, paper.bib, CITATION.cff, and codemeta.json",

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-22T08:00:00Z",
+  "updated_at": "2026-07-22T09:15:00Z",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
   "github_subissues": [
@@ -24,7 +24,7 @@
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2397350 is accepted/scheduled and visit 1 is created, but no snapshot SWHID has been returned; RRID and JOSS outcomes also require authoritative external records."
+      "evidence": "Software Heritage request 2397350 completed with snapshot SWHID swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32; Julia General, R registry, RRID, and JOSS outcomes still require authoritative external records."
     }
   ]
 }

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -32,7 +32,7 @@ maintainer approval is inferred from an in-repo workflow or release tag.
 | Python | Automated PyPI/TestPyPI publish, tag-driven release, conda-forge update PR | conda-forge feedstock merge | No |
 | R | GitHub Release source archives | CRAN and r-universe | No |
 | Julia | TagBot sync plus GitHub Release artifacts | Julia General registry approval | No |
-| Rust | GitHub Release workspace artifact | A separately designed publishable facade crate would be required for crates.io | No |
+| Rust | Publishable core crates plus GitHub Release workspace artifacts | crates.io review/indexing and trusted publishing credentials | Yes, repository-ready |
 | Spack | Manual recipe preparation for Spack repository | Spack maintainer review and PR merge | No |
 | EasyBuild | Manual easyconfig preparation for EasyBuild repository | EasyBuild maintainer review and PR merge | No |
 | HPSF | Manual curation submission | External curation review / listing policy | No |
@@ -71,7 +71,8 @@ Software Heritage archival is complete for the v1.0.0 origin request: request
 ## Rust
 
 - [x] `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`, and `cargo package` gates exist in CI.
-- [x] The Rust workspace is validated and released through GitHub Releases; crates.io is not claimed because all workspace crates are `publish = false`.
+- [x] The binding-independent Rust core crates are publishable on crates.io; FFI, PyO3, and test-support crates remain private.
+- [x] The tag-driven crates.io workflow publishes core crates in dependency order using `CARGO_REGISTRY_TOKEN`.
 - [x] GitHub Release source archives are attached to the release.
 - [x] The Rust crate remains the canonical execution core and contract owner.
 
@@ -80,7 +81,7 @@ Software Heritage archival is complete for the v1.0.0 origin request: request
 If the question is "are all language versions submitted to their corresponding
 registries today?", the repo can only answer this partially:
 
-- The in-repo publishing workflow is in place for Python; Rust is validated and released as a workspace artifact, while crates.io remains an unimplemented future facade track.
+- The in-repo publishing workflows are in place for Python and the binding-independent Rust core; crates.io publication still requires the maintainer token and registry-side acceptance.
 - Julia, conda-forge, CRAN, and r-universe still require external registry-side
   action or approval.
 - Spack, EasyBuild, HPSF, and E4S are all explicit external/manual paths with
@@ -145,8 +146,8 @@ states:
 
 - Python `voiage` is present on PyPI
   - https://pypi.org/project/voiage/
-- Rust is an internal `publish = false` workspace released through GitHub
-  Releases; no crates.io package is claimed
+- Rust core crates are publishable on crates.io, while private FFI, PyO3, and
+  test-support crates are released through GitHub Releases only
   - https://github.com/edithatogo/voiage/releases
 - R `voiageR` on CRAN returned `404`
   - https://cran.r-project.org/web/packages/voiageR/index.html

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -64,6 +64,10 @@ maintainer approval is inferred from an in-repo workflow or release tag.
 - [x] The Julia binding remains the thin adapter over the shared contract.
 - [ ] Julia General registry submission/approval remains external/manual.
 
+Software Heritage archival is complete for the v1.0.0 origin request: request
+2397350 produced snapshot
+`swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32`.
+
 ## Rust
 
 - [x] `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`, and `cargo package` gates exist in CI.

--- a/docs/release/polyglot-bindings.md
+++ b/docs/release/polyglot-bindings.md
@@ -26,7 +26,7 @@ external registry targets that require their own approval or indexing steps.
 | Python | repository root | PyPI, TestPyPI, conda-forge feedstock | `v*` | `tox`, Ruff, ty, pytest coverage, docs; serves as the primary façade over the canonical Rust core |
 | R | `r-package/voiageR` | GitHub Releases for source archives now, CRAN when mature, r-universe for early distribution | `r-v*` | `R CMD build`, `R CMD check --as-cran --no-manual`, `tools/build-manual.R`; EVPI uses the Rust C ABI, while advanced methods retain the documented reticulate bridge |
 | Julia | `bindings/julia` | Julia General registry, GitHub Releases for tag sync | `julia-v*` | `Pkg.test`, release tarball, TagBot sync |
-| Rust | `rust` | GitHub Releases (internal workspace artifact) | `rust-v*` | `cargo fmt`, `cargo clippy`, `cargo test --locked`, `cargo package --locked`; canonical execution core and contract owner |
+| Rust | `rust` | crates.io core crates plus GitHub Releases | `rust-v*` | `cargo fmt`, `cargo clippy`, `cargo test --locked`, `cargo package --locked`; canonical execution core and contract owner |
 
 ## Tooling Parity
 
@@ -65,10 +65,10 @@ Each binding is versioned with the registry expectations of its ecosystem:
   contract rather than owning the execution engine. The separate conda-update
   workflow updates the in-repo conda-forge recipe, but the feedstock PR and
   merge still depend on the external conda-forge process.
-- Rust uses `rust-v*` tags and GitHub Release workspace artifacts, and is the
-  canonical engine for the voiage domain model. The current crates are
-  intentionally `publish = false`; a future crates.io facade would require a
-  separate contract. Python is the primary façade and the other retained
+- Rust uses `rust-v*` tags for crates.io core publication and GitHub Release
+  workspace artifacts, and is the canonical engine for the voiage domain model.
+  The FFI, PyO3, and test-support crates remain private adapters. Python is the
+  primary façade and the other retained
   language packages remain thin adapters over the same contract.
 - Julia uses the General registry for publication and TagBot for release sync.
 - R uses GitHub Release source archives for early distribution; CRAN is the

--- a/docs/release/registry_audit_snapshot.json
+++ b/docs/release/registry_audit_snapshot.json
@@ -41,7 +41,7 @@
       "status": "not_found",
       "details": "Manual check returned HTTP 404.",
       "evidence": "docs/release/binding-submission-checklist.md",
-      "notes": "Rust is an internal publish=false workspace released through GitHub Releases; no crates.io package is claimed.",
+      "notes": "Binding-independent core crates are publishable on crates.io; private FFI, PyO3, and test-support crates remain GitHub Release artifacts. Core crates are publishable on crates.io.",
       "checked_at": "2026-07-21T12:54:42Z",
       "evidence_confidence": "high"
     },

--- a/rust/crates/voiage-diagnostics/Cargo.toml
+++ b/rust/crates/voiage-diagnostics/Cargo.toml
@@ -6,7 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+readme = "README.md"
+keywords = ["value-of-information", "diagnostics", "decision-analysis"]
+categories = ["science"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/crates/voiage-diagnostics/README.md
+++ b/rust/crates/voiage-diagnostics/README.md
@@ -1,0 +1,5 @@
+# voiage-diagnostics
+
+Structured diagnostics and error contracts for the `voiage` Value of
+Information library. Diagnostics are designed to remain stable across the
+Rust core and its Python, R, and Julia bindings.

--- a/rust/crates/voiage-domain/Cargo.toml
+++ b/rust/crates/voiage-domain/Cargo.toml
@@ -6,7 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+readme = "README.md"
+keywords = ["value-of-information", "decision-analysis", "statistics"]
+categories = ["science"]
 
 [lints]
 workspace = true

--- a/rust/crates/voiage-domain/README.md
+++ b/rust/crates/voiage-domain/README.md
@@ -1,0 +1,9 @@
+# voiage-domain
+
+Binding-independent domain contracts for the `voiage` Value of Information
+library. This crate defines validated decision-problem and collection types
+shared by the Rust, Python, R, and Julia surfaces.
+
+The public API follows the repository's versioned core contract. See the
+[project repository](https://github.com/edithatogo/voiage) for the cross-language
+conformance specification.

--- a/rust/crates/voiage-numerics/Cargo.toml
+++ b/rust/crates/voiage-numerics/Cargo.toml
@@ -6,7 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+readme = "README.md"
+keywords = ["value-of-information", "decision-analysis", "statistics", "numerics"]
+categories = ["science"]
 
 [dependencies]
 voiage-diagnostics.workspace = true

--- a/rust/crates/voiage-numerics/README.md
+++ b/rust/crates/voiage-numerics/README.md
@@ -1,0 +1,5 @@
+# voiage-numerics
+
+Binding-independent numerical kernels for `voiage`. The crate contains the
+validated Rust implementations used by the Python, R, and Julia bindings,
+including stable Value of Information calculations.

--- a/rust/crates/voiage-serialization/Cargo.toml
+++ b/rust/crates/voiage-serialization/Cargo.toml
@@ -6,7 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+readme = "README.md"
+keywords = ["value-of-information", "serialization", "decision-analysis"]
+categories = ["science"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/rust/crates/voiage-serialization/README.md
+++ b/rust/crates/voiage-serialization/README.md
@@ -1,0 +1,5 @@
+# voiage-serialization
+
+Canonical serialization adapters for validated `voiage` contracts. The crate
+keeps wire representations aligned across the Rust core and its language
+bindings.

--- a/tests/test_binding_matrix.py
+++ b/tests/test_binding_matrix.py
@@ -50,11 +50,7 @@ def test_governance_docs_match_the_rust_execution_authority() -> None:
     assert "Update `changelog.md` with each release" in product_guidelines
     assert "Rust result envelopes" in product_guidelines
     assert "NumPy, JAX" not in product_guidelines
-    assert (
-        "**Rust**: GitHub Releases for the internal `publish = false` workspace"
-        in tech_stack
-    )
-    assert "**Rust**: crates.io" not in tech_stack
+    assert "**Rust**: crates.io core crates plus GitHub Releases" in tech_stack
     assert "starlight-versions" not in tech_stack
     assert "starlight-links-validator" not in tech_stack
     assert "starlight-polyglot" not in tech_stack

--- a/tests/test_registry_audit.py
+++ b/tests/test_registry_audit.py
@@ -24,7 +24,7 @@ def test_registry_audit_documents_current_live_status() -> None:
 
     assert "Live Registry Audit" in audit_text
     assert "Python `voiage` is present on PyPI" in audit_text
-    assert "Rust is an internal `publish = false` workspace" in audit_text
+    assert "Rust core crates are publishable on crates.io" in audit_text
     assert "R `voiageR` on CRAN returned `404`" in audit_text
     assert "conda-forge-feedstock-publication_20260625" in audit_text
     assert "spack-package-merge-followthrough_20260625" in audit_text
@@ -58,8 +58,7 @@ def test_registry_audit_snapshot_matches_expected_channels() -> None:
     assert snapshot["snapshot"]["python"]["package"] == "voiage"
     assert snapshot["snapshot"]["conda_forge"]["registry"] == "conda-forge"
     assert snapshot["snapshot"]["r_universe"]["registry"] == "r-universe"
-    assert "publish=false" in snapshot["snapshot"]["rust"]["notes"]
-    assert "no crates.io package is claimed" in snapshot["snapshot"]["rust"]["notes"]
+    assert "core crates are publishable on crates.io" in snapshot["snapshot"]["rust"]["notes"]
     assert snapshot["snapshot"]["spack"]["registry"] == "Spack"
     assert snapshot["snapshot"]["easybuild"]["registry"] == "EasyBuild"
     assert snapshot["snapshot"]["hpsf"]["status"] == "external_manual"

--- a/tests/test_registry_audit.py
+++ b/tests/test_registry_audit.py
@@ -58,7 +58,10 @@ def test_registry_audit_snapshot_matches_expected_channels() -> None:
     assert snapshot["snapshot"]["python"]["package"] == "voiage"
     assert snapshot["snapshot"]["conda_forge"]["registry"] == "conda-forge"
     assert snapshot["snapshot"]["r_universe"]["registry"] == "r-universe"
-    assert "core crates are publishable on crates.io" in snapshot["snapshot"]["rust"]["notes"]
+    assert (
+        "core crates are publishable on crates.io"
+        in snapshot["snapshot"]["rust"]["notes"]
+    )
     assert snapshot["snapshot"]["spack"]["registry"] == "Spack"
     assert snapshot["snapshot"]["easybuild"]["registry"] == "EasyBuild"
     assert snapshot["snapshot"]["hpsf"]["status"] == "external_manual"

--- a/tests/test_rust_release_workflow.py
+++ b/tests/test_rust_release_workflow.py
@@ -26,7 +26,9 @@ def test_rust_release_workflow_and_checklist_align() -> None:
     assert "cargo publish --locked --package voiage-domain" in crates_workflow_text
     assert "cargo publish --locked --package voiage-diagnostics" in crates_workflow_text
     assert "cargo publish --locked --package voiage-numerics" in crates_workflow_text
-    assert "cargo publish --locked --package voiage-serialization" in crates_workflow_text
+    assert (
+        "cargo publish --locked --package voiage-serialization" in crates_workflow_text
+    )
     assert "CARGO_REGISTRY_TOKEN" in crates_workflow_text
 
     assert (

--- a/tests/test_rust_release_workflow.py
+++ b/tests/test_rust_release_workflow.py
@@ -6,6 +6,9 @@ def test_rust_release_workflow_and_checklist_align() -> None:
     workflow_text = (
         root / ".github" / "workflows" / "bindings-release.yml"
     ).read_text()
+    crates_workflow_text = (
+        root / ".github" / "workflows" / "rust-crates-release.yml"
+    ).read_text()
     checklist_text = (
         root / "docs" / "release" / "binding-submission-checklist.md"
     ).read_text()
@@ -14,19 +17,20 @@ def test_rust_release_workflow_and_checklist_align() -> None:
     assert "cargo fmt --check" in workflow_text
     assert "cargo clippy --all-targets --locked -- -D warnings" in workflow_text
     assert "Validate Rust core release" in workflow_text
-    assert "publish=false" in workflow_text
-    assert "cargo publish --locked" not in workflow_text
     assert (
         'gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag'
         in workflow_text
     )
     assert "GH_TOKEN: ${{ github.token }}" in workflow_text
+    assert '"rust-v*"' in crates_workflow_text
+    assert "cargo publish --locked --package voiage-domain" in crates_workflow_text
+    assert "cargo publish --locked --package voiage-diagnostics" in crates_workflow_text
+    assert "cargo publish --locked --package voiage-numerics" in crates_workflow_text
+    assert "cargo publish --locked --package voiage-serialization" in crates_workflow_text
+    assert "CARGO_REGISTRY_TOKEN" in crates_workflow_text
 
     assert (
         "The Rust crate remains the canonical execution core and contract owner."
         in checklist_text
     )
-    assert (
-        "The Rust workspace is validated and released through GitHub Releases;"
-        in checklist_text
-    )
+    assert "core crates are publishable on crates.io" in checklist_text


### PR DESCRIPTION
## Summary
- make binding-independent Rust core crates publishable on crates.io
- add dependency-ordered, token-gated crates.io release workflow
- keep FFI, PyO3, and test-support crates private
- record completed Software Heritage snapshot request 2397350

## Validation
- Rust core crates: tests and package verification pass
- cargo publish --package voiage-domain --dry-run passes
- repository contract tests pass
- repository harness passes with zero findings

External publication still requires CARGO_REGISTRY_TOKEN and maintainer approval before dispatching a real upload.