### PR TITLE
docs(conductor): record Frictionless profile decision

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/decisions.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/decisions.md
@@ -38,3 +38,42 @@ source-policy-preserving integration tests, explicit parser-capability
 declarations, receipt/provenance handling, and base-install isolation evidence.
 Only then may a later task add a version-bounded `mlcroissant` dependency to the
 `croissant` extra and publish the separate enhanced-parser profile.
+
+## P4-T6 — Frictionless parser dependency (2026-07-26)
+
+### Decision
+
+Keep the built-in Frictionless Data Package CSV adapter as the only supported
+runtime profile for now. Do not add `frictionless` to `voiage[frictionless]`
+in this task. The named extra remains intentionally empty until a provider
+implementation proves that descriptor loading and resource materialization
+cannot bypass `SourceAccessPolicy` and always emit VOIAGE materialization
+receipts.
+
+### Evidence considered
+
+- `uv lock --upgrade` and `python scripts/dependency_frontier.py . --strict`
+  completed. The lock refresh changed unrelated packages and was deliberately
+  discarded.
+- An isolated Python 3.14 resolver installation imported
+  `frictionless==5.19.0` successfully. That proves only resolver compatibility,
+  not that the library's loading, archive, cache, or remote-resource behaviour
+  obeys the VOIAGE source policy.
+- The track contract prohibits parser-controlled network access, archive
+  extraction, implicit authenticated access, and unreceipted materialization.
+
+### Supported profile after this decision
+
+The provider accepts one local `datapackage.json` descriptor with one declared
+CSV resource and explicit schema. Remote URLs, archives, implicit resource
+selection, and unsupported formats are rejected before resource access. This
+does not claim full Data Package or Table Schema conformance, nor a
+`frictionless` parser-capability profile.
+
+### Promotion criteria
+
+P4-T7 through P4-T10 must first add offline conformance and negative fixtures,
+source-policy-preserving integration tests, capability declarations,
+receipt/provenance handling, and base-install isolation evidence. Only then may
+a later task add a version-bounded `frictionless` dependency and publish a
+separate enhanced-parser profile.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -83,8 +83,8 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 
 ### Frictionless Data
 
-- [ ] **P4-T6 / AC-05:** Review and record the Frictionless dependency and
-  supported-profile decision through the same dependency-frontier evidence.
+- [x] **P4-T6 / AC-05:** Review and record the Frictionless dependency and
+  supported-profile decision through the same dependency-frontier evidence. (`frictionless==5.19.0` decision)
 - [ ] **P4-T7 / AC-05:** Write failing offline fixtures/tests for package and
   data validation, resources, schemas, dialects, types, constraints, missing
   values, keys, integrity, governance metadata, supported tabular formats, and


### PR DESCRIPTION
## Summary

- record the P4-T6 Frictionless dependency and supported-profile decision
- retain the empty optional extra until source-policy and materialization-receipt guarantees are demonstrated

Part of Phase 4 P4-T6 in #330.

## Evidence

- uv lock --upgrade and dependency-frontier audit completed; unrelated lock refresh was discarded
- isolated Python 3.14 import of frictionless 5.19.0 succeeded
- no runtime dependency or parser capability claim is added