### PR TITLE
test(ingestion): add cross-domain reference cases

### DIFF
--- a/docs/astro-site/src/content/docs/examples/index.mdx
+++ b/docs/astro-site/src/content/docs/examples/index.mdx
@@ -27,6 +27,7 @@ This index groups the runnable notebook tutorials and supporting long-form examp
 
 ## Cross-Domain Tutorials
 
+- [Standardized Ingestion Reference Cases](/examples/standardized-ingestion-reference-cases/) — identical explicit EVPI across Croissant, Frictionless, and direct inputs
 - [Financial VOI](https://github.com/edithatogo/voiage/blob/main/examples/financial_voi.ipynb)
 - [Environmental VOI](https://github.com/edithatogo/voiage/blob/main/examples/environmental_voi.ipynb)
 - [Engineering VOI](https://github.com/edithatogo/voiage/blob/main/examples/engineering_voi.ipynb)

--- a/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
+++ b/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
@@ -1,0 +1,42 @@
+---
+title: Standardized Ingestion Reference Cases
+description: Deterministic ML, engineering, and business EVPI examples using one explicit VOI binding.
+---
+
+These three synthetic, rights-cleared reference cases use the same pinned
+decision samples and the same explicit net-benefit binding. They demonstrate
+format interoperability, not domain-specific modelling: no field names,
+strategies, units, or transformations are inferred.
+
+| Community | Descriptor or input | Decision interpretation |
+| --- | --- | --- |
+| Machine learning | Croissant 1.1 | Compare model-selection net benefits across posterior samples. |
+| Engineering and operations | Frictionless Data Package | Compare design alternatives across simulated operating scenarios. |
+| Business | Direct normalized Arrow table | Compare investment strategies across decision scenarios. |
+
+The fixture records two strategies, `strategy_a` and `strategy_b`, and binds
+them explicitly as `A` and `B`:
+
+```python
+VOIBinding(
+    role="net_benefit",
+    table_id="samples",
+    field_ids=("strategy_a", "strategy_b"),
+    strategy_names=("A", "B"),
+)
+```
+
+Run the complete reproducible walkthrough from a source checkout:
+
+```bash
+uv run python examples/standardized_ingestion/reference_cases.py
+```
+
+The output contains identical EVPI values for `ml`, `engineering`, and
+`business`. The runner fails if any format reaches a different value, making
+the example an executable cross-format regression check as well as a tutorial.
+
+The input descriptors and their SHA-256 digests live in
+[`tests/fixtures/standardized_ingestion/`](https://github.com/edithatogo/voiage/tree/main/tests/fixtures/standardized_ingestion).
+Use `canonical-decision.manifest.json` to verify exact source artifacts before
+reproducing a result.

--- a/examples/standardized_ingestion/reference_cases.py
+++ b/examples/standardized_ingestion/reference_cases.py
@@ -1,0 +1,95 @@
+"""Run deterministic ML, engineering, and business ingestion reference cases."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+
+from voiage.contracts import (
+    DatasetManifest,
+    FieldManifest,
+    NormalizedInputBundle,
+    SourceProvenance,
+    TableManifest,
+    VOIBinding,
+    prepare_analysis_inputs,
+)
+from voiage.ingestion import SourceAccessPolicy, default_registry
+from voiage.methods.basic import evpi
+
+_ROOT = Path(__file__).parents[2]
+_FIXTURES = _ROOT / "tests" / "fixtures" / "standardized_ingestion"
+
+
+def _binding() -> VOIBinding:
+    return VOIBinding(
+        role="net_benefit",
+        table_id="samples",
+        field_ids=("strategy_a", "strategy_b"),
+        strategy_names=("A", "B"),
+    )
+
+
+def _bound(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
+    return NormalizedInputBundle(
+        manifest=bundle.manifest.model_copy(update={"bindings": (_binding(),)}),
+        tables=bundle.tables,
+    )
+
+
+def _direct() -> NormalizedInputBundle:
+    table = pa.table(
+        {"strategy_a": [10.0, 30.0, 20.0], "strategy_b": [20.0, 10.0, 25.0]}
+    )
+    return NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="canonical-decision-fixture",
+            tables=(
+                TableManifest(
+                    table_id="samples",
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-reference-case",
+                source_uri="urn:voiage:reference-case:business",
+                descriptor_digest="f" * 64,
+            ),
+            bindings=(_binding(),),
+        ),
+        tables={"samples": table},
+    )
+
+
+def run_reference_cases() -> dict[str, object]:
+    """Calculate one explicit EVPI case through each supported input surface."""
+    policy = SourceAccessPolicy(_FIXTURES)
+    bundles = {
+        "ml": _bound(
+            default_registry().ingest(
+                _FIXTURES / "canonical-decision.croissant.json", policy=policy
+            )
+        ),
+        "engineering": _bound(
+            default_registry().ingest(
+                _FIXTURES / "canonical-decision.datapackage.json", policy=policy
+            )
+        ),
+        "business": _direct(),
+    }
+    values = {
+        domain: float(evpi(prepare_analysis_inputs(bundle).net_benefits))
+        for domain, bundle in bundles.items()
+    }
+    if len(set(values.values())) != 1:
+        raise RuntimeError("reference cases must have identical explicit EVPI")
+    return {"binding": _binding().model_dump(mode="json"), "evpi": values}
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_reference_cases(), sort_keys=True))

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -1,0 +1,32 @@
+"""Executable evidence for the cross-domain standardized-ingestion examples."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def test_reference_cases_use_one_binding_and_one_evpi() -> None:
+    path = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "standardized_ingestion"
+        / "reference_cases.py"
+    )
+    spec = importlib.util.spec_from_file_location("reference_cases", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = module.run_reference_cases()
+
+    assert result["binding"]["role"] == "net_benefit"
+    assert result["binding"]["field_ids"] == ["strategy_a", "strategy_b"]
+    assert result["evpi"] == {
+        "ml": pytest.approx(5.0),
+        "engineering": pytest.approx(5.0),
+        "business": pytest.approx(5.0),
+    }


### PR DESCRIPTION
Links to #468. Depends on #532 for the canonical pinned fixture.

Adds an executable deterministic reference runner, regression test, and published walkthrough for three applications sharing one explicit VOI binding and one calculation path:
- ML through the Croissant descriptor;
- engineering through the Frictionless Data Package; and
- business through a direct normalized table.

The runner fails if EVPI differs across formats. It adds no domain-specific kernels or semantic inference.

Validation:
- uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_reference_cases.py -q --no-cov (1 passed)
- uv run ruff check examples/standardized_ingestion/reference_cases.py tests/test_standardized_ingestion_reference_cases.py
- uv run ruff format --check examples/standardized_ingestion/reference_cases.py tests/test_standardized_ingestion_reference_cases.py
- uv run --extra dev tox -e vale (0 errors, 0 warnings, 0 suggestions)