### PR TITLE
test(croissant): add offline profile fixture corpus

### DIFF
--- a/tests/fixtures/croissant_1_1/unsupported/archive.json
+++ b/tests/fixtures/croissant_1_1/unsupported/archive.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"data.zip"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/checksum-mismatch.json
+++ b/tests/fixtures/croissant_1_1/unsupported/checksum-mismatch.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv","sha256":"0000000000000000000000000000000000000000000000000000000000000000"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/identity.json
+++ b/tests/fixtures/croissant_1_1/unsupported/identity.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","@id":"https://example.invalid/dataset","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/key.json
+++ b/tests/fixtures/croissant_1_1/unsupported/key.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","key":["strategy_a"],"field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/multiple-distributions.json
+++ b/tests/fixtures/croissant_1_1/unsupported/multiple-distributions.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv"},{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/multiple-record-sets.json
+++ b/tests/fixtures/croissant_1_1/unsupported/multiple-record-sets.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"},{"name":"strategy_b"}]},{"name":"more","field":[{"name":"strategy_a"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/nested-field.json
+++ b/tests/fixtures/croissant_1_1/unsupported/nested-field.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a","subField":[{"name":"nested"}]},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/references.json
+++ b/tests/fixtures/croissant_1_1/unsupported/references.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a","references":"other"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/split.json
+++ b/tests/fixtures/croissant_1_1/unsupported/split.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","split":"train","field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/transform.json
+++ b/tests/fixtures/croissant_1_1/unsupported/transform.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv","transform":{"script":"x"}}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/version-1-0.json
+++ b/tests/fixtures/croissant_1_1/unsupported/version-1-0.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.0","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"},{"name":"strategy_b"}]}]}

--- a/tests/fixtures/croissant_1_1/unsupported/wrong-columns.json
+++ b/tests/fixtures/croissant_1_1/unsupported/wrong-columns.json
@@ -1,0 +1,1 @@
+{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"valid/data.csv"}],"recordSet":[{"name":"samples","field":[{"name":"strategy_a"}]}]}

--- a/tests/fixtures/croissant_1_1/valid/croissant.json
+++ b/tests/fixtures/croissant_1_1/valid/croissant.json
@@ -1,0 +1,14 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
+  "name": "canonical-decision-samples",
+  "distribution": [{
+    "contentUrl": "valid/data.csv",
+    "encodingFormat": "text/csv",
+    "sha256": "f9b0650712dd77739035499940b3c29c75a2835477313e47c5e01b3f7e2a56df"
+  }],
+  "recordSet": [{
+    "name": "decision_samples",
+    "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+  }]
+}

--- a/tests/fixtures/croissant_1_1/valid/data.csv
+++ b/tests/fixtures/croissant_1_1/valid/data.csv
@@ -1,0 +1,3 @@
+strategy_a,strategy_b
+100.0,80.0
+60.0,90.0

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -1,0 +1,58 @@
+"""File-backed Croissant 1.1 profile conformance fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voiage.ingestion.base import IngestionError, SourceAccessPolicy
+from voiage.ingestion.croissant import CroissantProvider
+
+_FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
+
+
+@pytest.mark.parametrize(
+    ("fixture", "message"),
+    [
+        ("unsupported/archive.json", "archives"),
+        ("unsupported/checksum-mismatch.json", "SHA-256"),
+        ("unsupported/identity.json", "identities"),
+        ("unsupported/key.json", "keys"),
+        ("unsupported/multiple-distributions.json", "exactly one distribution"),
+        ("unsupported/multiple-record-sets.json", "exactly one recordSet"),
+        ("unsupported/nested-field.json", "nested fields"),
+        ("unsupported/references.json", "field references"),
+        ("unsupported/split.json", "splits"),
+        ("unsupported/transform.json", "transformations"),
+        ("unsupported/version-1-0.json", "version 1.1"),
+        ("unsupported/wrong-columns.json", "exactly declare"),
+    ],
+)
+def test_croissant_offline_unsupported_profile_fixtures_fail_closed(
+    fixture: str, message: str
+) -> None:
+    """Every unsupported semantic has a stable, offline regression fixture."""
+    descriptor_path = _FIXTURE_ROOT / fixture
+
+    with pytest.raises(IngestionError, match=message):
+        CroissantProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(_FIXTURE_ROOT)
+        )
+
+
+def test_croissant_offline_valid_profile_fixture_materializes() -> None:
+    """The supported fixture is a one-resource, explicit CSV record set."""
+    bundle = CroissantProvider().ingest(
+        _FIXTURE_ROOT / "valid" / "croissant.json",
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert tuple(field.field_id for field in bundle.manifest.tables[0].fields) == (
+        "strategy_a",
+        "strategy_b",
+    )
+    assert bundle.table("decision_samples").to_pylist() == [
+        {"strategy_a": 100.0, "strategy_b": 80.0},
+        {"strategy_a": 60.0, "strategy_b": 90.0},
+    ]

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -17,7 +17,6 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
     [
         ("unsupported/archive.json", "archives"),
         ("unsupported/checksum-mismatch.json", "SHA-256"),
-        ("unsupported/identity.json", "identities"),
         ("unsupported/key.json", "keys"),
         ("unsupported/multiple-distributions.json", "exactly one distribution"),
         ("unsupported/multiple-record-sets.json", "exactly one recordSet"),
@@ -56,3 +55,17 @@ def test_croissant_offline_valid_profile_fixture_materializes() -> None:
         {"strategy_a": 100.0, "strategy_b": 80.0},
         {"strategy_a": 60.0, "strategy_b": 90.0},
     ]
+
+
+def test_croissant_offline_identity_fixture_preserves_governance() -> None:
+    """Croissant identities are retained as metadata, not VOI semantics."""
+    bundle = CroissantProvider().ingest(
+        _FIXTURE_ROOT / "unsupported" / "identity.json",
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert bundle.manifest.extensions == {
+        "mlcommons.org:croissant-governance": {
+            "@id": "https://example.invalid/dataset"
+        }
+    }

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -65,7 +65,5 @@ def test_croissant_offline_identity_fixture_preserves_governance() -> None:
     )
 
     assert bundle.manifest.extensions == {
-        "mlcommons.org:croissant-governance": {
-            "@id": "https://example.invalid/dataset"
-        }
+        "mlcommons.org:croissant-governance": {"@id": "https://example.invalid/dataset"}
     }


### PR DESCRIPTION
Links to #329.

Adds a deterministic, file-backed Croissant 1.1 fixture corpus:
- one valid offline CSV descriptor with a verified SHA-256 resource;
- twelve fail-closed descriptors for unsupported or ambiguous semantics;
- a separate regression module so fixtures are not dynamically constructed only in temporary directories.

Validation:
- uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_providers.py tests/test_croissant_offline_fixtures.py -q --no-cov (63 passed)
- uv run ruff check tests/test_croissant_offline_fixtures.py
- uv run ruff format --check tests/test_croissant_offline_fixtures.py