### PR TITLE
docs(registry): reconcile external publication state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reconciled registry-readiness records with the green conda-forge
+  cross-platform build, the reviewed release-bound JOSS PDF, and the
+  authenticated incomplete replacement arXiv submission.
 - Bound the JOSS manuscript and registry-readiness records to the public
   v2.0.0 release, its clean-install evidence, mixed-language CycloneDX SBOM,
   provenance, package digests, crates.io publications, and Software Heritage

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -3,9 +3,9 @@
   "channel": "research-software-registries",
   "status": "blocked",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-26T11:52:00Z",
-  "next_action": "Obtain the author's complete AI-policy attestation, document completed research-workflow use, obtain genuine human engagement through issue #471 or another attributable route, rebuild and review the release-bound PDF, and record the permanent arXiv identifier before direct JOSS submission. Monitor conda-forge PR 34308. Julia General, R registry, and SciCrunch/RRID remain separate paths.",
-  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, and clean-install evidence are complete. Conda-forge PR 34308 is submitted and externally reviewed. The observed arXiv state for submission 7861466 still lacks a permanent identifier. Demonstrated research use is a JOSS pre-review gate. Human community engagement is a detailed-review criterion, strong positive pre-review signal, and author-selected prerequisite. Author AI attestation, arXiv announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
+  "checked_at": "2026-07-26T12:49:21Z",
+  "next_action": "Obtain the author's complete AI-policy attestation, document completed research-workflow use, and obtain genuine human engagement through issue #471 or another attributable route. Complete replacement arXiv submission 7870358 through the author-controlled category and licence choices, then record its permanent identifier before direct JOSS submission. Monitor conda-forge PR 34308 for external review and merge. Julia General, R registry, and SciCrunch/RRID remain separate paths.",
+  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, clean-install evidence, and release-bound JOSS PDF review are complete. Conda-forge PR 34308 has green lint and Linux, macOS, and Windows builds but awaits external review and merge. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft expiring 9 August 2026 and is not completed submission evidence. Demonstrated research use is a JOSS pre-review gate. Human community engagement is a detailed-review criterion, strong positive pre-review signal, and author-selected prerequisite. Author AI attestation, arXiv completion and announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
   "release_evidence": {
     "tag": "v2.0.0",
     "commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
@@ -57,6 +57,15 @@
     "readiness_document": "docs/release/joss-submission-readiness.md",
     "validator": "scripts/validate_joss.py",
     "hosted_workflow": ".github/workflows/joss-paper.yml",
+    "release_bound_pdf": {
+      "workflow_run": 30202496481,
+      "revision": "5c472402ed0fa0e70af3bd98c6d1dde59b5d7811",
+      "artifact_id": 8632098142,
+      "artifact_digest": "sha256:85b58a21cba15577d874c690317c571192b9dde943007a0308a3a438bf127a8b",
+      "pdf_sha256": "132af479c9d76091478459652ff12091d04bd3dd426ef5e90265ec1e4bab3e71",
+      "pages": 6,
+      "visual_review": "passed"
+    },
     "package_validation": {
       "python": "clean PyPI install reports metadata and runtime version 2.0.0 and loads the Rust core from the published abi3 wheel",
       "rust": "workspace tests pass excluding the separately wheel-tested private PyO3 crate",
@@ -75,25 +84,26 @@
       "obtain the author's comprehensive AI-policy attestation and best-available tool-version inventory",
       "document completed research-workflow use of the released package",
       "obtain attributable or editor-verifiable human community engagement, external use, or collaborative input",
-      "build and inspect the release-bound Open Journals PDF",
       "record the permanent arXiv identifier after announcement",
       "perform the selected direct authenticated JOSS submission"
     ],
     "preprint_policy": "JOSS permits arXiv submission before, during, or after JOSS submission and does not treat a preprint as prior publication."
   },
   "arxiv_preprint_evidence": {
-    "status": "submitted_pending_identifier",
+    "status": "replacement_incomplete",
     "github_issue": "https://github.com/edithatogo/voiage/issues/312",
     "review_pr": "https://github.com/edithatogo/voiage/pull/311",
     "canonical_source": "paper/main.tex",
     "metadata": "paper/metadata.json",
     "readiness_manifest": "paper/readiness-manifest.json",
     "builder": "scripts/build_arxiv_submission.py",
-    "submission_performed": true,
-    "submission_id": "7861466",
-    "dashboard_checked_at": "2026-07-24T00:46:29Z",
-    "dashboard_state": "submitted and not yet listed as an announced article",
+    "submission_performed": false,
+    "prior_submission_id": "7861466",
+    "submission_id": "7870358",
+    "dashboard_checked_at": "2026-07-26T12:49:21Z",
+    "dashboard_state": "prior submission 7861466 absent; replacement 7870358 incomplete at the start stage, expiring 2026-08-09, with no files, metadata, category, or licence recorded",
     "remaining_human_gates": [
+      "select the category and licence and complete replacement submission 7870358",
       "record the permanent arXiv identifier after announcement"
     ]
   },
@@ -162,7 +172,7 @@
       "runner": "GitHub API, authenticated arXiv account, and official JOSS documentation",
       "status": "passed_with_external_gate",
       "artifact": "issue #471 and docs/release/joss-independent-validation.md",
-      "details": "Submission 7861466 remains submitted without a permanent identifier. Demonstrated research use is a hard pre-review gate. Non-author engagement is a strong positive pre-review signal and an explicit detailed-review criterion, so issue #471 remains an author-selected prerequisite for the direct JOSS route."
+      "details": "Prior submission 7861466 is absent. Replacement 7870358 is incomplete at the start stage and is not submission evidence. Demonstrated research use is a hard pre-review gate. Non-author engagement is a strong positive pre-review signal and an explicit detailed-review criterion, so issue #471 remains an author-selected prerequisite for the direct JOSS route."
     },
     {
       "command": "release workflow 30200134119; clean PyPI install; crates workflow 30200722982; Software Heritage request 2399846; supply-chain workflow 30200921515",
@@ -176,7 +186,7 @@
       "runner": "GitHub Actions and conda-forge staged-recipes",
       "status": "submitted_external_review",
       "artifact": "https://github.com/conda-forge/staged-recipes/pull/34308",
-      "details": "The workflow exposed a stale repository token, which was refreshed. The authenticated maintainer submitted the v2.0.0 recipe; conda-forge lint and platform builds remain external checks."
+      "details": "The workflow exposed a stale repository token, which was refreshed. The authenticated maintainer submitted the v2.0.0 recipe; conda-forge lint and Linux, macOS, and Windows builds pass. Maintainer review, merge, feedstock creation, and channel indexing remain external."
     }
   ]
 }

--- a/conductor/tracks/research_software_registry_readiness_20260721/index.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/index.md
@@ -1,11 +1,11 @@
 # research_software_registry_readiness_20260721
 
-Status: in progress; signed public v1.0.0 release evidence, Software Heritage
-archival, and authenticated arXiv submission are recorded. The exact v2 JOSS
-candidate, demonstrated research use, human engagement, author-confirmed AI
-attestation, arXiv
-announcement, RRID, JOSS, and external registry outcomes remain explicitly
-tracked.
+Status: in progress; signed public v2.0.0 release evidence, Software Heritage
+archival, crates.io publication, and the release-bound JOSS PDF are recorded.
+The prior arXiv submission is absent and replacement submission `7870358`
+remains incomplete. Demonstrated research use, human engagement,
+author-confirmed AI attestation, arXiv announcement, RRID, JOSS, and external
+registry outcomes remain explicitly tracked.
 
 Parent issue: [#296](https://github.com/edithatogo/voiage/issues/296)
 

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-26T11:52:00Z",
+  "updated_at": "2026-07-26T12:49:21Z",
   "description": "Track archival, identifier, language-registry, arXiv, and evidence-gated JOSS readiness from the signed v1.0.0 release through the exact v2 review candidate.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
@@ -33,7 +33,7 @@
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Authenticated arXiv submission 7861466 still lacks an observed permanent identifier. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 is submitted. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
+      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft and is not submission evidence. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 has green lint and cross-platform builds but awaits external review and merge. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
     }
   ],
   "github_cross_reference": {

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -16,8 +16,11 @@
   adaptation prepared; authenticated submission, editorial review, acceptance,
   and DOI assignment remain human or external gates.
   - [~] [Issue #312](https://github.com/edithatogo/voiage/issues/312) —
-    authenticated arXiv submission `7861466` is complete; announcement and a
-    permanent arXiv identifier remain external gates.
+    prior submission `7861466` is absent from the authenticated dashboard.
+    Replacement submission `7870358` exists only as an incomplete start-stage
+    draft expiring 9 August 2026; author selection of category and licence,
+    file upload, completion, moderation, announcement, and a permanent arXiv
+    identifier remain human or external gates.
 
 ## Phase 2A: JOSS readiness after arXiv submission [checkpoint: 80af0da]
 
@@ -29,9 +32,9 @@
 - [x] Audit reviewer-facing installation, packaging, documentation, examples,
   tests, and release evidence for the Python, Rust, R, and Julia surfaces,
   including the pyOpenSci/rOpenSci partner routes. (`80af0da`)
-- [x] Record the submitted arXiv draft as authoritative submission evidence and
-  retain announcement, permanent identifier, JOSS submission, review, and
-  acceptance as external gates. (`80af0da`)
+- [x] Record the historical submitted arXiv state and preserve later
+  authenticated disposition checks without treating a submission number as a
+  permanent identifier. (`80af0da`; refreshed 2026-07-26)
 
 ## Review fixes
 
@@ -60,6 +63,14 @@
   provenance, SBOM, digest, clean-installation, and Software Heritage evidence.
   (`cdc40de`; `v2.0.0`; release run `30200134119`; supply-chain run
   `30200921515`; Software Heritage request `2399846`)
+- [x] Build and visually inspect the release-bound Open Journals PDF from the
+  exact v2 evidence revision. (run `30202496481`; artifact `8632098142`;
+  six-page PDF SHA-256
+  `132af479c9d76091478459652ff12091d04bd3dd426ef5e90265ec1e4bab3e71`)
+- [x] Submit the v2.0.0 conda-forge staged recipe and obtain green lint,
+  Linux, macOS, and Windows build evidence. ([conda-forge PR
+  #34308](https://github.com/conda-forge/staged-recipes/pull/34308);
+  maintainer review and merge remain external)
 
 ## Phase 2B: Independent simulated JOSS editorial review
 
@@ -132,12 +143,13 @@
 - arXiv preprint package: canonical authored source is `paper/main.tex`; the
   deterministic, non-submitting readiness pipeline validates TeX Live
   2023/2025, source hygiene, PDF/font integrity, semantic HTML, and independent
-  cleaner/collector variants. Authenticated submission `7861466` is complete;
-  announcement and the permanent arXiv identifier remain external.
+  cleaner/collector variants. Prior submission `7861466` is absent from the
+  authenticated dashboard. Replacement submission `7870358` is incomplete at
+  the start stage and expires on 9 August 2026; it is not submission evidence.
 - Direct JOSS submission is authorised by the author but remains unperformed
   until issue #471 contains genuine human engagement evidence, the exact v2
-  release is archived, the AI attestation is confirmed, the final PDF is
-  reviewed, and the author-preferred arXiv announcement/permanent-identifier
-  boundary is resolved.
+  release is archived, the AI attestation is confirmed, and the
+  author-preferred arXiv announcement/permanent-identifier boundary is
+  resolved. The release-bound PDF has been built and reviewed.
 - JOSS permits an arXiv preprint before, during, or after JOSS submission;
   arXiv timing is therefore not a JOSS blocker.

--- a/docs/release/joss-submission-readiness.md
+++ b/docs/release/joss-submission-readiness.md
@@ -3,11 +3,12 @@
 ## Current boundary
 
 The authenticated arXiv account was rechecked on 26 July 2026. Submission
-`7861466` is no longer present in the active-submission table, and the account
-lists only the two previously announced articles. A permanent identifier,
-announcement, withdrawal, expiry, or other disposition must not be inferred
-without authoritative arXiv evidence. The author needs to resolve this external
-state before the selected arXiv-first JOSS sequence can continue.
+`7861466` is no longer present in the active-submission table. Replacement
+submission `7870358` exists only as an incomplete start-stage draft, expires on
+9 August 2026, and has no files, metadata, category, or licence recorded. It is
+not evidence of a completed resubmission. The author needs to complete the
+author-controlled fields and submission before the selected arXiv-first JOSS
+sequence can continue.
 
 The JOSS package is:
 
@@ -44,7 +45,7 @@ not replace it.
 | Research-workflow integration | The same-author `vop_poc_nz` bundle documents an intended interoperability contract, not completed execution of `voiage` in research | Candidly bounded; no independent adoption claimed |
 | Demonstrated research use | The current pre-review criteria require evidence that the software is used for research, at minimum by its developer. The worked demonstration and an optional same-author adapter do not yet establish completed research-workflow use | Externally pending; aspirational or fallback-only integrations do not qualify |
 | Collaborative-effort screening | The detailed review criteria treat a single-author project without community engagement, external use, or collaborative input as not acceptable. The submission and editorial guides separately describe non-author engagement as a strong positive pre-review signal rather than a hard gate. The [independent validation protocol](joss-independent-validation.md) and issue #471 seek attributable evidence | Author-selected prerequisite and material review risk; agents, bots, and same-author repositories do not qualify |
-| JOSS manuscript structure | All contracted sections are substantive and ordered; hosted run `30182384336` confirms 1,583 body words, inside the repository's 1,568–1,632 target and JOSS's 750–1,750 range | Ready for the release-bound source |
+| JOSS manuscript structure | All contracted sections are substantive and ordered; hosted release-bound run `30202496481` confirms the article contract, including 1,583 body words inside the repository's 1,568–1,632 target and JOSS's 750–1,750 range | Ready for the release-bound source |
 | Citation and prose assurance | SourceRight reconciles all 18 occurrences, all 15 references have queued sidecars, and six non-DOI software/web warnings remain; selected Authentext blocking patterns report no finding | Machine checks ready; final human source check pending |
 | Design-thinking account | The Rust reference-calculation boundary, protection against cross-language drift, native-build cost, and deliberately narrower R/Julia interfaces are described | Ready |
 | Author metadata | Dylan Mordaunt, ORCID and three affiliations confirmed by the author on 24 July 2026; each affiliation is linked to its verified ROR record | Ready |
@@ -52,8 +53,8 @@ not replace it.
 | Funding and competing interests | No external funding and no competing interests confirmed by the author on 24 July 2026 | Ready |
 | Permanent software archive | Software Heritage snapshot SWHID recorded | Ready; DOI-bearing archive still required at acceptance |
 | Release evidence | Exact v2.0.0 tag, commit, asset digests, verified provenance, mixed-language CycloneDX SBOM and SWHID are bound in `docs/release/v2.0.0-release-evidence.json` | Reviewed release evidence ready |
-| Reproducible JOSS PDF | Open Journals run `30182384336` built commit `766797398654fc7637e19767993535e416bb00c9`; artifact `8625969915` has digest `sha256:5098c43bea9b0f4bd6e94179d9f705387922419d9ad05ccb15a02a07e6c0995e`, and its six-page PDF has SHA-256 `43759919dbb9dccf2ecb3356da6a7a65ed67a5bf8043c2a776fa69b278156d22`. Every page was visually inspected; the hosted Textstat report remains review-only evidence | Ready for the release-bound source |
-| arXiv reference | Submission `7861466` is absent from the authenticated account's active-submission table and has no permanent identifier | External disposition gate |
+| Reproducible JOSS PDF | Open Journals run `30202496481` built commit `5c472402ed0fa0e70af3bd98c6d1dde59b5d7811`; artifact `8632098142` has digest `sha256:85b58a21cba15577d874c690317c571192b9dde943007a0308a3a438bf127a8b`, and its six-page PDF has SHA-256 `132af479c9d76091478459652ff12091d04bd3dd426ef5e90265ec1e4bab3e71`. Every page was visually inspected; the hosted Textstat report remains review-only evidence | Ready for the release-bound source |
+| arXiv reference | Submission `7861466` is absent. Replacement `7870358` is incomplete at the start stage, expires 9 August 2026, and has no permanent identifier | Author and external completion gate |
 | JOSS submission and review | No submission claimed | Author and external gate |
 
 Run the repository-owned preflight with:
@@ -125,9 +126,8 @@ The recommended sequence is:
   evidence exists.
 - Obtain the author's complete AI-policy affirmation and record every
   establishable tool/model version without inventing historical identifiers.
-- Rebuild and inspect the official JOSS PDF after the observed v2 release,
-  provenance, SBOM, digest, and SWHID evidence replaced the prospective
-  availability statement.
+- Keep the reviewed release-bound PDF evidence synchronized if `paper.md` or
+  its release evidence changes.
 - Record the permanent arXiv identifier when arXiv assigns it.
 - Perform the selected direct authenticated JOSS submission.
 - Treat editorial screening, review, acceptance and DOI assignment as external

--- a/roadmap.md
+++ b/roadmap.md
@@ -56,10 +56,10 @@ synthetic health example now reports simulation uncertainty, prespecified
 study-value sensitivity scenarios, and machine-readable numerical results.
 
 The authenticated arXiv account was rechecked on 26 July 2026. Submission
-`7861466` is no longer present in the active-submission table, and the account
-lists only the two previously announced articles. Its disposition must be
-resolved by the author or arXiv before any announcement or permanent identifier
-can be claimed. The JOSS adaptation follows the current 2026
+`7861466` is no longer present in the active-submission table. Replacement
+submission `7870358` exists only as an incomplete start-stage draft expiring
+9 August 2026; it has no files, metadata, category, or licence recorded and is
+not evidence of completed resubmission. The JOSS adaptation follows the current 2026
 screening and paper requirements, including design trade-offs, specific
 reproducible material supporting credible near-term significance, transparent
 AI-use disclosure, Software Heritage citation, a fail-closed local validator,
@@ -73,6 +73,7 @@ criterion, strong positive pre-review signal, and author-selected prerequisite.
 The signed v2.0.0 release, PyPI/TestPyPI packages, four crates.io crates,
 mixed-language SBOM, provenance, clean-install evidence, and Software Heritage
 snapshot are complete. Conda-forge PR #34308 is under external review.
+Its linter and Linux, macOS, and Windows builds are green.
 Author-confirmed AI attestation, final human source verification,
 authenticated submission, editorial review, acceptance, and DOI assignment
 remain explicit human or external gates. The round-nine JOSS source has passed its local article,

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -40,8 +40,12 @@ def test_registry_track_records_native_paper_issue_hierarchy() -> None:
     assert arxiv_issue in specification
     assert independent_validation_issue in specification
     assert handoff["arxiv_preprint_evidence"]["review_pr"].endswith("/pull/311")
-    assert handoff["arxiv_preprint_evidence"]["submission_id"] == "7861466"
-    assert "submission `7861466` is complete" in plan
+    assert handoff["arxiv_preprint_evidence"]["prior_submission_id"] == "7861466"
+    assert handoff["arxiv_preprint_evidence"]["submission_id"] == "7870358"
+    assert handoff["arxiv_preprint_evidence"]["status"] == "replacement_incomplete"
+    assert handoff["arxiv_preprint_evidence"]["submission_performed"] is False
+    assert "Replacement submission `7870358`" in plan
+    assert "it is not submission evidence" in plan
     assert handoff["joss_submission_evidence"]["selected_route"] == "direct_joss"
     assert (
         handoff["joss_submission_evidence"]["status"]
@@ -52,7 +56,11 @@ def test_registry_track_records_native_paper_issue_hierarchy() -> None:
     assert any("AI-policy attestation" in gate for gate in remaining)
     assert any("research-workflow use" in gate for gate in remaining)
     assert any("human community engagement" in gate for gate in remaining)
-    assert any("Open Journals PDF" in gate for gate in remaining)
+    assert not any("Open Journals PDF" in gate for gate in remaining)
+    assert (
+        handoff["joss_submission_evidence"]["release_bound_pdf"]["visual_review"]
+        == "passed"
+    )
     assert handoff["release_evidence"]["tag"] == "v2.0.0"
     assert (
         handoff["software_heritage_archival_request"]["snapshot_swhid"]

--- a/todo.md
+++ b/todo.md
@@ -61,12 +61,15 @@ This document lists the actionable tasks for `voiage` development. Agents should
         The signed v2.0.0 GitHub, PyPI, TestPyPI, crates.io, provenance, SBOM,
         clean-install, and Software Heritage evidence is complete.
         Author-confirmed AI attestation, final human source verification,
-        release-bound PDF review, and the external engagement record remain
-        open. Conda-forge PR #34308 is under external review.
+        and the external engagement record remain open. The release-bound PDF
+        has passed its hosted build and six-page visual review. Conda-forge PR
+        #34308 has green lint and cross-platform builds and is under external
+        review.
     *   The authenticated arXiv account was rechecked on 26 July 2026:
-        submission `7861466` is absent from the active-submission table and no
-        permanent identifier is available. Resolve that external disposition
-        before the author's arXiv-first JOSS submission step.
+        submission `7861466` is absent from the active-submission table.
+        Replacement `7870358` is an incomplete start-stage draft expiring
+        9 August 2026 and is not completed submission evidence. Resolve that
+        author and external gate before the arXiv-first JOSS submission step.
     *   Preparation is repository-owned; archival, identifiers, submission,
         review, acceptance, and indexing remain evidence-gated external states.
 


### PR DESCRIPTION
## Summary
- record the green conda-forge Linux, macOS, Windows, and linter evidence
- bind the release-bound JOSS PDF workflow, artifact digest, PDF hash, and visual review
- replace the stale arXiv-submitted claim with the authenticated incomplete replacement state
- update Conductor, roadmap, todo, readiness documentation, and regression tests

## Validation
- `uv run --extra ci --extra dev pytest tests/test_research_registry_readiness.py --no-cov`
- `uv run --extra ci --extra dev python scripts/validate_joss.py`
- `uv run --extra dev tox -e vale`
- scoped Ruff and formatting checks
- Conductor full validation: 223 historical baseline errors, no errors for the Research Software Registry Readiness track

## External boundaries
- arXiv submission 7870358 is incomplete; category, licence, files, metadata, completion, moderation, and announcement remain author/external gates
- conda-forge PR 34308 awaits maintainer review and merge
- issue 471 research-use and attributable non-author evidence remains open
- no JOSS submission is performed
