### PR TITLE
feat(ingestion): expose inspection capability profiles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `voiage ingest validate` for safe, machine-readable validation of a
   supported dataset descriptor and its declared local resources.
+- Expanded `voiage ingest inspect` with stable provider capabilities, safe
+  provenance, preserved governance metadata, and ingestion diagnostics.
 
 ### Changed
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -24,8 +24,10 @@ voiage ingest normalize datapackage.json --output normalized.arrow
 `datapackage.json` from its Data Package resource list, not from the filename.
 `validate` resolves the descriptor and every declared local resource through
 the source-access policy, then returns a stable JSON confirmation. The
-`inspect` response contains the provider, table row counts, schema fingerprint,
-and content digest; neither command echoes resource contents.
+`inspect` response contains the provider, its declared capability profile, safe
+descriptor provenance, preserved governance metadata, diagnostics, table row
+counts, schema fingerprint, and content digest; neither command echoes resource
+contents or credentials.
 
 For a VOI calculation, supply a `VOIBinding` that states the table, fields,
 strategies, units, and perspective. The library will not guess semantics from

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -16,6 +16,8 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
         json.dumps(
             {
                 "name": "cli-fixture",
+                "licenses": [{"name": "CC-BY-4.0"}],
+                "contributors": [{"title": "Fixture maintainer", "role": "author"}],
                 "resources": [
                     {
                         "name": "samples",
@@ -53,7 +55,25 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
     assert validated.exit_code == 0
     assert json.loads(validated.output)["valid"] is True
     assert inspected.exit_code == 0
-    assert json.loads(inspected.output)["provider"] == "frictionless"
+    inspection = json.loads(inspected.output)
+    assert inspection["provider"] == "frictionless"
+    assert inspection["capabilities"] == {
+        "format_versions": ["1"],
+        "media_types": ["text/csv"],
+        "provider_id": "frictionless",
+        "supported_transforms": [],
+        "supports_filtering": False,
+        "supports_projection": False,
+        "supports_random_access": False,
+        "supports_streaming": False,
+    }
+    assert inspection["provenance"]["license"] == "CC-BY-4.0"
+    assert inspection["governance"] == {
+        "frictionlessdata.org:contributors": [
+            {"role": "author", "title": "Fixture maintainer"}
+        ],
+        "frictionlessdata.org:licenses": [{"name": "CC-BY-4.0"}],
+    }
     assert normalized.exit_code == 0
     assert output.is_file()
     assert calculated.exit_code == 0

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -384,6 +384,15 @@ def test_provider_capabilities_declare_conservative_supported_profiles(
     assert capabilities.supports_random_access is False
 
 
+def test_registry_capability_lookup_rejects_unknown_provider() -> None:
+    """Inspection must not report a capability profile for an unregistered ID."""
+    registry = default_registry()
+
+    assert registry.capabilities_for("croissant").provider_id == "croissant"
+    with pytest.raises(IngestionError, match="unregistered provider"):
+        registry.capabilities_for("unknown")
+
+
 def test_source_policy_blocks_path_traversal_and_network(tmp_path) -> None:
     policy = SourceAccessPolicy(tmp_path)
 

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -25,11 +25,29 @@ app = typer.Typer(help="Validate and normalize standardized dataset descriptors.
 
 def _bundle_summary(descriptor: Path) -> dict[str, object]:
     """Return stable, non-secret metadata for a descriptor."""
-    bundle = default_registry().ingest(descriptor)
+    registry = default_registry()
+    bundle = registry.ingest(descriptor)
+    capabilities = registry.capabilities_for(bundle.manifest.provenance.provider_id)
     return {
+        "capabilities": {
+            "format_versions": capabilities.format_versions,
+            "media_types": capabilities.media_types,
+            "provider_id": capabilities.provider_id,
+            "supported_transforms": capabilities.supported_transforms,
+            "supports_filtering": capabilities.supports_filtering,
+            "supports_projection": capabilities.supports_projection,
+            "supports_random_access": capabilities.supports_random_access,
+            "supports_streaming": capabilities.supports_streaming,
+        },
         "content_digest": bundle.content_digest,
         "dataset_id": bundle.manifest.dataset_id,
+        "diagnostics": [
+            diagnostic.model_dump(mode="json")
+            for diagnostic in bundle.manifest.diagnostics
+        ],
+        "governance": bundle.manifest.model_dump(mode="json")["extensions"],
         "provider": bundle.manifest.provenance.provider_id,
+        "provenance": bundle.manifest.provenance.model_dump(mode="json"),
         "schema_fingerprint": bundle.schema_fingerprint,
         "tables": {name: table.num_rows for name, table in bundle.tables.items()},
     }

--- a/voiage/ingestion/registry.py
+++ b/voiage/ingestion/registry.py
@@ -14,7 +14,12 @@ if TYPE_CHECKING:
 from voiage.contracts.normalized_input import (
     NormalizedInputBundle,  # noqa: TC001 - public runtime API
 )
-from voiage.ingestion.base import IngestionError, IngestionProvider, SourceAccessPolicy
+from voiage.ingestion.base import (
+    IngestionError,
+    IngestionProvider,
+    ProviderCapabilities,
+    SourceAccessPolicy,
+)
 
 _ENTRY_POINT_GROUP = "voiage.ingestion.providers"
 
@@ -91,6 +96,13 @@ class ProviderRegistry:
         return matches[0].ingest(
             descriptor_path, policy=policy or SourceAccessPolicy(descriptor_path.parent)
         )
+
+    def capabilities_for(self, provider_id: str) -> ProviderCapabilities:
+        """Return the declared support profile for one registered provider."""
+        for provider in self._providers:
+            if provider.provider_id == provider_id:
+                return provider.capabilities
+        raise IngestionError("normalized bundle names an unregistered provider")
 
 
 def default_registry() -> ProviderRegistry:


### PR DESCRIPTION
Links to #329 and #332.

Implements the stable machine-readable inspection increment required by the Croissant/Frictionless provider and product-surface tracks. The response now exposes:
- the registered provider capability declaration;
- safe normalized provenance;
- preserved namespaced governance metadata; and
- ingestion diagnostics.

No source contents or credentials are emitted.

Validation:
- uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_providers.py tests/test_standardized_ingestion_cli.py -q --no-cov (62 passed)
- uv run ruff check voiage/ingestion/registry.py voiage/ingestion/cli.py tests/test_standardized_ingestion_cli.py
- uv run ruff format --check voiage/ingestion/registry.py voiage/ingestion/cli.py tests/test_standardized_ingestion_cli.py