### PR TITLE
fix(conda): expand supported Python matrix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expanded the compiled conda-forge recipe from a Python 3.12-only build to
+  the supported Python 3.12+ build matrix and added installed-package checks
+  for native Rust-core loading, version agreement, and a known EVPI result.
 - Reconciled registry-readiness records with the green conda-forge
   cross-platform build, the reviewed release-bound JOSS PDF, and the
   authenticated incomplete replacement arXiv submission.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "voiage" %}
 {% set version = "2.0.0" %}
-{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -12,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<312]
   entry_points:
     - voiage = voiage.cli:main
 
@@ -21,7 +21,7 @@ requirements:
     - {{ compiler('rust') }}
     - {{ stdlib('c') }}
   host:
-    - python {{ python_min }}
+    - python
     - pip
     - maturin >=1.9,<2.0
   run:
@@ -41,24 +41,25 @@ requirements:
 test:
   imports:
     - voiage
+    - voiage._core
     - voiage.analysis
     - voiage.schema
   commands:
     - pip check
     - voiage --help
+    - python -c "import numpy as np; import voiage; import voiage._core as core; assert core.runtime_info()['core_version'] == voiage.__version__; assert abs(voiage.evpi(np.array([[10.0, 12.0], [11.0, 9.0], [13.0, 14.0]])) - (2.0 / 3.0)) < 1e-12"
   requires:
-    - python {{ python_min }}
+    - python
     - pip
 
 about:
   home: https://github.com/edithatogo/voiage
-  summary: A Python library for Value of Information analysis
+  summary: Rust-centred Value of Information analysis with Python bindings
   description: |
-    voiage is a Python library for Value of Information (VOI) analysis, 
-    designed to provide a comprehensive, open-source toolkit for researchers 
-    and decision-makers. It implements core VOI methods including EVPI, EVPPI, 
-    and EVSI, as well as advanced methods for adaptive trial designs, network 
-    meta-analyses, and structural uncertainty.
+    voiage helps researchers and decision-makers quantify the expected value
+    of reducing uncertainty. This conda package provides the Python interface
+    to its Rust-backed numerical core, including EVPI, EVPPI, EVSI, ENBS,
+    decision-frontier, and structural-uncertainty methods.
   dev_url: https://github.com/edithatogo/voiage
   doc_url: https://edithatogo.github.io/voiage
   license: Apache-2.0

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -3,9 +3,9 @@
   "channel": "research-software-registries",
   "status": "blocked",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-26T12:49:21Z",
-  "next_action": "Obtain the author's complete AI-policy attestation, document completed research-workflow use, and obtain genuine human engagement through issue #471 or another attributable route. Complete replacement arXiv submission 7870358 through the author-controlled category and licence choices, then record its permanent identifier before direct JOSS submission. Monitor conda-forge PR 34308 for external review and merge. Julia General, R registry, and SciCrunch/RRID remain separate paths.",
-  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, clean-install evidence, and release-bound JOSS PDF review are complete. Conda-forge PR 34308 has green lint and Linux, macOS, and Windows builds but awaits external review and merge. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft expiring 9 August 2026 and is not completed submission evidence. Demonstrated research use is a JOSS pre-review gate. Human community engagement is a detailed-review criterion, strong positive pre-review signal, and author-selected prerequisite. Author AI attestation, arXiv completion and announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
+  "checked_at": "2026-07-26T23:38:33Z",
+  "next_action": "Verify the corrected Python 3.12+ compiled matrix and installed Rust-core smoke checks on conda-forge PR 34308, then request external review and monitor merge/feedstock creation. Obtain the author's complete AI-policy attestation, document completed research-workflow use, and obtain genuine human engagement through issue #471 or another attributable route. Complete replacement arXiv submission 7870358 through the author-controlled category and licence choices, then record its permanent identifier before direct JOSS submission. Julia General, R registry, and SciCrunch/RRID remain separate paths.",
+  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, clean-install evidence, and release-bound JOSS PDF review are complete. Conda-forge PR 34308 passed its initial lint and Linux, macOS, and Windows builds, but every initial artifact was Python 3.12-only; the corrected Python 3.12+ build matrix and installed Rust-core smoke checks require hosted verification before external review and merge. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft expiring 9 August 2026 and is not completed submission evidence. Demonstrated research use is a JOSS pre-review gate. Human community engagement is a detailed-review criterion, strong positive pre-review signal, and author-selected prerequisite. Author AI attestation, arXiv completion and announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
   "release_evidence": {
     "tag": "v2.0.0",
     "commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
@@ -186,7 +186,7 @@
       "runner": "GitHub Actions and conda-forge staged-recipes",
       "status": "submitted_external_review",
       "artifact": "https://github.com/conda-forge/staged-recipes/pull/34308",
-      "details": "The workflow exposed a stale repository token, which was refreshed. The authenticated maintainer submitted the v2.0.0 recipe; conda-forge lint and Linux, macOS, and Windows builds pass. Maintainer review, merge, feedstock creation, and channel indexing remain external."
+      "details": "The workflow exposed a stale repository token, which was refreshed. The authenticated maintainer submitted the v2.0.0 recipe; initial conda-forge lint and Linux, macOS, and Windows builds passed, but every artifact was Python 3.12-only. A corrected Python 3.12+ variant matrix plus installed Rust-core and known-result smoke checks are being verified before maintainer review, merge, feedstock creation, and channel indexing."
     }
   ]
 }

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-26T12:49:21Z",
+  "updated_at": "2026-07-26T23:38:33Z",
   "description": "Track archival, identifier, language-registry, arXiv, and evidence-gated JOSS readiness from the signed v1.0.0 release through the exact v2 review candidate.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
@@ -33,7 +33,7 @@
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft and is not submission evidence. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 has green lint and cross-platform builds but awaits external review and merge. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
+      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft and is not submission evidence. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 passed its initial lint and platform builds, but those artifacts were Python 3.12-only; the corrected Python 3.12+ matrix and installed Rust-core smoke checks require hosted verification before external review and merge. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
     }
   ],
   "github_cross_reference": {

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -71,6 +71,10 @@
   Linux, macOS, and Windows build evidence. ([conda-forge PR
   #34308](https://github.com/conda-forge/staged-recipes/pull/34308);
   maintainer review and merge remain external)
+- [~] Expand the compiled conda recipe from its initial Python 3.12-only
+  artifacts to the supported Python 3.12+ build matrix, add installed
+  Rust-core and numerical smoke evidence, and verify the revised hosted
+  matrix before requesting conda-forge review.
 
 ## Phase 2B: Independent simulated JOSS editorial review
 

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -120,9 +120,15 @@ def test_conda_release_recipe_is_single_native_maturin_contract() -> None:
     assert "GIT_DIR=%SRC_DIR%\\.conda-no-git" in Path("conda-recipe/bld.bat").read_text(
         encoding="utf-8"
     )
-    assert "    - python {{ python_min }}" in recipe
+    assert "{% set python_min" not in recipe
+    assert "  skip: true  # [py<312]" in recipe
+    assert "  host:\n    - python\n" in recipe
     assert "  run:\n    - python\n" in recipe
     assert "python >= {{ python_min }}" not in recipe
+    assert "    - voiage._core" in recipe
+    assert "core.runtime_info()['core_version'] == voiage.__version__" in recipe
+    assert "voiage.evpi(np.array(" in recipe
+    assert "  requires:\n    - python\n    - pip" in recipe
     assert (
         "sha256: 82514d3df571bf908bc64a85be2c8212ea66f5d7d53a3058054c7ddf219a35de"
         in recipe

--- a/todo.md
+++ b/todo.md
@@ -60,11 +60,13 @@ This document lists the actionable tasks for `voiage` development. Agents should
         visual review in PR #529.
         The signed v2.0.0 GitHub, PyPI, TestPyPI, crates.io, provenance, SBOM,
         clean-install, and Software Heritage evidence is complete.
+        The conda-forge recipe now requests the full supported Python 3.12+
+        compiled matrix and tests the installed Rust core and a known EVPI
+        result; hosted review and merge evidence remain external.
         Author-confirmed AI attestation, final human source verification,
         and the external engagement record remain open. The release-bound PDF
         has passed its hosted build and six-page visual review. Conda-forge PR
-        #34308 has green lint and cross-platform builds and is under external
-        review.
+        #34308 is under external review.
     *   The authenticated arXiv account was rechecked on 26 July 2026:
         submission `7861466` is absent from the active-submission table.
         Replacement `7870358` is an incomplete start-stage draft expiring


### PR DESCRIPTION
## Summary
- build the compiled conda package across supported Python 3.12+ variants instead of only Python 3.12
- verify the installed Rust extension, native/runtime version agreement, and a known EVPI result
- reconcile Conductor and release-readiness evidence with the corrected hosted verification boundary

## Verification
- `uv run --extra ci --extra dev pytest tests/test_python_release_workflow.py tests/test_research_registry_readiness.py --no-cov -q` (17 passed)
- `python scripts/repo_harness.py` (0 findings, 27 workflows)
- `CI=true uv run tox -q` (all environments passed; Python 3.12/3.13/3.14, min/max dependencies, Astro, Vale, JOSS, 91.85% coverage)

## External verification
The local conda solver lacks the `c_osx-arm64` compiler metapackage, so conda-forge staged-recipes remains the authoritative cross-platform render/build environment. After this PR merges, the canonical recipe will be copied to conda-forge PR #34308 and its full hosted variant matrix verified.