### PR TITLE
Authorize private draft release review

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,7 +391,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
-      contents: read
+      # Draft releases are visible only to tokens with push-level repository
+      # access. Keep this elevation scoped to the digest-review job.
+      contents: write
     env:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -213,6 +213,15 @@ def test_release_wheels_are_installed_and_exercised_before_upload() -> None:
     assert "WHEEL_VENV" in release_workflow
 
 
+def test_private_draft_review_has_scoped_push_access() -> None:
+    workflow = yaml.safe_load(
+        Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    )
+
+    assert workflow["jobs"]["resolve-tag"]["permissions"]["contents"] == "read"
+    assert workflow["jobs"]["reviewed-payload"]["permissions"]["contents"] == "write"
+
+
 def test_release_builds_embed_immutable_source_and_platform_provenance() -> None:
     workflow = yaml.safe_load(
         Path(".github/workflows/release.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- grant repository contents write access only to the digest-review job so its token can enumerate the existing private draft release
- retain read-only access for tag resolution and all unrelated jobs
- add a regression test for the scoped permission contract

## Evidence

Publication run 30183172370 failed at `gh release download` with `release not found` while the authenticated maintainer API confirms draft release 359900810 exists for v2.0.0. GitHub draft releases require push-level access.

## Verification

- `uv run --extra ci pytest tests/test_python_release_workflow.py tests/test_ci_cd_quality_gates.py --no-cov -q` (45 passed)