### PR TITLE
feat(ingestion): add opt-in provider discovery

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -22,6 +22,7 @@ from voiage.ingestion import (
     IngestionError,
     SourceAccessPolicy,
     default_registry,
+    discover_entry_point_providers,
     from_dataframe,
 )
 from voiage.ingestion._tabular import digest_file, read_csv
@@ -163,6 +164,71 @@ def test_registry_rejects_invalid_and_ambiguous_descriptors(tmp_path) -> None:
     invalid.write_text("{}", encoding="utf-8")
     with pytest.raises(IngestionError, match="exactly one"):
         ProviderRegistry().ingest(invalid)
+
+
+def test_entry_point_discovery_is_opt_in_and_allow_listed() -> None:
+    loaded: list[str] = []
+
+    class EntryPoint:
+        def __init__(self, name: str, value: object) -> None:
+            self.name = name
+            self._value = value
+
+        def load(self) -> object:
+            loaded.append(self.name)
+            return self._value
+
+    allowed = EntryPoint("example-provider", CroissantProvider())
+    ignored = EntryPoint("untrusted-provider", FrictionlessProvider())
+    resolver_calls: list[str] = []
+
+    def resolver(*, group: str):
+        resolver_calls.append(group)
+        return (ignored, allowed)
+
+    assert discover_entry_point_providers(allowlist=(), resolver=resolver) == ()
+    assert resolver_calls == []
+    assert loaded == []
+
+    providers = discover_entry_point_providers(
+        allowlist=("example-provider",), resolver=resolver
+    )
+
+    assert resolver_calls == ["voiage.ingestion.providers"]
+    assert loaded == ["example-provider"]
+    assert providers == (allowed._value,)
+
+
+def test_entry_point_discovery_rejects_missing_invalid_and_failing_providers() -> None:
+    class EntryPoint:
+        name = "example-provider"
+
+        def __init__(self, value: object, *, fail: bool = False) -> None:
+            self.value = value
+            self.fail = fail
+
+        def load(self) -> object:
+            if self.fail:
+                raise RuntimeError("private source details")
+            return self.value
+
+    def resolver(*, group: str):
+        assert group == "voiage.ingestion.providers"
+        return (EntryPoint(object()),)
+
+    with pytest.raises(IngestionError, match="does not satisfy"):
+        discover_entry_point_providers(allowlist=("example-provider",), resolver=resolver)
+    with pytest.raises(IngestionError, match="unavailable"):
+        discover_entry_point_providers(allowlist=("missing",), resolver=resolver)
+
+    def failing_resolver(*, group: str):
+        return (EntryPoint(CroissantProvider(), fail=True),)
+
+    with pytest.raises(IngestionError, match="could not be loaded") as error:
+        discover_entry_point_providers(
+            allowlist=("example-provider",), resolver=failing_resolver
+        )
+    assert "private source details" not in str(error.value)
 
 
 def test_tabular_and_preparation_rejection_paths(tmp_path) -> None:

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -217,7 +217,9 @@ def test_entry_point_discovery_rejects_missing_invalid_and_failing_providers() -
         return (EntryPoint(object()),)
 
     with pytest.raises(IngestionError, match="does not satisfy"):
-        discover_entry_point_providers(allowlist=("example-provider",), resolver=resolver)
+        discover_entry_point_providers(
+            allowlist=("example-provider",), resolver=resolver
+        )
     with pytest.raises(IngestionError, match="unavailable"):
         discover_entry_point_providers(allowlist=("missing",), resolver=resolver)
 

--- a/voiage/ingestion/__init__.py
+++ b/voiage/ingestion/__init__.py
@@ -9,7 +9,7 @@ from .base import (
 from .croissant import CroissantProvider
 from .dataframe import from_dataframe
 from .frictionless import FrictionlessProvider
-from .registry import ProviderRegistry, default_registry
+from .registry import ProviderRegistry, default_registry, discover_entry_point_providers
 
 __all__ = [
     "CroissantProvider",
@@ -20,5 +20,6 @@ __all__ = [
     "ProviderRegistry",
     "SourceAccessPolicy",
     "default_registry",
+    "discover_entry_point_providers",
     "from_dataframe",
 ]

--- a/voiage/ingestion/registry.py
+++ b/voiage/ingestion/registry.py
@@ -2,13 +2,65 @@
 
 from __future__ import annotations
 
+from importlib.metadata import entry_points
 import json
 from pathlib import Path  # noqa: TC003 - public runtime annotation
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
+    from importlib.metadata import EntryPoint
 
 from voiage.contracts.normalized_input import (
     NormalizedInputBundle,  # noqa: TC001 - public runtime API
 )
 from voiage.ingestion.base import IngestionError, IngestionProvider, SourceAccessPolicy
+
+_ENTRY_POINT_GROUP = "voiage.ingestion.providers"
+
+
+def _validate_provider(provider: object) -> IngestionProvider:
+    """Validate an explicitly loaded provider without importing its package."""
+    if not (
+        isinstance(getattr(provider, "provider_id", None), str)
+        and callable(getattr(provider, "can_handle", None))
+        and callable(getattr(provider, "ingest", None))
+        and getattr(provider, "capabilities", None) is not None
+    ):
+        raise IngestionError("entry-point provider does not satisfy the provider contract")
+    return cast("IngestionProvider", provider)
+
+
+def discover_entry_point_providers(
+    *,
+    allowlist: Collection[str],
+    resolver: Callable[..., Collection[EntryPoint]] = entry_points,
+) -> tuple[IngestionProvider, ...]:
+    """Load only explicitly allow-listed third-party provider entry points.
+
+    Discovery is opt-in: an empty allow-list does not inspect installed entry
+    points, and providers outside the allow-list are never imported. Entry
+    points must return initialized provider instances rather than factories.
+    """
+    allowed = frozenset(allowlist)
+    if not allowed:
+        return ()
+    candidates = resolver(group=_ENTRY_POINT_GROUP)
+    providers: list[IngestionProvider] = []
+    loaded_names: set[str] = set()
+    for candidate in sorted(candidates, key=lambda item: item.name):
+        if candidate.name not in allowed:
+            continue
+        try:
+            provider = candidate.load()
+        except Exception as error:
+            raise IngestionError("allow-listed provider could not be loaded") from error
+        providers.append(_validate_provider(provider))
+        loaded_names.add(candidate.name)
+    missing = allowed - loaded_names
+    if missing:
+        raise IngestionError("allow-listed provider entry point is unavailable")
+    return tuple(providers)
 
 
 class ProviderRegistry:

--- a/voiage/ingestion/registry.py
+++ b/voiage/ingestion/registry.py
@@ -27,7 +27,9 @@ def _validate_provider(provider: object) -> IngestionProvider:
         and callable(getattr(provider, "ingest", None))
         and getattr(provider, "capabilities", None) is not None
     ):
-        raise IngestionError("entry-point provider does not satisfy the provider contract")
+        raise IngestionError(
+            "entry-point provider does not satisfy the provider contract"
+        )
     return cast("IngestionProvider", provider)
 
 


### PR DESCRIPTION
Implements standardized dataset-ingestion P3-T5: third-party providers are discovered only on an explicit allow-listed request. Empty allow-lists do not query entry points; non-allow-listed entry points are never loaded; loaded providers are contract-validated; resolver injection makes the behavior deterministic and testable.\n\nFocused validation: `uv run ruff check ...`, `uv run ty check ...`, `uv run pytest tests/test_standardized_ingestion_providers.py --no-cov` (20 passed).