### PR TITLE
test(croissant): reject unsupported profile semantics

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -68,7 +68,7 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   `python scripts/dependency_frontier.py . --strict`; review and record the
   Croissant parser dependency and supported-profile decision before changing
   dependencies. (`e41591e`)
-- [ ] **P4-T2 / AC-04:** Write failing offline fixtures/tests for versioning,
+- [~] **P4-T2 / AC-04:** Write failing offline fixtures/tests for versioning,
   identities, resources, record sets, fields, keys, references, splits,
   supported transformations, integrity failures, archives, nesting, and
   ambiguous semantics.

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -524,6 +524,62 @@ def test_croissant_provider_rejects_unsupported_archives_and_transformations(
         CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
 
 
+@pytest.mark.parametrize(
+    (
+        "descriptor_update",
+        "distribution_update",
+        "record_set_update",
+        "field_update",
+        "message",
+    ),
+    [
+        ({"@id": "https://example.invalid/dataset"}, {}, {}, {}, "identities"),
+        (
+            {"conformsTo": "http://mlcommons.org/croissant/1.0"},
+            {},
+            {},
+            {},
+            "conformsTo",
+        ),
+        ({}, {"encodingFormat": "application/json"}, {}, {}, "CSV media type"),
+        ({}, {"sha256": "00"}, {}, {}, "integrity declarations"),
+        ({}, {}, {"key": ["a"]}, {}, "keys"),
+        ({}, {}, {"split": "train"}, {}, "splits"),
+        ({}, {}, {}, {"references": "other-table"}, "references"),
+        ({}, {}, {}, {"subField": [{"name": "nested"}]}, "nested fields"),
+        ({}, {}, {}, {"source": {"fileObject": "samples.csv"}}, "field sources"),
+    ],
+)
+def test_croissant_provider_rejects_unsupported_profile_semantics_explicitly(
+    tmp_path,
+    descriptor_update,
+    distribution_update,
+    record_set_update,
+    field_update,
+    message,
+) -> None:
+    """Unsupported descriptor semantics must never be silently ignored."""
+    _write_csv(tmp_path)
+    descriptor_path = tmp_path / "croissant.json"
+    field = {"name": "a", **field_update}
+    record_set = {
+        "name": "samples",
+        "field": [field, {"name": "b"}],
+        **record_set_update,
+    }
+    descriptor = {
+        "@context": "https://mlcommons.org/croissant/1.1",
+        "name": "unsupported-profile-semantics",
+        "distribution": [{"contentUrl": "samples.csv", **distribution_update}],
+        "recordSet": [record_set],
+        **descriptor_update,
+    }
+    descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+
+    with pytest.raises(IngestionError, match=message):
+        CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
 def test_dataframe_adapter_rejects_non_dataframe() -> None:
     with pytest.raises(ValueError, match="dataframe interchange"):
         from_dataframe(object(), dataset_id="bad")

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -58,6 +58,7 @@ class CroissantProvider:
             )
         record_set = cast("dict[str, object]", record_sets[0])
         distribution = cast("dict[str, object]", distributions[0])
+        self._reject_unsupported_semantics(descriptor, distribution, record_set)
         table_id = record_set.get("name")
         reference = distribution.get("contentUrl")
         fields = record_set.get("field")
@@ -106,3 +107,54 @@ class CroissantProvider:
             ),
             tables={table_id: table},
         )
+
+    @staticmethod
+    def _reject_unsupported_semantics(
+        descriptor: dict[str, object],
+        distribution: dict[str, object],
+        record_set: dict[str, object],
+    ) -> None:
+        """Reject semantics that the conservative profile cannot preserve."""
+        if "@id" in descriptor:
+            raise IngestionError(
+                "supported Croissant profile does not support identities"
+            )
+        conforms_to = descriptor.get("conformsTo")
+        if (
+            conforms_to is not None
+            and conforms_to != "http://mlcommons.org/croissant/1.1"
+        ):
+            raise IngestionError(
+                "supported Croissant profile requires Croissant 1.1 conformsTo"
+            )
+        encoding_format = distribution.get("encodingFormat")
+        if encoding_format is not None and encoding_format != "text/csv":
+            raise IngestionError("supported Croissant profile requires CSV media type")
+        if any(
+            key in distribution for key in ("sha256", "contentChecksum", "checksum")
+        ):
+            raise IngestionError(
+                "supported Croissant profile does not support integrity declarations"
+            )
+        if any(key in record_set for key in ("key", "primaryKey")):
+            raise IngestionError("supported Croissant profile does not support keys")
+        if "split" in record_set:
+            raise IngestionError("supported Croissant profile does not support splits")
+        fields = record_set.get("field")
+        if not isinstance(fields, list):
+            return
+        for field in fields:
+            if not isinstance(field, dict):
+                continue
+            if "references" in field:
+                raise IngestionError(
+                    "supported Croissant profile does not support field references"
+                )
+            if "subField" in field:
+                raise IngestionError(
+                    "supported Croissant profile does not support nested fields"
+                )
+            if "source" in field:
+                raise IngestionError(
+                    "supported Croissant profile does not support field sources"
+                )


### PR DESCRIPTION
## Summary
- adds offline Croissant negative fixtures for descriptor identities, version claims, media types, integrity declarations, keys, splits, references, nested fields, and field sources
- makes the conservative CSV profile reject every unsupported semantic before materialization
- keeps P4-T2 and issue #329 in progress because the full conformance fixture matrix remains incomplete

## Validation
- `uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_providers.py --no-cov` (35 passed)
- `uv run ruff check voiage/ingestion/croissant.py tests/test_standardized_ingestion_providers.py`
- `uv run ty check voiage/ingestion/croissant.py`

Closes no issues.