### PR TITLE
feat(ingestion): expose resource receipts in inspection

### DIFF
--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -33,7 +33,20 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
     runner = CliRunner()
 
     validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
-    inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
+    inspected = runner.invoke(
+        app,
+        [
+            "ingest",
+            "inspect",
+            str(descriptor),
+            "--table",
+            "samples",
+            "--field",
+            "a",
+            "--field",
+            "b",
+        ],
+    )
     output = tmp_path / "normalized.arrow"
     normalized = runner.invoke(
         app, ["ingest", "normalize", str(descriptor), "--output", str(output)]
@@ -74,6 +87,20 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
             {"role": "author", "title": "Fixture maintainer"}
         ],
         "frictionlessdata.org:licenses": [{"name": "CC-BY-4.0"}],
+    }
+    resolution = inspection["binding_resolution"]
+    assert resolution["binding"]["role"] == "net_benefit"
+    assert resolution["binding"]["table_id"] == "samples"
+    assert resolution["binding"]["field_ids"] == ["a", "b"]
+    assert len(resolution["binding_profile_digest"]) == 64
+    assert len(resolution["input_digest"]) == 64
+    assert resolution["data_quality"] == {
+        **resolution["data_quality"],
+        "null_counts": {"a": 0, "b": 0},
+        "row_count": 1,
+        "selected_field_ids": ["a", "b"],
+        "table_id": "samples",
+        "unique_value_counts": {"a": 1, "b": 1},
     }
     assert inspection["resources"] == [
         {

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -33,6 +33,7 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
     runner = CliRunner()
 
     validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
+    default_inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
     inspected = runner.invoke(
         app,
         [
@@ -68,6 +69,8 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
 
     assert validated.exit_code == 0
     assert json.loads(validated.output)["valid"] is True
+    assert default_inspected.exit_code == 0
+    assert json.loads(default_inspected.output)["binding_resolution"] is None
     assert inspected.exit_code == 0
     inspection = json.loads(inspected.output)
     assert inspection["provider"] == "frictionless"
@@ -115,6 +118,38 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
     assert output.is_file()
     assert calculated.exit_code == 0
     assert "input_digest" in json.loads(calculated.output)
+
+
+def test_inspect_requires_complete_explicit_binding_options(tmp_path) -> None:
+    (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "datapackage.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    table_only = runner.invoke(
+        app, ["ingest", "inspect", str(descriptor), "--table", "samples"]
+    )
+    fields_only = runner.invoke(
+        app, ["ingest", "inspect", str(descriptor), "--field", "a"]
+    )
+
+    assert table_only.exit_code == 2
+    assert fields_only.exit_code == 2
+    assert "--table and at least one --field" in table_only.output
+    assert "--table and at least one --field" in fields_only.output
 
 
 def test_ingest_cli_returns_safe_error_for_unrecognized_descriptor(tmp_path) -> None:

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from hashlib import sha256
 import json
 
 from typer.testing import CliRunner
@@ -74,7 +75,15 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
         ],
         "frictionlessdata.org:licenses": [{"name": "CC-BY-4.0"}],
     }
-    assert inspection["resources"] == []
+    assert inspection["resources"] == [
+        {
+            "byte_size": (tmp_path / "samples.csv").stat().st_size,
+            "media_type": "text/csv",
+            "resource_id": "samples",
+            "sha256": sha256((tmp_path / "samples.csv").read_bytes()).hexdigest(),
+            "uri": (tmp_path / "samples.csv").resolve().as_uri(),
+        }
+    ]
     assert normalized.exit_code == 0
     assert output.is_file()
     assert calculated.exit_code == 0

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -74,6 +74,7 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
         ],
         "frictionlessdata.org:licenses": [{"name": "CC-BY-4.0"}],
     }
+    assert inspection["resources"] == []
     assert normalized.exit_code == 0
     assert output.is_file()
     assert calculated.exit_code == 0

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -48,6 +48,16 @@ def _bundle_summary(descriptor: Path) -> dict[str, object]:
         "governance": bundle.manifest.model_dump(mode="json")["extensions"],
         "provider": bundle.manifest.provenance.provider_id,
         "provenance": bundle.manifest.provenance.model_dump(mode="json"),
+        "resources": [
+            {
+                "byte_size": resource.byte_size,
+                "media_type": resource.media_type,
+                "resource_id": resource.resource_id,
+                "sha256": resource.sha256,
+                "uri": resource.uri,
+            }
+            for resource in bundle.manifest.resources
+        ],
         "schema_fingerprint": bundle.schema_fingerprint,
         "tables": {name: table.num_rows for name, table in bundle.tables.items()},
     }

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -23,12 +23,59 @@ from voiage.methods.basic import evpi
 app = typer.Typer(help="Validate and normalize standardized dataset descriptors.")
 
 
-def _bundle_summary(descriptor: Path) -> dict[str, object]:
+def _prepared_summary(bundle: NormalizedInputBundle) -> dict[str, object]:
+    """Expose explicit binding resolution and data quality without inference."""
+    prepared = prepare_analysis_inputs(bundle)
+    quality = prepared.quality_report
+    return {
+        "binding": prepared.binding.model_dump(mode="json"),
+        "binding_profile_digest": prepared.binding_profile_digest,
+        "data_quality": {
+            "coercions": list(quality.coercions),
+            "duplicate_row_count": quality.duplicate_row_count,
+            "exclusions": list(quality.exclusions),
+            "join_coverage": dict(quality.join_coverage),
+            "null_counts": dict(quality.null_counts),
+            "population_transforms": list(quality.population_transforms),
+            "primary_key_duplicate_count": quality.primary_key_duplicate_count,
+            "primary_key_fields": list(quality.primary_key_fields),
+            "primary_key_null_count": quality.primary_key_null_count,
+            "row_count": quality.row_count,
+            "selected_field_ids": list(quality.selected_field_ids),
+            "selected_partitions": list(quality.selected_partitions),
+            "table_id": quality.table_id,
+            "unique_value_counts": dict(quality.unique_value_counts),
+        },
+        "input_digest": prepared.input_digest,
+    }
+
+
+def _inspection_binding(
+    table: str | None, field: list[str], strategy: list[str]
+) -> VOIBinding | None:
+    """Build an optional explicit inspection binding without semantic inference."""
+    if (table is None) != (not field):
+        raise ValueError("--table and at least one --field must be supplied together")
+    return (
+        VOIBinding(
+            role="net_benefit",
+            table_id=table,
+            field_ids=tuple(field),
+            strategy_names=tuple(strategy),
+        )
+        if table is not None
+        else None
+    )
+
+
+def _bundle_summary(
+    descriptor: Path, *, binding: VOIBinding | None = None
+) -> dict[str, object]:
     """Return stable, non-secret metadata for a descriptor."""
     registry = default_registry()
     bundle = registry.ingest(descriptor)
     capabilities = registry.capabilities_for(bundle.manifest.provenance.provider_id)
-    return {
+    summary: dict[str, object] = {
         "capabilities": {
             "format_versions": capabilities.format_versions,
             "media_types": capabilities.media_types,
@@ -61,6 +108,17 @@ def _bundle_summary(descriptor: Path) -> dict[str, object]:
         "schema_fingerprint": bundle.schema_fingerprint,
         "tables": {name: table.num_rows for name, table in bundle.tables.items()},
     }
+    if binding is not None:
+        manifest = DatasetManifest(
+            **bundle.manifest.model_dump(mode="python", exclude={"bindings"}),
+            bindings=(binding,),
+        )
+        summary["binding_resolution"] = _prepared_summary(
+            NormalizedInputBundle(manifest=manifest, tables=bundle.tables)
+        )
+    else:
+        summary["binding_resolution"] = None
+    return summary
 
 
 @app.command("validate")
@@ -78,11 +136,25 @@ def validate(
 
 
 @app.command()
-def inspect(descriptor: Path = typer.Argument(..., exists=True, readable=True)) -> None:
-    """Inspect a descriptor and emit its normalized identity as JSON."""
+def inspect(
+    descriptor: Path = typer.Argument(..., exists=True, readable=True),
+    table: str | None = typer.Option(
+        None, "--table", help="Optional explicit table ID for binding resolution."
+    ),
+    field: list[str] = typer.Option(
+        [], "--field", help="Net-benefit field; repeat per strategy."
+    ),
+    strategy: list[str] = typer.Option(
+        [], "--strategy", help="Optional strategy name; repeat in field order."
+    ),
+) -> None:
+    """Inspect identity and optionally resolve one explicit EVPI binding."""
     try:
-        typer.echo(json.dumps(_bundle_summary(descriptor), sort_keys=True))
-    except IngestionError as error:
+        binding = _inspection_binding(table, field, strategy)
+        typer.echo(
+            json.dumps(_bundle_summary(descriptor, binding=binding), sort_keys=True)
+        )
+    except (IngestionError, ValueError) as error:
         typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(2) from error
 


### PR DESCRIPTION
## Summary
- add stable resource receipt metadata to ingest validate and inspect responses
- keep non-materialized and direct inputs explicit as an empty receipt list

Implements part of #332; the product-surface issue remains open for its other acceptance criteria.