### PR TITLE
docs(ingestion): publish supported standard matrix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a second standardized-ingestion reference case that derives EVPI from
   explicit cost and outcome bindings across Croissant, Frictionless, and direct
   Arrow inputs.
+- Documented the conservative Croissant, Frictionless, and DataFrame
+  interoperability profiles and their explicit unsupported boundaries.
 - Added `voiage ingest validate` for safe, machine-readable validation of a
   supported dataset descriptor and its declared local resources.
 - Expanded `voiage ingest inspect` with stable provider capabilities, safe

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -69,6 +69,22 @@ field names. This keeps machine-learning, engineering, and business datasets
 on one preparation path while preserving the existing direct Python and CSV
 APIs.
 
+## Supported-standard matrix
+
+VOIAGE intentionally supports a narrow, auditable profile rather than claiming
+complete implementation of either upstream standard.
+
+| Input family | Supported profile | Explicitly not supported in the built-in provider |
+| --- | --- | --- |
+| Croissant ML | Croissant 1.1 descriptor, one declared local CSV distribution, one `recordSet`, explicit fields, local SHA-256 when declared | Remote downloads, archives, transformations, multiple resources, executable metadata, implicit schema inference |
+| Frictionless Data Package | Data Package v1-style descriptor, one local CSV resource with an explicit field schema | Remote URLs, archives, transformations, multiple resources, implicit schema inference |
+| DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | Inferred decision semantics and nested values that Arrow interchange cannot safely materialize |
+
+All providers default to local-only access. Inputs that fall outside these
+profiles fail with a stable `IngestionError`; they are not partially loaded or
+silently transformed. Compatibility will expand only with new fixtures,
+source-policy evidence, and a documented provider capability change.
+
 ## Worked examples
 
 The same contract supports more than one community-facing example:


### PR DESCRIPTION
## Summary
- document conservative Croissant, Frictionless, and DataFrame support profiles
- state the explicit rejected features and safe failure boundary

Implements part of #333; the release-assurance issue remains open for its other acceptance criteria.