### PR TITLE
fix(security): scope TagBot write permission

### DIFF
--- a/.github/workflows/julia-tagbot.yml
+++ b/.github/workflows/julia-tagbot.yml
@@ -7,12 +7,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tagbot:
     name: TagBot
     if: github.actor == 'JuliaTagBot'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1


### PR DESCRIPTION
## Summary
- keep workflow-wide contents access read-only
- grant contents write only to the actor-guarded TagBot job
- preserve repository-scoped SSH authentication and Julia subdirectory tags

## Verification
- `uv run pytest --no-cov tests/test_julia_binarybuilder_readiness.py tests/test_ci_cd_quality_gates.py -q` (35 passed)
- `uvx zizmor .github/workflows/julia-tagbot.yml` (no findings)