### PR TITLE
feat(julia): prepare BinaryBuilder and General publication

### DIFF
--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -121,7 +121,8 @@ jobs:
       - name: Test a standalone Julia package copy
         shell: bash
         run: |
-          standalone_dir="${RUNNER_TEMP}/voiage-julia-standalone"
+          runner_temp="${RUNNER_TEMP//\\//}"
+          standalone_dir="${runner_temp}/voiage-julia-standalone"
           mkdir -p "${standalone_dir}"
           git -C ../.. archive HEAD:bindings/julia | tar -x -C "${standalone_dir}"
           cd "${standalone_dir}"

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -95,6 +95,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Assert and record exact source head
+        shell: bash
         env:
           EXPECTED_SOURCE_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -70,7 +70,21 @@ jobs:
 
   julia:
     name: Julia binding
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        julia:
+          - "1.10"
+          - "1.11"
+          - "1.12"
+        os:
+          - runner: ubuntu-latest
+            library: rust/target/release/libvoiage_ffi.so
+          - runner: macos-latest
+            library: rust/target/release/libvoiage_ffi.dylib
+          - runner: windows-latest
+            library: rust/target/release/voiage_ffi.dll
+    runs-on: ${{ matrix.os.runner }}
     defaults:
       run:
         working-directory: bindings/julia
@@ -95,7 +109,7 @@ jobs:
         run: cargo build --release --locked --package voiage-ffi
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
         with:
-          version: "1.11"
+          version: ${{ matrix.julia }}
       - name: Verify packaged EVPI fixture matches the canonical reference
         run: >-
           julia --project=. -e
@@ -121,7 +135,7 @@ jobs:
             Pkg.test()
           '
         env:
-          VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/rust/target/release/libvoiage_ffi.so
+          VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/${{ matrix.os.library }}
 
   r:
     name: R binding

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -112,13 +112,9 @@ jobs:
           version: ${{ matrix.julia }}
       - name: Verify packaged EVPI fixture matches the canonical reference
         run: >-
-          julia --project=. -e
-          'using Pkg;
-          Pkg.instantiate();
-          using JSON;
-          packaged = JSON.parsefile("test/fixtures/evpi-cases.json");
-          canonical = JSON.parsefile("../../specs/numerical-reference/v1/evpi-cases.json");
-          @assert packaged == canonical'
+          git diff --no-index --exit-code
+          test/fixtures/evpi-cases.json
+          ../../specs/numerical-reference/v1/evpi-cases.json
       - name: Test a standalone Julia package copy
         shell: bash
         run: |

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -112,9 +112,11 @@ jobs:
           version: ${{ matrix.julia }}
       - name: Verify packaged EVPI fixture matches the canonical reference
         run: >-
-          git diff --no-index --exit-code
-          test/fixtures/evpi-cases.json
-          ../../specs/numerical-reference/v1/evpi-cases.json
+          python -c
+          "import json, pathlib;
+          packaged = json.loads(pathlib.Path('test/fixtures/evpi-cases.json').read_text());
+          canonical = json.loads(pathlib.Path('../../specs/numerical-reference/v1/evpi-cases.json').read_text());
+          assert packaged == canonical"
       - name: Test a standalone Julia package copy
         shell: bash
         run: |

--- a/.github/workflows/julia-tagbot.yml
+++ b/.github/workflows/julia-tagbot.yml
@@ -1,8 +1,9 @@
 name: Julia Registry Sync
 
 on:
-  schedule:
-    - cron: "0 7 * * 1"
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
 
 permissions:
@@ -11,9 +12,12 @@ permissions:
 jobs:
   tagbot:
     name: TagBot
+    if: github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@e4c81aa138ef4179bddea165bb4a9680c223aca4
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          subdir: bindings/julia
+          tag_prefix: julia

--- a/bindings/julia/LICENSE
+++ b/bindings/julia/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the Work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative
+    Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]" replaced
+with your own identifying information. (Don't include the brackets!)
+The text should be enclosed in the appropriate comment syntax for
+the file format. We also recommend that a file or class name and
+description of purpose be included on the same "printed page" as the
+copyright notice for easier identification within third-party
+archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,19 +1,22 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
-authors = ["voiage Contributors <voiage@users.noreply.github.com>"]
+authors = ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
 version = "2.0.0"
 
 [deps]
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "JSON", "Test"]
 
 [compat]
+Aqua = "0.8"
 JSON = "0.21"
+Libdl = "1.10"
+Test = "1.10"
 julia = "1.10"

--- a/bindings/julia/README.md
+++ b/bindings/julia/README.md
@@ -1,6 +1,6 @@
 # Voiage.jl
 
-Julia package scaffold for the voiage core API contract.
+Julia binding for the stable EVPI surface of the voiage Rust core.
 
 ## Setup
 
@@ -13,9 +13,30 @@ VOIAGE_FFI_LIBRARY="$PWD/rust/target/release/libvoiage_ffi.dylib" \
   julia --project=bindings/julia -e 'using Pkg; Pkg.instantiate(); Pkg.test()'
 ```
 
-Use `libvoiage_ffi.so` on Linux and `voiage_ffi.dll` on Windows. A
-Julia-native binary-artifact package is still required before the package can
-be installed from General without a separate Rust build.
+Use `libvoiage_ffi.so` on Linux and `voiage_ffi.dll` on Windows.
+
+## Binary artifact and registry status
+
+The repository-owned BinaryBuilder recipe is
+`packaging/yggdrasil/V/voiage_ffi/build_tarballs.jl`. It is submitted upstream
+as [Yggdrasil PR #14292](https://github.com/JuliaPackaging/Yggdrasil/pull/14292).
+That PR builds the signed v2.0.0 Rust source for 64-bit glibc and musl Linux,
+macOS, and Windows. JLL registration by the BinaryBuilder automation is the
+first external gate.
+
+After the generated `voiage_ffi_jll` exists in General, the package will depend
+on that JLL and use its `libvoiage_ffi` product by default. The environment
+variable above remains a development override. A clean-depot installation must
+then pass on every supported platform before the source package is submitted
+with:
+
+```text
+@JuliaRegistrator register subdir=bindings/julia
+```
+
+The resulting General registry merge is the second external gate. The package
+is not described as registered or independently installable until both gates
+have evidence.
 
 ## First workflow
 
@@ -30,11 +51,10 @@ evpi_value = evpi(net_benefits)
 
 This example returns `3.0` for the simple two-strategy matrix above.
 
-## Release and caveats
+## Release and scope
 
 The release workflow verifies that `Project.toml` matches the release tag,
-builds the FFI library, runs `Pkg.test()`, and attaches a source archive to the
-GitHub release. General registration remains blocked until platform-specific
-libraries are delivered through Julia's artifact system. After that packaging
-work, registry updates should use Registrator and TagBot. The walkthrough is a
-thin adapter story because the Rust core remains the semantic authority.
+builds the FFI library, and runs `Pkg.test()`. TagBot is configured for the
+`bindings/julia` subpackage and will create collision-free `julia-v*` tags
+after Registrator accepts a version. The binding intentionally exposes only
+the stable EVPI contract currently available through the shared Rust ABI.

--- a/bindings/julia/test/runtests.jl
+++ b/bindings/julia/test/runtests.jl
@@ -1,6 +1,11 @@
+using Aqua
 using JSON
 using Test
 using Voiage
+
+@testset "Package quality" begin
+    Aqua.test_all(Voiage)
+end
 
 @testset "EVPI" begin
     @test evpi([10.0 1.0; 2.0 8.0]) == 3.0

--- a/changelog.md
+++ b/changelog.md
@@ -1197,6 +1197,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unified accelerator evidence packet validation and deterministic indexing for passed GPU and blocked TPU/Metal runs, preserving CPU fallback and external-gate reasons.
 ## Unreleased
 
+- Submitted the signed v2.0.0 Rust C ABI to BinaryBuilder through Yggdrasil,
+  added the Julia package licence and Aqua checks, removed runtime-only test
+  dependencies and the committed library manifest, expanded Julia CI across
+  Julia 1.10--1.12 on Linux, macOS, and Windows, and made TagBot
+  subpackage-aware with repository-scoped deploy-key authentication for the
+  future General registration.
 - Selected direct JOSS review for the Rust-centred polyglot package, recorded
   the rechecked pending arXiv status, and added a non-author clean-install and
   research-use protocol without treating automated agents as community

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -47,6 +47,7 @@
   "julia_registry_evidence": {
     "status": "jll_recipe_submitted",
     "github_issue": "https://github.com/edithatogo/voiage/issues/555",
+    "repository_pull_request": "https://github.com/edithatogo/voiage/pull/561",
     "yggdrasil_pull_request": "https://github.com/JuliaPackaging/Yggdrasil/pull/14292",
     "source_revision": "e849e89152c306e79c96d0a8a9815ee5faca0529",
     "binary_product": "libvoiage_ffi",

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -3,9 +3,9 @@
   "channel": "research-software-registries",
   "status": "blocked",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-27T00:35:02Z",
-  "next_action": "Monitor conda-forge PR 34308 for external review, merge, feedstock creation, and channel indexing; its corrected hosted matrix is green and review has been requested. Obtain the author's complete AI-policy attestation, document completed research-workflow use, and obtain genuine human engagement through issue #471 or another attributable route. Complete replacement arXiv submission 7870358 through the author-controlled category and licence choices, then record its permanent identifier before direct JOSS submission. Julia General, R registry, and SciCrunch/RRID remain separate paths.",
-  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, clean-install evidence, and release-bound JOSS PDF review are complete. Conda-forge PR 34308 passes lint and staged-recipes build 1558265 for current Python 3.12/3.13 variants on Linux, macOS, and Windows; installed tests load the Rust core, reconcile native/package versions, and reproduce the known EVPI result. External review, merge, feedstock creation, and channel indexing remain pending. Python 3.14 should follow the normal conda-forge migration when global pins permit it. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft expiring 9 August 2026 and is not completed submission evidence. Demonstrated research use is a JOSS pre-review gate. Human community engagement is a detailed-review criterion, strong positive pre-review signal, and author-selected prerequisite. Author AI attestation, arXiv completion and announcement, Julia General, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and JOSS editorial outcomes remain human or externally controlled.",
+  "checked_at": "2026-07-27T02:18:11Z",
+  "next_action": "Monitor Yggdrasil PR 14292 and answer BinaryBuilder bot or maintainer feedback. After voiage_ffi_jll is registered, add its generated UUID and compat bound to bindings/julia, replace the local-library default with the JLL product, run clean-depot platform tests, merge the repository PR, and trigger @JuliaRegistrator register subdir=bindings/julia. Monitor conda-forge PR 34308 for external review and merge. Obtain the author's complete AI-policy attestation, demonstrated research use, and genuine human engagement; complete replacement arXiv submission 7870358 before direct JOSS submission. R registry and SciCrunch/RRID remain separate paths.",
+  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, clean-install evidence, and release-bound JOSS PDF review are complete. Conda-forge PR 34308 passes its current platform matrix; external review and merge remain pending. The Rust C ABI recipe is submitted as Yggdrasil PR 14292. BinaryBuilder must accept the recipe and register voiage_ffi_jll before Voiage can declare it as a General dependency; Registrator and General bots or maintainers then control source-package registration and merge. Prior arXiv submission 7861466 is absent; replacement 7870358 is incomplete. Demonstrated research use, human engagement, author AI attestation, arXiv completion and announcement, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and editorial outcomes remain human or externally controlled.",
   "release_evidence": {
     "tag": "v2.0.0",
     "commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
@@ -44,6 +44,20 @@
     "verification_at": "2026-07-26T11:50:00Z",
     "verification": "Software Heritage reports a full v2 visit and snapshot containing the signed v2.0.0 release."
   },
+  "julia_registry_evidence": {
+    "status": "jll_recipe_submitted",
+    "github_issue": "https://github.com/edithatogo/voiage/issues/555",
+    "yggdrasil_pull_request": "https://github.com/JuliaPackaging/Yggdrasil/pull/14292",
+    "source_revision": "e849e89152c306e79c96d0a8a9815ee5faca0529",
+    "binary_product": "libvoiage_ffi",
+    "target_package": "voiage_ffi_jll",
+    "repository_recipe": "packaging/yggdrasil/V/voiage_ffi/build_tarballs.jl",
+    "current_evidence": "The recipe parses and reaches BinaryBuilder runner creation locally. Yggdrasil Buildkite passes all seven requested targets: x86_64 and aarch64 glibc Linux, x86_64 and aarch64 musl Linux, x86_64 and aarch64 macOS, and x86_64 Windows.",
+    "next_external_gate": "BinaryBuilder bot and Yggdrasil maintainer acceptance followed by automatic JLL registration.",
+    "general_trigger": "@JuliaRegistrator register subdir=bindings/julia",
+    "general_gate": "The trigger is intentionally deferred until the registered JLL UUID exists and clean-depot artifact tests pass.",
+    "tagbot_authentication": "Verified repository-scoped write deploy key 158430276 is configured; its private key is stored as the DOCUMENTER_KEY Actions secret so TagBot can trigger downstream release workflows without a broad PAT."
+  },
   "joss_submission_evidence": {
       "status": "revision_in_progress_pending_human_and_external_evidence",
     "files": [
@@ -70,7 +84,7 @@
       "python": "clean PyPI install reports metadata and runtime version 2.0.0 and loads the Rust core from the published abi3 wheel",
       "rust": "workspace tests pass excluding the separately wheel-tested private PyO3 crate",
       "r": "fresh 1.0.0 source package passes R CMD check --as-cran with two environmental/new-submission notes",
-      "julia": "Pkg.test passes against a locally built voiage-ffi library; artifact/JLL distribution remains pending"
+      "julia": "Aqua and Pkg.test pass against a locally built voiage-ffi library; Yggdrasil PR 14292 is submitted and JLL acceptance remains pending"
     },
     "selected_route": "direct_joss",
     "route_rationale": "Direct JOSS preserves the submission's Rust-centred polyglot scope. pyOpenSci remains an optional later Python-package review rather than the selected route.",
@@ -187,6 +201,13 @@
       "status": "submitted_external_review",
       "artifact": "https://github.com/conda-forge/staged-recipes/pull/34308",
       "details": "The workflow exposed a stale repository token, which was refreshed. The authenticated maintainer submitted the v2.0.0 recipe. The corrected recipe passes lint and staged-recipes build 1558265 for current Python 3.12 and 3.13 variants on Linux, macOS, and Windows. Installed tests load the Rust core, reconcile native/package versions, and reproduce the known EVPI result. External maintainer review was requested; merge, feedstock creation, channel indexing, and future Python 3.14 migration remain externally controlled."
+    },
+    {
+      "command": "BinaryBuilder recipe parse; isolated Julia Aqua and Pkg.test; authenticated Yggdrasil fork and pull request",
+      "runner": "local Julia 1.12.6, Rust release build, GitHub API, and Yggdrasil Buildkite",
+      "status": "submitted_external_review",
+      "artifact": "https://github.com/JuliaPackaging/Yggdrasil/pull/14292",
+      "details": "The signed v2.0.0 Rust C ABI source builds locally and exports voiage_v1_evpi. The Julia source package passes all 11 Aqua checks, two EVPI tests, and 11 shared-reference assertions in an isolated package copy. Yggdrasil Buildkite passes all seven requested 64-bit glibc/musl Linux, macOS, and Windows targets. Repository-scoped deploy key 158430276 and DOCUMENTER_KEY enable TagBot-triggered downstream workflows without a broad PAT. JLL acceptance, generated UUID availability, Registrator submission, General merge, and indexing remain external or sequential gates."
     }
   ]
 }

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-27T00:35:02Z",
+  "updated_at": "2026-07-27T02:18:11Z",
   "description": "Track archival, identifier, language-registry, arXiv, and evidence-gated JOSS readiness from the signed v1.0.0 release through the exact v2 review candidate.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
@@ -13,7 +13,8 @@
     "https://github.com/edithatogo/voiage/issues/298",
     "https://github.com/edithatogo/voiage/issues/299",
     "https://github.com/edithatogo/voiage/issues/312",
-    "https://github.com/edithatogo/voiage/issues/471"
+    "https://github.com/edithatogo/voiage/issues/471",
+    "https://github.com/edithatogo/voiage/issues/555"
   ],
   "external_evidence_required": true,
   "gates": [
@@ -33,7 +34,7 @@
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft and is not submission evidence. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 passes lint and staged-recipes build 1558265 for current Python 3.12/3.13 variants on Linux, macOS, and Windows, including installed Rust-core/version and known-result smoke checks; external review and merge remain pending. Julia General, R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
+      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft and is not submission evidence. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 passes lint and staged-recipes build 1558265 for current Python 3.12/3.13 variants on Linux, macOS, and Windows, including installed Rust-core/version and known-result smoke checks; external review and merge remain pending. Julia issue #555 and Yggdrasil PR 14292 track the submitted Rust C ABI recipe; BinaryBuilder JLL acceptance must precede the Voiage Registrator trigger and General review. R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
     }
   ],
   "github_cross_reference": {

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -51,7 +51,8 @@
       "https://github.com/edithatogo/voiage/pull/470",
       "https://github.com/edithatogo/voiage/pull/472",
       "https://github.com/edithatogo/voiage/pull/473",
-      "https://github.com/edithatogo/voiage/pull/480"
+      "https://github.com/edithatogo/voiage/pull/480",
+      "https://github.com/edithatogo/voiage/pull/561"
     ],
     "pull_request_evidence": "evidenced"
   }

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -77,6 +77,11 @@
   matrix before requesting conda-forge review. (`581fcafb`; staged-recipes
   build `1558265` passes lint and current Python 3.12/3.13 variants on Linux,
   macOS, and Windows; external review requested)
+- [~] Publish the Rust C ABI through BinaryBuilder/Yggdrasil, consume the
+  generated JLL from the Julia binding, and initiate subdirectory registration
+  in Julia General with collision-free TagBot automation. BinaryBuilder,
+  General registry bots, and registry maintainers remain external acceptance
+  gates.
 
 ## Phase 2B: Independent simulated JOSS editorial review
 

--- a/docs/astro-site/src/content/docs/reference/bindings.mdx
+++ b/docs/astro-site/src/content/docs/reference/bindings.mdx
@@ -11,7 +11,7 @@ reference fixtures.
 | --- | --- | --- | --- | --- | --- |
 | Python | PyO3 | Python 3.12, 3.13, 3.14 | PyPI/TestPyPI; conda-forge | `v*` | conda-forge feedstock review and merge |
 | R | C ABI | R 4.3 | CRAN or approved R registry; r-universe | `r-v*` | CRAN maintainer review or approved R registry indexing |
-| Julia | C ABI | Julia 1.10, 1.11 | Julia General | `julia-v*` | Julia General registry review and merge |
+| Julia | C ABI through `voiage_ffi_jll` (submission in progress) | Julia 1.10, 1.11 | Julia General | `julia-v*` | BinaryBuilder acceptance, then General registration and merge |
 | Rust | Native Rust workspace | Rust 1.85, stable | GitHub Releases (workspace artifact) | `rust-v*` | A separately designed publishable facade crate is required for crates.io |
 
 The matrix is normative at

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -31,7 +31,7 @@ maintainer approval is inferred from an in-repo workflow or release tag.
 | --- | --- | --- | --- |
 | Python | Automated PyPI/TestPyPI publish, tag-driven release, conda-forge update PR | conda-forge feedstock merge | No |
 | R | GitHub Release source archives | CRAN and r-universe | No |
-| Julia | TagBot sync plus GitHub Release artifacts | Julia General registry approval | No |
+| Julia | Yggdrasil JLL build, Registrator, and subpackage TagBot sync | BinaryBuilder and Julia General bot/maintainer acceptance | No |
 | Rust | Publishable core crates plus GitHub Release workspace artifacts | crates.io review/indexing and trusted publishing credentials | Yes, repository-ready |
 | Spack | Manual recipe preparation for Spack repository | Spack maintainer review and PR merge | No |
 | EasyBuild | Manual easyconfig preparation for EasyBuild repository | EasyBuild maintainer review and PR merge | No |
@@ -58,11 +58,23 @@ maintainer approval is inferred from an in-repo workflow or release tag.
 
 ## Julia
 
-- [x] Package test gates exist in CI.
-- [x] GitHub Release source archives are produced from `julia-v*` tags.
-- [x] TagBot synchronization is configured.
+- [x] Package tests and Aqua quality gates exist in CI across Julia 1.10--1.12
+  on Linux, macOS, and Windows.
+- [x] The BinaryBuilder recipe is source-controlled and submitted as
+  [Yggdrasil PR #14292](https://github.com/JuliaPackaging/Yggdrasil/pull/14292).
+- [x] The package subdirectory contains the required licence copy and omits a
+  library-package `Manifest.toml`.
+- [x] TagBot synchronization is configured for the `bindings/julia`
+  subpackage, producing collision-free `julia-v*` tags.
+- [x] A repository-scoped write deploy key is stored as `DOCUMENTER_KEY`, so
+  TagBot releases can trigger downstream workflows without a broad personal
+  access token.
 - [x] The Julia binding remains the thin adapter over the shared contract.
-- [ ] Julia General registry submission/approval remains external/manual.
+- [ ] BinaryBuilder must accept the recipe and register `voiage_ffi_jll`.
+- [ ] After the JLL is registered, wire it into `Voiage`, pass clean-depot
+  artifact installation tests, and trigger
+  `@JuliaRegistrator register subdir=bindings/julia`.
+- [ ] Julia General registry merge and indexing remain external.
 
 Software Heritage archival is complete for the v1.0.0 origin request: request
 2397350 produced snapshot
@@ -82,8 +94,9 @@ If the question is "are all language versions submitted to their corresponding
 registries today?", the repo can only answer this partially:
 
 - The in-repo publishing workflows are in place for Python and the binding-independent Rust core; crates.io publication still requires the maintainer token and registry-side acceptance.
-- Julia, conda-forge, CRAN, and r-universe still require external registry-side
-  action or approval.
+- Julia's JLL recipe is submitted; BinaryBuilder acceptance must precede the
+  source-package Registrator submission. Conda-forge, CRAN, and r-universe
+  still require external registry-side action or approval.
 - Spack, EasyBuild, HPSF, and E4S are all explicit external/manual paths with
   no live confirmation from this repository.
 

--- a/docs/release/polyglot-bindings.md
+++ b/docs/release/polyglot-bindings.md
@@ -25,7 +25,7 @@ external registry targets that require their own approval or indexing steps.
 | --- | --- | --- | --- | --- |
 | Python | repository root | PyPI, TestPyPI, conda-forge feedstock | `v*` | `tox`, Ruff, ty, pytest coverage, docs; serves as the primary façade over the canonical Rust core |
 | R | `r-package/voiageR` | GitHub Releases for source archives now, CRAN when mature, r-universe for early distribution | `r-v*` | `R CMD build`, `R CMD check --as-cran --no-manual`, `tools/build-manual.R`; EVPI uses the Rust C ABI, while advanced methods retain the documented reticulate bridge |
-| Julia | `bindings/julia` | Julia General registry, GitHub Releases for tag sync | `julia-v*` | `Pkg.test`, release tarball, TagBot sync |
+| Julia | `bindings/julia` | BinaryBuilder/Yggdrasil JLL, then Julia General | `julia-v*` | Aqua, `Pkg.test`, platform matrix, subpackage TagBot |
 | Rust | `rust` | crates.io core crates plus GitHub Releases | `rust-v*` | `cargo fmt`, `cargo clippy`, `cargo test --locked`, `cargo package --locked`; canonical execution core and contract owner |
 
 ## Tooling Parity
@@ -70,7 +70,9 @@ Each binding is versioned with the registry expectations of its ecosystem:
   The FFI, PyO3, and test-support crates remain private adapters. Python is the
   primary façade and the other retained
   language packages remain thin adapters over the same contract.
-- Julia uses the General registry for publication and TagBot for release sync.
+- Julia first publishes the Rust shared library through BinaryBuilder. Once
+  `voiage_ffi_jll` is registered, Registrator submits the source package from
+  `bindings/julia` and subpackage-aware TagBot creates `julia-v*` releases.
 - R uses GitHub Release source archives for early distribution; CRAN is the
   primary long-term registry target, while r-universe remains an optional
   external indexing channel when the package policy is ready. The release

--- a/packaging/yggdrasil/V/voiage_ffi/build_tarballs.jl
+++ b/packaging/yggdrasil/V/voiage_ffi/build_tarballs.jl
@@ -1,0 +1,69 @@
+using BinaryBuilder
+using Pkg
+
+name = "voiage_ffi"
+version = v"2.0.0"
+
+sources = [
+    GitSource(
+        "https://github.com/edithatogo/voiage.git",
+        "e849e89152c306e79c96d0a8a9815ee5faca0529",
+    ),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/voiage/rust
+
+# Rust's musl targets default to a static C runtime, which cannot produce the
+# shared-library product consumed by a JLL package.
+if [[ "${target}" == *-musl* ]]; then
+    export RUSTFLAGS="-C target-feature=-crt-static"
+fi
+
+cargo build \
+    --release \
+    --locked \
+    --package voiage-ffi \
+    --target "${rust_target}"
+
+if [[ "${rust_target}" == *-windows-* ]]; then
+    source_library="target/${rust_target}/release/voiage_ffi.dll"
+else
+    source_library="target/${rust_target}/release/libvoiage_ffi.${dlext}"
+fi
+
+install -Dvm 755 \
+    "${source_library}" \
+    "${libdir}/libvoiage_ffi.${dlext}"
+install_license ../LICENSE
+"""
+
+platforms = [
+    Platform("x86_64", "linux"; libc = "glibc"),
+    Platform("aarch64", "linux"; libc = "glibc"),
+    Platform("x86_64", "linux"; libc = "musl"),
+    Platform("aarch64", "linux"; libc = "musl"),
+    Platform("x86_64", "macos"),
+    Platform("aarch64", "macos"),
+    Platform("x86_64", "windows"),
+]
+
+products = [
+    LibraryProduct("libvoiage_ffi", :libvoiage_ffi),
+]
+
+dependencies = Dependency[]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.10",
+    preferred_gcc_version = v"10",
+    compilers = [:c, :rust],
+)

--- a/roadmap.md
+++ b/roadmap.md
@@ -260,7 +260,10 @@ creates a second preparation path or domain-specific numerical kernel.
     *   Publishing targets must be planned with the implementation:
         - Python: PyPI, TestPyPI, and conda-forge feedstock recipe updates, with the feedstock PR/merge remaining external.
         - R: GitHub Releases for early source distribution, CRAN when mature, and optional r-universe indexing; the package docs story includes a deterministic vignette and PDF manual built from the same source tree, while external registry approval remains outside the repository.
-        - Julia: Julia General registry with TagBot sync and external registry registration.
+        - Julia: BinaryBuilder/Yggdrasil supplies the Rust C ABI through a JLL;
+          Registrator publishes the `bindings/julia` subpackage to General and
+          subpackage-aware TagBot creates collision-free releases. BinaryBuilder
+          and General acceptance remain external.
         - Rust: GitHub Releases for the internal `publish = false` workspace; a future crates.io facade would require a separate contract.
     *   CI/CD must be language-specific and release-aware for every binding:
         - Build, lint/format, type/static checks, unit tests, docs checks, and shared conformance fixtures.

--- a/tests/test_binding_lifecycle_contract.py
+++ b/tests/test_binding_lifecycle_contract.py
@@ -70,7 +70,7 @@ def test_retained_bindings_declare_supported_runtime_versions_and_ci_probes() ->
     workflow_requirements = {
         "python": ("python-version",),
         "r": ("setup-r",),
-        "julia": ('version: "1.11"',),
+        "julia": ("matrix.julia",),
         "rust": ("rust-msrv", 'toolchain: "1.85"'),
     }
     for binding in matrix["bindings"]:

--- a/tests/test_binding_walkthroughs.py
+++ b/tests/test_binding_walkthroughs.py
@@ -13,7 +13,7 @@ import pytest
             (
                 "## Setup",
                 "## First workflow",
-                "## Release and caveats",
+                "## Release and scope",
                 "using Voiage",
                 "evpi(",
             ),

--- a/tests/test_julia_binarybuilder_readiness.py
+++ b/tests/test_julia_binarybuilder_readiness.py
@@ -1,0 +1,75 @@
+"""Contracts for Julia artifact packaging and General registration."""
+
+from pathlib import Path
+import tomllib
+
+import yaml
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_binarybuilder_recipe_pins_release_and_supported_products() -> None:
+    recipe = (ROOT / "packaging/yggdrasil/V/voiage_ffi/build_tarballs.jl").read_text()
+
+    assert 'name = "voiage_ffi"' in recipe
+    assert 'version = v"2.0.0"' in recipe
+    assert "e849e89152c306e79c96d0a8a9815ee5faca0529" in recipe
+    assert 'LibraryProduct("libvoiage_ffi", :libvoiage_ffi)' in recipe
+    assert "compilers = [:c, :rust]" in recipe
+    assert 'Platform("x86_64", "linux"; libc = "glibc")' in recipe
+    assert 'Platform("aarch64", "macos")' in recipe
+    assert 'Platform("x86_64", "windows")' in recipe
+    assert 'RUSTFLAGS="-C target-feature=-crt-static"' in recipe
+    assert "install_license ../LICENSE" in recipe
+
+
+def test_julia_package_has_general_quality_metadata() -> None:
+    project_path = ROOT / "bindings/julia/Project.toml"
+    project = tomllib.loads(project_path.read_text())
+
+    assert project["name"] == "Voiage"
+    assert project["authors"] == ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
+    assert "Statistics" not in project.get("deps", {})
+    assert "JSON" not in project.get("deps", {})
+    assert {"Aqua", "JSON", "Test"} <= set(project["extras"])
+    assert {"Aqua", "JSON", "Test"} <= set(project["targets"]["test"])
+    assert project["compat"]["Aqua"] == "0.8"
+    assert project["compat"]["Libdl"] == "1.10"
+    assert project["compat"]["Test"] == "1.10"
+    assert (ROOT / "bindings/julia/LICENSE").read_bytes() == (
+        ROOT / "LICENSE"
+    ).read_bytes()
+    assert not (ROOT / "bindings/julia/Manifest.toml").exists()
+
+
+def test_tagbot_is_configured_for_the_julia_subpackage() -> None:
+    workflow_path = ROOT / ".github/workflows/julia-tagbot.yml"
+    workflow = yaml.safe_load(workflow_path.read_text())
+    rendered = workflow_path.read_text()
+
+    assert "issue_comment" in workflow[True]
+    assert "workflow_dispatch" in workflow[True]
+    assert workflow["jobs"]["tagbot"]["if"] == "github.actor == 'JuliaTagBot'"
+    assert "subdir: bindings/julia" in rendered
+    assert "tag_prefix: julia" in rendered
+    assert "JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1" in rendered
+
+
+def test_julia_ci_covers_supported_runtimes_and_platforms() -> None:
+    workflow_path = ROOT / ".github/workflows/bindings-ci.yml"
+    rendered = workflow_path.read_text()
+
+    for runtime in ("1.10", "1.11", "1.12"):
+        assert f'- "{runtime}"' in rendered
+    for runner in ("ubuntu-latest", "macos-latest", "windows-latest"):
+        assert f"runner: {runner}" in rendered
+    assert "matrix.os.library" in rendered
+
+
+def test_registration_documentation_preserves_the_two_external_gates() -> None:
+    readme = (ROOT / "bindings/julia/README.md").read_text()
+
+    assert "JuliaPackaging/Yggdrasil/pull/14292" in readme
+    assert "@JuliaRegistrator register subdir=bindings/julia" in readme
+    assert "JLL registration" in readme
+    assert "General registry merge" in readme

--- a/tests/test_julia_release_workflow.py
+++ b/tests/test_julia_release_workflow.py
@@ -22,6 +22,5 @@ def test_julia_release_workflow_and_checklist_align() -> None:
         in checklist_text
     )
     assert (
-        "Julia General registry submission/approval remains external/manual."
-        in checklist_text
+        "Julia General registry merge and indexing remain external." in checklist_text
     )

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -18,7 +18,7 @@ def test_registry_handoff_preserves_release_and_external_gates() -> None:
         "track_id": "research_software_registry_readiness_20260721",
         "channel": "research-software-registries",
         "status": "blocked",
-        "command_count": 10,
+        "command_count": 11,
         "evidence_count": 8,
     }
 

--- a/todo.md
+++ b/todo.md
@@ -68,6 +68,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         and the external engagement record remain open. The release-bound PDF
         has passed its hosted build and six-page visual review. Conda-forge PR
         #34308 is under external review.
+        Julia publication is tracked in #555. The Rust C ABI BinaryBuilder
+        recipe is submitted in Yggdrasil PR #14292; JLL acceptance must precede
+        the `bindings/julia` Registrator trigger and General merge.
     *   The authenticated arXiv account was rechecked on 26 July 2026:
         submission `7861466` is absent from the active-submission table.
         Replacement `7870358` is an incomplete start-stage draft expiring


### PR DESCRIPTION
Closes the repository-owned portion of #555.

## What changed
- submits the signed v2.0.0 `voiage-ffi` BinaryBuilder recipe through [Yggdrasil #14292](https://github.com/JuliaPackaging/Yggdrasil/pull/14292), where all seven requested platform builds pass;
- adds the Julia package licence copy, Aqua checks, bounded compat, and removes test-only runtime dependencies;
- expands Julia CI across Julia 1.10–1.12 on Linux, macOS, and Windows;
- configures Registrator-compatible subdirectory TagBot automation with the existing `julia-v*` release convention;
- records the BinaryBuilder-first sequence and external acceptance gates in Conductor and release documentation.

A repository-scoped write deploy key is configured as `DOCUMENTER_KEY`, allowing TagBot tags to trigger downstream workflows without a broad PAT.

## Verification
- isolated Julia package: 11/11 Aqua, 2/2 EVPI, 11/11 shared-reference assertions;
- `uv run tox -p auto`: all environments passed;
- Yggdrasil Buildkite: all seven requested targets passed.

## Remaining external sequence
1. BinaryBuilder/Yggdrasil accepts #14292 and registers `voiage_ffi_jll`.
2. A follow-up adds the generated JLL UUID/compat and makes its library product the default.
3. Clean-depot artifact tests pass.
4. `@JuliaRegistrator register subdir=bindings/julia` opens the General PR.
5. General bots/maintainers merge and index it.