### PR TITLE
docs(joss): record declarations and harden preflight

### DIFF
--- a/.github/workflows/joss-paper.yml
+++ b/.github/workflows/joss-paper.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "paper.md"
       - "paper.bib"
+      - "CITATION.cff"
+      - "codemeta.json"
       - "scripts/validate_joss.py"
       - "tests/test_joss_readiness.py"
       - ".github/workflows/joss-paper.yml"
@@ -13,6 +15,8 @@ on:
     paths:
       - "paper.md"
       - "paper.bib"
+      - "CITATION.cff"
+      - "codemeta.json"
       - "scripts/validate_joss.py"
       - "tests/test_joss_readiness.py"
       - ".github/workflows/joss-paper.yml"

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added cross-file JOSS preflight checks for CFF and CodeMeta release metadata,
+  including version, repository, licence, URL, ORCID, release, and download
+  identity checks, and run the hosted JOSS build when either metadata file
+  changes.
 - Added current-format JOSS paper content, concrete research-use and
   software-design evidence, transparent AI disclosure, a Software Heritage
   citation, a fail-closed manuscript validator, and a pinned Open Journals

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -3,8 +3,8 @@
   "channel": "research-software-registries",
   "status": "blocked",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-24T00:46:29Z",
-  "next_action": "Obtain the non-author installation and research-use evidence tracked in issue #471, record the permanent arXiv identifier after announcement, confirm the JOSS funding and conflict statements, and then perform the selected direct JOSS submission. Julia General still needs artifact/JLL packaging; R registry submission and SciCrunch/RRID curation remain separate external paths.",
+  "checked_at": "2026-07-24T02:36:19Z",
+  "next_action": "Obtain the non-author installation and research-use evidence tracked in issue #471, record the permanent arXiv identifier after announcement, and then perform the selected direct JOSS submission. Julia General still needs artifact/JLL packaging; R registry submission and SciCrunch/RRID curation remain separate external paths.",
   "external_gate": "The signed public v1.0.0 release, Software Heritage snapshot, and authenticated arXiv submission are complete. The arXiv dashboard still reports submission 7861466 as submitted without a permanent identifier. Independent non-author validation, arXiv announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
   "release_evidence": {
     "tag": "v1.0.0",
@@ -38,7 +38,7 @@
     "verification": "Software Heritage reports a full visit and snapshot for the repository origin."
   },
   "joss_submission_evidence": {
-    "status": "repository_ready_for_author_confirmation",
+    "status": "repository_ready_pending_external_evidence",
     "files": ["paper.md", "paper.bib", "codemeta.json", "CITATION.cff"],
     "readiness_document": "docs/release/joss-submission-readiness.md",
     "validator": "scripts/validate_joss.py",
@@ -57,8 +57,7 @@
       "protocol": "docs/release/joss-independent-validation.md",
       "boundary": "The public repository history currently contains the author and automated accounts only. Bots, AI agents, and same-author integrations are not independent community engagement."
     },
-    "remaining_author_gates": [
-      "confirm funding and conflicts of interest",
+    "remaining_submission_gates": [
       "obtain attributable or editor-verifiable non-author validation",
       "perform the selected direct authenticated JOSS submission"
     ],
@@ -103,7 +102,7 @@
       "runner": "local Git worktree",
       "status": "passed",
       "artifact": "paper.md, paper.bib, CITATION.cff, codemeta.json, validator, and hosted workflow",
-      "details": "JOSS draft paper and metadata are prepared; funding confirmation, route selection, PDF review, and authenticated submission remain."
+      "details": "JOSS draft paper and metadata are prepared; the author confirmed metadata, funding, competing-interest, and AI-disclosure statements on 24 July 2026. Independent validation and authenticated submission remain."
     },
     {
       "command": "review RRID software registration guidance",

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-24T00:46:29Z",
+  "updated_at": "2026-07-24T02:36:19Z",
   "description": "Track archival, identifier, language-registry, arXiv, and deferred JOSS readiness for the signed v1.0.0 research software release.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
@@ -27,7 +27,7 @@
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2397350 completed with snapshot SWHID swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32. Authenticated arXiv submission 7861466 remains submitted but awaits announcement and a permanent identifier. Direct JOSS is the selected route; issue #471 tracks independent non-author installation and research-use evidence before submission. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
+      "evidence": "Software Heritage request 2397350 completed with snapshot SWHID swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32. Authenticated arXiv submission 7861466 remains submitted but awaits announcement and a permanent identifier. The author confirmed JOSS authorship, affiliations, ORCID, funding, competing-interest, and AI-disclosure statements on 24 July 2026. Direct JOSS is the selected route; issue #471 tracks independent non-author installation and research-use evidence before submission. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
     }
   ],
   "github_cross_reference": {

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -44,6 +44,8 @@
   (`c37c78e`)
 - [x] Select direct JOSS review for the Rust-centred polyglot package and
   publish a bounded independent-validation protocol. (issue #471)
+- [~] Extend the JOSS preflight to reconcile CFF and CodeMeta release metadata
+  and trigger hosted JOSS validation for either metadata file.
 - [~] Obtain attributable non-author installation and research-use evidence
   before direct JOSS submission. ([Issue
   #471](https://github.com/edithatogo/voiage/issues/471); external participant
@@ -69,8 +71,9 @@
 - RRID route: SciCrunch General Resource registration; assignment and curation external.
 - JOSS route: direct JOSS is selected for the Rust-centred polyglot package.
   The canonical arXiv LaTeX preprint and JOSS adaptation are repository-ready;
-  independent validation, funding and conflict confirmation, authenticated
-  submission, and editorial review remain human or external.
+  independent validation, authenticated submission, and editorial review remain
+  human or external. The author confirmed funding, competing-interest,
+  affiliation, ORCID, and JOSS AI-disclosure statements on 24 July 2026.
 - Signed v1.0 release: complete at https://github.com/edithatogo/voiage/releases/tag/v1.0.0; live archival, identifier, submission, review, and indexing gates remain external.
 - GitHub work hierarchy: #296 is the registry parent; #297--#299 are native
   registry subissues; #312 is the native arXiv subissue of #299 and is present
@@ -78,16 +81,17 @@
   #299.
 - JOSS submission package: draft-ready with `paper.md`, `paper.bib`,
   `codemeta.json`, `CITATION.cff`, and `docs/joss-submission-readiness.md`.
-  Author affiliations and ORCID are recorded; the funding and conflict
-  statements still require author confirmation. Concrete developer-led
-  research use is stated without claiming independent adoption, and issue #471
-  records the current single-author community-engagement evidence gate.
+  Author affiliations, ORCID, funding, competing-interest, and AI-disclosure
+  statements are confirmed. Concrete developer-led research use is stated
+  without claiming independent adoption, and issue #471 records the current
+  single-author community-engagement evidence gate.
 - arXiv preprint package: canonical authored source is `paper/main.tex`; the
   deterministic, non-submitting readiness pipeline validates TeX Live
   2023/2025, source hygiene, PDF/font integrity, semantic HTML, and independent
   cleaner/collector variants. Authenticated submission `7861466` is complete;
   announcement and the permanent arXiv identifier remain external.
-- JOSS submission is explicitly deferred for this execution; no JOSS submission
-  or editorial action is claimed.
+- Direct JOSS submission is authorised by the author but remains unperformed
+  until issue #471 contains genuine non-author evidence and the author-preferred
+  arXiv announcement/permanent-identifier boundary is resolved.
 - JOSS permits an arXiv preprint before, during, or after JOSS submission;
   arXiv timing is therefore not a JOSS blocker.

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -44,8 +44,8 @@
   (`c37c78e`)
 - [x] Select direct JOSS review for the Rust-centred polyglot package and
   publish a bounded independent-validation protocol. (issue #471)
-- [~] Extend the JOSS preflight to reconcile CFF and CodeMeta release metadata
-  and trigger hosted JOSS validation for either metadata file.
+- [x] Extend the JOSS preflight to reconcile CFF and CodeMeta release metadata
+  and trigger hosted JOSS validation for either metadata file. (`2ba6e854`)
 - [~] Obtain attributable non-author installation and research-use evidence
   before direct JOSS submission. ([Issue
   #471](https://github.com/edithatogo/voiage/issues/471); external participant

--- a/docs/release/joss-submission-readiness.md
+++ b/docs/release/joss-submission-readiness.md
@@ -31,8 +31,9 @@ not replace it.
 | Single-author community engagement | Public history contains only the author and automated accounts; [independent validation protocol](joss-independent-validation.md) and issue #471 are ready | External evidence required before submission |
 | JOSS manuscript structure | All current required sections and 750–1,750-word contract | Ready |
 | Design-thinking account | Kernel/orchestration boundary and cross-language trade-offs described | Ready |
-| AI usage disclosure | Tools, retained version limits, scope, human decisions and validation stated | Ready for author verification |
-| Funding acknowledgement | Draft says no external funding is declared | Author confirmation required |
+| Author metadata | Dylan Mordaunt, ORCID and three affiliations confirmed by the author on 24 July 2026 | Ready |
+| AI usage disclosure | Tools, retained version limits, scope, human decisions and validation stated; confirmed by the author on 24 July 2026 | Ready |
+| Funding and competing interests | No external funding and no competing interests confirmed by the author on 24 July 2026 | Ready |
 | Permanent software archive | Software Heritage snapshot SWHID recorded | Ready; DOI-bearing archive still required at acceptance |
 | Reproducible JOSS PDF | Official Open Journals action pinned by commit; three-page artifact visually reviewed | Ready |
 | arXiv reference | Submission verified; permanent identifier pending | External gate |
@@ -83,20 +84,15 @@ The recommended sequence is:
 1. obtain one attributable or editor-verifiable independent installation and
    research-use report through issue #471;
 2. resolve any problems identified by that exercise;
-3. confirm the paper's funding statement, authorship, affiliations, ORCID,
-   conflicts of interest, and AI disclosure;
-4. wait for and record the permanent arXiv identifier, following the author's
+3. wait for and record the permanent arXiv identifier, following the author's
    preferred arXiv-first sequence;
-5. submit the repository and `paper.md` directly to JOSS;
-6. respond to review comments personally and without generative AI drafting;
-7. after acceptance-ready review, tag the reviewed version and create a
+4. submit the repository and `paper.md` directly to JOSS;
+5. respond to review comments personally and without generative AI drafting;
+6. after acceptance-ready review, tag the reviewed version and create a
    DOI-bearing Zenodo or Figshare archive requested by JOSS.
 
 ## Remaining gates
 
-- Confirm that “No external funding is declared for this submission” is
-  accurate.
-- Confirm the author list, affiliations and ORCID metadata.
 - Obtain independent installation and research-use evidence through issue #471;
   automated accounts and same-author integrations do not satisfy this gate.
 - Record the permanent arXiv identifier when arXiv assigns it.

--- a/paper.md
+++ b/paper.md
@@ -149,7 +149,8 @@ editors or reviewers.
 
 The author acknowledges the maintainers of the statistical,
 scientific-computing, packaging, and research-software infrastructure on which
-this work depends. No external funding is declared for this submission.
+this work depends. No external funding is declared for this submission. The
+author declares no competing interests.
 
 # References
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -63,9 +63,8 @@ developer research use, transparent AI-use disclosure, Software Heritage
 citation, a fail-closed local validator, and a pinned Open Journals draft build.
 Direct JOSS review is selected for the Rust-centred polyglot package. Issue #471
 tracks the remaining independent non-author installation and research-use
-evidence; funding and conflict confirmation, authenticated submission,
-editorial review, acceptance, and DOI assignment remain explicit human or
-external gates.
+evidence; authenticated submission, editorial review, acceptance, and DOI
+assignment remain explicit human or external gates.
 
 Three completed-in-repository assurance tracks remain archived with their
 explicit human gates visible: Domain Abstraction Excellence

--- a/scripts/validate_joss.py
+++ b/scripts/validate_joss.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import argparse
+from datetime import date
+import json
 from pathlib import Path
 import re
+from typing import Any
 
 REQUIRED_SECTIONS = (
     "Summary",
@@ -26,6 +29,11 @@ PLACEHOLDER_PATTERNS = (
 WORD_PATTERN = re.compile(r"\b[\w'-]+\b")
 CITATION_PATTERN = re.compile(r"@([A-Za-z0-9_:-]+)")
 BIB_KEY_PATTERN = re.compile(r"@\w+\{\s*([^,\s]+)")
+CFF_SCALAR_PATTERN = re.compile(
+    r'^(?P<key>[A-Za-z][A-Za-z0-9-]*):\s*(?:"(?P<quoted>[^"]*)"|(?P<plain>[^#\n]+?))\s*$',
+    re.MULTILINE,
+)
+CFF_ORCID_PATTERN = re.compile(r"^\s+orcid:\s*(?P<orcid>\S+)\s*$", re.MULTILINE)
 
 
 def _body_without_front_matter(text: str) -> str:
@@ -33,6 +41,92 @@ def _body_without_front_matter(text: str) -> str:
         return text
     parts = text.split("---", maxsplit=2)
     return parts[2] if len(parts) == 3 else text
+
+
+def _cff_scalars(text: str) -> dict[str, str]:
+    """Extract the small stable scalar surface used from CITATION.cff."""
+    return {
+        match.group("key"): (match.group("quoted") or match.group("plain")).strip()
+        for match in CFF_SCALAR_PATTERN.finditer(text)
+    }
+
+
+def _validate_discovery_metadata(root: Path) -> list[str]:
+    """Validate CFF and CodeMeta identity fields needed by JOSS reviewers."""
+    findings: list[str] = []
+    cff_path = root / "CITATION.cff"
+    codemeta_path = root / "codemeta.json"
+    if not cff_path.is_file():
+        findings.append("CITATION.cff is missing")
+    if not codemeta_path.is_file():
+        findings.append("codemeta.json is missing")
+    if findings:
+        return findings
+
+    scalars = _cff_scalars(cff_path.read_text(encoding="utf-8"))
+    required_cff_fields = (
+        "title",
+        "version",
+        "date-released",
+        "repository-code",
+        "url",
+        "license",
+    )
+    findings.extend(
+        f"CITATION.cff is missing {field}"
+        for field in required_cff_fields
+        if field not in scalars
+    )
+    orcid_match = CFF_ORCID_PATTERN.search(cff_path.read_text(encoding="utf-8"))
+    if orcid_match is None:
+        findings.append("CITATION.cff is missing an author ORCID")
+    try:
+        date.fromisoformat(scalars.get("date-released", ""))
+    except ValueError:
+        findings.append("CITATION.cff date-released must use ISO-8601 format")
+
+    try:
+        codemeta: dict[str, Any] = json.loads(codemeta_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return [*findings, "codemeta.json is not valid JSON"]
+
+    version = scalars.get("version")
+    repository = scalars.get("repository-code")
+    licence = scalars.get("license")
+    if version and codemeta.get("version") != version:
+        findings.append("codemeta.json version must match CITATION.cff version")
+    if repository and codemeta.get("codeRepository") != repository:
+        findings.append(
+            "codemeta.json codeRepository must match CITATION.cff repository-code"
+        )
+    if scalars.get("url") and codemeta.get("url") != scalars["url"]:
+        findings.append("codemeta.json url must match CITATION.cff url")
+    if licence and licence not in str(codemeta.get("license", "")):
+        findings.append("codemeta.json license must identify the CITATION.cff licence")
+    if (
+        version
+        and codemeta.get("downloadUrl") != f"https://pypi.org/project/voiage/{version}/"
+    ):
+        findings.append(
+            "codemeta.json downloadUrl must identify the CITATION.cff release"
+        )
+    if (
+        version
+        and codemeta.get("releaseNotes") != f"{repository}/releases/tag/v{version}"
+    ):
+        findings.append(
+            "codemeta.json releaseNotes must identify the CITATION.cff release"
+        )
+
+    authors = codemeta.get("author")
+    codemeta_orcid = (
+        authors[0].get("@id")
+        if isinstance(authors, list) and authors and isinstance(authors[0], dict)
+        else None
+    )
+    if orcid_match and codemeta_orcid != orcid_match.group("orcid"):
+        findings.append("codemeta.json author ORCID must match CITATION.cff")
+    return findings
 
 
 def validate_joss_package(root: Path) -> list[str]:
@@ -44,6 +138,8 @@ def validate_joss_package(root: Path) -> list[str]:
         return ["paper.md is missing"]
     if not bibliography_path.is_file():
         return ["paper.bib is missing"]
+
+    findings.extend(_validate_discovery_metadata(root))
 
     paper = paper_path.read_text(encoding="utf-8")
     bibliography = bibliography_path.read_text(encoding="utf-8")

--- a/tests/test_joss_readiness.py
+++ b/tests/test_joss_readiness.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from scripts.validate_joss import validate_joss_package
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_submission_metadata(destination: Path) -> None:
+    """Copy the checked-in discovery metadata into a temporary JOSS package."""
+    for filename in ("CITATION.cff", "codemeta.json"):
+        shutil.copy2(ROOT / filename, destination / filename)
 
 
 def test_current_joss_package_satisfies_repository_contract() -> None:
@@ -29,6 +36,8 @@ def test_joss_independent_validation_protocol_is_bounded() -> None:
     assert "AI-agent run" in protocol
     assert "The selected route is **direct JOSS submission**" in readiness
     assert "automated accounts" in readiness
+    assert "confirmed by the author on 24 July 2026" in readiness
+    assert "No external funding and no competing interests" in readiness
 
 
 def test_joss_workflow_uses_pinned_open_journals_builder() -> None:
@@ -42,6 +51,8 @@ def test_joss_workflow_uses_pinned_open_journals_builder() -> None:
     ) in workflow
     assert "python3 scripts/validate_joss.py" in workflow
     assert "if-no-files-found: error" in workflow
+    assert '"CITATION.cff"' in workflow
+    assert '"codemeta.json"' in workflow
 
 
 def test_joss_validator_rejects_missing_required_section(tmp_path: Path) -> None:
@@ -52,6 +63,7 @@ def test_joss_validator_rejects_missing_required_section(tmp_path: Path) -> None
         encoding="utf-8",
     )
     (tmp_path / "paper.bib").write_text("@misc{example, title={Example}}\n")
+    _write_submission_metadata(tmp_path)
 
     findings = validate_joss_package(tmp_path)
 
@@ -72,6 +84,7 @@ def test_joss_validator_rejects_placeholder_language(tmp_path: Path) -> None:
         (ROOT / "paper.bib").read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    _write_submission_metadata(tmp_path)
 
     findings = validate_joss_package(tmp_path)
 
@@ -92,9 +105,34 @@ def test_joss_validator_rejects_placeholder_bibliography_authors(
         ),
         encoding="utf-8",
     )
+    _write_submission_metadata(tmp_path)
 
     findings = validate_joss_package(tmp_path)
 
     assert findings == [
         "paper.bib contains placeholder author lists; record complete authors"
     ]
+
+
+def test_joss_validator_rejects_discovery_metadata_version_drift(
+    tmp_path: Path,
+) -> None:
+    """Citation and discovery records must describe the released JOSS package."""
+    (tmp_path / "paper.md").write_text(
+        (ROOT / "paper.md").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (tmp_path / "paper.bib").write_text(
+        (ROOT / "paper.bib").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    _write_submission_metadata(tmp_path)
+    codemeta = tmp_path / "codemeta.json"
+    codemeta.write_text(
+        codemeta.read_text(encoding="utf-8").replace(
+            '"version": "1.0.0"', '"version": "0.9.0"'
+        ),
+        encoding="utf-8",
+    )
+
+    findings = validate_joss_package(tmp_path)
+
+    assert "codemeta.json version must match CITATION.cff version" in findings

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -43,3 +43,7 @@ def test_registry_track_records_native_paper_issue_hierarchy() -> None:
     assert handoff["arxiv_preprint_evidence"]["submission_id"] == "7861466"
     assert "submission `7861466` is complete" in plan
     assert handoff["joss_submission_evidence"]["selected_route"] == "direct_joss"
+    assert (
+        handoff["joss_submission_evidence"]["status"]
+        == "repository_ready_pending_external_evidence"
+    )


### PR DESCRIPTION
## Summary

- record author-confirmed JOSS authorship, affiliations, ORCID, funding, competing-interest, and AI-disclosure statements
- add a factual no-competing-interests statement to the JOSS paper
- validate `CITATION.cff` and `codemeta.json` against the published release identity
- trigger the JOSS PDF/preflight workflow when either discovery metadata file changes
- retain #471 and the arXiv announcement as genuine external gates; post a public, non-endorsement validation request on #471

## Validation

- `uv run --extra dev tox`
- `uv run --extra ci pytest tests/test_joss_readiness.py tests/test_research_registry_readiness.py --no-cov -q`
- `uv run --extra ci python scripts/validate_joss.py`
- `uv run ruff check scripts/validate_joss.py tests/test_joss_readiness.py tests/test_research_registry_readiness.py`
- `uv run python scripts/validate_external_track_handoff.py conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json`

The full Conductor validator remains blocked by pre-existing archived-track registry drift outside this change; the active track's focused tests and handoff validation pass.
