### PR TITLE
Bind v2 release and registry evidence

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,7 +82,7 @@ jobs:
         PY
 
     - name: Upload production numerics benchmark
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: rust-numerics-foundational-benchmark
         path: rust-numerics-benchmark.txt

--- a/.github/workflows/c15-cross-platform.yml
+++ b/.github/workflows/c15-cross-platform.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           uv run --frozen python scripts/c15_artifact_digest.py record --archive-dir dist --kind wheel --runner "${{ runner.os }}-${{ runner.arch }}" --output c15-evidence/report-wheel.json
           uv run --frozen python scripts/c15_artifact_digest.py record --archive-dir dist --kind sdist --runner "${{ runner.os }}-${{ runner.arch }}" --output c15-evidence/report-sdist.json
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: c15-digest-${{ runner.os }}
@@ -74,7 +74,7 @@ jobs:
         with:
           version: "0.11.29"
       - run: uv sync --frozen --extra ci
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: c15-digest-*
           path: c15-digests
@@ -94,7 +94,7 @@ jobs:
           --left c15-digests/c15-digest-Linux/report-sdist.json
           --right c15-digests/c15-digest-Windows/report-sdist.json
           --output c15-evidence/comparison-sdist.json
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: c15-cross-platform-comparison
@@ -137,7 +137,7 @@ jobs:
           uv run --frozen python scripts/c15_performance_ratchet.py
           --baseline benchmarks/c15_performance_baseline.json
           --output c15-evidence/performance.json
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: c15-performance-${{ runner.os }}
@@ -173,7 +173,7 @@ jobs:
           uv run --frozen pytest -q --no-cov
           tests/test_c15_reproducibility.py tests/test_c15_performance.py
           tests/test_c15_otel.py tests/test_c15_oracles.py
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: c15-telemetry-oracle-evidence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       run: uv lock --check
 
     - name: Retain exact lock evidence
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: frozen-lock-${{ github.sha }}
         path: uv.lock
@@ -430,7 +430,7 @@ jobs:
 
     - name: Upload contract bundle performance evidence
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: contract-bundle-performance
         path: .benchmarks/contract-bundle-performance.json
@@ -611,7 +611,7 @@ jobs:
         fi
     - name: Upload mutation evidence
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: mutation-evidence
         path: |
@@ -665,7 +665,7 @@ jobs:
 
     - name: Upload profiling evidence
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: scalene-profile
         path: |

--- a/.github/workflows/conda-update.yml
+++ b/.github/workflows/conda-update.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Update conda-recipe/meta.yaml
       run: |
         mkdir -p recipes/voiage
-        cp conda-recipe/meta.yaml recipes/voiage/meta.yaml
+        cp conda-recipe/meta.yaml conda-recipe/build.sh conda-recipe/bld.bat recipes/voiage/
         python - <<'PY'
         from pathlib import Path
         import re
@@ -115,7 +115,8 @@ jobs:
         feedstock="$RUNNER_TEMP/staged-recipes"
         git clone "https://github.com/edithatogo/staged-recipes.git" "$feedstock"
         mkdir -p "$feedstock/recipes/voiage"
-        cp recipes/voiage/meta.yaml "$feedstock/recipes/voiage/meta.yaml"
+        cp recipes/voiage/meta.yaml recipes/voiage/build.sh recipes/voiage/bld.bat \
+          "$feedstock/recipes/voiage/"
         cd "$feedstock"
         branch="voiage-${RELEASE_VERSION}"
         git checkout -B "$branch"

--- a/.github/workflows/dependency-frontier.yml
+++ b/.github/workflows/dependency-frontier.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload observational frontier evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: dependency-frontier-observation
           path: |

--- a/.github/workflows/lock-refresh.yml
+++ b/.github/workflows/lock-refresh.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Verify frozen resolution
         run: uv lock --check
       - name: Retain exact lock evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: frozen-lock-${{ github.sha }}
           path: uv.lock

--- a/.github/workflows/operational-assurance.yml
+++ b/.github/workflows/operational-assurance.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: Upload operational assurance evidence
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: operational-assurance-evidence
         if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Record architecture manifest
         run: python -c "from pathlib import Path; wheel=next(Path('dist').glob('*.whl')); Path('dist/wheel-manifest-${{ matrix.platform }}.txt').write_text(wheel.name + '\n', encoding='utf-8')"
       - name: Upload native wheel
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voiage-wheel-${{ matrix.platform }}
           path: |
@@ -270,7 +270,7 @@ jobs:
           cd "$RUNNER_TEMP/sdist-black-box"
           uv run --python "$WHEEL_VENV" --no-project pytest test_wheel_black_box.py --import-mode=importlib
       - name: Upload source distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voiage-sdist
           path: dist/*.tar.gz
@@ -304,7 +304,7 @@ jobs:
           git fetch --force --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           test "$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")" = "$TAG_SHA"
       - name: Download all release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: voiage-*
           path: dist
@@ -320,7 +320,7 @@ jobs:
         with:
           subject-path: "dist/*"
       - name: Upload attested release set
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: voiage-attested-release
           path: |
@@ -355,7 +355,7 @@ jobs:
           test "$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")" = "$TAG_SHA"
           test "$(git cat-file -t "refs/tags/$RELEASE_TAG")" = tag
       - name: Download attested release set
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: voiage-attested-release
           path: dist
@@ -377,7 +377,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Retain immutable publication payload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-payload-${{ env.RELEASE_TAG }}
           path: dist/
@@ -422,7 +422,7 @@ jobs:
           test "$(sha256sum "${sdists[0]}" | cut -d ' ' -f1)" = "$EXPECTED_SDIST_SHA256"
           test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = true
       - name: Upload reviewed release payload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: reviewed-release-payload
           path: dist/
@@ -450,7 +450,7 @@ jobs:
           ref: ${{ needs.resolve-tag.outputs.tag_sha }}
           persist-credentials: false
       - name: Download reviewed release payload
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: reviewed-release-payload
           path: dist
@@ -543,7 +543,7 @@ jobs:
           ref: ${{ needs.resolve-tag.outputs.tag_sha }}
           persist-credentials: false
       - name: Download reviewed release payload
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: reviewed-release-payload
           path: dist
@@ -585,7 +585,7 @@ jobs:
           git fetch --force --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           test "$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")" = "$TAG_SHA"
       - name: Download attested release set
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: voiage-attested-release
           path: dist

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -45,7 +45,7 @@ jobs:
           --all-features --locked --fail-under-lines 80
           --cobertura --output-path rust-coverage.xml
       - name: Upload Rust coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: rust-workspace-coverage
           path: rust-coverage.xml

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ repository-code: https://github.com/edithatogo/voiage
 url: https://edithatogo.github.io/voiage
 identifiers:
   - type: swh
-    value: swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32
-    description: Historical Software Heritage snapshot of the v1.0 repository
+    value: swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d
+    description: Software Heritage snapshot containing the signed v2.0.0 release
 license: Apache-2.0
 abstract: >-
   voiage provides Value of Information analysis through a hybrid Rust and

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bound the JOSS manuscript and registry-readiness records to the public
+  v2.0.0 release, its clean-install evidence, mixed-language CycloneDX SBOM,
+  provenance, package digests, crates.io publications, and Software Heritage
+  snapshot.
+- Updated the conda-forge recipe for v2.0.0 and the confirmed maintainer
+  identity, and moved artifact workflows to immutable Node 24-native action
+  revisions.
+
 ### Fixed
+
+- Corrected the compiled conda recipe's runtime Python requirement so it
+  satisfies conda-forge's non-noarch packaging contract.
 
 ## [2.0.0] - 2026-07-26
 

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,4 @@
+@echo on
+set "GIT_DIR=%SRC_DIR%\.conda-no-git"
+"%PYTHON%" -m pip install . --no-deps --no-build-isolation -vv
+if errorlevel 1 exit /b 1

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export GIT_DIR="${SRC_DIR}/.conda-no-git"
+"${PYTHON}" -m pip install . --no-deps --no-build-isolation -vv

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "voiage" %}
-{% set version = "1.0.0" %}
+{% set version = "2.0.0" %}
 {% set python_min = "3.12" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: UPDATE_ON_RELEASE
+  sha256: 82514d3df571bf908bc64a85be2c8212ea66f5d7d53a3058054c7ddf219a35de
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
     - pip
     - maturin >=1.9,<2.0
   run:
-    - python >= {{ python_min }}
+    - python
     - click >=8.3.3,<9
     - numpy >=2.2.6,<3.0
     - scipy >=1.16.3,<1.17
@@ -65,4 +65,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - doughnut
+    - edithatogo

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
 
 requirements:
   host:
+    - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - {{ stdlib('c') }}
     - python {{ python_min }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,13 +12,15 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: GIT_DIR="$SRC_DIR/.conda-no-git" {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [unix]
+  script: set "GIT_DIR=%SRC_DIR%\.conda-no-git" && {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [win]
   entry_points:
     - voiage = voiage.cli:main
 
 requirements:
   host:
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - python {{ python_min }}
     - pip
     - maturin >=1.9,<2.0

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,10 +16,11 @@ build:
     - voiage = voiage.cli:main
 
 requirements:
-  host:
+  build:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - {{ stdlib('c') }}
+  host:
     - python {{ python_min }}
     - pip
     - maturin >=1.9,<2.0

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,8 +12,6 @@ source:
 
 build:
   number: 0
-  script: GIT_DIR="$SRC_DIR/.conda-no-git" {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [unix]
-  script: set "GIT_DIR=%SRC_DIR%\.conda-no-git" && {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [win]
   entry_points:
     - voiage = voiage.cli:main
 

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -21,13 +21,13 @@ exist; repository manifest, validation, and PR handoff are being finalized.*
 
 ## [~] Track: Research Software Registry Readiness
 *Link: [./tracks/research_software_registry_readiness_20260721/index.md](./tracks/research_software_registry_readiness_20260721/index.md)*
-*Execution order: 02 of 02, after the signed v1.0 release provides immutable
+*Execution order: 02 of 02, after the signed releases provide immutable
 release and archival evidence.*
-*Status: in progress — release and Software Heritage evidence are complete;
-RRID curation, arXiv author review/submission, JOSS deferral, and external
-language-registry outcomes remain explicit gates. Repository readiness can
-proceed before release, but live
-archival, identifiers, submission, review, and acceptance remain external.*
+*Status: in progress — signed v2.0.0 release, PyPI/TestPyPI, crates.io,
+Software Heritage, SBOM, provenance, digest, and clean-install evidence are
+complete; conda-forge PR #34308 is submitted. RRID curation, arXiv
+identification, human JOSS evidence, and external language-registry outcomes
+remain explicit gates.*
 
 ---
 

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -3,42 +3,49 @@
   "channel": "research-software-registries",
   "status": "blocked",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-26T00:00:00+10:00",
-  "next_action": "Publish and archive the exact v2 release, obtain the author's complete AI-policy attestation, document completed research-workflow use, obtain genuine human engagement through issue #471 or another attributable route, review the release-bound PDF, and record the permanent arXiv identifier before direct JOSS submission. Julia General, R registry, and SciCrunch/RRID remain separate paths.",
-  "external_gate": "The signed public v1.0.0 release, its Software Heritage snapshot, and authenticated arXiv submission are complete. The arXiv dashboard still reports submission 7861466 as submitted without a permanent identifier. Demonstrated research use is a JOSS pre-review gate. Human community engagement is a detailed-review criterion, strong positive pre-review signal, and author-selected prerequisite. Author AI attestation, arXiv announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled. The exact v2 release and archive are repository-owned work that is not yet complete.",
+  "checked_at": "2026-07-26T11:52:00Z",
+  "next_action": "Obtain the author's complete AI-policy attestation, document completed research-workflow use, obtain genuine human engagement through issue #471 or another attributable route, rebuild and review the release-bound PDF, and record the permanent arXiv identifier before direct JOSS submission. Monitor conda-forge PR 34308. Julia General, R registry, and SciCrunch/RRID remain separate paths.",
+  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, and clean-install evidence are complete. Conda-forge PR 34308 is submitted and externally reviewed. The observed arXiv state for submission 7861466 still lacks a permanent identifier. Demonstrated research use is a JOSS pre-review gate. Human community engagement is a detailed-review criterion, strong positive pre-review signal, and author-selected prerequisite. Author AI attestation, arXiv announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
   "release_evidence": {
-    "tag": "v1.0.0",
-    "url": "https://github.com/edithatogo/voiage/releases/tag/v1.0.0",
-    "published_at": "2026-07-22T06:35:22Z",
+    "tag": "v2.0.0",
+    "commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
+    "url": "https://github.com/edithatogo/voiage/releases/tag/v2.0.0",
+    "published_at": "2026-07-26T11:41:47Z",
     "draft": false,
     "prerelease": false,
     "assets": [
       "SHA256SUMS",
-      "voiage-1.0.0.tar.gz",
-      "voiage-1.0.0-cp312-abi3-macosx_11_0_arm64.whl",
-      "voiage-1.0.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-      "voiage-1.0.0-cp312-abi3-win_amd64.whl"
+      "voiage-2.0.0.tar.gz",
+      "voiage-2.0.0-cp312-abi3-macosx_11_0_arm64.whl",
+      "voiage-2.0.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "voiage-2.0.0-cp312-abi3-win_amd64.whl"
     ],
-    "checksums_url": "https://github.com/edithatogo/voiage/releases/download/v1.0.0/SHA256SUMS",
-    "pypi_url": "https://pypi.org/project/voiage/1.0.0/"
+    "checksums_url": "https://github.com/edithatogo/voiage/releases/download/v2.0.0/SHA256SUMS",
+    "pypi_url": "https://pypi.org/project/voiage/2.0.0/",
+    "testpypi_url": "https://test.pypi.org/project/voiage/2.0.0/",
+    "release_workflow_run": 30200134119,
+    "supply_chain_workflow_run": 30200921515,
+    "release_evidence": "docs/release/v2.0.0-release-evidence.json",
+    "sbom": "docs/release/v2.0.0-sbom.cdx.json",
+    "rust_crates_workflow_run": 30200722982,
+    "conda_forge_pull_request": "https://github.com/conda-forge/staged-recipes/pull/34308"
   },
   "software_heritage_archival_request": {
-    "request_id": 2397350,
-    "request_url": "https://archive.softwareheritage.org/api/1/origin/save/2397350/",
+    "request_id": 2399846,
+    "request_url": "https://archive.softwareheritage.org/api/1/origin/save/2399846/",
     "origin_url": "https://github.com/edithatogo/voiage",
     "visit_type": "git",
-    "requested_at": "2026-07-22T08:01:40.253001Z",
+    "requested_at": "2026-07-26T11:47:48.184103Z",
     "request_status": "accepted",
     "task_status": "succeeded",
-    "visit": 1,
     "visit_status": "full",
-    "snapshot_swhid": "swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32",
-    "snapshot_url": "https://archive.softwareheritage.org/api/1/snapshot/767efde24c97d9f6d730764c1b3bc1a91ba20c32/",
-    "verification_at": "2026-07-22T09:13:00Z",
-    "verification": "Software Heritage reports a full visit and snapshot for the repository origin."
+    "snapshot_swhid": "swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d",
+    "snapshot_url": "https://archive.softwareheritage.org/api/1/snapshot/31f89375852737bb9eb62ebc03fadfbc7ff70c2d/",
+    "verification_at": "2026-07-26T11:50:00Z",
+    "verification": "Software Heritage reports a full v2 visit and snapshot containing the signed v2.0.0 release."
   },
   "joss_submission_evidence": {
-    "status": "revision_in_progress_pending_release_and_external_evidence",
+      "status": "revision_in_progress_pending_human_and_external_evidence",
     "files": [
       "paper.md",
       "paper.bib",
@@ -51,7 +58,7 @@
     "validator": "scripts/validate_joss.py",
     "hosted_workflow": ".github/workflows/joss-paper.yml",
     "package_validation": {
-      "python": "clean PyPI install reports metadata and runtime version 1.0.0",
+      "python": "clean PyPI install reports metadata and runtime version 2.0.0 and loads the Rust core from the published abi3 wheel",
       "rust": "workspace tests pass excluding the separately wheel-tested private PyO3 crate",
       "r": "fresh 1.0.0 source package passes R CMD check --as-cran with two environmental/new-submission notes",
       "julia": "Pkg.test passes against a locally built voiage-ffi library; artifact/JLL distribution remains pending"
@@ -65,7 +72,6 @@
       "boundary": "Completed research-workflow use of the released package is not yet documented. The public repository history currently contains the author and automated accounts only. Current JOSS pre-review guidance treats demonstrated research use as a hard gate and non-author engagement as a strong positive signal, while the detailed review criteria still treat absent single-author engagement as not acceptable. Bots, AI agents, fallback-only adapters, and same-author aspirations do not qualify."
     },
     "remaining_submission_gates": [
-      "publish, verify, and archive the exact v2 release described by the paper",
       "obtain the author's comprehensive AI-policy attestation and best-available tool-version inventory",
       "document completed research-workflow use of the released package",
       "obtain attributable or editor-verifiable human community engagement, external use, or collaborative input",
@@ -157,6 +163,20 @@
       "status": "passed_with_external_gate",
       "artifact": "issue #471 and docs/release/joss-independent-validation.md",
       "details": "Submission 7861466 remains submitted without a permanent identifier. Demonstrated research use is a hard pre-review gate. Non-author engagement is a strong positive pre-review signal and an explicit detailed-review criterion, so issue #471 remains an author-selected prerequisite for the direct JOSS route."
+    },
+    {
+      "command": "release workflow 30200134119; clean PyPI install; crates workflow 30200722982; Software Heritage request 2399846; supply-chain workflow 30200921515",
+      "runner": "GitHub-hosted release runners, public package registries, clean local virtual environment, and Software Heritage",
+      "status": "passed",
+      "artifact": "docs/release/v2.0.0-release-evidence.json and docs/release/v2.0.0-sbom.cdx.json",
+      "details": "The signed v2.0.0 release is public on GitHub, PyPI, TestPyPI, and crates.io. Its wheels, source, digests, provenance, mixed-language CycloneDX SBOM, clean Rust-core import, and Software Heritage snapshot are bound to commit e849e89152c306e79c96d0a8a9815ee5faca0529."
+    },
+    {
+      "command": "manual conda workflow dispatch followed by authenticated fork submission",
+      "runner": "GitHub Actions and conda-forge staged-recipes",
+      "status": "submitted_external_review",
+      "artifact": "https://github.com/conda-forge/staged-recipes/pull/34308",
+      "details": "The workflow exposed a stale repository token, which was refreshed. The authenticated maintainer submitted the v2.0.0 recipe; conda-forge lint and platform builds remain external checks."
     }
   ]
 }

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-26T00:00:00+10:00",
+  "updated_at": "2026-07-26T11:52:00Z",
   "description": "Track archival, identifier, language-registry, arXiv, and evidence-gated JOSS readiness from the signed v1.0.0 release through the exact v2 review candidate.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
@@ -24,10 +24,16 @@
       "evidence": "Signed public v1.0.0 release exists at https://github.com/edithatogo/voiage/releases/tag/v1.0.0; release artifact digests and provenance evidence are published."
     },
     {
+      "id": "immutable-v2-release-and-archive",
+      "kind": "release",
+      "status": "satisfied",
+      "evidence": "Signed public v2.0.0 release, PyPI/TestPyPI packages, four crates.io crates, clean-install evidence, mixed-language CycloneDX SBOM, provenance, digests, and Software Heritage snapshot swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d are verified."
+    },
+    {
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2397350 completed with snapshot SWHID swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32. Authenticated arXiv submission 7861466 remains submitted but awaits announcement and a permanent identifier. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Exact v2 publication and archival evidence, Julia General, R registry, SciCrunch/RRID, and JOSS still require repository work, external submission, curation, evidence, or editorial decisions."
+      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Authenticated arXiv submission 7861466 still lacks an observed permanent identifier. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 is submitted. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
     }
   ],
   "github_cross_reference": {

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -55,9 +55,11 @@
   required; agents, bots, and same-author repositories do not qualify)
 - [ ] Obtain the author's explicit JOSS AI-policy affirmation and bind every
   tool/model version that can be established without guessing.
-- [ ] Publish, verify, and archive the exact v2 release described by `paper.md`,
+- [x] Publish, verify, and archive the exact v2 release described by `paper.md`,
   then replace prospective availability wording with observed release,
   provenance, SBOM, digest, clean-installation, and Software Heritage evidence.
+  (`cdc40de`; `v2.0.0`; release run `30200134119`; supply-chain run
+  `30200921515`; Software Heritage request `2399846`)
 
 ## Phase 2B: Independent simulated JOSS editorial review
 
@@ -99,22 +101,23 @@
 ## Current evidence boundary
 
 - Repository readiness audit: complete at 2026-07-22T00:41:31Z.
-- Signed public release evidence: complete; `v1.0.0` was published at
-  https://github.com/edithatogo/voiage/releases/tag/v1.0.0 on 2026-07-22T06:35:22Z.
+- Signed public release evidence: complete; `v2.0.0` was published at
+  https://github.com/edithatogo/voiage/releases/tag/v2.0.0 on 2026-07-26T11:41:47Z.
   The release includes `SHA256SUMS`, source, and macOS, Linux, and Windows
-  wheels; PyPI mirrors the source release at https://pypi.org/project/voiage/1.0.0/.
-- Software Heritage archival: complete with request `2397350`, full visit `1`,
+  wheels; PyPI and TestPyPI publish version 2.0.0, and the four public Rust
+  crates publish version 2.0.0.
+- Software Heritage archival: complete with request `2399846`, a full visit,
   and snapshot
-  `swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32`.
+  `swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d`.
 - RRID route: SciCrunch General Resource registration; assignment and curation external.
 - JOSS route: direct JOSS is selected for the Rust-centred polyglot package.
   The canonical arXiv LaTeX preprint and JOSS adaptation are repository-ready;
-  exact v2 publication, demonstrated research use, human engagement,
-  author-confirmed AI attestation,
+  demonstrated research use, human engagement, author-confirmed AI attestation,
   authenticated submission, and editorial review remain human or external.
   The author confirmed funding, competing-interest, affiliation, and ORCID
   metadata on 24 July 2026.
-- Signed v1.0 release: complete at https://github.com/edithatogo/voiage/releases/tag/v1.0.0; live archival, identifier, submission, review, and indexing gates remain external.
+- Signed v2.0 release and matching archive: complete; remaining identifier,
+  submission, review, adoption, and indexing gates remain external.
 - GitHub work hierarchy: #296 is the registry parent; #297--#299 are native
   registry subissues; #312 is the native arXiv subissue of #299 and is present
   in GitHub Project 28; #471 is the native independent-validation subissue of

--- a/docs/release/joss-submission-readiness.md
+++ b/docs/release/joss-submission-readiness.md
@@ -51,7 +51,7 @@ not replace it.
 | AI usage disclosure | Tool families, retained identifier limits, scope, and verification approach are stated. JOSS also requires versions and the author's comprehensive affirmation that the human author made the core decisions and reviewed, edited, and validated every retained AI-assisted output | Awaiting explicit author attestation and best-available version inventory; identifiers must not be guessed |
 | Funding and competing interests | No external funding and no competing interests confirmed by the author on 24 July 2026 | Ready |
 | Permanent software archive | Software Heritage snapshot SWHID recorded | Ready; DOI-bearing archive still required at acceptance |
-| Release evidence | Exact v1.0.0 tag, commit, asset digests, verified provenance, Python runtime CycloneDX SBOM and SWHID are bound in `docs/release/v1.0.0-release-evidence.json`; version 2.0.0 is the reviewed release candidate | Historical evidence ready; publish and bind the v2.0.0 mixed-language SBOM, provenance, digests and archive identifier before submission |
+| Release evidence | Exact v2.0.0 tag, commit, asset digests, verified provenance, mixed-language CycloneDX SBOM and SWHID are bound in `docs/release/v2.0.0-release-evidence.json` | Reviewed release evidence ready |
 | Reproducible JOSS PDF | Open Journals run `30182384336` built commit `766797398654fc7637e19767993535e416bb00c9`; artifact `8625969915` has digest `sha256:5098c43bea9b0f4bd6e94179d9f705387922419d9ad05ccb15a02a07e6c0995e`, and its six-page PDF has SHA-256 `43759919dbb9dccf2ecb3356da6a7a65ed67a5bf8043c2a776fa69b278156d22`. Every page was visually inspected; the hosted Textstat report remains review-only evidence | Ready for the release-bound source |
 | arXiv reference | Submission `7861466` is absent from the authenticated account's active-submission table and has no permanent identifier | External disposition gate |
 | JOSS submission and review | No submission claimed | Author and external gate |
@@ -75,7 +75,7 @@ for version 2.0.0 is the Python package:
 
 | Surface | Reviewer path | Current evidence | Boundary |
 | --- | --- | --- | --- |
-| Python | `python -m pip install voiage==2.0.0` | Release-candidate wheel/source build and Python 3.12–3.14 CI; public PyPI installation must be verified after publication | Primary JOSS installation |
+| Python | `python -m pip install voiage==2.0.0` | Public PyPI wheel clean-installed outside the checkout; runtime reports the Rust core at version 2.0.0 and source revision `e849e89152c306e79c96d0a8a9815ee5faca0529` | Primary JOSS installation |
 | Rust | `cargo test --manifest-path rust/Cargo.toml --workspace --exclude voiage-python` plus the PyO3 wheel build | Native crates, property tests, fuzzing, Miri, sanitizers and coverage | Internal workspace; crates.io publication is not required for JOSS |
 | R | `cargo build --manifest-path rust/Cargo.toml --release --locked --package voiage-ffi`, then `R CMD build r-package/voiageR`, `R CMD check --as-cran --no-manual voiageR_*.tar.gz`, and an installed smoke test with `VOIAGE_FFI_LIBRARY` set to the platform library | Installed package calls the separately built Rust EVPI library; tests pass, while the current package check reports two vignette warnings; Linux/macOS/Windows native smoke matrix is configured | Secondary binding; CRAN/r-universe review is independent of JOSS |
 | Julia | `cargo build --manifest-path rust/Cargo.toml --release --locked --package voiage-ffi`, then `VOIAGE_FFI_LIBRARY=<platform-library> julia --project=bindings/julia -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` | The fixture is packaged with the Julia source, and CI tests an archived standalone package copy against the separately built native library | Secondary binding; a Julia artifact/JLL is required before standalone General installation |
@@ -125,10 +125,9 @@ The recommended sequence is:
   evidence exists.
 - Obtain the author's complete AI-policy affirmation and record every
   establishable tool/model version without inventing historical identifiers.
-- Publish and archive the exact v2 release, then replace prospective manuscript
-  wording with observed release, digest, provenance, SBOM, and SWHID evidence.
-- Rebuild and inspect the official JOSS PDF after the exact v2 release metadata
-  replaces the current prospective availability statement.
+- Rebuild and inspect the official JOSS PDF after the observed v2 release,
+  provenance, SBOM, digest, and SWHID evidence replaced the prospective
+  availability statement.
 - Record the permanent arXiv identifier when arXiv assigns it.
 - Perform the selected direct authenticated JOSS submission.
 - Treat editorial screening, review, acceptance and DOI assignment as external

--- a/docs/release/v2.0.0-release-evidence.json
+++ b/docs/release/v2.0.0-release-evidence.json
@@ -1,0 +1,86 @@
+{
+  "attestation": {
+    "invocation": "https://github.com/edithatogo/voiage/actions/runs/30182943849/attempts/1",
+    "predicate_type": "https://slsa.dev/provenance/v1",
+    "source_commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
+    "source_uri": "git+https://github.com/edithatogo/voiage@refs/tags/v2.0.0",
+    "status": "verified",
+    "subjects": [
+      {
+        "name": "voiage-2.0.0-cp312-abi3-macosx_11_0_arm64.whl",
+        "sha256": "5956e5cf253b14123d8d75cead0ea41b946cd73c54a3f15e657413e339477a1e"
+      },
+      {
+        "name": "voiage-2.0.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "sha256": "b8fddd5c16c77fcf0bce0a6507686c696b3a77c94482e07156a3bfd04c2b053e"
+      },
+      {
+        "name": "voiage-2.0.0-cp312-abi3-win_amd64.whl",
+        "sha256": "831fdbe308bece3505f4a61d8667663c9d687827a1369e5a060bea7fcebc7968"
+      },
+      {
+        "name": "voiage-2.0.0.tar.gz",
+        "sha256": "82514d3df571bf908bc64a85be2c8212ea66f5d7d53a3058054c7ddf219a35de"
+      }
+    ]
+  },
+  "release": {
+    "commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
+    "repository": "edithatogo/voiage",
+    "tag": "v2.0.0",
+    "url": "https://github.com/edithatogo/voiage/releases/tag/v2.0.0",
+    "version": "2.0.0"
+  },
+  "release_assets": [
+    {
+      "name": "SHA256SUMS",
+      "path": "release-assets/SHA256SUMS",
+      "sha256": "9f01e71c1e247ce09a6bf38d1da19b3ecd5ce30dec9581e6da05a0c8937a1718",
+      "size": 439,
+      "url": "https://github.com/edithatogo/voiage/releases/download/v2.0.0/SHA256SUMS"
+    },
+    {
+      "name": "voiage-2.0.0-cp312-abi3-macosx_11_0_arm64.whl",
+      "path": "release-assets/voiage-2.0.0-cp312-abi3-macosx_11_0_arm64.whl",
+      "sha256": "5956e5cf253b14123d8d75cead0ea41b946cd73c54a3f15e657413e339477a1e",
+      "size": 818115,
+      "url": "https://github.com/edithatogo/voiage/releases/download/v2.0.0/voiage-2.0.0-cp312-abi3-macosx_11_0_arm64.whl"
+    },
+    {
+      "name": "voiage-2.0.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "path": "release-assets/voiage-2.0.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "sha256": "b8fddd5c16c77fcf0bce0a6507686c696b3a77c94482e07156a3bfd04c2b053e",
+      "size": 877982,
+      "url": "https://github.com/edithatogo/voiage/releases/download/v2.0.0/voiage-2.0.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+    },
+    {
+      "name": "voiage-2.0.0-cp312-abi3-win_amd64.whl",
+      "path": "release-assets/voiage-2.0.0-cp312-abi3-win_amd64.whl",
+      "sha256": "831fdbe308bece3505f4a61d8667663c9d687827a1369e5a060bea7fcebc7968",
+      "size": 722767,
+      "url": "https://github.com/edithatogo/voiage/releases/download/v2.0.0/voiage-2.0.0-cp312-abi3-win_amd64.whl"
+    },
+    {
+      "name": "voiage-2.0.0.tar.gz",
+      "path": "release-assets/voiage-2.0.0.tar.gz",
+      "sha256": "82514d3df571bf908bc64a85be2c8212ea66f5d7d53a3058054c7ddf219a35de",
+      "size": 465524,
+      "url": "https://github.com/edithatogo/voiage/releases/download/v2.0.0/voiage-2.0.0.tar.gz"
+    }
+  ],
+  "sbom": {
+    "attached_to_github_release": false,
+    "attachment_status": "not_attached",
+    "format": "CycloneDX",
+    "path": "docs/release/v2.0.0-sbom.cdx.json",
+    "sha256": "34700cbdec2d27c5f82f2aae453566ff570b070b161fdca7d1d1714f2303b805",
+    "source_commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
+    "source_tag": "v2.0.0",
+    "spec_version": "1.6"
+  },
+  "schema_version": "1.0.0",
+  "software_heritage": {
+    "origin": "https://github.com/edithatogo/voiage",
+    "snapshot_swhid": "swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d"
+  }
+}

--- a/docs/release/v2.0.0-sbom.cdx.json
+++ b/docs/release/v2.0.0-sbom.cdx.json
@@ -1,0 +1,4807 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "bom-ref": "Pygments==2.20.0",
+      "description": "Pygments is a syntax highlighting package written in Python.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://pygments.org/docs"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/pygments/pygments/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/pygments/pygments"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/pygments/pygments/blob/master/CHANGES"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://pygments.org"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "BSD-2-Clause"
+          }
+        }
+      ],
+      "name": "Pygments",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/pygments@2.20.0",
+      "type": "library",
+      "version": "2.20.0"
+    },
+    {
+      "bom-ref": "annotated-doc==0.0.4",
+      "description": "Document parameters, class attributes, return types, and variables inline, with Annotated.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://github.com/fastapi/annotated-doc"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/fastapi/annotated-doc/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/fastapi/annotated-doc/release-notes.md"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/fastapi/annotated-doc"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/fastapi/annotated-doc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "annotated-doc",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/annotated-doc@0.0.4",
+      "type": "library",
+      "version": "0.0.4"
+    },
+    {
+      "bom-ref": "annotated-types==0.8.0",
+      "description": "Reusable constraint types to use with typing.Annotated",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/annotated-types/annotated-types"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/annotated-types/annotated-types/releases"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/annotated-types/annotated-types"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "annotated-types",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/annotated-types@0.8.0",
+      "type": "library",
+      "version": "0.8.0"
+    },
+    {
+      "bom-ref": "click==8.4.2",
+      "description": "Composable command line interface toolkit",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Chat",
+          "type": "chat",
+          "url": "https://discord.gg/pallets"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://click.palletsprojects.com/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/pallets/click/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Donate",
+          "type": "other",
+          "url": "https://palletsprojects.com/donate"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changes",
+          "type": "release-notes",
+          "url": "https://click.palletsprojects.com/page/changes/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "click",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/click@8.4.2",
+      "type": "library",
+      "version": "8.4.2"
+    },
+    {
+      "bom-ref": "joblib==1.5.3",
+      "description": "Lightweight pipelining with Python functions",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/joblib/joblib"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://joblib.readthedocs.io"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "joblib",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/joblib@1.5.3",
+      "type": "library",
+      "version": "1.5.3"
+    },
+    {
+      "bom-ref": "markdown-it-py==4.2.0",
+      "description": "Python port of markdown-it. Markdown parsing, done right!",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://markdown-it-py.readthedocs.io"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/executablebooks/markdown-it-py"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "markdown-it-py",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/markdown-it-py@4.2.0",
+      "type": "library",
+      "version": "4.2.0"
+    },
+    {
+      "bom-ref": "mdurl==0.1.2",
+      "description": "Markdown URL utilities",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/executablebooks/mdurl"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "mdurl",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/mdurl@0.1.2",
+      "type": "library",
+      "version": "0.1.2"
+    },
+    {
+      "bom-ref": "narwhals==2.24.0",
+      "description": "Extremely lightweight compatibility layer between dataframe libraries",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://narwhals-dev.github.io/narwhals/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/narwhals-dev/narwhals/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/narwhals-dev/narwhals"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/narwhals-dev/narwhals"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "narwhals",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/narwhals@2.24.0",
+      "type": "library",
+      "version": "2.24.0"
+    },
+    {
+      "bom-ref": "numpy==2.5.1",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: download",
+          "type": "distribution",
+          "url": "https://pypi.org/project/numpy/#files"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: documentation",
+          "type": "documentation",
+          "url": "https://numpy.org/doc/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/numpy/numpy/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: source",
+          "type": "other",
+          "url": "https://github.com/numpy/numpy"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: release notes",
+          "type": "other",
+          "url": "https://numpy.org/doc/stable/release"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: homepage",
+          "type": "website",
+          "url": "https://numpy.org"
+        }
+      ],
+      "licenses": [
+        {
+          "acknowledgement": "declared",
+          "expression": "BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@2.5.1",
+      "type": "library",
+      "version": "2.5.1"
+    },
+    {
+      "bom-ref": "packaging==26.2",
+      "description": "Core utilities for Python packages",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://packaging.pypa.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/pypa/packaging"
+        }
+      ],
+      "licenses": [
+        {
+          "acknowledgement": "declared",
+          "expression": "Apache-2.0 OR BSD-2-Clause"
+        }
+      ],
+      "name": "packaging",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/packaging@26.2",
+      "type": "library",
+      "version": "26.2"
+    },
+    {
+      "bom-ref": "pandas==2.3.3",
+      "description": "Powerful data structures for data analysis, time series, and statistics",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: documentation",
+          "type": "documentation",
+          "url": "https://pandas.pydata.org/docs/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: repository",
+          "type": "vcs",
+          "url": "https://github.com/pandas-dev/pandas"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: homepage",
+          "type": "website",
+          "url": "https://pandas.pydata.org"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "name": "License :: OSI Approved :: BSD License"
+          }
+        }
+      ],
+      "name": "pandas",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/pandas@2.3.3",
+      "type": "library",
+      "version": "2.3.3"
+    },
+    {
+      "bom-ref": "pkg:cargo/autocfg@1.5.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+        }
+      ],
+      "name": "autocfg",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/autocfg@1.5.1",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/bit-set@0.8.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+        }
+      ],
+      "name": "bit-set",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/bit-set@0.8.0",
+      "type": "library",
+      "version": "0.8.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/bit-vec@0.8.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+        }
+      ],
+      "name": "bit-vec",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/bit-vec@0.8.0",
+      "type": "library",
+      "version": "0.8.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/bitflags@2.13.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+        }
+      ],
+      "name": "bitflags",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/bitflags@2.13.1",
+      "type": "library",
+      "version": "2.13.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/block-buffer@0.12.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+        }
+      ],
+      "name": "block-buffer",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/block-buffer@0.12.1",
+      "type": "library",
+      "version": "0.12.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/cfg-if@1.0.4",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+        }
+      ],
+      "name": "cfg-if",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/cfg-if@1.0.4",
+      "type": "library",
+      "version": "1.0.4"
+    },
+    {
+      "bom-ref": "pkg:cargo/const-oid@0.10.2",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+        }
+      ],
+      "name": "const-oid",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/const-oid@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "pkg:cargo/cpufeatures@0.3.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+        }
+      ],
+      "name": "cpufeatures",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/cpufeatures@0.3.0",
+      "type": "library",
+      "version": "0.3.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/crypto-common@0.2.2",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+        }
+      ],
+      "name": "crypto-common",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/crypto-common@0.2.2",
+      "type": "library",
+      "version": "0.2.2"
+    },
+    {
+      "bom-ref": "pkg:cargo/digest@0.11.3",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+        }
+      ],
+      "name": "digest",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/digest@0.11.3",
+      "type": "library",
+      "version": "0.11.3"
+    },
+    {
+      "bom-ref": "pkg:cargo/errno@0.3.14",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+        }
+      ],
+      "name": "errno",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/errno@0.3.14",
+      "type": "library",
+      "version": "0.3.14"
+    },
+    {
+      "bom-ref": "pkg:cargo/fastrand@2.5.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+        }
+      ],
+      "name": "fastrand",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/fastrand@2.5.0",
+      "type": "library",
+      "version": "2.5.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/fnv@1.0.7",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+        }
+      ],
+      "name": "fnv",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/fnv@1.0.7",
+      "type": "library",
+      "version": "1.0.7"
+    },
+    {
+      "bom-ref": "pkg:cargo/getrandom@0.3.4",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+        }
+      ],
+      "name": "getrandom",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/getrandom@0.3.4",
+      "type": "library",
+      "version": "0.3.4"
+    },
+    {
+      "bom-ref": "pkg:cargo/getrandom@0.4.3",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+        }
+      ],
+      "name": "getrandom",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/getrandom@0.4.3",
+      "type": "library",
+      "version": "0.4.3"
+    },
+    {
+      "bom-ref": "pkg:cargo/heck@0.5.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+        }
+      ],
+      "name": "heck",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/heck@0.5.0",
+      "type": "library",
+      "version": "0.5.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/hybrid-array@0.4.13",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+        }
+      ],
+      "name": "hybrid-array",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/hybrid-array@0.4.13",
+      "type": "library",
+      "version": "0.4.13"
+    },
+    {
+      "bom-ref": "pkg:cargo/itoa@1.0.18",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+        }
+      ],
+      "name": "itoa",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/itoa@1.0.18",
+      "type": "library",
+      "version": "1.0.18"
+    },
+    {
+      "bom-ref": "pkg:cargo/libc@0.2.187",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+        }
+      ],
+      "name": "libc",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/libc@0.2.187",
+      "type": "library",
+      "version": "0.2.187"
+    },
+    {
+      "bom-ref": "pkg:cargo/linux-raw-sys@0.12.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+        }
+      ],
+      "name": "linux-raw-sys",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/linux-raw-sys@0.12.1",
+      "type": "library",
+      "version": "0.12.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/memchr@2.8.3",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+        }
+      ],
+      "name": "memchr",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/memchr@2.8.3",
+      "type": "library",
+      "version": "2.8.3"
+    },
+    {
+      "bom-ref": "pkg:cargo/num-traits@0.2.19",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+        }
+      ],
+      "name": "num-traits",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/num-traits@0.2.19",
+      "type": "library",
+      "version": "0.2.19"
+    },
+    {
+      "bom-ref": "pkg:cargo/once_cell@1.21.4",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+        }
+      ],
+      "name": "once_cell",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/once_cell@1.21.4",
+      "type": "library",
+      "version": "1.21.4"
+    },
+    {
+      "bom-ref": "pkg:cargo/portable-atomic@1.14.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+        }
+      ],
+      "name": "portable-atomic",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/portable-atomic@1.14.0",
+      "type": "library",
+      "version": "1.14.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/ppv-lite86@0.2.21",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+        }
+      ],
+      "name": "ppv-lite86",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/ppv-lite86@0.2.21",
+      "type": "library",
+      "version": "0.2.21"
+    },
+    {
+      "bom-ref": "pkg:cargo/proc-macro2@1.0.107",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+        }
+      ],
+      "name": "proc-macro2",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/proc-macro2@1.0.107",
+      "type": "library",
+      "version": "1.0.107"
+    },
+    {
+      "bom-ref": "pkg:cargo/proptest@1.11.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+        }
+      ],
+      "name": "proptest",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/proptest@1.11.0",
+      "type": "library",
+      "version": "1.11.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/pyo3-build-config@0.29.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+        }
+      ],
+      "name": "pyo3-build-config",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/pyo3-build-config@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/pyo3-ffi@0.29.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+        }
+      ],
+      "name": "pyo3-ffi",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/pyo3-ffi@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/pyo3-macros-backend@0.29.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+        }
+      ],
+      "name": "pyo3-macros-backend",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/pyo3-macros-backend@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/pyo3-macros@0.29.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+        }
+      ],
+      "name": "pyo3-macros",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/pyo3-macros@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/pyo3@0.29.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+        }
+      ],
+      "name": "pyo3",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/pyo3@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/quick-error@1.2.3",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+        }
+      ],
+      "name": "quick-error",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/quick-error@1.2.3",
+      "type": "library",
+      "version": "1.2.3"
+    },
+    {
+      "bom-ref": "pkg:cargo/quote@1.0.47",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+        }
+      ],
+      "name": "quote",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/quote@1.0.47",
+      "type": "library",
+      "version": "1.0.47"
+    },
+    {
+      "bom-ref": "pkg:cargo/r-efi@5.3.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+        }
+      ],
+      "name": "r-efi",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/r-efi@5.3.0",
+      "type": "library",
+      "version": "5.3.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/r-efi@6.0.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+        }
+      ],
+      "name": "r-efi",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/r-efi@6.0.0",
+      "type": "library",
+      "version": "6.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/rand@0.9.5",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+        }
+      ],
+      "name": "rand",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/rand@0.9.5",
+      "type": "library",
+      "version": "0.9.5"
+    },
+    {
+      "bom-ref": "pkg:cargo/rand_chacha@0.9.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+        }
+      ],
+      "name": "rand_chacha",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/rand_chacha@0.9.0",
+      "type": "library",
+      "version": "0.9.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/rand_core@0.9.5",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+        }
+      ],
+      "name": "rand_core",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/rand_core@0.9.5",
+      "type": "library",
+      "version": "0.9.5"
+    },
+    {
+      "bom-ref": "pkg:cargo/rand_xorshift@0.4.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+        }
+      ],
+      "name": "rand_xorshift",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/rand_xorshift@0.4.0",
+      "type": "library",
+      "version": "0.4.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/regex-syntax@0.8.11",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+        }
+      ],
+      "name": "regex-syntax",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/regex-syntax@0.8.11",
+      "type": "library",
+      "version": "0.8.11"
+    },
+    {
+      "bom-ref": "pkg:cargo/rustix@1.1.4",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+        }
+      ],
+      "name": "rustix",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/rustix@1.1.4",
+      "type": "library",
+      "version": "1.1.4"
+    },
+    {
+      "bom-ref": "pkg:cargo/rusty-fork@0.3.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+        }
+      ],
+      "name": "rusty-fork",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/rusty-fork@0.3.1",
+      "type": "library",
+      "version": "0.3.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/ryu-js@1.0.3",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+        }
+      ],
+      "name": "ryu-js",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/ryu-js@1.0.3",
+      "type": "library",
+      "version": "1.0.3"
+    },
+    {
+      "bom-ref": "pkg:cargo/serde@1.0.229",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+        }
+      ],
+      "name": "serde",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/serde@1.0.229",
+      "type": "library",
+      "version": "1.0.229"
+    },
+    {
+      "bom-ref": "pkg:cargo/serde_core@1.0.229",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+        }
+      ],
+      "name": "serde_core",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/serde_core@1.0.229",
+      "type": "library",
+      "version": "1.0.229"
+    },
+    {
+      "bom-ref": "pkg:cargo/serde_derive@1.0.229",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+        }
+      ],
+      "name": "serde_derive",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/serde_derive@1.0.229",
+      "type": "library",
+      "version": "1.0.229"
+    },
+    {
+      "bom-ref": "pkg:cargo/serde_json@1.0.151",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+        }
+      ],
+      "name": "serde_json",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/serde_json@1.0.151",
+      "type": "library",
+      "version": "1.0.151"
+    },
+    {
+      "bom-ref": "pkg:cargo/serde_json_canonicalizer@0.3.2",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+        }
+      ],
+      "name": "serde_json_canonicalizer",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/serde_json_canonicalizer@0.3.2",
+      "type": "library",
+      "version": "0.3.2"
+    },
+    {
+      "bom-ref": "pkg:cargo/sha2@0.11.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+        }
+      ],
+      "name": "sha2",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/sha2@0.11.0",
+      "type": "library",
+      "version": "0.11.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/syn@2.0.119",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+        }
+      ],
+      "name": "syn",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/syn@2.0.119",
+      "type": "library",
+      "version": "2.0.119"
+    },
+    {
+      "bom-ref": "pkg:cargo/syn@3.0.2",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+        }
+      ],
+      "name": "syn",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/syn@3.0.2",
+      "type": "library",
+      "version": "3.0.2"
+    },
+    {
+      "bom-ref": "pkg:cargo/target-lexicon@0.13.5",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+        }
+      ],
+      "name": "target-lexicon",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/target-lexicon@0.13.5",
+      "type": "library",
+      "version": "0.13.5"
+    },
+    {
+      "bom-ref": "pkg:cargo/tempfile@3.27.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+        }
+      ],
+      "name": "tempfile",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/tempfile@3.27.0",
+      "type": "library",
+      "version": "3.27.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/typenum@1.20.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+        }
+      ],
+      "name": "typenum",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/typenum@1.20.1",
+      "type": "library",
+      "version": "1.20.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/unarray@0.1.4",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+        }
+      ],
+      "name": "unarray",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/unarray@0.1.4",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "pkg:cargo/unicode-ident@1.0.24",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+        }
+      ],
+      "name": "unicode-ident",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/unicode-ident@1.0.24",
+      "type": "library",
+      "version": "1.0.24"
+    },
+    {
+      "bom-ref": "pkg:cargo/voiage-diagnostics@2.0.0",
+      "description": "Structured diagnostics and error contracts for voiage.",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage-diagnostics",
+      "properties": [
+        {
+          "name": "voiage:cargo:workspace-member",
+          "value": "true"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/voiage-diagnostics@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/voiage-domain@2.0.0",
+      "description": "Validated, binding-independent domain contracts for voiage.",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage-domain",
+      "properties": [
+        {
+          "name": "voiage:cargo:workspace-member",
+          "value": "true"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/voiage-domain@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/voiage-ffi@2.0.0",
+      "description": "Leaf C ABI adapter for the voiage Rust core.",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage-ffi",
+      "properties": [
+        {
+          "name": "voiage:cargo:workspace-member",
+          "value": "true"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/voiage-ffi@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/voiage-numerics@2.0.0",
+      "description": "Binding-independent numerical kernels for voiage.",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage-numerics",
+      "properties": [
+        {
+          "name": "voiage:cargo:workspace-member",
+          "value": "true"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/voiage-numerics@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/voiage-python@2.0.0",
+      "description": "Private PyO3 adapter for the voiage Rust core.",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage-python",
+      "properties": [
+        {
+          "name": "voiage:cargo:workspace-member",
+          "value": "true"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/voiage-python@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/voiage-serialization@2.0.0",
+      "description": "Canonical serialization adapters for validated voiage contracts.",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage-serialization",
+      "properties": [
+        {
+          "name": "voiage:cargo:workspace-member",
+          "value": "true"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/voiage-serialization@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/voiage-test-support@2.0.0",
+      "description": "Shared fixture and test support for the voiage Rust workspace.",
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage-test-support",
+      "properties": [
+        {
+          "name": "voiage:cargo:workspace-member",
+          "value": "true"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/voiage-test-support@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:cargo/wait-timeout@0.2.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+        }
+      ],
+      "name": "wait-timeout",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/wait-timeout@0.2.1",
+      "type": "library",
+      "version": "0.2.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/wasip2@1.0.4%2Bwasi-0.2.12",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+        }
+      ],
+      "name": "wasip2",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/wasip2@1.0.4%2Bwasi-0.2.12",
+      "type": "library",
+      "version": "1.0.4+wasi-0.2.12"
+    },
+    {
+      "bom-ref": "pkg:cargo/windows-link@0.2.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+        }
+      ],
+      "name": "windows-link",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/windows-link@0.2.1",
+      "type": "library",
+      "version": "0.2.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/windows-sys@0.61.2",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+        }
+      ],
+      "name": "windows-sys",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/windows-sys@0.61.2",
+      "type": "library",
+      "version": "0.61.2"
+    },
+    {
+      "bom-ref": "pkg:cargo/wit-bindgen@0.57.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+        }
+      ],
+      "name": "wit-bindgen",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/wit-bindgen@0.57.1",
+      "type": "library",
+      "version": "0.57.1"
+    },
+    {
+      "bom-ref": "pkg:cargo/zerocopy-derive@0.8.55",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+        }
+      ],
+      "name": "zerocopy-derive",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/zerocopy-derive@0.8.55",
+      "type": "library",
+      "version": "0.8.55"
+    },
+    {
+      "bom-ref": "pkg:cargo/zerocopy@0.8.55",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+        }
+      ],
+      "name": "zerocopy",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/zerocopy@0.8.55",
+      "type": "library",
+      "version": "0.8.55"
+    },
+    {
+      "bom-ref": "pkg:cargo/zmij@1.0.23",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+        }
+      ],
+      "name": "zmij",
+      "properties": [
+        {
+          "name": "voiage:cargo:source",
+          "value": "registry+https://github.com/rust-lang/crates.io-index"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "cargo"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-lock"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "rust/Cargo.lock"
+        }
+      ],
+      "purl": "pkg:cargo/zmij@1.0.23",
+      "type": "library",
+      "version": "1.0.23"
+    },
+    {
+      "bom-ref": "pkg:cran/knitr",
+      "name": "knitr",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "r"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "Suggests"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "r-package/voiageR/DESCRIPTION"
+        },
+        {
+          "name": "voiage:inventory:version-constraint",
+          "value": ">= 1.45"
+        }
+      ],
+      "purl": "pkg:cran/knitr",
+      "scope": "optional",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:cran/reticulate",
+      "name": "reticulate",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "r"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "Suggests"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "r-package/voiageR/DESCRIPTION"
+        },
+        {
+          "name": "voiage:inventory:version-constraint",
+          "value": ">= 1.20"
+        }
+      ],
+      "purl": "pkg:cran/reticulate",
+      "scope": "optional",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:cran/rmarkdown",
+      "name": "rmarkdown",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "r"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "Suggests"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "r-package/voiageR/DESCRIPTION"
+        },
+        {
+          "name": "voiage:inventory:version-constraint",
+          "value": ">= 2.26"
+        }
+      ],
+      "purl": "pkg:cran/rmarkdown",
+      "scope": "optional",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:cran/testthat",
+      "name": "testthat",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "r"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "Suggests"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "r-package/voiageR/DESCRIPTION"
+        },
+        {
+          "name": "voiage:inventory:version-constraint",
+          "value": ">= 3.0.0"
+        }
+      ],
+      "purl": "pkg:cran/testthat",
+      "scope": "optional",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:cran/voiageR@2.0.0",
+      "description": "An R interface to the Rust-backed voiage core for Value of Information analysis, with a direct Rust C ABI EVPI path and helper functions for Python environment management where advanced methods still use reticulate. Provides functions for calculating Expected Value of Perfect Information (EVPI), Expected Value of Partial Perfect Information (EVPPI), and Expected Value of Sample Information (EVSI).",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License (>= 2.0)"
+          }
+        }
+      ],
+      "name": "voiageR",
+      "properties": [
+        {
+          "name": "voiage:binding:native-component",
+          "value": "pkg:cargo/voiage-ffi@2.0.0"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "r"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "r-package/voiageR/DESCRIPTION"
+        }
+      ],
+      "purl": "pkg:cran/voiageR@2.0.0",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "pkg:julia/JSON?uuid=682c06a0-de6a-54ab-a142-c8b1cf79cde6",
+      "name": "JSON",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "julia"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "deps"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "bindings/julia/Project.toml"
+        },
+        {
+          "name": "voiage:inventory:version-constraint",
+          "value": "0.21"
+        },
+        {
+          "name": "voiage:julia:uuid",
+          "value": "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+        }
+      ],
+      "purl": "pkg:julia/JSON?uuid=682c06a0-de6a-54ab-a142-c8b1cf79cde6",
+      "scope": "required",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:julia/Libdl?uuid=8f399da3-3557-5675-b5ff-fb832c97cbdb",
+      "name": "Libdl",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "julia"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "deps"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "bindings/julia/Project.toml"
+        },
+        {
+          "name": "voiage:julia:uuid",
+          "value": "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+        }
+      ],
+      "purl": "pkg:julia/Libdl?uuid=8f399da3-3557-5675-b5ff-fb832c97cbdb",
+      "scope": "required",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:julia/Statistics?uuid=10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+      "name": "Statistics",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "julia"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "deps"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "bindings/julia/Project.toml"
+        },
+        {
+          "name": "voiage:julia:uuid",
+          "value": "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+        }
+      ],
+      "purl": "pkg:julia/Statistics?uuid=10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+      "scope": "required",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:julia/Test?uuid=8dfed614-e22c-5e08-85e1-65c5234f0b40",
+      "name": "Test",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "julia"
+        },
+        {
+          "name": "voiage:inventory:dependency-field",
+          "value": "extras"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared-unresolved"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "bindings/julia/Project.toml"
+        },
+        {
+          "name": "voiage:julia:uuid",
+          "value": "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+        }
+      ],
+      "purl": "pkg:julia/Test?uuid=8dfed614-e22c-5e08-85e1-65c5234f0b40",
+      "scope": "optional",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:julia/Voiage@2.0.0?uuid=8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f",
+      "name": "Voiage",
+      "properties": [
+        {
+          "name": "voiage:binding:native-component",
+          "value": "pkg:cargo/voiage-ffi@2.0.0"
+        },
+        {
+          "name": "voiage:ecosystem",
+          "value": "julia"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "declared"
+        },
+        {
+          "name": "voiage:inventory:source",
+          "value": "bindings/julia/Project.toml"
+        },
+        {
+          "name": "voiage:julia:uuid",
+          "value": "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
+        },
+        {
+          "name": "voiage:julia:version-constraint",
+          "value": "1.10"
+        }
+      ],
+      "purl": "pkg:julia/Voiage@2.0.0?uuid=8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f",
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "bom-ref": "polars-runtime-32==1.43.0",
+      "description": "Blazingly fast DataFrame library",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://docs.pola.rs/api/python/stable/reference/index.html"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/pola-rs/polars/releases"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/pola-rs/polars"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://www.pola.rs/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "polars-runtime-32",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/polars-runtime-32@1.43.0",
+      "type": "library",
+      "version": "1.43.0"
+    },
+    {
+      "bom-ref": "polars==1.43.0",
+      "description": "Blazingly fast DataFrame library",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://docs.pola.rs/api/python/stable/reference/index.html"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/pola-rs/polars/releases"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/pola-rs/polars"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://www.pola.rs/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "polars",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/polars@1.43.0",
+      "type": "library",
+      "version": "1.43.0"
+    },
+    {
+      "bom-ref": "pyarrow==25.0.0",
+      "description": "Python library for Apache Arrow",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://arrow.apache.org/docs/python"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/apache/arrow/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/apache/arrow"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://arrow.apache.org/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "pyarrow",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/pyarrow@25.0.0",
+      "type": "library",
+      "version": "25.0.0"
+    },
+    {
+      "bom-ref": "pydantic==2.13.4",
+      "description": "Data validation using Python type hints",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://docs.pydantic.dev"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/pydantic/pydantic"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://github.com/sponsors/samuelcolvin"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://docs.pydantic.dev/latest/changelog/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/pydantic/pydantic"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "pydantic",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/pydantic@2.13.4",
+      "type": "library",
+      "version": "2.13.4"
+    },
+    {
+      "bom-ref": "pydantic_core==2.46.4",
+      "description": "Core functionality for Pydantic validation and serialization",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/pydantic/pydantic/tree/main/pydantic-core"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://github.com/sponsors/samuelcolvin"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/pydantic"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/pydantic/pydantic"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "pydantic_core",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/pydantic-core@2.46.4",
+      "type": "library",
+      "version": "2.46.4"
+    },
+    {
+      "bom-ref": "python-dateutil==2.9.0.post0",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://dateutil.readthedocs.io/en/stable/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/dateutil/dateutil"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/dateutil/dateutil"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "name": "License :: OSI Approved :: Apache Software License"
+          }
+        },
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "name": "License :: OSI Approved :: BSD License"
+          }
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.9.0.post0",
+      "type": "library",
+      "version": "2.9.0.post0"
+    },
+    {
+      "bom-ref": "pytz==2026.2",
+      "description": "World timezone definitions, modern and historical",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Download-URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/pytz/"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "http://pythonhosted.org/pytz"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "pytz",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/pytz@2026.2",
+      "type": "library",
+      "version": "2026.2"
+    },
+    {
+      "bom-ref": "rich==15.0.0",
+      "description": "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://rich.readthedocs.io/en/latest/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/Textualize/rich"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "rich",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/rich@15.0.0",
+      "type": "library",
+      "version": "15.0.0"
+    },
+    {
+      "bom-ref": "scikit-learn==1.9.0",
+      "description": "A set of python modules for machine learning and data mining",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: download",
+          "type": "distribution",
+          "url": "https://pypi.org/project/scikit-learn/#files"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/scikit-learn/scikit-learn/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: source",
+          "type": "other",
+          "url": "https://github.com/scikit-learn/scikit-learn"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: release notes",
+          "type": "other",
+          "url": "https://scikit-learn.org/stable/whats_new"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: homepage",
+          "type": "website",
+          "url": "https://scikit-learn.org"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "scikit-learn",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/scikit-learn@1.9.0",
+      "type": "library",
+      "version": "1.9.0"
+    },
+    {
+      "bom-ref": "scipy==1.16.3",
+      "description": "Fundamental algorithms for scientific computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: download",
+          "type": "distribution",
+          "url": "https://github.com/scipy/scipy/releases"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: documentation",
+          "type": "documentation",
+          "url": "https://docs.scipy.org/doc/scipy/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/scipy/scipy/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: source",
+          "type": "other",
+          "url": "https://github.com/scipy/scipy"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: homepage",
+          "type": "website",
+          "url": "https://scipy.org/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "name": "License :: OSI Approved :: BSD License"
+          }
+        }
+      ],
+      "name": "scipy",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/scipy@1.16.3",
+      "type": "library",
+      "version": "1.16.3"
+    },
+    {
+      "bom-ref": "shellingham==1.5.4",
+      "description": "Tool to Detect Surrounding Shell",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/sarugaku/shellingham"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "ISC"
+          }
+        }
+      ],
+      "name": "shellingham",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/shellingham@1.5.4",
+      "type": "library",
+      "version": "1.5.4"
+    },
+    {
+      "bom-ref": "six==1.17.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/benjaminp/six"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.17.0",
+      "type": "library",
+      "version": "1.17.0"
+    },
+    {
+      "bom-ref": "threadpoolctl==3.6.0",
+      "description": "threadpoolctl",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/joblib/threadpoolctl"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "BSD-3-Clause"
+          }
+        },
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "name": "License :: OSI Approved :: BSD License"
+          }
+        }
+      ],
+      "name": "threadpoolctl",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/threadpoolctl@3.6.0",
+      "type": "library",
+      "version": "3.6.0"
+    },
+    {
+      "bom-ref": "typer==0.27.0",
+      "description": "Typer, build great CLIs. Easy to code. Based on Python type hints.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://typer.tiangolo.com"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/fastapi/typer/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://typer.tiangolo.com/release-notes/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/fastapi/typer"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/fastapi/typer"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "typer",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/typer@0.27.0",
+      "type": "library",
+      "version": "0.27.0"
+    },
+    {
+      "bom-ref": "typing-inspection==0.4.2",
+      "description": "Runtime typing introspection tools",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://pydantic.github.io/typing-inspection/dev/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/pydantic/typing-inspection"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/pydantic/typing-inspection/blob/main/HISTORY.md"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/pydantic/typing-inspection"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "typing-inspection",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/typing-inspection@0.4.2",
+      "type": "library",
+      "version": "0.4.2"
+    },
+    {
+      "bom-ref": "typing_extensions==4.16.0",
+      "description": "Backported and Experimental Type Hints for Python 3.9+",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://typing-extensions.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/python/typing_extensions/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Q & A",
+          "type": "other",
+          "url": "https://github.com/python/typing/discussions"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changes",
+          "type": "release-notes",
+          "url": "https://github.com/python/typing_extensions/blob/main/CHANGELOG.md"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/python/typing_extensions"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Home",
+          "type": "website",
+          "url": "https://github.com/python/typing_extensions"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "PSF-2.0"
+          }
+        }
+      ],
+      "name": "typing_extensions",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/typing-extensions@4.16.0",
+      "type": "library",
+      "version": "4.16.0"
+    },
+    {
+      "bom-ref": "tzdata==2026.3",
+      "description": "Provider of IANA time zone data",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://tzdata.python.org"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Bug Reports",
+          "type": "issue-tracker",
+          "url": "https://github.com/python/tzdata/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/python/tzdata"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/python/tzdata"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "tzdata",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/tzdata@2026.3",
+      "type": "library",
+      "version": "2026.3"
+    },
+    {
+      "bom-ref": "xarray==2024.11.0",
+      "description": "N-D labeled arrays and datasets in Python",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://docs.xarray.dev"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: issue-tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/pydata/xarray/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: source-code",
+          "type": "other",
+          "url": "https://github.com/pydata/xarray"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: SciPy2015-talk",
+          "type": "other",
+          "url": "https://www.youtube.com/watch?v=X0pAhJgySxk"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: homepage",
+          "type": "website",
+          "url": "https://xarray.dev/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "name": "License :: OSI Approved :: Apache Software License"
+          }
+        }
+      ],
+      "name": "xarray",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        }
+      ],
+      "purl": "pkg:pypi/xarray@2024.11.0",
+      "type": "library",
+      "version": "2024.11.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "Pygments==2.20.0"
+    },
+    {
+      "ref": "annotated-doc==0.0.4"
+    },
+    {
+      "ref": "annotated-types==0.8.0"
+    },
+    {
+      "ref": "click==8.4.2"
+    },
+    {
+      "ref": "joblib==1.5.3"
+    },
+    {
+      "dependsOn": [
+        "mdurl==0.1.2"
+      ],
+      "ref": "markdown-it-py==4.2.0"
+    },
+    {
+      "ref": "mdurl==0.1.2"
+    },
+    {
+      "dependsOn": [
+        "packaging==26.2",
+        "pandas==2.3.3",
+        "polars==1.43.0",
+        "pyarrow==25.0.0"
+      ],
+      "ref": "narwhals==2.24.0"
+    },
+    {
+      "ref": "numpy==2.5.1"
+    },
+    {
+      "ref": "packaging==26.2"
+    },
+    {
+      "dependsOn": [
+        "numpy==2.5.1",
+        "pyarrow==25.0.0",
+        "python-dateutil==2.9.0.post0",
+        "pytz==2026.2",
+        "scipy==1.16.3",
+        "tzdata==2026.3",
+        "xarray==2024.11.0"
+      ],
+      "ref": "pandas==2.3.3"
+    },
+    {
+      "ref": "pkg:cargo/autocfg@1.5.1"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/bit-vec@0.8.0"
+      ],
+      "ref": "pkg:cargo/bit-set@0.8.0"
+    },
+    {
+      "ref": "pkg:cargo/bit-vec@0.8.0"
+    },
+    {
+      "ref": "pkg:cargo/bitflags@2.13.1"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/hybrid-array@0.4.13"
+      ],
+      "ref": "pkg:cargo/block-buffer@0.12.1"
+    },
+    {
+      "ref": "pkg:cargo/cfg-if@1.0.4"
+    },
+    {
+      "ref": "pkg:cargo/const-oid@0.10.2"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/libc@0.2.187"
+      ],
+      "ref": "pkg:cargo/cpufeatures@0.3.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/hybrid-array@0.4.13"
+      ],
+      "ref": "pkg:cargo/crypto-common@0.2.2"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/block-buffer@0.12.1",
+        "pkg:cargo/const-oid@0.10.2",
+        "pkg:cargo/crypto-common@0.2.2"
+      ],
+      "ref": "pkg:cargo/digest@0.11.3"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/libc@0.2.187",
+        "pkg:cargo/windows-sys@0.61.2"
+      ],
+      "ref": "pkg:cargo/errno@0.3.14"
+    },
+    {
+      "ref": "pkg:cargo/fastrand@2.5.0"
+    },
+    {
+      "ref": "pkg:cargo/fnv@1.0.7"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/cfg-if@1.0.4",
+        "pkg:cargo/libc@0.2.187",
+        "pkg:cargo/r-efi@5.3.0",
+        "pkg:cargo/wasip2@1.0.4%2Bwasi-0.2.12"
+      ],
+      "ref": "pkg:cargo/getrandom@0.3.4"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/cfg-if@1.0.4",
+        "pkg:cargo/libc@0.2.187",
+        "pkg:cargo/r-efi@6.0.0"
+      ],
+      "ref": "pkg:cargo/getrandom@0.4.3"
+    },
+    {
+      "ref": "pkg:cargo/heck@0.5.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/typenum@1.20.1"
+      ],
+      "ref": "pkg:cargo/hybrid-array@0.4.13"
+    },
+    {
+      "ref": "pkg:cargo/itoa@1.0.18"
+    },
+    {
+      "ref": "pkg:cargo/libc@0.2.187"
+    },
+    {
+      "ref": "pkg:cargo/linux-raw-sys@0.12.1"
+    },
+    {
+      "ref": "pkg:cargo/memchr@2.8.3"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/autocfg@1.5.1"
+      ],
+      "ref": "pkg:cargo/num-traits@0.2.19"
+    },
+    {
+      "ref": "pkg:cargo/once_cell@1.21.4"
+    },
+    {
+      "ref": "pkg:cargo/portable-atomic@1.14.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/zerocopy@0.8.55"
+      ],
+      "ref": "pkg:cargo/ppv-lite86@0.2.21"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/unicode-ident@1.0.24"
+      ],
+      "ref": "pkg:cargo/proc-macro2@1.0.107"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/bit-set@0.8.0",
+        "pkg:cargo/bit-vec@0.8.0",
+        "pkg:cargo/bitflags@2.13.1",
+        "pkg:cargo/num-traits@0.2.19",
+        "pkg:cargo/rand@0.9.5",
+        "pkg:cargo/rand_chacha@0.9.0",
+        "pkg:cargo/rand_xorshift@0.4.0",
+        "pkg:cargo/regex-syntax@0.8.11",
+        "pkg:cargo/rusty-fork@0.3.1",
+        "pkg:cargo/tempfile@3.27.0",
+        "pkg:cargo/unarray@0.1.4"
+      ],
+      "ref": "pkg:cargo/proptest@1.11.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/target-lexicon@0.13.5"
+      ],
+      "ref": "pkg:cargo/pyo3-build-config@0.29.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/libc@0.2.187",
+        "pkg:cargo/pyo3-build-config@0.29.0"
+      ],
+      "ref": "pkg:cargo/pyo3-ffi@0.29.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/heck@0.5.0",
+        "pkg:cargo/proc-macro2@1.0.107",
+        "pkg:cargo/quote@1.0.47",
+        "pkg:cargo/syn@2.0.119"
+      ],
+      "ref": "pkg:cargo/pyo3-macros-backend@0.29.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proc-macro2@1.0.107",
+        "pkg:cargo/pyo3-macros-backend@0.29.0",
+        "pkg:cargo/quote@1.0.47",
+        "pkg:cargo/syn@2.0.119"
+      ],
+      "ref": "pkg:cargo/pyo3-macros@0.29.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/libc@0.2.187",
+        "pkg:cargo/once_cell@1.21.4",
+        "pkg:cargo/portable-atomic@1.14.0",
+        "pkg:cargo/pyo3-build-config@0.29.0",
+        "pkg:cargo/pyo3-ffi@0.29.0",
+        "pkg:cargo/pyo3-macros@0.29.0"
+      ],
+      "ref": "pkg:cargo/pyo3@0.29.0"
+    },
+    {
+      "ref": "pkg:cargo/quick-error@1.2.3"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proc-macro2@1.0.107"
+      ],
+      "ref": "pkg:cargo/quote@1.0.47"
+    },
+    {
+      "ref": "pkg:cargo/r-efi@5.3.0"
+    },
+    {
+      "ref": "pkg:cargo/r-efi@6.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/rand_chacha@0.9.0",
+        "pkg:cargo/rand_core@0.9.5"
+      ],
+      "ref": "pkg:cargo/rand@0.9.5"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/ppv-lite86@0.2.21",
+        "pkg:cargo/rand_core@0.9.5"
+      ],
+      "ref": "pkg:cargo/rand_chacha@0.9.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/getrandom@0.3.4"
+      ],
+      "ref": "pkg:cargo/rand_core@0.9.5"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/rand_core@0.9.5"
+      ],
+      "ref": "pkg:cargo/rand_xorshift@0.4.0"
+    },
+    {
+      "ref": "pkg:cargo/regex-syntax@0.8.11"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/bitflags@2.13.1",
+        "pkg:cargo/errno@0.3.14",
+        "pkg:cargo/libc@0.2.187",
+        "pkg:cargo/linux-raw-sys@0.12.1",
+        "pkg:cargo/windows-sys@0.61.2"
+      ],
+      "ref": "pkg:cargo/rustix@1.1.4"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/fnv@1.0.7",
+        "pkg:cargo/quick-error@1.2.3",
+        "pkg:cargo/tempfile@3.27.0",
+        "pkg:cargo/wait-timeout@0.2.1"
+      ],
+      "ref": "pkg:cargo/rusty-fork@0.3.1"
+    },
+    {
+      "ref": "pkg:cargo/ryu-js@1.0.3"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/serde_core@1.0.229",
+        "pkg:cargo/serde_derive@1.0.229"
+      ],
+      "ref": "pkg:cargo/serde@1.0.229"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/serde_derive@1.0.229"
+      ],
+      "ref": "pkg:cargo/serde_core@1.0.229"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proc-macro2@1.0.107",
+        "pkg:cargo/quote@1.0.47",
+        "pkg:cargo/syn@3.0.2"
+      ],
+      "ref": "pkg:cargo/serde_derive@1.0.229"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/itoa@1.0.18",
+        "pkg:cargo/memchr@2.8.3",
+        "pkg:cargo/serde@1.0.229",
+        "pkg:cargo/serde_core@1.0.229",
+        "pkg:cargo/zmij@1.0.23"
+      ],
+      "ref": "pkg:cargo/serde_json@1.0.151"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/ryu-js@1.0.3",
+        "pkg:cargo/serde@1.0.229",
+        "pkg:cargo/serde_json@1.0.151"
+      ],
+      "ref": "pkg:cargo/serde_json_canonicalizer@0.3.2"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/cfg-if@1.0.4",
+        "pkg:cargo/cpufeatures@0.3.0",
+        "pkg:cargo/digest@0.11.3"
+      ],
+      "ref": "pkg:cargo/sha2@0.11.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proc-macro2@1.0.107",
+        "pkg:cargo/quote@1.0.47",
+        "pkg:cargo/unicode-ident@1.0.24"
+      ],
+      "ref": "pkg:cargo/syn@2.0.119"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proc-macro2@1.0.107",
+        "pkg:cargo/quote@1.0.47",
+        "pkg:cargo/unicode-ident@1.0.24"
+      ],
+      "ref": "pkg:cargo/syn@3.0.2"
+    },
+    {
+      "ref": "pkg:cargo/target-lexicon@0.13.5"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/fastrand@2.5.0",
+        "pkg:cargo/getrandom@0.4.3",
+        "pkg:cargo/once_cell@1.21.4",
+        "pkg:cargo/rustix@1.1.4",
+        "pkg:cargo/windows-sys@0.61.2"
+      ],
+      "ref": "pkg:cargo/tempfile@3.27.0"
+    },
+    {
+      "ref": "pkg:cargo/typenum@1.20.1"
+    },
+    {
+      "ref": "pkg:cargo/unarray@0.1.4"
+    },
+    {
+      "ref": "pkg:cargo/unicode-ident@1.0.24"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/serde@1.0.229",
+        "pkg:cargo/serde_json@1.0.151",
+        "pkg:cargo/voiage-domain@2.0.0"
+      ],
+      "ref": "pkg:cargo/voiage-diagnostics@2.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proptest@1.11.0",
+        "pkg:cargo/serde@1.0.229",
+        "pkg:cargo/serde_json@1.0.151"
+      ],
+      "ref": "pkg:cargo/voiage-domain@2.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/voiage-diagnostics@2.0.0",
+        "pkg:cargo/voiage-domain@2.0.0",
+        "pkg:cargo/voiage-numerics@2.0.0",
+        "pkg:cargo/voiage-serialization@2.0.0"
+      ],
+      "ref": "pkg:cargo/voiage-ffi@2.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proptest@1.11.0",
+        "pkg:cargo/voiage-diagnostics@2.0.0",
+        "pkg:cargo/voiage-domain@2.0.0"
+      ],
+      "ref": "pkg:cargo/voiage-numerics@2.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/pyo3@0.29.0",
+        "pkg:cargo/serde@1.0.229",
+        "pkg:cargo/serde_json@1.0.151",
+        "pkg:cargo/serde_json_canonicalizer@0.3.2",
+        "pkg:cargo/sha2@0.11.0",
+        "pkg:cargo/voiage-diagnostics@2.0.0",
+        "pkg:cargo/voiage-domain@2.0.0",
+        "pkg:cargo/voiage-numerics@2.0.0",
+        "pkg:cargo/voiage-serialization@2.0.0"
+      ],
+      "ref": "pkg:cargo/voiage-python@2.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/serde@1.0.229",
+        "pkg:cargo/serde_json@1.0.151",
+        "pkg:cargo/voiage-diagnostics@2.0.0",
+        "pkg:cargo/voiage-domain@2.0.0"
+      ],
+      "ref": "pkg:cargo/voiage-serialization@2.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/serde@1.0.229",
+        "pkg:cargo/serde_json@1.0.151",
+        "pkg:cargo/voiage-diagnostics@2.0.0",
+        "pkg:cargo/voiage-domain@2.0.0",
+        "pkg:cargo/voiage-numerics@2.0.0",
+        "pkg:cargo/voiage-serialization@2.0.0"
+      ],
+      "ref": "pkg:cargo/voiage-test-support@2.0.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/libc@0.2.187"
+      ],
+      "ref": "pkg:cargo/wait-timeout@0.2.1"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/wit-bindgen@0.57.1"
+      ],
+      "ref": "pkg:cargo/wasip2@1.0.4%2Bwasi-0.2.12"
+    },
+    {
+      "ref": "pkg:cargo/windows-link@0.2.1"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/windows-link@0.2.1"
+      ],
+      "ref": "pkg:cargo/windows-sys@0.61.2"
+    },
+    {
+      "ref": "pkg:cargo/wit-bindgen@0.57.1"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/proc-macro2@1.0.107",
+        "pkg:cargo/quote@1.0.47",
+        "pkg:cargo/syn@2.0.119"
+      ],
+      "ref": "pkg:cargo/zerocopy-derive@0.8.55"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/zerocopy-derive@0.8.55"
+      ],
+      "ref": "pkg:cargo/zerocopy@0.8.55"
+    },
+    {
+      "ref": "pkg:cargo/zmij@1.0.23"
+    },
+    {
+      "ref": "pkg:cran/knitr"
+    },
+    {
+      "ref": "pkg:cran/reticulate"
+    },
+    {
+      "ref": "pkg:cran/rmarkdown"
+    },
+    {
+      "ref": "pkg:cran/testthat"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/voiage-ffi@2.0.0",
+        "pkg:cran/knitr",
+        "pkg:cran/reticulate",
+        "pkg:cran/rmarkdown",
+        "pkg:cran/testthat"
+      ],
+      "ref": "pkg:cran/voiageR@2.0.0"
+    },
+    {
+      "ref": "pkg:julia/JSON?uuid=682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+    },
+    {
+      "ref": "pkg:julia/Libdl?uuid=8f399da3-3557-5675-b5ff-fb832c97cbdb"
+    },
+    {
+      "ref": "pkg:julia/Statistics?uuid=10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+    },
+    {
+      "ref": "pkg:julia/Test?uuid=8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    },
+    {
+      "dependsOn": [
+        "pkg:cargo/voiage-ffi@2.0.0",
+        "pkg:julia/JSON?uuid=682c06a0-de6a-54ab-a142-c8b1cf79cde6",
+        "pkg:julia/Libdl?uuid=8f399da3-3557-5675-b5ff-fb832c97cbdb",
+        "pkg:julia/Statistics?uuid=10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+        "pkg:julia/Test?uuid=8dfed614-e22c-5e08-85e1-65c5234f0b40"
+      ],
+      "ref": "pkg:julia/Voiage@2.0.0?uuid=8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
+    },
+    {
+      "ref": "polars-runtime-32==1.43.0"
+    },
+    {
+      "dependsOn": [
+        "numpy==2.5.1",
+        "pandas==2.3.3",
+        "polars-runtime-32==1.43.0",
+        "pyarrow==25.0.0",
+        "pydantic==2.13.4",
+        "tzdata==2026.3"
+      ],
+      "ref": "polars==1.43.0"
+    },
+    {
+      "ref": "pyarrow==25.0.0"
+    },
+    {
+      "dependsOn": [
+        "annotated-types==0.8.0",
+        "pydantic_core==2.46.4",
+        "typing-inspection==0.4.2",
+        "typing_extensions==4.16.0",
+        "tzdata==2026.3"
+      ],
+      "ref": "pydantic==2.13.4"
+    },
+    {
+      "dependsOn": [
+        "typing_extensions==4.16.0"
+      ],
+      "ref": "pydantic_core==2.46.4"
+    },
+    {
+      "dependsOn": [
+        "six==1.17.0"
+      ],
+      "ref": "python-dateutil==2.9.0.post0"
+    },
+    {
+      "ref": "pytz==2026.2"
+    },
+    {
+      "dependsOn": [
+        "Pygments==2.20.0",
+        "markdown-it-py==4.2.0"
+      ],
+      "ref": "rich==15.0.0"
+    },
+    {
+      "dependsOn": [
+        "click==8.4.2",
+        "numpy==2.5.1",
+        "pandas==2.3.3",
+        "pkg:cargo/voiage-diagnostics@2.0.0",
+        "pkg:cargo/voiage-domain@2.0.0",
+        "pkg:cargo/voiage-ffi@2.0.0",
+        "pkg:cargo/voiage-numerics@2.0.0",
+        "pkg:cargo/voiage-python@2.0.0",
+        "pkg:cargo/voiage-serialization@2.0.0",
+        "pkg:cargo/voiage-test-support@2.0.0",
+        "pkg:cran/voiageR@2.0.0",
+        "pkg:julia/Voiage@2.0.0?uuid=8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f",
+        "polars==1.43.0",
+        "pyarrow==25.0.0",
+        "pydantic==2.13.4",
+        "scikit-learn==1.9.0",
+        "scipy==1.16.3",
+        "typer==0.27.0",
+        "typing_extensions==4.16.0",
+        "xarray==2024.11.0"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "dependsOn": [
+        "joblib==1.5.3",
+        "narwhals==2.24.0",
+        "numpy==2.5.1",
+        "pandas==2.3.3",
+        "polars==1.43.0",
+        "pyarrow==25.0.0",
+        "rich==15.0.0",
+        "scipy==1.16.3",
+        "threadpoolctl==3.6.0"
+      ],
+      "ref": "scikit-learn==1.9.0"
+    },
+    {
+      "dependsOn": [
+        "numpy==2.5.1",
+        "threadpoolctl==3.6.0",
+        "typing_extensions==4.16.0"
+      ],
+      "ref": "scipy==1.16.3"
+    },
+    {
+      "ref": "shellingham==1.5.4"
+    },
+    {
+      "ref": "six==1.17.0"
+    },
+    {
+      "ref": "threadpoolctl==3.6.0"
+    },
+    {
+      "dependsOn": [
+        "annotated-doc==0.0.4",
+        "rich==15.0.0",
+        "shellingham==1.5.4"
+      ],
+      "ref": "typer==0.27.0"
+    },
+    {
+      "dependsOn": [
+        "typing_extensions==4.16.0"
+      ],
+      "ref": "typing-inspection==0.4.2"
+    },
+    {
+      "ref": "typing_extensions==4.16.0"
+    },
+    {
+      "ref": "tzdata==2026.3"
+    },
+    {
+      "dependsOn": [
+        "numpy==2.5.1",
+        "packaging==26.2",
+        "pandas==2.3.3",
+        "scipy==1.16.3"
+      ],
+      "ref": "xarray==2024.11.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "Value of Information analysis with a Rust core and Python, R, and Julia interfaces.",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: Documentation",
+          "type": "documentation",
+          "url": "https://edithatogo.github.io/voiage"
+        },
+        {
+          "comment": "from pyproject urls: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/edithatogo/voiage/issues"
+        },
+        {
+          "comment": "from pyproject urls: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/edithatogo/voiage/blob/main/changelog.md"
+        },
+        {
+          "comment": "from pyproject urls: Repository",
+          "type": "vcs",
+          "url": "https://github.com/edithatogo/voiage"
+        },
+        {
+          "comment": "from pyproject urls: Homepage",
+          "type": "website",
+          "url": "https://github.com/edithatogo/voiage"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "acknowledgement": "declared",
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "voiage",
+      "properties": [
+        {
+          "name": "voiage:ecosystem",
+          "value": "python"
+        },
+        {
+          "name": "voiage:inventory:resolution",
+          "value": "resolved-installed"
+        },
+        {
+          "name": "voiage:sbom:aggregate-root",
+          "value": "true"
+        }
+      ],
+      "type": "library",
+      "version": "2.0.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      },
+      {
+        "name": "voiage:sbom:cargo",
+        "value": "resolved-cargo-lock-workspace"
+      },
+      {
+        "name": "voiage:sbom:ecosystems",
+        "value": "python,cargo,r,julia"
+      },
+      {
+        "name": "voiage:sbom:julia",
+        "value": "declared-project-dependencies"
+      },
+      {
+        "name": "voiage:sbom:python",
+        "value": "resolved-installed-runtime-environment"
+      },
+      {
+        "name": "voiage:sbom:r",
+        "value": "declared-description-dependencies"
+      },
+      {
+        "name": "voiage:sbom:scope",
+        "value": "mixed-language-release"
+      },
+      {
+        "name": "voiage:source:commit",
+        "value": "e849e89152c306e79c96d0a8a9815ee5faca0529"
+      },
+      {
+        "name": "voiage:source:tag",
+        "value": "v2.0.0"
+      }
+    ],
+    "tools": {
+      "components": [
+        {
+          "description": "CycloneDX Software Bill of Materials (SBOM) generator for Python projects and environments",
+          "externalReferences": [
+            {
+              "type": "build-system",
+              "url": "https://github.com/CycloneDX/cyclonedx-python/actions"
+            },
+            {
+              "type": "distribution",
+              "url": "https://pypi.org/project/cyclonedx-bom/"
+            },
+            {
+              "type": "documentation",
+              "url": "https://cyclonedx-bom-tool.readthedocs.io/"
+            },
+            {
+              "type": "issue-tracker",
+              "url": "https://github.com/CycloneDX/cyclonedx-python/issues"
+            },
+            {
+              "type": "license",
+              "url": "https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE"
+            },
+            {
+              "type": "release-notes",
+              "url": "https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md"
+            },
+            {
+              "type": "vcs",
+              "url": "https://github.com/CycloneDX/cyclonedx-python/"
+            },
+            {
+              "type": "website",
+              "url": "https://github.com/CycloneDX/cyclonedx-python/#readme"
+            }
+          ],
+          "group": "CycloneDX",
+          "licenses": [
+            {
+              "license": {
+                "acknowledgement": "declared",
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "name": "cyclonedx-py",
+          "type": "application",
+          "version": "7.3.0"
+        },
+        {
+          "description": "Python library for CycloneDX",
+          "externalReferences": [
+            {
+              "type": "build-system",
+              "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+            },
+            {
+              "type": "distribution",
+              "url": "https://pypi.org/project/cyclonedx-python-lib/"
+            },
+            {
+              "type": "documentation",
+              "url": "https://cyclonedx-python-library.readthedocs.io/"
+            },
+            {
+              "type": "issue-tracker",
+              "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+            },
+            {
+              "type": "license",
+              "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+            },
+            {
+              "type": "release-notes",
+              "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+            },
+            {
+              "type": "vcs",
+              "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+            },
+            {
+              "type": "website",
+              "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+            }
+          ],
+          "group": "CycloneDX",
+          "licenses": [
+            {
+              "license": {
+                "acknowledgement": "declared",
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "name": "cyclonedx-python-lib",
+          "type": "library",
+          "version": "11.11.0"
+        }
+      ]
+    }
+  },
+  "specVersion": "1.6",
+  "version": 1
+}

--- a/paper.bib
+++ b/paper.bib
@@ -46,11 +46,11 @@
   author = {Mordaunt, Dylan},
   title = {{voiage}},
   year = {2026},
-  date = {2026-07-22},
+  date = {2026-07-26},
   publisher = {GitHub},
-  url = {https://github.com/edithatogo/voiage/releases/tag/v1.0.0},
-  version = {1.0.0},
-  note = {Signed tag at commit 05cc373d78ae74143194e889ff1317de4dfea52e}
+  url = {https://github.com/edithatogo/voiage/releases/tag/v2.0.0},
+  version = {2.0.0},
+  note = {Signed tag at commit e849e89152c306e79c96d0a8a9815ee5faca0529}
 }
 
 @software{voiage_software_heritage,
@@ -58,8 +58,8 @@
   title = {Archived snapshot of edithatogo/voiage},
   year = {2026},
   howpublished = {Software Heritage},
-  url = {https://archive.softwareheritage.org/swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32},
-  note = {Snapshot SWHID: swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32; signed v1.0.0 release SWHID: swh:1:rel:2ec50b766379cc9d537383344239679a37515122}
+  url = {https://archive.softwareheritage.org/swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d},
+  note = {Snapshot SWHID: swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d; includes the signed v2.0.0 tag}
 }
 
 @software{voi_cran2024,

--- a/paper.md
+++ b/paper.md
@@ -214,14 +214,14 @@ interests.
 
 # Software and data availability
 
-The source code and release 1.0.0 are public [@voiage2026]. The fixed-seed
+The source code and release 2.0.0 are public [@voiage2026]. The fixed-seed
 health-example script, `scripts/generate_paper_health_example.py`, and its
-machine-readable outputs use synthetic data. The signed v1.0.0 tag is included
+machine-readable outputs use synthetic data. The signed v2.0.0 tag is included
 in the Software Heritage snapshot
-`swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32`
-[@voiage_software_heritage]. Release 1.0.0 predates the revised EVSI contract
-described here. The exact reviewed revision therefore requires a new release
-and archive before JOSS submission. Its reproduction manifest records the
+`swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d`
+[@voiage_software_heritage]. The release-evidence manifest binds the reviewed
+commit, package assets, checksums, provenance, mixed-language software bill of
+materials, and archive identifier. The reproduction manifest records the
 inputs, fixed seeds, lockfile digest, output hashes, and verification command.
 
 # References

--- a/paper/joss-claim-evidence.json
+++ b/paper/joss-claim-evidence.json
@@ -358,7 +358,7 @@
     {
       "id": "archive-scope",
       "section": "Software and data availability",
-      "statement": "The signed v1.0.0 tag is included in the Software Heritage snapshot `swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32`.",
+      "statement": "The signed v2.0.0 tag is included in the Software Heritage snapshot `swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d`.",
       "status": "verified",
       "citation_keys": [
         "voiage_software_heritage"
@@ -366,15 +366,15 @@
       "evidence": [
         {
           "type": "release-evidence",
-          "locator": "docs/release/v1.0.0-release-evidence.json"
+          "locator": "docs/release/v2.0.0-release-evidence.json"
         }
       ]
     },
     {
       "id": "reviewed-release-pending",
       "section": "Software and data availability",
-      "statement": "The exact reviewed revision therefore requires a new release and archive before JOSS submission.",
-      "status": "bounded",
+      "statement": "The release-evidence manifest binds the reviewed commit, package assets, checksums, provenance, mixed-language software bill of materials, and archive identifier.",
+      "status": "verified",
       "evidence": [
         {
           "type": "readiness-manifest",
@@ -558,7 +558,7 @@
     {
       "id": "reproduction-manifest-contents",
       "section": "Software and data availability",
-      "statement": "Its reproduction manifest records the inputs, fixed seeds, lockfile digest, output hashes, and verification command.",
+      "statement": "The reproduction manifest records the inputs, fixed seeds, lockfile digest, output hashes, and verification command.",
       "status": "verified",
       "evidence": [
         {

--- a/paper/joss-editorial-assurance.json
+++ b/paper/joss-editorial-assurance.json
@@ -8,8 +8,8 @@
       "commit": "dde39b3bb334f79f12e395a5317b21e036336bdd",
       "mode": "read_only",
       "status": "pass_with_warnings",
-      "source_sha256": "5fac4db6e37a7aa7ebc24386f84f6ad01f879f6d30013dca3ea634bef6b19e91",
-      "bibliography_sha256": "a63cf808c1ae6980b9964c4c86abc7785bca7eb3347185db6138f0ecf97a5880",
+      "source_sha256": "59162ab08b3d74bc6e49e57518ebc9956e38bffcd07530f3439a86ba920e3948",
+      "bibliography_sha256": "abed876b3d7b0738113fe3729a710eb38c3c56ba955b09336dd34ea061f4e816",
       "citation_occurrences": 18,
       "citation_matches": 18,
       "citation_issues": 0,
@@ -26,7 +26,7 @@
       ],
       "automated_coverage": "selected deterministic blocking patterns",
       "status": "pass",
-      "source_sha256": "5fac4db6e37a7aa7ebc24386f84f6ad01f879f6d30013dca3ea634bef6b19e91",
+      "source_sha256": "59162ab08b3d74bc6e49e57518ebc9956e38bffcd07530f3439a86ba920e3948",
       "finding_count": 0
     },
     "textstat": {

--- a/paper/joss-readiness-manifest.json
+++ b/paper/joss-readiness-manifest.json
@@ -54,8 +54,8 @@
   "repository_gates": {
     "public_development_history": "ready",
     "license_documentation_tests_and_contribution_paths": "ready",
-    "exact_reviewed_v2_release": "pending",
-    "exact_reviewed_immutable_archive": "pending"
+    "exact_reviewed_v2_release": "ready",
+    "exact_reviewed_immutable_archive": "ready"
   },
   "external_gates": {
     "demonstrated_research_use": "pending",

--- a/roadmap.md
+++ b/roadmap.md
@@ -70,10 +70,12 @@ Rust-centred polyglot package. Issue #471 tracks demonstrated research use and
 attributable human community engagement, external use, or collaborative input.
 The former is a hard pre-review gate; the latter remains a detailed-review
 criterion, strong positive pre-review signal, and author-selected prerequisite.
-Exact v2 release evidence, author-confirmed
-AI attestation, final human source verification, authenticated submission,
-editorial review, acceptance, and DOI assignment remain explicit human or
-external gates. The round-nine JOSS source has passed its local article,
+The signed v2.0.0 release, PyPI/TestPyPI packages, four crates.io crates,
+mixed-language SBOM, provenance, clean-install evidence, and Software Heritage
+snapshot are complete. Conda-forge PR #34308 is under external review.
+Author-confirmed AI attestation, final human source verification,
+authenticated submission, editorial review, acceptance, and DOI assignment
+remain explicit human or external gates. The round-nine JOSS source has passed its local article,
 SourceRight, Authentext, Open Journals, and page-by-page visual checks. The
 decision-maker wording retained for the release-bound source passed a fresh
 exact-revision Open Journals build and six-page visual review in PR #529. The

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -111,8 +111,8 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     assert "{{ compiler('rust') }}" in recipe
     assert "{{ stdlib('c') }}" in recipe
     assert "maturin >=1.9,<2.0" in recipe
-    assert 'GIT_DIR="$SRC_DIR/.conda-no-git"' in recipe
-    assert 'GIT_DIR=%SRC_DIR%\\.conda-no-git' in recipe
+    assert "GIT_DIR=\"$SRC_DIR/.conda-no-git\"" in recipe
+    assert "GIT_DIR=%SRC_DIR%\\.conda-no-git" in recipe
     assert "    - python {{ python_min }}" in recipe
     assert "  run:\n    - python\n" in recipe
     assert "python >= {{ python_min }}" not in recipe

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -109,7 +109,10 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     assert not Path("conda/meta.yaml").exists()
     assert "noarch: python" not in recipe
     assert "{{ compiler('rust') }}" in recipe
+    assert "{{ stdlib('c') }}" in recipe
     assert "maturin >=1.9,<2.0" in recipe
+    assert 'GIT_DIR="$SRC_DIR/.conda-no-git"' in recipe
+    assert 'GIT_DIR=%SRC_DIR%\\.conda-no-git' in recipe
     assert "    - python {{ python_min }}" in recipe
     assert "  run:\n    - python\n" in recipe
     assert "python >= {{ python_min }}" not in recipe

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -111,7 +111,7 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     assert "{{ compiler('rust') }}" in recipe
     assert "{{ stdlib('c') }}" in recipe
     assert "maturin >=1.9,<2.0" in recipe
-    assert "GIT_DIR=\"$SRC_DIR/.conda-no-git\"" in recipe
+    assert 'GIT_DIR="$SRC_DIR/.conda-no-git"' in recipe  # noqa: Q000
     assert "GIT_DIR=%SRC_DIR%\\.conda-no-git" in recipe
     assert "    - python {{ python_min }}" in recipe
     assert "  run:\n    - python\n" in recipe

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -111,8 +111,13 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     assert "{{ compiler('rust') }}" in recipe
     assert "{{ stdlib('c') }}" in recipe
     assert "maturin >=1.9,<2.0" in recipe
-    assert 'GIT_DIR="$SRC_DIR/.conda-no-git"' in recipe  # noqa: Q000
-    assert "GIT_DIR=%SRC_DIR%\\.conda-no-git" in recipe
+    assert "script:" not in recipe
+    assert 'GIT_DIR="${SRC_DIR}/.conda-no-git"' in Path(
+        "conda-recipe/build.sh"
+    ).read_text(encoding="utf-8")
+    assert "GIT_DIR=%SRC_DIR%\\.conda-no-git" in Path(
+        "conda-recipe/bld.bat"
+    ).read_text(encoding="utf-8")
     assert "    - python {{ python_min }}" in recipe
     assert "  run:\n    - python\n" in recipe
     assert "python >= {{ python_min }}" not in recipe
@@ -121,6 +126,11 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     workflow = Path(".github/workflows/conda-update.yml").read_text(encoding="utf-8")
     assert 'meta = Path("recipes/voiage/meta.yaml")' in workflow
     assert 'r"sha256: [0-9a-fA-F_]+"' in workflow
+    assert (
+        "cp conda-recipe/meta.yaml conda-recipe/build.sh conda-recipe/bld.bat"
+        in workflow
+    )
+    assert "recipes/voiage/bld.bat" in workflow
 
 
 def test_python_release_publish_job_is_exact_tag_and_least_privilege() -> None:

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -117,13 +117,16 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     assert 'GIT_DIR="${SRC_DIR}/.conda-no-git"' in Path(
         "conda-recipe/build.sh"
     ).read_text(encoding="utf-8")
-    assert "GIT_DIR=%SRC_DIR%\\.conda-no-git" in Path(
-        "conda-recipe/bld.bat"
-    ).read_text(encoding="utf-8")
+    assert "GIT_DIR=%SRC_DIR%\\.conda-no-git" in Path("conda-recipe/bld.bat").read_text(
+        encoding="utf-8"
+    )
     assert "    - python {{ python_min }}" in recipe
     assert "  run:\n    - python\n" in recipe
     assert "python >= {{ python_min }}" not in recipe
-    assert "sha256: 82514d3df571bf908bc64a85be2c8212ea66f5d7d53a3058054c7ddf219a35de" in recipe
+    assert (
+        "sha256: 82514d3df571bf908bc64a85be2c8212ea66f5d7d53a3058054c7ddf219a35de"
+        in recipe
+    )
 
     workflow = Path(".github/workflows/conda-update.yml").read_text(encoding="utf-8")
     assert 'meta = Path("recipes/voiage/meta.yaml")' in workflow

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -73,11 +73,11 @@ def test_python_release_workflow_builds_and_publishes_aggregated_artifacts() -> 
         'python -m voiage.versioning --release-tag "$RELEASE_TAG"' in release_workflow
     )
     assert (
-        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
         in release_workflow
     )
     assert (
-        "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
+        "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
         in release_workflow
     )
     assert (
@@ -110,8 +110,10 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     assert "noarch: python" not in recipe
     assert "{{ compiler('rust') }}" in recipe
     assert "maturin >=1.9,<2.0" in recipe
-    assert "python >= {{ python_min }}" in recipe
-    assert "sha256: UPDATE_ON_RELEASE" in recipe
+    assert "    - python {{ python_min }}" in recipe
+    assert "  run:\n    - python\n" in recipe
+    assert "python >= {{ python_min }}" not in recipe
+    assert "sha256: 82514d3df571bf908bc64a85be2c8212ea66f5d7d53a3058054c7ddf219a35de" in recipe
 
     workflow = Path(".github/workflows/conda-update.yml").read_text(encoding="utf-8")
     assert 'meta = Path("recipes/voiage/meta.yaml")' in workflow

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -108,6 +108,7 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
 
     assert not Path("conda/meta.yaml").exists()
     assert "noarch: python" not in recipe
+    assert "  build:\n    - {{ compiler('c') }}" in recipe
     assert "{{ compiler('c') }}" in recipe
     assert "{{ compiler('rust') }}" in recipe
     assert "{{ stdlib('c') }}" in recipe

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -108,6 +108,7 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
 
     assert not Path("conda/meta.yaml").exists()
     assert "noarch: python" not in recipe
+    assert "{{ compiler('c') }}" in recipe
     assert "{{ compiler('rust') }}" in recipe
     assert "{{ stdlib('c') }}" in recipe
     assert "maturin >=1.9,<2.0" in recipe

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -18,7 +18,7 @@ def test_registry_handoff_preserves_release_and_external_gates() -> None:
         "track_id": "research_software_registry_readiness_20260721",
         "channel": "research-software-registries",
         "status": "blocked",
-        "command_count": 8,
+        "command_count": 10,
         "evidence_count": 8,
     }
 
@@ -45,11 +45,16 @@ def test_registry_track_records_native_paper_issue_hierarchy() -> None:
     assert handoff["joss_submission_evidence"]["selected_route"] == "direct_joss"
     assert (
         handoff["joss_submission_evidence"]["status"]
-        == "revision_in_progress_pending_release_and_external_evidence"
+        == "revision_in_progress_pending_human_and_external_evidence"
     )
     remaining = handoff["joss_submission_evidence"]["remaining_submission_gates"]
-    assert any("exact v2 release" in gate for gate in remaining)
+    assert not any("exact v2 release" in gate for gate in remaining)
     assert any("AI-policy attestation" in gate for gate in remaining)
     assert any("research-workflow use" in gate for gate in remaining)
     assert any("human community engagement" in gate for gate in remaining)
     assert any("Open Journals PDF" in gate for gate in remaining)
+    assert handoff["release_evidence"]["tag"] == "v2.0.0"
+    assert (
+        handoff["software_heritage_archival_request"]["snapshot_swhid"]
+        == "swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d"
+    )

--- a/todo.md
+++ b/todo.md
@@ -58,8 +58,11 @@ This document lists the actionable tasks for `voiage` development. Agents should
         PDF and six-page visual review passed for PR #522; the retained
         decision-maker wording passed its release-bound rebuild and six-page
         visual review in PR #529.
-        Exact v2 release identity, author-confirmed AI attestation, final human
-        source verification, and the external engagement record remain open.
+        The signed v2.0.0 GitHub, PyPI, TestPyPI, crates.io, provenance, SBOM,
+        clean-install, and Software Heritage evidence is complete.
+        Author-confirmed AI attestation, final human source verification,
+        release-bound PDF review, and the external engagement record remain
+        open. Conda-forge PR #34308 is under external review.
     *   The authenticated arXiv account was rechecked on 26 July 2026:
         submission `7861466` is absent from the active-submission table and no
         permanent identifier is available. Resolve that external disposition


### PR DESCRIPTION
## Summary
- bind the public v2.0.0 GitHub, PyPI, TestPyPI, crates.io, SBOM, provenance, clean-install, and Software Heritage evidence
- replace prospective JOSS availability claims with observed release facts and refresh SourceRight/AuthenText-bound assurance
- submit and harden the v2 conda-forge recipe
- move artifact workflows to immutable Node 24-native action revisions
- reconcile the registry-readiness Conductor track while retaining human and external gates

## Verification
- 48 focused JOSS/release/SBOM/conda tests passed
- `scripts/validate_joss.py` passed
- `scripts/release_evidence_manifest.py validate` passed
- `scripts/repo_harness.py` passed for all 27 workflows
- clean PyPI installation loaded Rust core 2.0.0
- Software Heritage request 2399846 completed with `swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d`
- Rust crates release run 30200722982 passed
- conda-forge staged-recipes PR 34308 is under platform validation

The full Conductor validator retains 223 historical findings outside the changed registry-readiness track; it reports no finding for that track.