### PR TITLE
feat(ingestion): record local materialization receipts

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -83,6 +83,12 @@ def test_built_in_providers_normalize_supported_csv_profile(
 
     assert bundle.manifest.dataset_id in {"ml-fixture", "operations-fixture"}
     assert bundle.table("samples").column_names == ["a", "b"]
+    assert bundle.manifest.resources[0].resource_id == "samples"
+    assert bundle.manifest.resources[0].sha256 == digest_file(tmp_path / "samples.csv")
+    assert (
+        bundle.manifest.resources[0].byte_size
+        == (tmp_path / "samples.csv").stat().st_size
+    )
 
 
 def test_frictionless_provider_validates_declared_types_constraints_and_primary_key(

--- a/voiage/ingestion/_tabular.py
+++ b/voiage/ingestion/_tabular.py
@@ -8,6 +8,7 @@ from pathlib import Path  # noqa: TC003 - public runtime annotation
 import pyarrow as pa
 from pyarrow import csv
 
+from voiage.contracts.normalized_input import ResourceManifest
 from voiage.ingestion.base import IngestionError, SourceAccessPolicy
 
 
@@ -25,3 +26,17 @@ def read_csv(reference: str, policy: SourceAccessPolicy) -> pa.Table:
         return csv.read_csv(path)
     except pa.ArrowException as error:
         raise IngestionError("declared CSV resource cannot be parsed") from error
+
+
+def materialization_receipt(
+    reference: str, resource_id: str, policy: SourceAccessPolicy
+) -> ResourceManifest:
+    """Return immutable local-resource identity after policy resolution."""
+    path = policy.resolve(reference)
+    return ResourceManifest(
+        resource_id=resource_id,
+        uri=path.as_uri(),
+        sha256=digest_file(path),
+        media_type="text/csv",
+        byte_size=path.stat().st_size,
+    )

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -14,7 +14,7 @@ from voiage.contracts.normalized_input import (
     SourceProvenance,
     TableManifest,
 )
-from voiage.ingestion._tabular import digest_file, read_csv
+from voiage.ingestion._tabular import digest_file, materialization_receipt, read_csv
 from voiage.ingestion.base import (
     IngestionError,
     ProviderCapabilities,
@@ -105,6 +105,7 @@ class CroissantProvider:
             manifest=DatasetManifest(
                 dataset_id=str(descriptor.get("name", table_id)),
                 tables=(TableManifest(table_id=table_id, fields=manifest_fields),),
+                resources=(materialization_receipt(reference, table_id, policy),),
                 provenance=SourceProvenance(
                     provider_id=self.provider_id,
                     source_uri=descriptor_path.resolve().as_uri(),

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -18,7 +18,7 @@ from voiage.contracts.normalized_input import (
     SourceProvenance,
     TableManifest,
 )
-from voiage.ingestion._tabular import read_csv
+from voiage.ingestion._tabular import materialization_receipt, read_csv
 from voiage.ingestion.base import (
     IngestionError,
     ProviderCapabilities,
@@ -110,6 +110,7 @@ class FrictionlessProvider:
                         primary_key=primary_key,
                     ),
                 ),
+                resources=(materialization_receipt(reference, table_id, policy),),
                 provenance=SourceProvenance(
                     provider_id=self.provider_id,
                     source_uri=descriptor_path.resolve().as_uri(),


### PR DESCRIPTION
Links to #329, #330, and #333.

Built-in Croissant and Frictionless providers now populate the existing core ResourceManifest contract after SourceAccessPolicy resolution. Every receipt records the local file URI, SHA-256, CSV media type, and byte size without retaining source contents.

Validation:
- uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_providers.py -q --no-cov (59 passed)
- uv run ruff check voiage/ingestion/_tabular.py voiage/ingestion/croissant.py voiage/ingestion/frictionless.py tests/test_standardized_ingestion_providers.py
- uv run ruff format --check voiage/ingestion/_tabular.py voiage/ingestion/croissant.py voiage/ingestion/frictionless.py tests/test_standardized_ingestion_providers.py