### PR TITLE
feat(cli): validate standardized dataset descriptors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `voiage ingest validate` for safe, machine-readable validation of a
+  supported dataset descriptor and its declared local resources.
+
 ### Changed
 
 ### Fixed

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -15,14 +15,17 @@ column inference, and path traversal are rejected. This makes an input
 portable, auditable, and suitable for an offline calculation workflow.
 
 ```bash
+voiage ingest validate datapackage.json
 voiage ingest inspect croissant.json
 voiage ingest normalize datapackage.json --output normalized.arrow
 ```
 
 `croissant.json` is recognized from its Croissant context and
 `datapackage.json` from its Data Package resource list, not from the filename.
-The `inspect` response contains the provider, table row counts, schema
-fingerprint, and content digest; it does not echo resource contents.
+`validate` resolves the descriptor and every declared local resource through
+the source-access policy, then returns a stable JSON confirmation. The
+`inspect` response contains the provider, table row counts, schema fingerprint,
+and content digest; neither command echoes resource contents.
 
 For a VOI calculation, supply a `VOIBinding` that states the table, fields,
 strategies, units, and perspective. The library will not guess semantics from

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -29,6 +29,7 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
     )
     runner = CliRunner()
 
+    validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
     inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
     output = tmp_path / "normalized.arrow"
     normalized = runner.invoke(
@@ -49,6 +50,8 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
         ],
     )
 
+    assert validated.exit_code == 0
+    assert json.loads(validated.output)["valid"] is True
     assert inspected.exit_code == 0
     assert json.loads(inspected.output)["provider"] == "frictionless"
     assert normalized.exit_code == 0
@@ -62,9 +65,12 @@ def test_ingest_cli_returns_safe_error_for_unrecognized_descriptor(tmp_path) -> 
     descriptor.write_text("{}", encoding="utf-8")
 
     result = CliRunner().invoke(app, ["ingest", "inspect", str(descriptor)])
+    validated = CliRunner().invoke(app, ["ingest", "validate", str(descriptor)])
 
     assert result.exit_code == 2
     assert "exactly one" in result.output
+    assert validated.exit_code == 2
+    assert "exactly one" in validated.output
 
 
 def test_normalize_and_calculate_return_safe_errors(tmp_path) -> None:

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -35,6 +35,20 @@ def _bundle_summary(descriptor: Path) -> dict[str, object]:
     }
 
 
+@app.command("validate")
+def validate(
+    descriptor: Path = typer.Argument(..., exists=True, readable=True),
+) -> None:
+    """Validate a supported descriptor and its declared local resources."""
+    try:
+        typer.echo(
+            json.dumps({"valid": True, **_bundle_summary(descriptor)}, sort_keys=True)
+        )
+    except IngestionError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(2) from error
+
+
 @app.command()
 def inspect(descriptor: Path = typer.Argument(..., exists=True, readable=True)) -> None:
     """Inspect a descriptor and emit its normalized identity as JSON."""


### PR DESCRIPTION
## Summary
- Add the ingest validate command for standardized dataset descriptors.
- Validate descriptors and declared local resources through the existing safe provider registry.
- Return stable JSON on success and safe exit-code-2 diagnostics on failure.

## Validation
- uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_cli.py -q --no-cov