### PR TITLE
feat(preparation): declare method input capabilities

### DIFF
--- a/tests/test_normalized_input_bundle.py
+++ b/tests/test_normalized_input_bundle.py
@@ -22,6 +22,7 @@ from voiage.contracts import (
     TableManifest,
     VOIBinding,
     analysis_spec_from_prepared_inputs,
+    method_input_capability,
     prepare_analysis_inputs,
     run_evpi,
 )
@@ -201,6 +202,20 @@ def test_preparation_uses_the_explicit_binding_profile_identity() -> None:
     prepared = prepare_analysis_inputs(profiled_bundle)
 
     assert prepared.binding_profile_digest == profile.digest
+
+
+def test_method_input_capability_matrix_is_explicit_and_fail_closed() -> None:
+    capability = method_input_capability("evpi")
+
+    assert capability.required_binding_roles == ("net_benefit",)
+    assert capability.accepted_input_kinds == (
+        "direct-python",
+        "csv",
+        "normalized-bundle",
+    )
+    assert capability.requires_sample_alignment is True
+    with pytest.raises(ValueError, match="no normalized input capability"):
+        method_input_capability("evsi")
 
 
 def test_manifest_matches_published_json_schema() -> None:

--- a/voiage/contracts/__init__.py
+++ b/voiage/contracts/__init__.py
@@ -66,7 +66,9 @@ from .normalized_input import (
 from .perspective import PerspectivePayload, adapt_perspective_result, run_perspective
 from .preparation import (
     DataQualityReport,
+    MethodInputCapability,
     PreparedAnalysisInputs,
+    method_input_capability,
     prepare_analysis_inputs,
 )
 
@@ -95,6 +97,7 @@ __all__ = [
     "KernelRequirements",
     "KeyReference",
     "LegacyBackendAdapter",
+    "MethodInputCapability",
     "NormalizedInputBundle",
     "NumericalPolicy",
     "ParameterSpec",
@@ -120,6 +123,7 @@ __all__ = [
     "canonical_bundle_digest",
     "dispatch_calculation",
     "evaluate_backend",
+    "method_input_capability",
     "prepare_analysis_inputs",
     "run_evpi",
     "run_perspective",

--- a/voiage/contracts/preparation.py
+++ b/voiage/contracts/preparation.py
@@ -43,6 +43,39 @@ class DataQualityReport:
 
 
 @dataclass(frozen=True)
+class MethodInputCapability:
+    """Declared normalized-input requirements for one supported method family."""
+
+    method_family: str
+    required_binding_roles: tuple[str, ...]
+    accepted_input_kinds: tuple[str, ...]
+    requires_sample_alignment: bool
+    allows_implicit_transforms: bool = False
+
+
+_METHOD_INPUT_CAPABILITIES: Mapping[str, MethodInputCapability] = MappingProxyType(
+    {
+        "evpi": MethodInputCapability(
+            method_family="evpi",
+            required_binding_roles=("net_benefit",),
+            accepted_input_kinds=("direct-python", "csv", "normalized-bundle"),
+            requires_sample_alignment=True,
+        )
+    }
+)
+
+
+def method_input_capability(method_family: str) -> MethodInputCapability:
+    """Return the normalized-input contract for a method or fail closed."""
+    try:
+        return _METHOD_INPUT_CAPABILITIES[method_family]
+    except KeyError as error:
+        raise ValueError(
+            f"no normalized input capability is declared for {method_family!r}"
+        ) from error
+
+
+@dataclass(frozen=True)
 class PreparedAnalysisInputs:
     """Existing runtime values with their normalized-data provenance attached."""
 


### PR DESCRIPTION
## Summary
- add an explicit, immutable normalized-input capability matrix
- declare EVPI requirements and supported direct Python, CSV, and normalized-bundle inputs
- fail closed for undeclared method families, without changing existing direct entry points

## Verification
- `uv run pytest tests/test_normalized_input_bundle.py tests/test_standardized_ingestion_providers.py --no-cov`