### PR TITLE
test(ingestion): cover dataframe interchange edge cases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recorded a fail-closed assessment of Hugging Face and OpenML registry
   integrations; no registry-specific provider is enabled without pinned,
   receipt-bound remote-materialization evidence.
+- Extended the generic DataFrame-interchange adapter with explicit no-copy
+  enforcement and pandas category, nullable-value, and timezone conformance
+  coverage.
 
 ### Changed
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -79,6 +79,11 @@ The same contract supports more than one community-facing example:
 - Business: a Polars or pandas-compatible DataFrame passed through the
   dataframe-interchange adapter for competing investment strategies.
 
+The adapter deliberately keeps the exchange boundary visible. Use
+`from_dataframe(frame, dataset_id="business", allow_copy=False)` when the
+caller requires Arrow to reject a conversion that would copy the source data;
+the resulting bundle always follows the same normalized preparation path.
+
 Each example must declare its binding rather than relying on a domain-specific
 calculation path, so their resulting net-benefit matrices are directly
 comparable with the existing VOI APIs.

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from types import SimpleNamespace
 
+import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
@@ -466,6 +467,41 @@ def test_dataframe_interchange_preserves_supported_nullable_and_temporal_values(
             "observed_at": datetime(2026, 1, 2, tzinfo=UTC),
         },
     ]
+
+
+def test_dataframe_interchange_preserves_pandas_category_null_and_timezone_values() -> (
+    None
+):
+    index = pd.Index(["first", "second"], name="scenario")
+    frame = pd.DataFrame(
+        {
+            "tier": pd.Series(["standard", None], dtype="category", index=index),
+            "cost": pd.Series([10, None], dtype="Int64", index=index),
+            "observed_at": pd.Series(
+                pd.to_datetime(["2026-01-01T00:00:00Z", None]), index=index
+            ),
+        },
+        index=index,
+    )
+
+    bundle = from_dataframe(frame, dataset_id="business")
+
+    assert bundle.table("data").to_pylist() == [
+        {
+            "tier": "standard",
+            "cost": 10,
+            "observed_at": datetime(2026, 1, 1, tzinfo=UTC),
+        },
+        {"tier": None, "cost": None, "observed_at": None},
+    ]
+    assert bundle.table("data").column_names == ["tier", "cost", "observed_at"]
+
+
+def test_dataframe_interchange_reports_a_disallowed_copy() -> None:
+    frame = pl.DataFrame({"label": ["one", "two"]})
+
+    with pytest.raises(ValueError, match="requested copy policy"):
+        from_dataframe(frame, dataset_id="no-copy", allow_copy=False)
 
 
 def test_dataframe_interchange_rejects_unsupported_nested_values_with_stable_error() -> (

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 import json
 import subprocess
 import sys
@@ -435,6 +436,45 @@ def test_dataframe_interchange_adapter_does_not_require_a_specific_frame_library
 
     assert bundle.manifest.provenance.provider_id == "dataframe-interchange"
     assert bundle.table("data").column_names == ["a", "b"]
+
+
+def test_dataframe_interchange_preserves_supported_nullable_and_temporal_values() -> (
+    None
+):
+    frame = pl.DataFrame(
+        {
+            "active": [True, None],
+            "label": ["alpha", None],
+            "observed_at": [
+                datetime(2026, 1, 1, tzinfo=UTC),
+                datetime(2026, 1, 2, tzinfo=UTC),
+            ],
+        }
+    )
+
+    bundle = from_dataframe(frame, dataset_id="engineering")
+
+    assert bundle.table("data").to_pylist() == [
+        {
+            "active": True,
+            "label": "alpha",
+            "observed_at": datetime(2026, 1, 1, tzinfo=UTC),
+        },
+        {
+            "active": None,
+            "label": None,
+            "observed_at": datetime(2026, 1, 2, tzinfo=UTC),
+        },
+    ]
+
+
+def test_dataframe_interchange_rejects_unsupported_nested_values_with_stable_error() -> (
+    None
+):
+    frame = pl.DataFrame({"scenario": [["one", "two"]]})
+
+    with pytest.raises(ValueError, match="dataframe interchange protocol"):
+        from_dataframe(frame, dataset_id="nested")
 
 
 @pytest.mark.parametrize(

--- a/voiage/ingestion/dataframe.py
+++ b/voiage/ingestion/dataframe.py
@@ -23,13 +23,19 @@ def from_dataframe(
     dataset_id: str,
     table_id: str = "data",
     bindings: tuple[VOIBinding, ...] = (),
+    allow_copy: bool = True,
 ) -> NormalizedInputBundle:
-    """Convert any dataframe-interchange producer to the normalized contract."""
+    """Convert any dataframe-interchange producer to the normalized contract.
+
+    Set ``allow_copy=False`` when callers need the Arrow interchange layer to
+    reject conversions that cannot preserve a zero-copy boundary.
+    """
     try:
-        table = arrow_from_dataframe(dataframe)
-    except (TypeError, ValueError, pa.ArrowException) as error:
+        table = arrow_from_dataframe(dataframe, allow_copy=allow_copy)
+    except (TypeError, ValueError, RuntimeError, pa.ArrowException) as error:
         raise ValueError(
-            "input does not implement the dataframe interchange protocol"
+            "input does not satisfy the dataframe interchange protocol "
+            "with the requested copy policy"
         ) from error
     descriptor_digest = hashlib.sha256(
         f"dataframe-interchange:{dataset_id}:{table_id}".encode()


### PR DESCRIPTION
## Summary
- verify nullable boolean, string, and UTC temporal dataframe interchange values
- verify nested dataframe values fail with the stable public error

Implements part of #467; the SDK issue remains open for its other acceptance criteria.