### PR TITLE
feat(ingestion): bound local resource sizes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supported dataset descriptor and its declared local resources.
 - Expanded `voiage ingest inspect` with stable provider capabilities, safe
   provenance, preserved governance metadata, and ingestion diagnostics.
+- Added fail-closed configurable local-resource size limits to standardized
+  ingestion source policies.
 
 ### Changed
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -29,6 +29,12 @@ descriptor provenance, preserved governance metadata, diagnostics, table row
 counts, schema fingerprint, and content digest; neither command echoes resource
 contents or credentials.
 
+Local resources are fail-closed: paths cannot escape the configured descriptor
+root, network access is disabled by default, and a resource larger than the
+default 512 MiB policy limit is rejected before parsing. Applications can set a
+smaller explicit `SourceAccessPolicy.max_resource_bytes` limit for constrained
+workloads.
+
 For a VOI calculation, supply a `VOIBinding` that states the table, fields,
 strategies, units, and perspective. The library will not guess semantics from
 field names. This keeps machine-learning, engineering, and business datasets

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -422,6 +422,9 @@ def test_source_policy_enforces_an_explicit_resource_size_limit(tmp_path) -> Non
     with pytest.raises(IngestionError, match="configured size limit"):
         SourceAccessPolicy(tmp_path, max_resource_bytes=4).resolve(resource.name)
 
+    with pytest.raises(ValueError, match="must be positive"):
+        SourceAccessPolicy(tmp_path, max_resource_bytes=0)
+
 
 def test_dataframe_interchange_adapter_does_not_require_a_specific_frame_library() -> (
     None

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -414,6 +414,15 @@ def test_source_policy_blocks_path_traversal_and_network(tmp_path) -> None:
         policy.resolve("missing.csv")
 
 
+def test_source_policy_enforces_an_explicit_resource_size_limit(tmp_path) -> None:
+    """Oversized local inputs are rejected before a parser can load them."""
+    resource = tmp_path / "oversized.csv"
+    resource.write_bytes(b"abcde")
+
+    with pytest.raises(IngestionError, match="configured size limit"):
+        SourceAccessPolicy(tmp_path, max_resource_bytes=4).resolve(resource.name)
+
+
 def test_dataframe_interchange_adapter_does_not_require_a_specific_frame_library() -> (
     None
 ):

--- a/voiage/ingestion/base.py
+++ b/voiage/ingestion/base.py
@@ -32,9 +32,18 @@ class ProviderCapabilities:
 class SourceAccessPolicy:
     """Fail-closed local source policy for descriptor-relative resources."""
 
-    def __init__(self, root: Path, *, allow_network: bool = False) -> None:
+    def __init__(
+        self,
+        root: Path,
+        *,
+        allow_network: bool = False,
+        max_resource_bytes: int = 512 * 1024 * 1024,
+    ) -> None:
+        if max_resource_bytes <= 0:
+            raise ValueError("max_resource_bytes must be positive")
         self.root = root.resolve()
         self.allow_network = allow_network
+        self.max_resource_bytes = max_resource_bytes
 
     def resolve(self, reference: str) -> Path:
         """Resolve a relative local reference without allowing path traversal."""
@@ -47,6 +56,8 @@ class SourceAccessPolicy:
             raise IngestionError("resource path escapes the configured source root")
         if not candidate.is_file():
             raise IngestionError("declared resource does not exist")
+        if candidate.stat().st_size > self.max_resource_bytes:
+            raise IngestionError("declared resource exceeds configured size limit")
         return candidate
 
 


### PR DESCRIPTION
Links to #333.

Adds a fail-closed local-resource byte limit at the shared `SourceAccessPolicy` boundary. The default is 512 MiB and callers can choose a smaller explicit limit. Oversized content is rejected before it reaches a parser.

Validation:
- uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_providers.py::test_source_policy_enforces_an_explicit_resource_size_limit tests/test_standardized_ingestion_providers.py::test_source_policy_blocks_path_traversal_and_network -q --no-cov (2 passed)
- uv run ruff check voiage/ingestion/base.py tests/test_standardized_ingestion_providers.py
- uv run ruff format --check voiage/ingestion/base.py tests/test_standardized_ingestion_providers.py