### PR TITLE
feat(preparation): emit normalized input quality reports

### DIFF
--- a/tests/test_normalized_input_bundle.py
+++ b/tests/test_normalized_input_bundle.py
@@ -111,6 +111,11 @@ def test_preparation_preserves_explicit_binding_and_digest() -> None:
     assert prepared.net_benefits.strategy_names == ["A", "B"]
     assert prepared.net_benefits.numpy_values.tolist() == [[1.0, 2.0], [3.0, 1.0]]
     assert prepared.input_digest == _bundle().content_digest
+    assert prepared.quality_report.table_id == "net_benefit"
+    assert prepared.quality_report.selected_field_ids == ("strategy_a", "strategy_b")
+    assert prepared.quality_report.row_count == 2
+    assert prepared.quality_report.null_counts == {"strategy_a": 0, "strategy_b": 0}
+    assert prepared.quality_report.population_transforms == ()
 
 
 def test_manifest_matches_published_json_schema() -> None:

--- a/voiage/contracts/__init__.py
+++ b/voiage/contracts/__init__.py
@@ -63,7 +63,11 @@ from .normalized_input import (
     VOIBinding,
 )
 from .perspective import PerspectivePayload, adapt_perspective_result, run_perspective
-from .preparation import PreparedAnalysisInputs, prepare_analysis_inputs
+from .preparation import (
+    DataQualityReport,
+    PreparedAnalysisInputs,
+    prepare_analysis_inputs,
+)
 
 __all__ = [
     "AnalysisResult",
@@ -78,6 +82,7 @@ __all__ = [
     "ConcernSpec",
     "ContractModel",
     "ContractPerformanceBudget",
+    "DataQualityReport",
     "DatasetManifest",
     "DiagnosticEnvelope",
     "DiagnosticRecord",

--- a/voiage/contracts/preparation.py
+++ b/voiage/contracts/preparation.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pyarrow as pa
@@ -15,6 +17,21 @@ from voiage.contracts.normalized_input import (  # noqa: TC001 - public runtime 
 )
 from voiage.schema import ValueArray
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True)
+class DataQualityReport:
+    """Machine-readable evidence that preparation retained the input population."""
+
+    table_id: str
+    selected_field_ids: tuple[str, ...]
+    row_count: int
+    null_counts: Mapping[str, int]
+    duplicate_row_count: int
+    population_transforms: tuple[str, ...] = ()
+
 
 @dataclass(frozen=True)
 class PreparedAnalysisInputs:
@@ -23,6 +40,7 @@ class PreparedAnalysisInputs:
     net_benefits: ValueArray
     input_digest: str
     binding: VOIBinding
+    quality_report: DataQualityReport
 
 
 def prepare_analysis_inputs(bundle: NormalizedInputBundle) -> PreparedAnalysisInputs:
@@ -48,8 +66,19 @@ def prepare_analysis_inputs(bundle: NormalizedInputBundle) -> PreparedAnalysisIn
             raise ValueError(f"net-benefit field {field!r} is not numeric") from error
     values = np.column_stack(arrays).astype(float, copy=False)
     strategies = list(binding.strategy_names or binding.field_ids)
+    rows = tuple(tuple(row.values()) for row in selected.to_pylist())
+    quality_report = DataQualityReport(
+        table_id=binding.table_id,
+        selected_field_ids=tuple(binding.field_ids),
+        row_count=selected.num_rows,
+        null_counts=MappingProxyType(
+            {field: selected[field].null_count for field in binding.field_ids}
+        ),
+        duplicate_row_count=selected.num_rows - len(set(rows)),
+    )
     return PreparedAnalysisInputs(
         net_benefits=ValueArray.from_numpy(values, strategies),
         input_digest=bundle.content_digest,
         binding=binding,
+        quality_report=quality_report,
     )


### PR DESCRIPTION
## Summary\n- add machine-readable preparation quality reports\n- preserve selected table/fields, row count, null counts, duplicates, and explicit no-transform policy\n\nIncremental work toward #327; this does not close the track.\n\n## Validation\n- ..................................                                       [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
  /private/tmp/voiage-standardized-ingestion-20260723/.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
    NAT_TYPES = {np.datetime64("NaT").dtype, np.timedelta64("NaT").dtype}

tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_adapter_does_not_require_a_specific_frame_library
  /private/tmp/voiage-standardized-ingestion-20260723/.venv/lib/python3.14/site-packages/pyarrow/interchange/from_dataframe.py:88: DeprecationWarning: Support for the dataframe interchange protocol is deprecated since version 1.40.0
    return _from_dataframe(df.__dataframe__(allow_copy=allow_copy),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
34 passed, 3 warnings in 1.62s\n- All checks passed!