### PR TITLE
feat(ingestion): preserve Frictionless governance metadata

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -191,6 +191,7 @@ def test_frictionless_provider_preserves_package_governance_metadata(tmp_path) -
         ([{"title": "BSD-3-Clause"}], "BSD-3-Clause"),
         ([{"path": "LICENSE"}], "LICENSE"),
         ([{}, "GPL-3.0-only"], "GPL-3.0-only"),
+        ([0], None),
         ([], None),
     ],
 )

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -190,6 +190,7 @@ def test_frictionless_provider_preserves_package_governance_metadata(tmp_path) -
         (["Apache-2.0"], "Apache-2.0"),
         ([{"title": "BSD-3-Clause"}], "BSD-3-Clause"),
         ([{"path": "LICENSE"}], "LICENSE"),
+        ([{}, "GPL-3.0-only"], "GPL-3.0-only"),
         ([], None),
     ],
 )

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -30,7 +30,12 @@ from voiage.ingestion import (
 )
 from voiage.ingestion._tabular import digest_file, read_csv
 from voiage.ingestion.croissant import CroissantProvider
-from voiage.ingestion.frictionless import FrictionlessProvider
+from voiage.ingestion.frictionless import (
+    FrictionlessProvider,
+    _citation_label,
+    _governance_extensions,
+    _license_label,
+)
 from voiage.ingestion.registry import ProviderRegistry
 
 
@@ -118,6 +123,84 @@ def test_frictionless_provider_validates_declared_types_constraints_and_primary_
 
     assert bundle.manifest.tables[0].primary_key == ("id",)
     assert bundle.table("samples").column_names == ["id", "value"]
+
+
+def test_frictionless_provider_preserves_package_governance_metadata(tmp_path) -> None:
+    (tmp_path / "samples.csv").write_text("id,value\n1,1.5\n", encoding="utf-8")
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "name": "governed-operations-fixture",
+                "title": "Governed operations fixture",
+                "description": "Synthetic, rights-cleared test data.",
+                "version": "1.0.0",
+                "profile": "tabular-data-package",
+                "citation": "Example et al. (2026)",
+                "licenses": [
+                    {"name": "CC-BY-4.0", "path": "https://example.invalid/license"}
+                ],
+                "sources": [{"title": "Synthetic source", "path": "source.md"}],
+                "contributors": [{"title": "Maintainer", "role": "author"}],
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {
+                            "fields": [
+                                {"name": "id", "type": "integer"},
+                                {"name": "value", "type": "number"},
+                            ]
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = FrictionlessProvider().ingest(
+        descriptor_path, policy=SourceAccessPolicy(tmp_path)
+    )
+
+    assert bundle.manifest.provenance.license == "CC-BY-4.0"
+    assert bundle.manifest.provenance.citation == "Example et al. (2026)"
+    assert bundle.manifest.extensions == {
+        "frictionlessdata.org:contributors": (
+            {"role": "author", "title": "Maintainer"},
+        ),
+        "frictionlessdata.org:description": "Synthetic, rights-cleared test data.",
+        "frictionlessdata.org:licenses": (
+            {"name": "CC-BY-4.0", "path": "https://example.invalid/license"},
+        ),
+        "frictionlessdata.org:profile": "tabular-data-package",
+        "frictionlessdata.org:sources": (
+            {"path": "source.md", "title": "Synthetic source"},
+        ),
+        "frictionlessdata.org:title": "Governed operations fixture",
+        "frictionlessdata.org:version": "1.0.0",
+    }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("MIT", "MIT"),
+        (None, None),
+        (["Apache-2.0"], "Apache-2.0"),
+        ([{"title": "BSD-3-Clause"}], "BSD-3-Clause"),
+        ([{"path": "LICENSE"}], "LICENSE"),
+        ([], None),
+    ],
+)
+def test_frictionless_governance_helpers_preserve_only_explicit_labels(
+    value, expected
+) -> None:
+    assert _license_label(value) == expected
+    assert _citation_label(value) == (value if isinstance(value, str) else None)
+    assert _governance_extensions({"title": "fixture", "resources": []}) == {
+        "frictionlessdata.org:title": "fixture"
+    }
 
 
 @pytest.mark.parametrize(

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -114,8 +114,10 @@ class FrictionlessProvider:
                     provider_id=self.provider_id,
                     source_uri=descriptor_path.resolve().as_uri(),
                     descriptor_digest=digest,
-                    license=cast("str | None", descriptor.get("licenses")),
+                    license=_license_label(descriptor.get("licenses")),
+                    citation=_citation_label(descriptor.get("citation")),
                 ),
+                extensions=_governance_extensions(descriptor),
             ),
             tables={table_id: table},
         )
@@ -191,3 +193,43 @@ class FrictionlessProvider:
                 raise IngestionError(
                     "Data Package unique field contains duplicate values"
                 )
+
+
+def _license_label(value: object) -> str | None:
+    """Expose one human-readable licence label while preserving full metadata."""
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, list):
+        return None
+    for item in value:
+        if isinstance(item, str):
+            return item
+        if isinstance(item, dict):
+            for key in ("name", "title", "path"):
+                candidate = item.get(key)
+                if isinstance(candidate, str):
+                    return candidate
+    return None
+
+
+def _citation_label(value: object) -> str | None:
+    """Accept only an explicit scalar citation for the compact provenance field."""
+    return value if isinstance(value, str) else None
+
+
+def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:
+    """Preserve standard package governance metadata without semantic inference."""
+    keys = (
+        "licenses",
+        "sources",
+        "contributors",
+        "profile",
+        "version",
+        "title",
+        "description",
+    )
+    return {
+        f"frictionlessdata.org:{key}": descriptor[key]
+        for key in keys
+        if key in descriptor
+    }


### PR DESCRIPTION
## Summary
- preserve standard Data Package governance metadata in namespaced normalized extensions
- expose explicit licence and citation labels in normalized provenance
- retain the existing strict, local CSV profile and add coverage for metadata handling

## Validation
- .........................................................                [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
  /private/tmp/voiage-p4-frictionless-governance/.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
    NAT_TYPES = {np.datetime64("NaT").dtype, np.timedelta64("NaT").dtype}

tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_adapter_does_not_require_a_specific_frame_library
tests/test_standardized_ingestion_providers.py::test_registry_supports_a_fake_provider_with_injected_source_policy
  /private/tmp/voiage-p4-frictionless-governance/.venv/lib/python3.14/site-packages/pyarrow/interchange/from_dataframe.py:88: DeprecationWarning: Support for the dataframe interchange protocol is deprecated since version 1.40.0
    return _from_dataframe(df.__dataframe__(allow_copy=allow_copy),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- All checks passed!