### PR TITLE
docs(joss): finalize submission evidence gates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1044,6 +1044,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unified accelerator evidence packet validation and deterministic indexing for passed GPU and blocked TPU/Metal runs, preserving CPU fallback and external-gate reasons.
 ## Unreleased
 
+- Selected direct JOSS review for the Rust-centred polyglot package, recorded
+  the rechecked pending arXiv status, and added a non-author clean-install and
+  research-use protocol without treating automated agents as community
+  adoption.
 - Fixed source-distribution reproducibility by embedding the committed source
   identity before isolated builds, and repaired invalid exception syntax and
   type-only backend annotations in the assurance branch.

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -3,9 +3,9 @@
   "channel": "research-software-registries",
   "status": "blocked",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-24T00:31:21Z",
-  "next_action": "Record the permanent arXiv identifier after announcement, confirm the JOSS funding statement and direct-versus-pyOpenSci route, and then perform the authenticated JOSS submission. Julia General still needs artifact/JLL packaging; R registry submission and SciCrunch/RRID curation remain separate external paths.",
-  "external_gate": "The signed public v1.0.0 release, Software Heritage snapshot, and authenticated arXiv submission are complete. ArXiv announcement, a permanent arXiv identifier, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
+  "checked_at": "2026-07-24T00:46:29Z",
+  "next_action": "Obtain the non-author installation and research-use evidence tracked in issue #471, record the permanent arXiv identifier after announcement, confirm the JOSS funding and conflict statements, and then perform the selected direct JOSS submission. Julia General still needs artifact/JLL packaging; R registry submission and SciCrunch/RRID curation remain separate external paths.",
+  "external_gate": "The signed public v1.0.0 release, Software Heritage snapshot, and authenticated arXiv submission are complete. The arXiv dashboard still reports submission 7861466 as submitted without a permanent identifier. Independent non-author validation, arXiv announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
   "release_evidence": {
     "tag": "v1.0.0",
     "url": "https://github.com/edithatogo/voiage/releases/tag/v1.0.0",
@@ -49,11 +49,18 @@
       "r": "fresh 1.0.0 source package passes R CMD check --as-cran with two environmental/new-submission notes",
       "julia": "Pkg.test passes against a locally built voiage-ffi library; artifact/JLL distribution remains pending"
     },
-    "partner_route": "pyOpenSci is the relevant optional partner because Python is the primary installable surface; direct JOSS is also valid, and the two reviews must not run concurrently.",
+    "selected_route": "direct_joss",
+    "route_rationale": "Direct JOSS preserves the submission's Rust-centred polyglot scope. pyOpenSci remains an optional later Python-package review rather than the selected route.",
+    "independent_validation": {
+      "status": "external_evidence_required",
+      "github_issue": "https://github.com/edithatogo/voiage/issues/471",
+      "protocol": "docs/release/joss-independent-validation.md",
+      "boundary": "The public repository history currently contains the author and automated accounts only. Bots, AI agents, and same-author integrations are not independent community engagement."
+    },
     "remaining_author_gates": [
       "confirm funding and conflicts of interest",
-      "choose direct JOSS or pyOpenSci-first review",
-      "perform the authenticated JOSS submission"
+      "obtain attributable or editor-verifiable non-author validation",
+      "perform the selected direct authenticated JOSS submission"
     ],
     "preprint_policy": "JOSS permits arXiv submission before, during, or after JOSS submission and does not treat a preprint as prior publication."
   },
@@ -67,6 +74,8 @@
     "builder": "scripts/build_arxiv_submission.py",
     "submission_performed": true,
     "submission_id": "7861466",
+    "dashboard_checked_at": "2026-07-24T00:46:29Z",
+    "dashboard_state": "submitted and not yet listed as an announced article",
     "remaining_human_gates": [
       "record the permanent arXiv identifier after announcement"
     ]
@@ -76,6 +85,8 @@
     "https://docs.softwareheritage.org/user/faq/",
     "https://www.rrids.org/new-page-1",
     "https://joss.readthedocs.io/en/latest/paper.html",
+    "https://joss.readthedocs.io/en/latest/submitting.html",
+    "https://joss.readthedocs.io/en/latest/review_criteria.html",
     "https://pubmed.ncbi.nlm.nih.gov/10537899/",
     "https://pubmed.ncbi.nlm.nih.gov/15090106/"
   ],
@@ -128,6 +139,13 @@
       "status": "passed_with_corrections",
       "artifact": "three-page Open Journals review PDF and corrected paper.bib",
       "details": "The PDF has no clipping, overlap, broken glyphs, or unreadable references. Two mismatched DOI records were replaced with authoritative Claxton 1999 and Ades, Lu, and Claxton 2004 metadata."
+    },
+    {
+      "command": "audit public contributor, issue, and pull-request authors; recheck authenticated arXiv dashboard; reconcile current JOSS pre-review criteria",
+      "runner": "GitHub API, authenticated arXiv account, and official JOSS documentation",
+      "status": "passed_with_external_gate",
+      "artifact": "issue #471 and docs/release/joss-independent-validation.md",
+      "details": "Submission 7861466 remains submitted without a permanent identifier. The public repository contains the author and automated contributors only, so independent non-author validation remains an explicit JOSS screening gate; direct JOSS is selected for the Rust-centred polyglot package."
     }
   ]
 }

--- a/conductor/tracks/research_software_registry_readiness_20260721/index.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/index.md
@@ -20,4 +20,4 @@ Paper hierarchy: [#299](https://github.com/edithatogo/voiage/issues/299) >
 
 - Track issue: [#296](https://github.com/edithatogo/voiage/issues/296)
 - Project: [VOP–VOIAGE Conductor Roadmap](https://github.com/users/edithatogo/projects/28)
-- Pull requests: [#300](https://github.com/edithatogo/voiage/pull/300), [#308](https://github.com/edithatogo/voiage/pull/308), [#309](https://github.com/edithatogo/voiage/pull/309), [#310](https://github.com/edithatogo/voiage/pull/310), [#311](https://github.com/edithatogo/voiage/pull/311)
+- Pull requests: [#300](https://github.com/edithatogo/voiage/pull/300), [#308](https://github.com/edithatogo/voiage/pull/308), [#309](https://github.com/edithatogo/voiage/pull/309), [#310](https://github.com/edithatogo/voiage/pull/310), [#311](https://github.com/edithatogo/voiage/pull/311), [#469](https://github.com/edithatogo/voiage/pull/469), [#470](https://github.com/edithatogo/voiage/pull/470), [#472](https://github.com/edithatogo/voiage/pull/472)

--- a/conductor/tracks/research_software_registry_readiness_20260721/index.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/index.md
@@ -8,7 +8,8 @@ tracked
 Parent issue: [#296](https://github.com/edithatogo/voiage/issues/296)
 
 Paper hierarchy: [#299](https://github.com/edithatogo/voiage/issues/299) >
-[#312](https://github.com/edithatogo/voiage/issues/312)
+[#312](https://github.com/edithatogo/voiage/issues/312) and
+[#471](https://github.com/edithatogo/voiage/issues/471)
 
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-24T00:31:21Z",
+  "updated_at": "2026-07-24T00:46:29Z",
   "description": "Track archival, identifier, language-registry, arXiv, and deferred JOSS readiness for the signed v1.0.0 research software release.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
@@ -12,7 +12,8 @@
     "https://github.com/edithatogo/voiage/issues/297",
     "https://github.com/edithatogo/voiage/issues/298",
     "https://github.com/edithatogo/voiage/issues/299",
-    "https://github.com/edithatogo/voiage/issues/312"
+    "https://github.com/edithatogo/voiage/issues/312",
+    "https://github.com/edithatogo/voiage/issues/471"
   ],
   "external_evidence_required": true,
   "gates": [
@@ -26,7 +27,7 @@
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2397350 completed with snapshot SWHID swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32. Authenticated arXiv submission 7861466 is complete but awaits announcement and a permanent identifier. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, or editorial decisions."
+      "evidence": "Software Heritage request 2397350 completed with snapshot SWHID swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32. Authenticated arXiv submission 7861466 remains submitted but awaits announcement and a permanent identifier. Direct JOSS is the selected route; issue #471 tracks independent non-author installation and research-use evidence before submission. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
     }
   ],
   "github_cross_reference": {

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -39,7 +39,10 @@
       "https://github.com/edithatogo/voiage/pull/308",
       "https://github.com/edithatogo/voiage/pull/309",
       "https://github.com/edithatogo/voiage/pull/310",
-      "https://github.com/edithatogo/voiage/pull/311"
+      "https://github.com/edithatogo/voiage/pull/311",
+      "https://github.com/edithatogo/voiage/pull/469",
+      "https://github.com/edithatogo/voiage/pull/470",
+      "https://github.com/edithatogo/voiage/pull/472"
     ],
     "pull_request_evidence": "evidenced"
   }

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -42,6 +42,12 @@
 - [x] Replace mismatched foundational bibliography records with authoritative
   source metadata and reject placeholder author lists in JOSS preflight.
   (`c37c78e`)
+- [x] Select direct JOSS review for the Rust-centred polyglot package and
+  publish a bounded independent-validation protocol. (issue #471)
+- [~] Obtain attributable non-author installation and research-use evidence
+  before direct JOSS submission. ([Issue
+  #471](https://github.com/edithatogo/voiage/issues/471); external participant
+  required)
 
 ## Phase 3: Reconciliation and closeout
 
@@ -61,18 +67,21 @@
   and snapshot
   `swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32`.
 - RRID route: SciCrunch General Resource registration; assignment and curation external.
-- JOSS route: the canonical arXiv LaTeX preprint and JOSS adaptation are
-  repository-ready; funding confirmation, submission-route selection,
-  authenticated submission, and editorial review remain human or external.
+- JOSS route: direct JOSS is selected for the Rust-centred polyglot package.
+  The canonical arXiv LaTeX preprint and JOSS adaptation are repository-ready;
+  independent validation, funding and conflict confirmation, authenticated
+  submission, and editorial review remain human or external.
 - Signed v1.0 release: complete at https://github.com/edithatogo/voiage/releases/tag/v1.0.0; live archival, identifier, submission, review, and indexing gates remain external.
 - GitHub work hierarchy: #296 is the registry parent; #297--#299 are native
   registry subissues; #312 is the native arXiv subissue of #299 and is present
-  in GitHub Project 28.
+  in GitHub Project 28; #471 is the native independent-validation subissue of
+  #299.
 - JOSS submission package: draft-ready with `paper.md`, `paper.bib`,
   `codemeta.json`, `CITATION.cff`, and `docs/joss-submission-readiness.md`.
-  Author affiliations and ORCID are recorded; the funding statement still
-  requires author confirmation. Concrete developer-led research use is stated
-  without claiming independent adoption.
+  Author affiliations and ORCID are recorded; the funding and conflict
+  statements still require author confirmation. Concrete developer-led
+  research use is stated without claiming independent adoption, and issue #471
+  records the current single-author community-engagement evidence gate.
 - arXiv preprint package: canonical authored source is `paper/main.tex`; the
   deterministic, non-submitting readiness pipeline validates TeX Live
   2023/2025, source hygiene, PDF/font integrity, semantic HTML, and independent

--- a/conductor/tracks/research_software_registry_readiness_20260721/spec.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/spec.md
@@ -21,11 +21,15 @@ Parent: [#296](https://github.com/edithatogo/voiage/issues/296)
 - [#299](https://github.com/edithatogo/voiage/issues/299)
   - [#312](https://github.com/edithatogo/voiage/issues/312) — arXiv preprint
     readiness, author review, and submission evidence
+  - [#471](https://github.com/edithatogo/voiage/issues/471) — independent
+    installation, usability, and research-use evidence before JOSS submission
 
 ## Acceptance
 
 The planning structure is complete when all subissues are linked,
 project-visible, and traceable from this track. The arXiv preparation lane is
 represented separately from JOSS submission so that an arXiv-first author
-decision does not imply a JOSS submission. Individual registry deliverables
-close only with authoritative evidence or a documented ineligibility decision.
+decision does not imply a JOSS submission. The JOSS lane distinguishes
+developer research use from independent community evidence and does not count
+automated accounts as external adoption. Individual registry deliverables close
+only with authoritative evidence or a documented ineligibility decision.

--- a/docs/release/joss-independent-validation.md
+++ b/docs/release/joss-independent-validation.md
@@ -1,0 +1,94 @@
+# JOSS independent validation protocol
+
+## Purpose
+
+The Journal of Open Source Software (JOSS) evaluates whether research software
+has credible research use and, for a single-author project, evidence of
+community engagement. Automated agents, dependency bots, and another repository
+maintained by the same author are not independent evidence.
+
+This protocol gives a non-author researcher or research-software practitioner a
+small, reproducible exercise. It does not ask for an endorsement. Problems,
+confusion, and unsuccessful installation attempts are useful evidence and
+should be reported accurately.
+
+Tracking issue: [#471](https://github.com/edithatogo/voiage/issues/471).
+
+## Clean installation
+
+Use Python 3.12, 3.13, or 3.14 in a new environment:
+
+```console
+python -m venv voiage-joss-review
+source voiage-joss-review/bin/activate
+python -m pip install --upgrade pip
+python -m pip install voiage==1.0.0
+python -c "import voiage; print(voiage.__version__)"
+```
+
+On Windows, activate the environment with
+`voiage-joss-review\Scripts\activate` instead.
+
+The final command should report `1.0.0`.
+
+## Core calculation
+
+Run this example without cloning the repository:
+
+```python
+import numpy as np
+
+from voiage.analysis import DecisionAnalysis
+from voiage.schema import ValueArray
+
+net_benefit = ValueArray.from_numpy(
+    np.array(
+        [
+            [10.0, 12.0],
+            [11.0, 9.0],
+            [13.0, 14.0],
+        ]
+    ),
+    strategy_names=["Standard care", "New treatment"],
+)
+
+analysis = DecisionAnalysis(net_benefit)
+print(f"EVPI: {analysis.evpi():.3f}")
+```
+
+The expected result is:
+
+```text
+EVPI: 0.667
+```
+
+The participant should then follow one worked example relevant to their
+interests from the [voiage documentation](https://edithatogo.github.io/voiage/)
+and record whether the assumptions, units, inputs, result, and limitations were
+understandable.
+
+## Evidence to report
+
+Please comment on issue #471 or open a linked issue with:
+
+- participant role or research context, without personal information that they
+  do not want made public;
+- operating system, processor architecture, Python version, and installation
+  command;
+- whether installation and the core calculation succeeded;
+- the second example attempted and its outcome;
+- any unclear terminology, assumptions, warnings, or documentation;
+- any defect, unexpected result, or missing prerequisite;
+- whether author intervention was needed.
+
+If the participant cannot report publicly, the author may instead retain an
+editor-verifiable record and tell the JOSS editor that confidential evidence is
+available. The manuscript should mention external use only when the evidence
+supports that exact statement.
+
+## Completion boundary
+
+This gate is complete only when a non-author has performed the exercise and
+reported attributable or editor-verifiable evidence. A locally repeated test,
+an AI-agent run, or an automated continuous-integration result does not satisfy
+it.

--- a/docs/release/joss-submission-readiness.md
+++ b/docs/release/joss-submission-readiness.md
@@ -2,9 +2,10 @@
 
 ## Current boundary
 
-The arXiv draft submission `7861466` is recorded by the authenticated arXiv
-account as `submitted`. A permanent arXiv identifier and announcement are not
-yet available and must not be inferred from the submission number.
+The arXiv draft submission `7861466` was rechecked on 24 July 2026 in the
+authenticated arXiv account and remains `submitted`. It is not yet listed under
+the account's announced articles. A permanent arXiv identifier and announcement
+are not available and must not be inferred from the submission number.
 
 The JOSS package is:
 
@@ -27,6 +28,7 @@ not replace it.
 | Iterative open development | Distributed commits, issues, pull requests, changelog and tagged releases | Ready |
 | Research application | VOI analysis for research prioritisation and probabilistic decision models | Ready |
 | Demonstrated developer research use | Fixed-seed health example and versioned `vop_poc_nz` integration contract | Ready, but independent adoption would strengthen screening |
+| Single-author community engagement | Public history contains only the author and automated accounts; [independent validation protocol](joss-independent-validation.md) and issue #471 are ready | External evidence required before submission |
 | JOSS manuscript structure | All current required sections and 750–1,750-word contract | Ready |
 | Design-thinking account | Kernel/orchestration boundary and cross-language trade-offs described | Ready |
 | AI usage disclosure | Tools, retained version limits, scope, human decisions and validation stated | Ready for author verification |
@@ -63,32 +65,31 @@ that they are independently installable from their language registries. A JOSS
 reviewer can assess the primary Python package without installing those
 secondary surfaces.
 
-## Direct JOSS versus partner review
+## Selected submission route
 
-Two valid routes are available:
+The selected route is **direct JOSS submission** after the remaining evidence
+gates are satisfied. This preserves the package's Rust-centred, polyglot scope
+rather than presenting the Python binding as the entire submission.
 
-1. **Direct JOSS submission.** This is the shorter route and reviews the paper,
-   research-software significance, installation, documentation, functionality,
-   tests and open-development evidence.
-2. **pyOpenSci review before JOSS.** pyOpenSci provides a deeper Python
-   packaging, usability and maintenance review. An accepted package that also
-   meets JOSS scope can use the pyOpenSci/JOSS partnership without a second
-   software review. The package should not be under simultaneous active review
-   at pyOpenSci and JOSS.
-
-pyOpenSci is the relevant partner because the primary installable user surface
-is Python. rOpenSci would become relevant only if `voiageR` were developed into
-the primary independently installable research package; the current R binding
-is not the appropriate submission unit.
+pyOpenSci remains a useful later review of the Python package's packaging,
+usability, and maintenance practices. Its partner route is not selected for
+this submission because it reviews the Python surface rather than the complete
+Rust-centred polyglot package. The project will not enter simultaneous active
+reviews at pyOpenSci and JOSS. rOpenSci would be relevant only if `voiageR`
+became the primary independently installable research package.
 
 The recommended sequence is:
 
-1. confirm the paper's funding statement, authorship and AI disclosure;
-2. wait for and record the permanent arXiv identifier;
-3. choose either direct JOSS or pyOpenSci-first review;
-4. for direct JOSS, submit the repository and `paper.md`;
-5. respond to review comments personally and without generative AI drafting;
-6. after acceptance-ready review, tag the reviewed version and create a
+1. obtain one attributable or editor-verifiable independent installation and
+   research-use report through issue #471;
+2. resolve any problems identified by that exercise;
+3. confirm the paper's funding statement, authorship, affiliations, ORCID,
+   conflicts of interest, and AI disclosure;
+4. wait for and record the permanent arXiv identifier, following the author's
+   preferred arXiv-first sequence;
+5. submit the repository and `paper.md` directly to JOSS;
+6. respond to review comments personally and without generative AI drafting;
+7. after acceptance-ready review, tag the reviewed version and create a
    DOI-bearing Zenodo or Figshare archive requested by JOSS.
 
 ## Remaining gates
@@ -96,9 +97,9 @@ The recommended sequence is:
 - Confirm that “No external funding is declared for this submission” is
   accurate.
 - Confirm the author list, affiliations and ORCID metadata.
+- Obtain independent installation and research-use evidence through issue #471;
+  automated accounts and same-author integrations do not satisfy this gate.
 - Record the permanent arXiv identifier when arXiv assigns it.
-- Choose direct JOSS or pyOpenSci-first review; do not run both reviews
-  concurrently.
-- Authorise and perform the authenticated JOSS submission.
+- Perform the selected direct authenticated JOSS submission.
 - Treat editorial screening, review, acceptance and DOI assignment as external
   outcomes.

--- a/roadmap.md
+++ b/roadmap.md
@@ -55,15 +55,17 @@ to Conductor track `research_software_registry_readiness_20260721`. The
 synthetic health example now reports simulation uncertainty, prespecified
 study-value sensitivity scenarios, and machine-readable numerical results.
 
-The authenticated arXiv draft is now recorded as submitted under submission
-number `7861466`; announcement and a permanent arXiv identifier remain external
-gates. The JOSS adaptation now follows the current 2026 screening and paper
-requirements, including design trade-offs, concrete developer research use,
-transparent AI-use disclosure, Software Heritage citation, a fail-closed local
-validator, and a pinned Open Journals draft build. Funding confirmation,
-selection of direct JOSS versus pyOpenSci-first review, authenticated
-submission, editorial review, acceptance, and DOI assignment remain explicit
-human or external gates.
+The authenticated arXiv draft was rechecked on 24 July 2026 and remains
+submitted under submission number `7861466`; announcement and a permanent arXiv
+identifier remain external gates. The JOSS adaptation follows the current 2026
+screening and paper requirements, including design trade-offs, concrete
+developer research use, transparent AI-use disclosure, Software Heritage
+citation, a fail-closed local validator, and a pinned Open Journals draft build.
+Direct JOSS review is selected for the Rust-centred polyglot package. Issue #471
+tracks the remaining independent non-author installation and research-use
+evidence; funding and conflict confirmation, authenticated submission,
+editorial review, acceptance, and DOI assignment remain explicit human or
+external gates.
 
 Three completed-in-repository assurance tracks remain archived with their
 explicit human gates visible: Domain Abstraction Excellence

--- a/tests/test_joss_readiness.py
+++ b/tests/test_joss_readiness.py
@@ -14,6 +14,23 @@ def test_current_joss_package_satisfies_repository_contract() -> None:
     assert validate_joss_package(ROOT) == []
 
 
+def test_joss_independent_validation_protocol_is_bounded() -> None:
+    """Independent evidence must not be substituted with automated activity."""
+    protocol = (ROOT / "docs/release/joss-independent-validation.md").read_text(
+        encoding="utf-8"
+    )
+    readiness = (ROOT / "docs/release/joss-submission-readiness.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "voiage==1.0.0" in protocol
+    assert "EVPI: 0.667" in protocol
+    assert "issue #471" in protocol
+    assert "AI-agent run" in protocol
+    assert "The selected route is **direct JOSS submission**" in readiness
+    assert "automated accounts" in readiness
+
+
 def test_joss_workflow_uses_pinned_open_journals_builder() -> None:
     """Hosted rendering should use the official pinned JOSS toolchain."""
     workflow = (ROOT / ".github/workflows/joss-paper.yml").read_text(encoding="utf-8")

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -18,8 +18,8 @@ def test_registry_handoff_preserves_release_and_external_gates() -> None:
         "track_id": "research_software_registry_readiness_20260721",
         "channel": "research-software-registries",
         "status": "blocked",
-        "command_count": 7,
-        "evidence_count": 6,
+        "command_count": 8,
+        "evidence_count": 8,
     }
 
 
@@ -32,9 +32,14 @@ def test_registry_track_records_native_paper_issue_hierarchy() -> None:
     specification = (track / "spec.md").read_text()
 
     arxiv_issue = "https://github.com/edithatogo/voiage/issues/312"
+    independent_validation_issue = "https://github.com/edithatogo/voiage/issues/471"
     assert arxiv_issue in metadata["github_subissues"]
+    assert independent_validation_issue in metadata["github_subissues"]
     assert arxiv_issue in plan
+    assert independent_validation_issue in plan
     assert arxiv_issue in specification
+    assert independent_validation_issue in specification
     assert handoff["arxiv_preprint_evidence"]["review_pr"].endswith("/pull/311")
     assert handoff["arxiv_preprint_evidence"]["submission_id"] == "7861466"
     assert "submission `7861466` is complete" in plan
+    assert handoff["joss_submission_evidence"]["selected_route"] == "direct_joss"

--- a/todo.md
+++ b/todo.md
@@ -28,6 +28,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         deliverables in #297--#299.
     *   The arXiv-first manuscript lane is native subissue #312 under #299;
         PR #311 contains the final repository-owned review changes.
+    *   Direct JOSS review is selected; native subissue #471 records the
+        independent non-author installation and research-use evidence required
+        before submission.
     *   Preparation is repository-owned; archival, identifiers, submission,
         review, acceptance, and indexing remain evidence-gated external states.
 


### PR DESCRIPTION
## Summary

- select direct JOSS review for the Rust-centred polyglot package
- record the authenticated arXiv dashboard recheck without inventing a permanent identifier
- add a bounded independent installation and research-use protocol linked to native subissue #471
- reconcile the Conductor registry-readiness track, roadmap, task list, and regression contracts

## Evidence

- `uv run --extra dev tox` (all environments passed except the initial lint formatting check; the single file was formatted and `tox -e lint` then passed)
- Python 3.12, 3.13, 3.14, minimum and maximum dependency suites passed
- coverage: 91.22%
- `uv run --extra dev tox -e lint`
- `uv run --extra dev tox -e vale`
- `uv run --extra ci python scripts/validate_joss.py`
- `uv run --extra ci pytest tests/test_joss_readiness.py tests/test_research_registry_readiness.py --no-cov -q`
- repository harness, Astro docs, type, frontier-contract, and version-sync environments passed

## External boundary

The repository has only the author and automated contributor accounts. Issue #471 therefore remains open for attributable or editor-verifiable non-author validation. Funding/conflict confirmation, the permanent arXiv identifier, authenticated JOSS submission, and editorial outcomes remain external or human gates.

Closes no external evidence issue.