### PR TITLE
docs(ingestion): add provider SDK example

### DIFF
--- a/examples/standardized_ingestion/example_provider.py
+++ b/examples/standardized_ingestion/example_provider.py
@@ -1,0 +1,75 @@
+"""Minimal third-party provider example using only VOIAGE public contracts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyarrow import csv
+
+from voiage.contracts import (
+    DatasetManifest,
+    FieldManifest,
+    NormalizedInputBundle,
+    SourceProvenance,
+    TableManifest,
+)
+from voiage.ingestion import IngestionError, ProviderCapabilities, SourceAccessPolicy
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ExampleCSVProvider:
+    """Recognize a deliberately small descriptor profile owned by an application."""
+
+    provider_id = "example-csv"
+    capabilities = ProviderCapabilities(
+        provider_id=provider_id,
+        format_versions=("1",),
+        media_types=("text/csv",),
+    )
+
+    def can_handle(self, descriptor: dict[str, object]) -> bool:
+        """Recognize a descriptor without I/O or optional-parser imports."""
+        return descriptor.get("voiage_example") == "1"
+
+    def ingest(
+        self, descriptor_path: Path, *, policy: SourceAccessPolicy
+    ) -> NormalizedInputBundle:
+        """Materialize the declared local CSV through the caller's policy."""
+        import json
+
+        descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+        resource = descriptor.get("resource")
+        if not isinstance(resource, str):
+            raise IngestionError("example descriptor requires a string resource")
+        path = policy.resolve(resource)
+        if path.suffix.lower() != ".csv":
+            raise IngestionError("example provider supports CSV resources only")
+        try:
+            table = csv.read_csv(path)
+        except Exception as error:
+            raise IngestionError("example CSV resource cannot be parsed") from error
+        return NormalizedInputBundle(
+            manifest=DatasetManifest(
+                dataset_id=descriptor_path.stem,
+                tables=(
+                    TableManifest(
+                        table_id="data",
+                        fields=tuple(
+                            FieldManifest(field_id=field.name, dtype=str(field.type))
+                            for field in table.schema
+                        ),
+                    ),
+                ),
+                provenance=SourceProvenance(
+                    provider_id=self.provider_id,
+                    source_uri=descriptor_path.resolve().as_uri(),
+                    descriptor_digest="0" * 64,
+                ),
+            ),
+            tables={"data": table},
+        )
+
+
+provider = ExampleCSVProvider()

--- a/tests/test_standardized_ingestion_provider_example.py
+++ b/tests/test_standardized_ingestion_provider_example.py
@@ -1,0 +1,34 @@
+"""Consumer-style evidence for the documented third-party provider surface."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from voiage.ingestion import ProviderRegistry, SourceAccessPolicy
+
+
+def test_example_provider_uses_only_the_public_provider_contract(tmp_path) -> None:
+    (tmp_path / "data.csv").write_text("value\n1\n", encoding="utf-8")
+    descriptor = tmp_path / "example.json"
+    descriptor.write_text(
+        '{"voiage_example": "1", "resource": "data.csv"}', encoding="utf-8"
+    )
+    source = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "standardized_ingestion"
+        / "example_provider.py"
+    )
+    spec = importlib.util.spec_from_file_location("example_provider", source)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    bundle = ProviderRegistry((module.provider,)).ingest(
+        descriptor, policy=SourceAccessPolicy(tmp_path)
+    )
+
+    assert bundle.manifest.provenance.provider_id == "example-csv"
+    assert bundle.table("data").to_pylist() == [{"value": 1}]


### PR DESCRIPTION
## Summary
- add a minimal external-style CSV provider example
- prove consumer registration through the public provider contract
- keep the example outside calculation internals

Implements part of #467; the SDK issue remains open for its other acceptance criteria.