### PR TITLE
feat(ingestion): preserve Croissant governance metadata

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -819,7 +819,6 @@ def test_croissant_provider_rejects_unsupported_archives_and_transformations(
         "message",
     ),
     [
-        ({"@id": "https://example.invalid/dataset"}, {}, {}, {}, "identities"),
         (
             {"conformsTo": "http://mlcommons.org/croissant/1.0"},
             {},
@@ -864,6 +863,64 @@ def test_croissant_provider_rejects_unsupported_profile_semantics_explicitly(
 
     with pytest.raises(IngestionError, match=message):
         CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
+def test_croissant_provider_preserves_governance_metadata_without_inference(
+    tmp_path,
+) -> None:
+    """Governance descriptors remain inspectable but never change calculation input."""
+    _write_csv(tmp_path)
+    descriptor_path = tmp_path / "croissant.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "@id": "https://example.invalid/datasets/posterior-samples",
+                "name": "governed-ml-fixture",
+                "citation": "Example et al. (2026)",
+                "license": "CC-BY-4.0",
+                "creator": [{"name": "ML team"}],
+                "datePublished": "2026-01-01",
+                "description": "Synthetic posterior samples.",
+                "isAccessibleForFree": True,
+                "keywords": ["VOI", "synthetic"],
+                "odrl": {"permission": "use"},
+                "provenance": {"wasGeneratedBy": "simulation"},
+                "rai": {"risk": "low"},
+                "sameAs": ["https://example.invalid/catalog/record"],
+                "usageInfo": "Use only for deterministic tests.",
+                "distribution": [{"contentUrl": "samples.csv"}],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = CroissantProvider().ingest(
+        descriptor_path, policy=SourceAccessPolicy(tmp_path)
+    )
+
+    assert bundle.manifest.provenance.license == "CC-BY-4.0"
+    assert bundle.manifest.provenance.citation == "Example et al. (2026)"
+    assert bundle.manifest.extensions == {
+        "mlcommons.org:croissant-governance": {
+            "@id": "https://example.invalid/datasets/posterior-samples",
+            "citation": "Example et al. (2026)",
+            "creator": ({"name": "ML team"},),
+            "datePublished": "2026-01-01",
+            "description": "Synthetic posterior samples.",
+            "isAccessibleForFree": True,
+            "keywords": ("VOI", "synthetic"),
+            "license": "CC-BY-4.0",
+            "odrl": {"permission": "use"},
+            "provenance": {"wasGeneratedBy": "simulation"},
+            "rai": {"risk": "low"},
+            "sameAs": ("https://example.invalid/catalog/record",),
+            "usageInfo": "Use only for deterministic tests.",
+        }
+    }
 
 
 @pytest.mark.parametrize(

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -185,8 +185,12 @@ def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:
         "sameAs",
         "usageInfo",
     )
-    return {
-        "mlcommons.org:croissant-governance": {
-            key: descriptor[key] for key in keys if key in descriptor
+    return (
+        {
+            "mlcommons.org:croissant-governance": {
+                key: descriptor[key] for key in keys if key in descriptor
+            }
         }
-    } if any(key in descriptor for key in keys) else {}
+        if any(key in descriptor for key in keys)
+        else {}
+    )

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -109,9 +109,10 @@ class CroissantProvider:
                     provider_id=self.provider_id,
                     source_uri=descriptor_path.resolve().as_uri(),
                     descriptor_digest=digest,
-                    license=cast("str | None", descriptor.get("license")),
-                    citation=cast("str | None", descriptor.get("citation")),
+                    license=_scalar_metadata(descriptor.get("license")),
+                    citation=_scalar_metadata(descriptor.get("citation")),
                 ),
+                extensions=_governance_extensions(descriptor),
             ),
             tables={table_id: table},
         )
@@ -123,10 +124,6 @@ class CroissantProvider:
         record_set: dict[str, object],
     ) -> None:
         """Reject semantics that the conservative profile cannot preserve."""
-        if "@id" in descriptor:
-            raise IngestionError(
-                "supported Croissant profile does not support identities"
-            )
         conforms_to = descriptor.get("conformsTo")
         if (
             conforms_to is not None
@@ -164,3 +161,32 @@ class CroissantProvider:
                 raise IngestionError(
                     "supported Croissant profile does not support field sources"
                 )
+
+
+def _scalar_metadata(value: object) -> str | None:
+    """Expose scalar metadata in provenance without coercing structured values."""
+    return value if isinstance(value, str) else None
+
+
+def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:
+    """Retain Croissant governance metadata without inferring VOI semantics."""
+    keys = (
+        "@id",
+        "citation",
+        "creator",
+        "datePublished",
+        "description",
+        "isAccessibleForFree",
+        "keywords",
+        "license",
+        "odrl",
+        "provenance",
+        "rai",
+        "sameAs",
+        "usageInfo",
+    )
+    return {
+        "mlcommons.org:croissant-governance": {
+            key: descriptor[key] for key in keys if key in descriptor
+        }
+    } if any(key in descriptor for key in keys) else {}


### PR DESCRIPTION
## Summary
- preserve declared Croissant identity, citation, provenance, ODRL, RAI, and usage metadata in a stable namespaced extension
- expose only scalar licence and citation values in normalized provenance
- keep calculation semantics and the supported local CSV profile unchanged

## Validation
- All checks passed!
- hosted CI will exercise the focused provider suite