### PR TITLE
feat(croissant): validate local resource checksums

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -542,7 +542,7 @@ def test_croissant_provider_rejects_unsupported_archives_and_transformations(
             "conformsTo",
         ),
         ({}, {"encodingFormat": "application/json"}, {}, {}, "CSV media type"),
-        ({}, {"sha256": "00"}, {}, {}, "integrity declarations"),
+        ({}, {"contentChecksum": "00"}, {}, {}, "integrity declarations"),
         ({}, {}, {"key": ["a"]}, {}, "keys"),
         ({}, {}, {"split": "train"}, {}, "splits"),
         ({}, {}, {}, {"references": "other-table"}, "references"),
@@ -578,6 +578,53 @@ def test_croissant_provider_rejects_unsupported_profile_semantics_explicitly(
 
     with pytest.raises(IngestionError, match=message):
         CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("checksum", "message"),
+    [
+        (None, None),
+        ("0" * 64, "SHA-256"),
+    ],
+)
+def test_croissant_provider_validates_declared_local_sha256(
+    tmp_path, checksum, message
+) -> None:
+    """A declared local FileObject checksum must be verified before parsing."""
+    _write_csv(tmp_path)
+    descriptor_path = tmp_path / "croissant.json"
+    distribution = {"contentUrl": "samples.csv"}
+    if checksum is None:
+        distribution["sha256"] = digest_file(tmp_path / "samples.csv")
+    else:
+        distribution["sha256"] = checksum
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "name": "checksum-fixture",
+                "distribution": [distribution],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    if message is not None:
+        with pytest.raises(IngestionError, match=message):
+            CroissantProvider().ingest(
+                descriptor_path, policy=SourceAccessPolicy(tmp_path)
+            )
+    else:
+        assert (
+            CroissantProvider()
+            .ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+            .table("samples")
+            .num_rows
+            == 2
+        )
 
 
 def test_dataframe_adapter_rejects_non_dataframe() -> None:

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -14,7 +14,7 @@ from voiage.contracts.normalized_input import (
     SourceProvenance,
     TableManifest,
 )
-from voiage.ingestion._tabular import read_csv
+from voiage.ingestion._tabular import digest_file, read_csv
 from voiage.ingestion.base import (
     IngestionError,
     ProviderCapabilities,
@@ -78,6 +78,14 @@ class CroissantProvider:
             raise IngestionError(
                 "supported Croissant profile does not support transformations"
             )
+        declared_sha256 = distribution.get("sha256")
+        if declared_sha256 is not None and (
+            not isinstance(declared_sha256, str)
+            or digest_file(policy.resolve(reference)).lower() != declared_sha256.lower()
+        ):
+            raise IngestionError(
+                "declared Croissant SHA-256 does not match local content"
+            )
         table = read_csv(reference, policy)
         manifest_fields = tuple(
             FieldManifest(field_id=name, dtype=str(table.schema.field(name).type))
@@ -130,9 +138,7 @@ class CroissantProvider:
         encoding_format = distribution.get("encodingFormat")
         if encoding_format is not None and encoding_format != "text/csv":
             raise IngestionError("supported Croissant profile requires CSV media type")
-        if any(
-            key in distribution for key in ("sha256", "contentChecksum", "checksum")
-        ):
+        if any(key in distribution for key in ("contentChecksum", "checksum")):
             raise IngestionError(
                 "supported Croissant profile does not support integrity declarations"
             )


### PR DESCRIPTION
## Summary
- verifies declared local Croissant `sha256` values before CSV parsing
- emits a stable mismatch error rather than silently accepting changed content
- keeps unsupported non-SHA-256 integrity declarations fail-closed

## Validation
- `pytest -q tests/test_standardized_ingestion_providers.py --no-cov` (37 passed)
- Ruff and ty on Croissant provider and tests

Partial P4-T2 only; does not close #329.