### PR TITLE
feat(croissant): reject unsupported archives and transforms

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -491,6 +491,39 @@ def test_croissant_provider_rejects_unsupported_version_explicitly(tmp_path) -> 
         CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
 
 
+@pytest.mark.parametrize(
+    ("distribution", "message"),
+    [
+        ({"contentUrl": "samples.zip"}, "archives"),
+        (
+            {"contentUrl": "samples.csv", "transform": {"script": "x"}},
+            "transformations",
+        ),
+    ],
+)
+def test_croissant_provider_rejects_unsupported_archives_and_transformations(
+    tmp_path, distribution, message
+) -> None:
+    _write_csv(tmp_path)
+    descriptor_path = tmp_path / "croissant.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "name": "unsupported-profile-feature",
+                "distribution": [distribution],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
 def test_dataframe_adapter_rejects_non_dataframe() -> None:
     with pytest.raises(ValueError, match="dataframe interchange"):
         from_dataframe(object(), dataset_id="bad")

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -69,6 +69,14 @@ class CroissantProvider:
             raise IngestionError(
                 "Croissant recordSet requires name, field, and distribution contentUrl"
             )
+        if reference.lower().endswith((".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz")):
+            raise IngestionError(
+                "supported Croissant profile does not support archives"
+            )
+        if distribution.get("transform") not in (None, []):
+            raise IngestionError(
+                "supported Croissant profile does not support transformations"
+            )
         table = read_csv(reference, policy)
         manifest_fields = tuple(
             FieldManifest(field_id=name, dtype=str(table.schema.field(name).type))


### PR DESCRIPTION
Adds explicit conservative-profile rejections for Croissant archive resources and declared transformations, with offline fixtures.\n\nFocused validation: Ruff, type check, and `tests/test_standardized_ingestion_providers.py` (26 passed).