### PR TITLE
feat(ingestion): declare provider capabilities

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -76,6 +76,24 @@ def test_built_in_providers_normalize_supported_csv_profile(
     assert bundle.table("samples").column_names == ["a", "b"]
 
 
+@pytest.mark.parametrize(
+    ("provider", "version"),
+    [(CroissantProvider(), "1.1"), (FrictionlessProvider(), "1")],
+)
+def test_provider_capabilities_declare_conservative_supported_profiles(
+    provider, version
+) -> None:
+    capabilities = provider.capabilities
+
+    assert capabilities.provider_id == provider.provider_id
+    assert version in capabilities.format_versions
+    assert capabilities.media_types == ("text/csv",)
+    assert capabilities.supports_projection is False
+    assert capabilities.supports_filtering is False
+    assert capabilities.supports_streaming is False
+    assert capabilities.supports_random_access is False
+
+
 def test_source_policy_blocks_path_traversal_and_network(tmp_path) -> None:
     policy = SourceAccessPolicy(tmp_path)
 

--- a/voiage/ingestion/__init__.py
+++ b/voiage/ingestion/__init__.py
@@ -1,6 +1,11 @@
 """Optional source-format adapters for the normalized VOI input contract."""
 
-from .base import IngestionError, IngestionProvider, SourceAccessPolicy
+from .base import (
+    IngestionError,
+    IngestionProvider,
+    ProviderCapabilities,
+    SourceAccessPolicy,
+)
 from .croissant import CroissantProvider
 from .dataframe import from_dataframe
 from .frictionless import FrictionlessProvider
@@ -11,6 +16,7 @@ __all__ = [
     "FrictionlessProvider",
     "IngestionError",
     "IngestionProvider",
+    "ProviderCapabilities",
     "ProviderRegistry",
     "SourceAccessPolicy",
     "default_registry",

--- a/voiage/ingestion/base.py
+++ b/voiage/ingestion/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003 - protocol runtime annotation
 from typing import Protocol
 
@@ -12,6 +13,20 @@ from voiage.contracts.normalized_input import (
 
 class IngestionError(ValueError):
     """Stable, safe error raised when an external source cannot be ingested."""
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Conservative, source-neutral statement of a provider's support surface."""
+
+    provider_id: str
+    format_versions: tuple[str, ...]
+    media_types: tuple[str, ...]
+    supported_transforms: tuple[str, ...] = ()
+    supports_projection: bool = False
+    supports_filtering: bool = False
+    supports_streaming: bool = False
+    supports_random_access: bool = False
 
 
 class SourceAccessPolicy:
@@ -39,6 +54,7 @@ class IngestionProvider(Protocol):
     """Adapter protocol; implementations must return only a normalized bundle."""
 
     provider_id: str
+    capabilities: ProviderCapabilities
 
     def can_handle(self, descriptor: dict[str, object]) -> bool:
         """Return whether this provider recognizes the already-read descriptor."""

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -15,13 +15,22 @@ from voiage.contracts.normalized_input import (
     TableManifest,
 )
 from voiage.ingestion._tabular import read_csv
-from voiage.ingestion.base import IngestionError, SourceAccessPolicy
+from voiage.ingestion.base import (
+    IngestionError,
+    ProviderCapabilities,
+    SourceAccessPolicy,
+)
 
 
 class CroissantProvider:
     """Convert an offline Croissant descriptor with one CSV RecordSet."""
 
     provider_id = "croissant"
+    capabilities = ProviderCapabilities(
+        provider_id=provider_id,
+        format_versions=("1.1",),
+        media_types=("text/csv",),
+    )
 
     def can_handle(self, descriptor: dict[str, object]) -> bool:
         """Recognize the Croissant context rather than a filename convention."""

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -15,13 +15,22 @@ from voiage.contracts.normalized_input import (
     TableManifest,
 )
 from voiage.ingestion._tabular import read_csv
-from voiage.ingestion.base import IngestionError, SourceAccessPolicy
+from voiage.ingestion.base import (
+    IngestionError,
+    ProviderCapabilities,
+    SourceAccessPolicy,
+)
 
 
 class FrictionlessProvider:
     """Convert an offline Data Package with exactly one CSV resource."""
 
     provider_id = "frictionless"
+    capabilities = ProviderCapabilities(
+        provider_id=provider_id,
+        format_versions=("1",),
+        media_types=("text/csv",),
+    )
 
     def can_handle(self, descriptor: dict[str, object]) -> bool:
         """Recognize a Data Package from its resource list."""


### PR DESCRIPTION
## Summary
- add immutable, source-neutral provider capability declarations
- declare the conservative Croissant 1.1 CSV and Frictionless v1 CSV profiles
- extend the provider protocol without adding parser dependencies to conductor contracts

## Verification
- `uv run pytest tests/test_standardized_ingestion_providers.py --no-cov`