### PR TITLE
feat(ingestion): add verified offline materialization cache

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provenance, preserved governance metadata, and ingestion diagnostics.
 - Added fail-closed configurable local-resource size limits to standardized
   ingestion source policies.
+- Added policy-scoped, content-addressed local materialization caches with
+  SHA-256 verification and explicit offline replay for standardized-dataset
+  resources.
 
 ### Changed
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -35,6 +35,34 @@ default 512 MiB policy limit is rejected before parsing. Applications can set a
 smaller explicit `SourceAccessPolicy.max_resource_bytes` limit for constrained
 workloads.
 
+## Verified local replay
+
+`SourceAccessPolicy` is local-only by default. For a reviewable offline
+workflow, materialize an explicitly declared resource with its expected SHA-256
+digest into a policy-scoped content-addressed cache. Later, an `offline=True`
+policy can replay only that verified digest; it never falls back to a changed or
+missing source file and never performs a network refresh.
+
+```python
+from pathlib import Path
+
+from voiage.ingestion import SourceAccessPolicy
+
+policy = SourceAccessPolicy(Path("fixtures"), cache_dir=Path(".voiage-cache"))
+resource = policy.materialize("samples.csv", sha256="<64-character-sha256>")
+
+replay = SourceAccessPolicy(
+    Path("fixtures"),
+    cache_dir=Path(".voiage-cache"),
+    offline=True,
+)
+resource = replay.materialize("samples.csv", sha256="<same-sha256>")
+```
+
+Use a stable, explicit `cache_namespace` when multiple trusted source-policy
+contexts share a cache directory. Cache entries are digest-checked on write and
+replay and are kept separate by that namespace.
+
 For a VOI calculation, supply a `VOIBinding` that states the table, fields,
 strategies, units, and perspective. The library will not guess semantics from
 field names. This keeps machine-learning, engineering, and business datasets

--- a/tests/test_source_policy_cache.py
+++ b/tests/test_source_policy_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import shutil
 
 import pytest
 
@@ -52,6 +53,13 @@ def test_offline_materialize_requires_a_digest_and_never_refreshes(tmp_path) -> 
         policy.materialize("missing.csv")
     with pytest.raises(IngestionError, match="verified offline materialization"):
         policy.materialize("missing.csv", sha256=_digest(b"missing"))
+
+
+def test_offline_materialize_without_a_cache_rejects_a_valid_digest(tmp_path) -> None:
+    with pytest.raises(IngestionError, match="verified offline materialization"):
+        SourceAccessPolicy(tmp_path, offline=True).materialize(
+            "missing.csv", sha256=_digest(b"missing")
+        )
 
 
 def test_materialize_rejects_checksum_mismatch_and_cache_context_mismatch(
@@ -131,3 +139,20 @@ def test_materialize_rejects_a_symlinked_cache_entry(tmp_path) -> None:
 
     with pytest.raises(IngestionError, match="cached materialization checksum"):
         policy.materialize("source.csv", sha256=digest)
+
+
+def test_materialize_rejects_a_corrupt_copy_result(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    original_copyfile = shutil.copyfile
+
+    def corrupt_copy(source_path, target_path):
+        original_copyfile(source_path, target_path)
+        target_path.write_bytes(b"corrupt")
+
+    monkeypatch.setattr("voiage.ingestion.base.shutil.copyfile", corrupt_copy)
+    with pytest.raises(IngestionError, match="cached materialization checksum"):
+        SourceAccessPolicy(tmp_path, cache_dir=tmp_path / "cache").materialize(
+            "source.csv", sha256=_digest(payload)
+        )

--- a/tests/test_source_policy_cache.py
+++ b/tests/test_source_policy_cache.py
@@ -1,0 +1,78 @@
+"""Behavioural evidence for verified offline source materializations."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from voiage.ingestion import IngestionError, SourceAccessPolicy
+
+
+def _digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def test_materialize_writes_a_content_addressed_verified_cache(tmp_path) -> None:
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    cache = tmp_path / "cache"
+    policy = SourceAccessPolicy(tmp_path, cache_dir=cache, cache_namespace="fixture")
+
+    materialized = policy.materialize("source.csv", sha256=_digest(payload))
+
+    assert materialized.read_bytes() == payload
+    assert materialized.is_relative_to(cache)
+    assert materialized.name == _digest(payload)
+
+
+def test_offline_materialize_replays_a_verified_cache_without_source(tmp_path) -> None:
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    digest = _digest(payload)
+    cache = tmp_path / "cache"
+    online = SourceAccessPolicy(tmp_path, cache_dir=cache, cache_namespace="fixture")
+    online.materialize("source.csv", sha256=digest)
+    source.unlink()
+
+    offline = SourceAccessPolicy(
+        tmp_path, cache_dir=cache, cache_namespace="fixture", offline=True
+    )
+
+    assert offline.materialize("source.csv", sha256=digest).read_bytes() == payload
+
+
+def test_offline_materialize_requires_a_digest_and_never_refreshes(tmp_path) -> None:
+    cache = tmp_path / "cache"
+    policy = SourceAccessPolicy(tmp_path, cache_dir=cache, offline=True)
+
+    with pytest.raises(IngestionError, match="requires an expected SHA-256"):
+        policy.materialize("missing.csv")
+    with pytest.raises(IngestionError, match="verified offline materialization"):
+        policy.materialize("missing.csv", sha256=_digest(b"missing"))
+
+
+def test_materialize_rejects_checksum_mismatch_and_cache_context_mismatch(
+    tmp_path,
+) -> None:
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    cache = tmp_path / "cache"
+    digest = _digest(payload)
+
+    with pytest.raises(IngestionError, match="checksum does not match"):
+        SourceAccessPolicy(tmp_path, cache_dir=cache).materialize(
+            "source.csv", sha256=_digest(b"different")
+        )
+
+    SourceAccessPolicy(tmp_path, cache_dir=cache, cache_namespace="one").materialize(
+        "source.csv", sha256=digest
+    )
+    other_context = SourceAccessPolicy(
+        tmp_path, cache_dir=cache, cache_namespace="two", offline=True
+    )
+    with pytest.raises(IngestionError, match="verified offline materialization"):
+        other_context.materialize("source.csv", sha256=digest)

--- a/tests/test_source_policy_cache.py
+++ b/tests/test_source_policy_cache.py
@@ -76,3 +76,58 @@ def test_materialize_rejects_checksum_mismatch_and_cache_context_mismatch(
     )
     with pytest.raises(IngestionError, match="verified offline materialization"):
         other_context.materialize("source.csv", sha256=digest)
+
+
+def test_materialize_without_cache_returns_the_verified_source(tmp_path) -> None:
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+
+    assert (
+        SourceAccessPolicy(tmp_path).materialize("source.csv", sha256=_digest(payload))
+        == source
+    )
+
+
+@pytest.mark.parametrize("digest", ["not-a-digest", "g" * 64])
+def test_materialize_rejects_malformed_expected_digest(tmp_path, digest) -> None:
+    with pytest.raises(IngestionError, match="lowercase hexadecimal"):
+        SourceAccessPolicy(tmp_path).materialize("missing.csv", sha256=digest)
+
+
+def test_materialize_rejects_corrupted_cached_data_on_replay_and_cache_hit(
+    tmp_path,
+) -> None:
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    digest = _digest(payload)
+    cache = tmp_path / "cache"
+    policy = SourceAccessPolicy(tmp_path, cache_dir=cache)
+    cached = policy.materialize("source.csv", sha256=digest)
+
+    assert policy.materialize("source.csv", sha256=digest) == cached
+    cached.write_bytes(b"modified")
+    with pytest.raises(IngestionError, match="cached materialization checksum"):
+        policy.materialize("source.csv", sha256=digest)
+    with pytest.raises(IngestionError, match="cached materialization checksum"):
+        SourceAccessPolicy(tmp_path, cache_dir=cache, offline=True).materialize(
+            "source.csv", sha256=digest
+        )
+
+
+def test_materialize_rejects_a_symlinked_cache_entry(tmp_path) -> None:
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    digest = _digest(payload)
+    cache = tmp_path / "cache"
+    policy = SourceAccessPolicy(tmp_path, cache_dir=cache)
+    cached = policy.materialize("source.csv", sha256=digest)
+    replacement = tmp_path / "replacement.csv"
+    replacement.write_bytes(payload)
+    cached.unlink()
+    cached.symlink_to(replacement)
+
+    with pytest.raises(IngestionError, match="cached materialization checksum"):
+        policy.materialize("source.csv", sha256=digest)

--- a/voiage/ingestion/base.py
+++ b/voiage/ingestion/base.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 from pathlib import Path  # noqa: TC003 - protocol runtime annotation
+import shutil
 from typing import Protocol
 
 from voiage.contracts.normalized_input import (
@@ -38,12 +40,19 @@ class SourceAccessPolicy:
         *,
         allow_network: bool = False,
         max_resource_bytes: int = 512 * 1024 * 1024,
+        cache_dir: Path | None = None,
+        cache_namespace: str | None = None,
+        offline: bool = False,
     ) -> None:
         if max_resource_bytes <= 0:
             raise ValueError("max_resource_bytes must be positive")
         self.root = root.resolve()
         self.allow_network = allow_network
         self.max_resource_bytes = max_resource_bytes
+        self.cache_dir = cache_dir.resolve() if cache_dir is not None else None
+        self.offline = offline
+        context = cache_namespace or f"root={self.root};network={allow_network}"
+        self._cache_context = hashlib.sha256(context.encode("utf-8")).hexdigest()
 
     def resolve(self, reference: str) -> Path:
         """Resolve a relative local reference without allowing path traversal."""
@@ -59,6 +68,73 @@ class SourceAccessPolicy:
         if candidate.stat().st_size > self.max_resource_bytes:
             raise IngestionError("declared resource exceeds configured size limit")
         return candidate
+
+    def materialize(self, reference: str, *, sha256: str | None = None) -> Path:
+        """Return a digest-verified local materialization, optionally from cache.
+
+        This method never performs network I/O.  Offline replay is intentionally
+        possible only with an expected digest, so a mutable source cannot be
+        silently substituted for a previously reviewed materialization.
+        """
+        expected = self._validate_digest(sha256) if sha256 is not None else None
+        if self.offline:
+            if expected is None:
+                raise IngestionError(
+                    "offline replay requires an expected SHA-256 digest"
+                )
+            cached = self._cache_path(expected)
+            if cached is None or not cached.is_file() or cached.is_symlink():
+                raise IngestionError("no verified offline materialization is available")
+            if self._digest(cached) != expected:
+                raise IngestionError("cached materialization checksum does not match")
+            return cached
+
+        source = self.resolve(reference)
+        actual = self._digest(source)
+        if expected is not None and actual != expected:
+            raise IngestionError("materialized resource checksum does not match")
+        if self.cache_dir is None:
+            return source
+
+        cached = self._cache_path(actual)
+        assert cached is not None
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        if cached.exists():
+            if (
+                not cached.is_file()
+                or cached.is_symlink()
+                or self._digest(cached) != actual
+            ):
+                raise IngestionError("cached materialization checksum does not match")
+            return cached
+        shutil.copyfile(source, cached)
+        if self._digest(cached) != actual:
+            raise IngestionError("cached materialization checksum does not match")
+        return cached
+
+    def _cache_path(self, digest: str) -> Path | None:
+        if self.cache_dir is None:
+            return None
+        return self.cache_dir / self._cache_context / digest[:2] / digest
+
+    @staticmethod
+    def _validate_digest(digest: str) -> str:
+        candidate = digest.lower()
+        if len(candidate) != 64 or any(
+            char not in "0123456789abcdef" for char in candidate
+        ):
+            raise IngestionError(
+                "expected SHA-256 digest must be lowercase hexadecimal"
+            )
+        return candidate
+
+    @staticmethod
+    def _digest(path: Path) -> str:
+        hasher = hashlib.sha256()
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
 
 
 class IngestionProvider(Protocol):


### PR DESCRIPTION
## Summary
- add policy-scoped content-addressed local materialization caching
- verify SHA-256 on cache writes and offline replay
- document explicit offline replay and cover cache safety behaviour

Implements part of #333; the Phase 7 issue remains open for its other acceptance criteria.