### PR TITLE
feat(preparation): expand input quality evidence

### DIFF
--- a/tests/test_normalized_input_bundle.py
+++ b/tests/test_normalized_input_bundle.py
@@ -121,6 +121,53 @@ def test_preparation_preserves_explicit_binding_and_digest() -> None:
     assert prepared.quality_report.population_transforms == ()
 
 
+def test_preparation_quality_report_records_keys_and_explicit_noop_decisions() -> None:
+    bundle = NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="quality-fixture",
+            tables=(
+                TableManifest(
+                    table_id="net_benefit",
+                    fields=(
+                        FieldManifest(field_id="sample_id", dtype="int64"),
+                        FieldManifest(field_id="strategy_a", dtype="float64"),
+                        FieldManifest(field_id="strategy_b", dtype="float64"),
+                    ),
+                    primary_key=("sample_id",),
+                ),
+            ),
+            provenance=_bundle().manifest.provenance,
+            bindings=(
+                VOIBinding(
+                    role="net_benefit",
+                    table_id="net_benefit",
+                    field_ids=("strategy_a", "strategy_b"),
+                ),
+            ),
+        ),
+        tables={
+            "net_benefit": pa.table(
+                {
+                    "sample_id": [1, 1, None],
+                    "strategy_a": [1.0, 1.0, 3.0],
+                    "strategy_b": [2.0, 2.0, 1.0],
+                }
+            )
+        },
+    )
+
+    report = prepare_analysis_inputs(bundle).quality_report
+
+    assert report.unique_value_counts == {"strategy_a": 2, "strategy_b": 2}
+    assert report.primary_key_fields == ("sample_id",)
+    assert report.primary_key_null_count == 1
+    assert report.primary_key_duplicate_count == 1
+    assert report.join_coverage == {}
+    assert report.coercions == ()
+    assert report.exclusions == ()
+    assert report.selected_partitions == ()
+
+
 def test_prepared_inputs_propagate_normalized_identity_into_calculation() -> None:
     prepared = prepare_analysis_inputs(_bundle())
     spec = analysis_spec_from_prepared_inputs(

--- a/voiage/contracts/preparation.py
+++ b/voiage/contracts/preparation.py
@@ -31,6 +31,14 @@ class DataQualityReport:
     row_count: int
     null_counts: Mapping[str, int]
     duplicate_row_count: int
+    unique_value_counts: Mapping[str, int]
+    primary_key_fields: tuple[str, ...]
+    primary_key_null_count: int
+    primary_key_duplicate_count: int
+    join_coverage: Mapping[str, float]
+    coercions: tuple[str, ...] = ()
+    exclusions: tuple[str, ...] = ()
+    selected_partitions: tuple[str, ...] = ()
     population_transforms: tuple[str, ...] = ()
 
 
@@ -73,6 +81,16 @@ def prepare_analysis_inputs(bundle: NormalizedInputBundle) -> PreparedAnalysisIn
     values = np.column_stack(arrays).astype(float, copy=False)
     strategies = list(binding.strategy_names or binding.field_ids)
     rows = tuple(tuple(row.values()) for row in selected.to_pylist())
+    table_manifest = next(
+        item for item in bundle.manifest.tables if item.table_id == binding.table_id
+    )
+    primary_key_rows = tuple(
+        tuple(row[field] for field in table_manifest.primary_key)
+        for row in table.to_pylist()
+    )
+    primary_key_null_count = sum(
+        any(value is None for value in row) for row in primary_key_rows
+    )
     quality_report = DataQualityReport(
         table_id=binding.table_id,
         selected_field_ids=tuple(binding.field_ids),
@@ -81,6 +99,20 @@ def prepare_analysis_inputs(bundle: NormalizedInputBundle) -> PreparedAnalysisIn
             {field: selected[field].null_count for field in binding.field_ids}
         ),
         duplicate_row_count=selected.num_rows - len(set(rows)),
+        unique_value_counts=MappingProxyType(
+            {
+                field: len(set(selected[field].to_pylist()))
+                for field in binding.field_ids
+            }
+        ),
+        primary_key_fields=table_manifest.primary_key,
+        primary_key_null_count=primary_key_null_count,
+        primary_key_duplicate_count=(
+            len(primary_key_rows) - len(set(primary_key_rows))
+            if table_manifest.primary_key
+            else 0
+        ),
+        join_coverage=MappingProxyType({}),
     )
     return PreparedAnalysisInputs(
         net_benefits=ValueArray.from_numpy(values, strategies),


### PR DESCRIPTION
## Summary
- enrich `DataQualityReport` with selected-field uniqueness, primary-key integrity, and explicit no-op join/coercion/exclusion/partition records
- retain the existing single normalized preparation and numerical calculation path

## Verification
- `uv run pytest tests/test_normalized_input_bundle.py tests/test_standardized_ingestion_providers.py --no-cov`