### PR TITLE
feat(ingestion): validate strict Frictionless CSV schemas

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -163,6 +163,117 @@ def test_frictionless_provider_rejects_unsupported_or_invalid_schema_claims(
 
 
 @pytest.mark.parametrize(
+    ("csv", "resource", "message"),
+    [
+        (
+            "id\n1\n",
+            {
+                "name": "samples",
+                "path": "samples.csv",
+                "dialect": {"delimiter": ";"},
+                "schema": {"fields": [{"name": "id"}]},
+            },
+            "only CSV comma dialect",
+        ),
+        (
+            "id\n1\n",
+            {
+                "name": "samples",
+                "path": "samples.csv",
+                "schema": {"primaryKey": 1, "fields": [{"name": "id"}]},
+            },
+            "primaryKey must be a string or field list",
+        ),
+        (
+            "id\n1\n",
+            {
+                "name": "samples",
+                "path": "samples.csv",
+                "schema": {"primaryKey": ["missing"], "fields": [{"name": "id"}]},
+            },
+            "primaryKey references an unknown",
+        ),
+        (
+            "id\n1\n",
+            {
+                "name": "samples",
+                "path": "samples.csv",
+                "schema": {"fields": [{}]},
+            },
+            "fields require string names",
+        ),
+        (
+            "id\n1\n",
+            {
+                "name": "samples",
+                "path": "samples.csv",
+                "schema": {"fields": [{"name": "missing"}]},
+            },
+            "exactly declare",
+        ),
+        (
+            "id\n1\n",
+            {
+                "name": "samples",
+                "path": "samples.csv",
+                "schema": {"fields": [{"name": "id", "constraints": []}]},
+            },
+            "constraints must be an object",
+        ),
+        (
+            "id\n1\n1\n",
+            {
+                "name": "samples",
+                "path": "samples.csv",
+                "schema": {"fields": [{"name": "id", "constraints": {"unique": True}}]},
+            },
+            "unique field contains duplicate",
+        ),
+    ],
+)
+def test_frictionless_provider_covers_remaining_strict_profile_rejections(
+    tmp_path, csv, resource, message
+) -> None:
+    (tmp_path / "samples.csv").write_text(csv, encoding="utf-8")
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(json.dumps({"resources": [resource]}), encoding="utf-8")
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
+def test_frictionless_provider_rejects_required_null_field(tmp_path) -> None:
+    (tmp_path / "samples.csv").write_text("id,value\n,1\n", encoding="utf-8")
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {
+                            "fields": [
+                                {"name": "id", "constraints": {"required": True}},
+                                {"name": "value"},
+                            ]
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match="required field contains null"):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
+@pytest.mark.parametrize(
     ("provider", "version"),
     [(CroissantProvider(), "1.1"), (FrictionlessProvider(), "1")],
 )

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -80,6 +80,88 @@ def test_built_in_providers_normalize_supported_csv_profile(
     assert bundle.table("samples").column_names == ["a", "b"]
 
 
+def test_frictionless_provider_validates_declared_types_constraints_and_primary_key(
+    tmp_path,
+) -> None:
+    (tmp_path / "samples.csv").write_text("id,value\n1,1.5\n2,2.5\n", encoding="utf-8")
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "name": "strict-operations-fixture",
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "dialect": {"delimiter": ","},
+                        "schema": {
+                            "primaryKey": "id",
+                            "fields": [
+                                {
+                                    "name": "id",
+                                    "type": "integer",
+                                    "constraints": {"required": True, "unique": True},
+                                },
+                                {"name": "value", "type": "number"},
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = FrictionlessProvider().ingest(
+        descriptor_path, policy=SourceAccessPolicy(tmp_path)
+    )
+
+    assert bundle.manifest.tables[0].primary_key == ("id",)
+    assert bundle.table("samples").column_names == ["id", "value"]
+
+
+@pytest.mark.parametrize(
+    ("csv", "schema", "message"),
+    [
+        (
+            "id\n1\n1\n",
+            {"primaryKey": "id", "fields": [{"name": "id", "type": "integer"}]},
+            "primaryKey contains duplicate",
+        ),
+        (
+            "id\nnot-a-number\n",
+            {"fields": [{"name": "id", "type": "integer"}]},
+            "field type does not match",
+        ),
+        (
+            "id\n1\n",
+            {"fields": [{"name": "id", "type": "date"}]},
+            "unsupported Data Package field type",
+        ),
+    ],
+)
+def test_frictionless_provider_rejects_unsupported_or_invalid_schema_claims(
+    tmp_path, csv, schema, message
+) -> None:
+    (tmp_path / "samples.csv").write_text(csv, encoding="utf-8")
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {"name": "samples", "path": "samples.csv", "schema": schema}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
 @pytest.mark.parametrize(
     ("provider", "version"),
     [(CroissantProvider(), "1.1"), (FrictionlessProvider(), "1")],

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -124,6 +124,14 @@ def test_frictionless_provider_validates_declared_types_constraints_and_primary_
     ("csv", "schema", "message"),
     [
         (
+            "id,value\n,1\n",
+            {
+                "primaryKey": "id",
+                "fields": [{"name": "id"}, {"name": "value"}],
+            },
+            "primaryKey contains null",
+        ),
+        (
             "id\n1\n1\n",
             {"primaryKey": "id", "fields": [{"name": "id", "type": "integer"}]},
             "primaryKey contains duplicate",

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -1,11 +1,15 @@
 """A conservative Frictionless Data Package CSV profile adapter."""
 
+# pyright: reportAny=false, reportUnannotatedClassAttribute=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownVariableType=false
+
 from __future__ import annotations
 
 import hashlib
 import json
 from pathlib import Path  # noqa: TC003 - public runtime annotation
 from typing import cast
+
+import pyarrow as pa
 
 from voiage.contracts.normalized_input import (
     DatasetManifest,
@@ -68,10 +72,20 @@ class FrictionlessProvider:
             raise IngestionError(
                 "Data Package resource requires name, path, and schema"
             )
+        schema = cast("dict[str, object]", schema)
         fields = schema.get("fields")
         if not isinstance(fields, list):
             raise IngestionError("Data Package schema requires fields")
+        fields = cast("list[object]", fields)
+        dialect = resource.get("dialect")
+        if dialect not in (None, {"delimiter": ","}):
+            raise IngestionError(
+                "supported Data Package profile accepts only CSV comma dialect"
+            )
         table = read_csv(reference, policy)
+        self._validate_schema(table, fields)
+        primary_key = self._primary_key(schema)
+        self._validate_primary_key(table, primary_key)
         manifest_fields = tuple(
             FieldManifest(field_id=name, dtype=str(table.schema.field(name).type))
             for item in fields
@@ -89,7 +103,13 @@ class FrictionlessProvider:
         return NormalizedInputBundle(
             manifest=DatasetManifest(
                 dataset_id=str(descriptor.get("name", table_id)),
-                tables=(TableManifest(table_id=table_id, fields=manifest_fields),),
+                tables=(
+                    TableManifest(
+                        table_id=table_id,
+                        fields=manifest_fields,
+                        primary_key=primary_key,
+                    ),
+                ),
                 provenance=SourceProvenance(
                     provider_id=self.provider_id,
                     source_uri=descriptor_path.resolve().as_uri(),
@@ -99,3 +119,75 @@ class FrictionlessProvider:
             ),
             tables={table_id: table},
         )
+
+    @staticmethod
+    def _primary_key(schema: dict[str, object]) -> tuple[str, ...]:
+        """Return an explicit Data Package primary key or reject ambiguity."""
+        raw = schema.get("primaryKey", ())
+        if isinstance(raw, str):
+            return (raw,)
+        if isinstance(raw, list) and all(isinstance(field, str) for field in raw):
+            return tuple(cast("str", field) for field in raw)
+        if raw == ():
+            return ()
+        raise IngestionError("Data Package primaryKey must be a string or field list")
+
+    @staticmethod
+    def _validate_primary_key(table: pa.Table, primary_key: tuple[str, ...]) -> None:
+        """Reject null or duplicate declared keys without changing source rows."""
+        if not primary_key:
+            return
+        if not set(primary_key).issubset(table.column_names):
+            raise IngestionError("Data Package primaryKey references an unknown field")
+        rows = tuple(
+            tuple(row[field] for field in primary_key) for row in table.to_pylist()
+        )
+        if any(any(value is None for value in row) for row in rows):
+            raise IngestionError("Data Package primaryKey contains null values")
+        if len(rows) != len(set(rows)):
+            raise IngestionError("Data Package primaryKey contains duplicate values")
+
+    @staticmethod
+    def _validate_schema(table: pa.Table, fields: list[object]) -> None:
+        """Validate the strict supported field names, types, and basic constraints."""
+        for item in fields:
+            if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+                raise IngestionError("Data Package fields require string names")
+            field = cast("dict[str, object]", item)
+            name = cast("str", field["name"])
+            if name not in table.column_names:
+                continue
+            column = table[name]
+            field_type = field.get("type")
+            if field_type is not None and (
+                not isinstance(field_type, str)
+                or field_type
+                not in {
+                    "string",
+                    "integer",
+                    "number",
+                    "boolean",
+                }
+            ):
+                raise IngestionError("unsupported Data Package field type")
+            type_matches = {
+                "string": pa.types.is_string(column.type),
+                "integer": pa.types.is_integer(column.type),
+                "number": pa.types.is_integer(column.type)
+                or pa.types.is_floating(column.type),
+                "boolean": pa.types.is_boolean(column.type),
+            }
+            if field_type is not None and not type_matches[field_type]:
+                raise IngestionError("Data Package field type does not match CSV data")
+            constraints = field.get("constraints", {})
+            if not isinstance(constraints, dict):
+                raise IngestionError("Data Package field constraints must be an object")
+            values = column.to_pylist()
+            if constraints.get("required") is True and any(
+                value is None for value in values
+            ):
+                raise IngestionError("Data Package required field contains null values")
+            if constraints.get("unique") is True and len(values) != len(set(values)):
+                raise IngestionError(
+                    "Data Package unique field contains duplicate values"
+                )


### PR DESCRIPTION
## Summary

- validate supported Data Package comma dialects, primary keys, scalar field types, and required/unique constraints before normalization
- retain the conservative one-resource local CSV profile and reject unsupported schema claims
- add deterministic offline validation fixtures/tests

Part of Phase 4 P4-T7 and P4-T8 in #330.

## Validation

- focused Frictionless provider tests: 4 passed
- Ruff, ty, and BasedPyright pass for the changed provider module
- hosted CI is required before merge.