### PR TITLE
docs(registry): prepare SciCrunch RRID submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,9 @@ boundaries include:
 - broader native R and Julia API parity;
 - experimental frontier-method validation and promotion;
 - external registry review or indexing where not yet evidenced;
-- SciCrunch/RRID curation and later arXiv/JOSS author-led submissions;
+- SciCrunch registration is prepared and validated; its account declarations,
+  submission, curation, and RRID assignment remain external, alongside later
+  arXiv/JOSS author-led submissions;
 - physical FPGA or fabricated-silicon evidence.
 
 See [`roadmap.md`](roadmap.md), [`todo.md`](todo.md), and the

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a validated SciCrunch registration answer-and-evidence packet with
+  explicit account-declaration, submission, curation, and RRID-assignment
+  boundaries.
 - Switched dependency-update policy from Dependabot version updates to the
   Renovate configuration, covering Python/uv, Cargo, npm, and GitHub Actions.
 - Added a second standardized-ingestion reference case that derives EVPI from

--- a/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json
@@ -3,9 +3,9 @@
   "channel": "research-software-registries",
   "status": "blocked",
   "owner": "voiage-maintainers",
-  "checked_at": "2026-07-27T02:18:11Z",
-  "next_action": "Monitor Yggdrasil PR 14292 and answer BinaryBuilder bot or maintainer feedback. After voiage_ffi_jll is registered, add its generated UUID and compat bound to bindings/julia, replace the local-library default with the JLL product, run clean-depot platform tests, merge the repository PR, and trigger @JuliaRegistrator register subdir=bindings/julia. Monitor conda-forge PR 34308 for external review and merge. Obtain the author's complete AI-policy attestation, demonstrated research use, and genuine human engagement; complete replacement arXiv submission 7870358 before direct JOSS submission. R registry and SciCrunch/RRID remain separate paths.",
-  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, clean-install evidence, and release-bound JOSS PDF review are complete. Conda-forge PR 34308 passes its current platform matrix; external review and merge remain pending. The Rust C ABI recipe is submitted as Yggdrasil PR 14292. BinaryBuilder must accept the recipe and register voiage_ffi_jll before Voiage can declare it as a General dependency; Registrator and General bots or maintainers then control source-package registration and merge. Prior arXiv submission 7861466 is absent; replacement 7870358 is incomplete. Demonstrated research use, human engagement, author AI attestation, arXiv completion and announcement, CRAN/r-universe, SciCrunch curation, RRID assignment, direct JOSS submission, and editorial outcomes remain human or externally controlled.",
+  "checked_at": "2026-07-27T04:32:23Z",
+  "next_action": "Use the validated SciCrunch packet to run the portal duplicate check, complete the authenticated accuracy and terms declarations, submit, and preserve confirmation evidence; then answer curator questions and record the assigned RRID without anticipating it. Monitor Yggdrasil PR 14292 and conda-forge PR 34308. Obtain the author's complete AI-policy attestation, demonstrated research use, and genuine human engagement; complete replacement arXiv submission 7870358 before direct JOSS submission. R registry remains a separate path.",
+  "external_gate": "The signed public v2.0.0 release, matching Software Heritage snapshot, PyPI/TestPyPI packages, four crates.io crates, SBOM, provenance, digests, clean-install evidence, release-bound JOSS PDF review, and SciCrunch answer-and-evidence packet are complete. The SciCrunch portal's duplicate check, account-bound declarations, final submission, curator decision, and RRID assignment remain human or external. Conda-forge PR 34308 passes its current platform matrix; external review and merge remain pending. The Rust C ABI recipe is submitted as Yggdrasil PR 14292. BinaryBuilder must accept the recipe and register voiage_ffi_jll before Voiage can declare it as a General dependency; Registrator and General bots or maintainers then control source-package registration and merge. Prior arXiv submission 7861466 is absent; replacement 7870358 is incomplete. Demonstrated research use, human engagement, author AI attestation, arXiv completion and announcement, CRAN/r-universe, direct JOSS submission, and editorial outcomes remain human or externally controlled.",
   "release_evidence": {
     "tag": "v2.0.0",
     "commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
@@ -43,6 +43,34 @@
     "snapshot_url": "https://archive.softwareheritage.org/api/1/snapshot/31f89375852737bb9eb62ebc03fadfbc7ff70c2d/",
     "verification_at": "2026-07-26T11:50:00Z",
     "verification": "Software Heritage reports a full v2 visit and snapshot containing the signed v2.0.0 release."
+  },
+  "scicrunch_rrid_evidence": {
+    "status": "ready_for_account_submission",
+    "github_issue": "https://github.com/edithatogo/voiage/issues/298",
+    "official_form": "https://scicrunch.org/create/resource",
+    "official_guidance": "https://scicrunch.org/scicrunch/about/Curation%20Guidelines",
+    "answer_packet": "docs/release/scicrunch-rrid-registration.json",
+    "human_handoff": "docs/release/scicrunch-rrid-registration.md",
+    "validator": "scripts/validate_scicrunch_rrid.py",
+    "required_answers": [
+      "resource_name",
+      "url",
+      "description"
+    ],
+    "submission_performed": false,
+    "curation_status": "not_started",
+    "rrid": null,
+    "remaining_account_gates": [
+      "run the portal's authoritative duplicate check",
+      "confirm the rendered information is accurate",
+      "accept the current account terms",
+      "perform final submission and retain confirmation evidence"
+    ],
+    "remaining_external_gates": [
+      "SciCrunch curator review or questions",
+      "curator approval and RRID assignment",
+      "public resolver indexing"
+    ]
   },
   "julia_registry_evidence": {
     "status": "jll_recipe_submitted",
@@ -151,8 +179,15 @@
       "command": "review RRID software registration guidance",
       "runner": "official RRID documentation audit",
       "status": "passed",
-      "artifact": "SciCrunch General Resource registration identified",
-      "details": "Software tools not found in the RRID portal are registered through the NIF SciCrunch Registry; assignment and curation remain external."
+      "artifact": "docs/release/scicrunch-rrid-registration.json and docs/release/scicrunch-rrid-registration.md",
+      "details": "Official guidance confirms software tools use the SciCrunch Registry and requires name, URL, and description. The validated packet adds optional metadata and release/archive evidence while preserving account-declaration, submission, curation, and RRID-assignment boundaries."
+    },
+    {
+      "command": "python scripts/validate_scicrunch_rrid.py && pytest tests/test_scicrunch_rrid_readiness.py --no-cov -q",
+      "runner": "local Git worktree",
+      "status": "passed",
+      "artifact": "validated SciCrunch/RRID registration packet and state-boundary tests",
+      "details": "The validator binds answers to v2.0.0 and its Software Heritage snapshot, rejects missing required answers and invented identifiers, and confirms that registration, curation, and RRID assignment have not yet been claimed."
     },
     {
       "command": "review JOSS paper and submission requirements",

--- a/conductor/tracks/research_software_registry_readiness_20260721/index.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/index.md
@@ -4,8 +4,9 @@ Status: in progress; signed public v2.0.0 release evidence, Software Heritage
 archival, crates.io publication, and the release-bound JOSS PDF are recorded.
 The prior arXiv submission is absent and replacement submission `7870358`
 remains incomplete. Demonstrated research use, human engagement,
-author-confirmed AI attestation, arXiv announcement, RRID, JOSS, and external
-registry outcomes remain explicitly tracked.
+author-confirmed AI attestation, arXiv announcement, SciCrunch account
+declarations and submission, RRID assignment, JOSS, and external registry
+outcomes remain explicitly tracked.
 
 Parent issue: [#296](https://github.com/edithatogo/voiage/issues/296)
 
@@ -17,6 +18,7 @@ Paper hierarchy: [#299](https://github.com/edithatogo/voiage/issues/299) >
 - [Implementation Plan](./plan.md)
 - [Metadata](./metadata.json)
 - [Registry readiness handoff](./handoff/registry-readiness.json)
+- [SciCrunch/RRID registration handoff](../../../docs/release/scicrunch-rrid-registration.md)
 
 ## GitHub traceability
 

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-27T02:18:11Z",
+  "updated_at": "2026-07-27T04:32:23Z",
   "description": "Track archival, identifier, language-registry, arXiv, and evidence-gated JOSS readiness from the signed v1.0.0 release through the exact v2 review candidate.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",
@@ -34,7 +34,7 @@
       "id": "external-registry-decisions",
       "kind": "publication",
       "status": "pending",
-      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft and is not submission evidence. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 passes lint and staged-recipes build 1558265 for current Python 3.12/3.13 variants on Linux, macOS, and Windows, including installed Rust-core/version and known-result smoke checks; external review and merge remain pending. Julia issue #555 and Yggdrasil PR 14292 track the submitted Rust C ABI recipe; BinaryBuilder JLL acceptance must precede the Voiage Registrator trigger and General review. R registry, SciCrunch/RRID, and JOSS still require external submission, curation, evidence, or editorial decisions."
+      "evidence": "Software Heritage request 2399846 completed with v2 snapshot SWHID swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d. The SciCrunch required answers, optional metadata, release/archive evidence, declaration checklist, and fail-closed validator are complete; the portal duplicate check, account declarations, submission, curation, and RRID assignment remain external. Prior arXiv submission 7861466 is absent; replacement 7870358 is an incomplete start-stage draft and is not submission evidence. JOSS authorship, affiliations, ORCID, funding, and competing-interest metadata are confirmed; the comprehensive AI attestation and best-available version inventory remain pending. Direct JOSS is selected. Issue #471 tracks demonstrated research use and genuine human community engagement, external use, or collaborative input. Conda-forge PR 34308 passes lint and staged-recipes build 1558265 for current Python 3.12/3.13 variants on Linux, macOS, and Windows, including installed Rust-core/version and known-result smoke checks; external review and merge remain pending. Julia issue #555 and Yggdrasil PR 14292 track the submitted Rust C ABI recipe; BinaryBuilder JLL acceptance must precede the Voiage Registrator trigger and General review. R registry and JOSS still require external submission, curation, evidence, or editorial decisions."
     }
   ],
   "github_cross_reference": {

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -11,7 +11,10 @@
   Heritage snapshot verified as
   `swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32`.
 - [~] [Issue #298](https://github.com/edithatogo/voiage/issues/298) — SciCrunch
-  registration prepared; RRID assignment and curation remain external.
+  registration has a validated answer-and-evidence packet at
+  `docs/release/scicrunch-rrid-registration.json`. The authenticated accuracy
+  and terms declarations, final submission, curation, and RRID assignment
+  remain human or external.
 - [~] [Issue #299](https://github.com/edithatogo/voiage/issues/299) — JOSS
   adaptation prepared; authenticated submission, editorial review, acceptance,
   and DOI assignment remain human or external gates.
@@ -131,7 +134,11 @@
 - Software Heritage archival: complete with request `2399846`, a full visit,
   and snapshot
   `swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d`.
-- RRID route: SciCrunch General Resource registration; assignment and curation external.
+- RRID route: the SciCrunch General Resource registration answers, optional
+  metadata, release/archive evidence, declaration checklist, and fail-closed
+  validator are complete. The portal's authoritative duplicate check,
+  account-bound accuracy and terms declarations, final submission, curation,
+  and assignment remain human or external.
 - JOSS route: direct JOSS is selected for the Rust-centred polyglot package.
   The canonical arXiv LaTeX preprint and JOSS adaptation are repository-ready;
   demonstrated research use, human engagement, author-confirmed AI attestation,

--- a/docs/release/scicrunch-rrid-registration.json
+++ b/docs/release/scicrunch-rrid-registration.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "1.0.0",
+  "checked_at": "2026-07-27T04:32:23Z",
+  "official_route": "SciCrunch Registry: suggest a resource",
+  "official_form": "https://scicrunch.org/create/resource",
+  "state": "ready_for_account_submission",
+  "answers": {
+    "resource_name": "voiage",
+    "url": "https://github.com/edithatogo/voiage",
+    "description": "voiage is software for Value of Information analysis in research, implementation, and decision making. It calculates the expected value of reducing uncertainty about decisions, parameters, models, studies, populations, implementation, and timing. A Rust core supplies stable numerical kernels; Python provides the broad analysis interface, with R and Julia bindings to the shared native library.",
+    "resource_type": [
+      "software resource",
+      "data analysis software",
+      "software library",
+      "source code"
+    ],
+    "availability": "Free and openly available",
+    "license": "Apache-2.0",
+    "version": "2.0.0",
+    "release_date": "2026-07-26",
+    "abbreviation": null,
+    "synonyms": [
+      "voiage Value of Information analysis"
+    ],
+    "keywords": [
+      "value of information",
+      "decision analysis",
+      "health economics",
+      "uncertainty quantification",
+      "expected value of perfect information",
+      "expected value of partial perfect information",
+      "expected value of sample information",
+      "expected net benefit of sampling",
+      "research prioritisation",
+      "Rust",
+      "Python",
+      "R",
+      "Julia"
+    ],
+    "alternate_urls": [
+      "https://edithatogo.github.io/voiage/",
+      "https://pypi.org/project/voiage/2.0.0/",
+      "https://crates.io/crates/voiage-core"
+    ],
+    "creator": {
+      "name": "Dylan A. Mordaunt",
+      "orcid": "https://orcid.org/0000-0002-9775-0603"
+    },
+    "affiliations": [
+      "Faculty of Health, Education and Psychology, Victoria University of Wellington",
+      "College of Medicine and Public Health, Flinders University",
+      "Centre for Health Policy, The University of Melbourne"
+    ],
+    "defining_citation": null,
+    "funding": null
+  },
+  "declarations": {
+    "resource_owner": {
+      "answer": true,
+      "basis": "The submitter is the repository owner and named software creator."
+    },
+    "information_accurate": {
+      "answer": null,
+      "required_actor": "authenticated account holder",
+      "reason": "This declaration must be made against the final rendered form."
+    },
+    "account_terms_accepted": {
+      "answer": null,
+      "required_actor": "authenticated account holder",
+      "reason": "Acceptance is account-bound and may change independently of this repository."
+    }
+  },
+  "submission": {
+    "performed": false,
+    "submitted_at": null,
+    "submitter_account": null,
+    "confirmation_id": null,
+    "confirmation_url": null
+  },
+  "curation": {
+    "status": "not_started",
+    "rrid": null,
+    "assigned_at": null,
+    "curator_correspondence": []
+  },
+  "evidence": {
+    "release": {
+      "tag": "v2.0.0",
+      "commit": "e849e89152c306e79c96d0a8a9815ee5faca0529",
+      "published_at": "2026-07-26T11:41:47Z"
+    },
+    "software_heritage": {
+      "swhid": "swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d",
+      "request_id": 2399846,
+      "visit_status": "full"
+    },
+    "metadata_sources": [
+      "CITATION.cff",
+      "codemeta.json",
+      "paper/metadata.json",
+      "docs/release/v2.0.0-release-evidence.json"
+    ]
+  },
+  "evidence_links": [
+    "https://github.com/edithatogo/voiage",
+    "https://github.com/edithatogo/voiage/releases/tag/v2.0.0",
+    "https://github.com/edithatogo/voiage/blob/v2.0.0/LICENSE",
+    "https://github.com/edithatogo/voiage/blob/v2.0.0/CITATION.cff",
+    "https://edithatogo.github.io/voiage/",
+    "https://pypi.org/project/voiage/2.0.0/",
+    "https://test.pypi.org/project/voiage/2.0.0/",
+    "https://crates.io/crates/voiage-core",
+    "https://crates.io/crates/voiage-analysis",
+    "https://crates.io/crates/voiage-ffi",
+    "https://crates.io/crates/voiage-io",
+    "https://archive.softwareheritage.org/api/1/snapshot/31f89375852737bb9eb62ebc03fadfbc7ff70c2d/"
+  ]
+}

--- a/docs/release/scicrunch-rrid-registration.md
+++ b/docs/release/scicrunch-rrid-registration.md
@@ -1,0 +1,102 @@
+# SciCrunch/RRID registration handoff
+
+Checked: 27 July 2026
+
+Status: **ready for account-bound submission; not submitted; no RRID assigned**
+
+SciCrunch accepts software tools in its Registry. Its current curation guidance
+requires a resource name, URL, and description. Other fields may help curation
+but are not mandatory. A submitted suggestion does not receive an RRID until a
+SciCrunch curator approves it.
+
+Before entering a new record, use the form's first step to check for an existing
+`voiage` record. The public searches checked during preparation returned no
+matching record, but the form performs the authoritative duplicate check.
+
+## Required answers
+
+**Resource name**
+
+`voiage`
+
+**URL**
+
+`https://github.com/edithatogo/voiage`
+
+**Description**
+
+> voiage is software for Value of Information analysis in research,
+> implementation, and decision making. It calculates the expected value of
+> reducing uncertainty about decisions, parameters, models, studies,
+> populations, implementation, and timing. A Rust core supplies stable
+> numerical kernels; Python provides the broad analysis interface, with R and
+> Julia bindings to the shared native library.
+
+## Recommended optional answers
+
+- Resource type: software resource; data analysis software; software library;
+  source code.
+- Availability: free and openly available.
+- Licence: Apache-2.0.
+- Current version: 2.0.0, released 26 July 2026.
+- Creator: Dylan A. Mordaunt,
+  ORCID `https://orcid.org/0000-0002-9775-0603`.
+- Alternate URLs: documentation, the exact PyPI release, and the root
+  `voiage-core` crates.io package.
+- Keywords: copy the ordered list from the machine-readable packet.
+- Defining citation: leave empty until the arXiv preprint or JOSS article has a
+  permanent identifier. Do not use an incomplete submission identifier.
+- Funding: leave empty unless the account holder supplies an attributable
+  funding statement.
+- Abbreviation: leave empty; `voiage` is the resource name, not a declared
+  expansion.
+
+The complete copyable answer set and evidence ledger are in
+`scicrunch-rrid-registration.json`.
+
+## Account-holder checkpoint
+
+The authenticated account holder should:
+
+1. Open `https://scicrunch.org/create/resource`.
+2. Run the portal's duplicate check for `voiage`.
+3. Enter the prepared answers and inspect the rendered record.
+4. Confirm that the information is accurate and accept the current portal
+   terms.
+5. Submit and retain the confirmation email, identifier, URL, and timestamp.
+
+After submission, update the machine-readable state to `submitted`, set
+`submission.performed` to `true`, and record authoritative confirmation
+evidence. Keep `curation.rrid` null until SciCrunch assigns an identifier.
+
+## Curator-response protocol
+
+- Record questions and answers verbatim or link to an attributable copy.
+- Answer from versioned repository evidence; do not infer funding, institutional
+  ownership, a defining publication, or registry acceptance.
+- If accepted, record the assigned identifier in the
+  `RRID:SCR_######` form, the assignment timestamp, and the resolver URL.
+- Allow the documented indexing delay before treating the resolver record as
+  publicly discoverable.
+- If rejected or identified as a duplicate, preserve the decision and use the
+  curator-provided canonical record.
+
+## Validation
+
+Run:
+
+```bash
+python scripts/validate_scicrunch_rrid.py
+pytest tests/test_scicrunch_rrid_readiness.py --no-cov -q
+```
+
+The validator fails if local preparation is represented as submission or
+curation, if an RRID is invented, if required answers are absent, or if the
+release and Software Heritage evidence is malformed.
+
+## Authoritative guidance
+
+- Registration form: `https://scicrunch.org/create/resource`
+- Registry overview and curation guidance:
+  `https://scicrunch.org/scicrunch/about/Curation%20Guidelines`
+- RRID system: `https://www.rrids.org/rrid-system`

--- a/scripts/validate_scicrunch_rrid.py
+++ b/scripts/validate_scicrunch_rrid.py
@@ -1,0 +1,120 @@
+"""Validate the SciCrunch/RRID registration packet without changing external state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+RRID_PATTERN = re.compile(r"^RRID:SCR_\d{6}$")
+SWHID_PATTERN = re.compile(r"^swh:1:snp:[0-9a-f]{40}$")
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+REQUIRED_ANSWERS = ("resource_name", "url", "description")
+PROHIBITED_PLACEHOLDERS = ("todo", "tbd", "replace me", "human-selection-required")
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError("registration packet must be a JSON object")
+    return value
+
+
+def validate_registration(path: Path) -> dict[str, str | int]:
+    """Validate prepared answers, evidence, and external-state boundaries."""
+    packet = _load_object(path)
+    errors: list[str] = []
+
+    answers = packet.get("answers")
+    if not isinstance(answers, dict):
+        errors.append("answers must be an object")
+        answers = {}
+    for field in REQUIRED_ANSWERS:
+        value = answers.get(field)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"answers.{field} is required")
+        elif any(marker in value.lower() for marker in PROHIBITED_PLACEHOLDERS):
+            errors.append(f"answers.{field} contains a placeholder")
+
+    if answers.get("resource_name") != "voiage":
+        errors.append("resource name must match the released software name")
+    if answers.get("url") != "https://github.com/edithatogo/voiage":
+        errors.append("URL must be the canonical repository")
+
+    evidence = packet.get("evidence")
+    if not isinstance(evidence, dict):
+        errors.append("evidence must be an object")
+        evidence = {}
+    release = evidence.get("release", {})
+    if release.get("tag") != "v2.0.0":
+        errors.append("release evidence must be bound to v2.0.0")
+    if not SHA_PATTERN.fullmatch(str(release.get("commit", ""))):
+        errors.append("release commit must be a full Git SHA")
+    archive = evidence.get("software_heritage", {})
+    if not SWHID_PATTERN.fullmatch(str(archive.get("swhid", ""))):
+        errors.append("Software Heritage evidence must contain a snapshot SWHID")
+
+    evidence_links = packet.get("evidence_links")
+    if not isinstance(evidence_links, list) or not all(
+        isinstance(value, str) and value.startswith("https://")
+        for value in evidence_links
+    ):
+        errors.append("evidence_links must be a list of HTTPS URLs")
+
+    submission = packet.get("submission", {})
+    curation = packet.get("curation", {})
+    state = packet.get("state")
+    if state == "ready_for_account_submission":
+        if submission.get("performed") is not False:
+            errors.append("ready state cannot claim an external submission")
+        if submission.get("submitted_at") is not None:
+            errors.append("unsubmitted packet cannot contain submitted_at")
+        if curation.get("status") != "not_started":
+            errors.append("curation must remain not_started before submission")
+        if curation.get("rrid") is not None:
+            errors.append("RRID must be null until assigned by SciCrunch")
+    rrid = curation.get("rrid")
+    if rrid is not None and not RRID_PATTERN.fullmatch(str(rrid)):
+        errors.append("assigned RRID must use the RRID:SCR_###### form")
+
+    declarations = packet.get("declarations", {})
+    for name in ("resource_owner", "information_accurate", "account_terms_accepted"):
+        declaration = declarations.get(name)
+        if not isinstance(declaration, dict) or "answer" not in declaration:
+            errors.append(f"declarations.{name}.answer is required")
+    if declarations.get("information_accurate", {}).get("answer") is not None:
+        errors.append("account holder must make the accuracy declaration")
+    if declarations.get("account_terms_accepted", {}).get("answer") is not None:
+        errors.append("account holder must accept the current portal terms")
+
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    return {
+        "resource_name": str(answers["resource_name"]),
+        "release": str(release["tag"]),
+        "state": str(state),
+        "required_answer_count": len(REQUIRED_ANSWERS),
+        "evidence_count": len(evidence_links),
+    }
+
+
+def main() -> int:
+    """Validate the configured packet and print its stable summary."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "packet",
+        nargs="?",
+        type=Path,
+        default=Path("docs/release/scicrunch-rrid-registration.json"),
+    )
+    args = parser.parse_args()
+    summary = validate_registration(args.packet)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -18,7 +18,7 @@ def test_registry_handoff_preserves_release_and_external_gates() -> None:
         "track_id": "research_software_registry_readiness_20260721",
         "channel": "research-software-registries",
         "status": "blocked",
-        "command_count": 11,
+        "command_count": 12,
         "evidence_count": 8,
     }
 

--- a/tests/test_scicrunch_rrid_readiness.py
+++ b/tests/test_scicrunch_rrid_readiness.py
@@ -1,0 +1,41 @@
+"""Contracts for the SciCrunch/RRID registration handoff."""
+
+import json
+from pathlib import Path
+
+from scripts.validate_scicrunch_rrid import validate_registration
+
+PACKET = Path("docs/release/scicrunch-rrid-registration.json")
+
+
+def test_scicrunch_registration_packet_is_ready_for_account_submission() -> None:
+    summary = validate_registration(PACKET)
+
+    assert summary == {
+        "resource_name": "voiage",
+        "release": "v2.0.0",
+        "state": "ready_for_account_submission",
+        "required_answer_count": 3,
+        "evidence_count": 12,
+    }
+
+
+def test_scicrunch_packet_preserves_external_state_boundaries() -> None:
+    packet = json.loads(PACKET.read_text())
+
+    assert packet["submission"]["performed"] is False
+    assert packet["submission"]["submitted_at"] is None
+    assert packet["curation"]["status"] == "not_started"
+    assert packet["curation"]["rrid"] is None
+    assert packet["curation"]["assigned_at"] is None
+    assert packet["declarations"]["resource_owner"]["answer"] is True
+    assert packet["declarations"]["information_accurate"]["answer"] is None
+    assert packet["declarations"]["account_terms_accepted"]["answer"] is None
+    assert packet["answers"]["url"] == "https://github.com/edithatogo/voiage"
+    assert packet["evidence"]["release"]["tag"] == "v2.0.0"
+    assert packet["evidence"]["release"]["commit"] == (
+        "e849e89152c306e79c96d0a8a9815ee5faca0529"
+    )
+    assert packet["evidence"]["software_heritage"]["swhid"] == (
+        "swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d"
+    )

--- a/todo.md
+++ b/todo.md
@@ -71,6 +71,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         Julia publication is tracked in #555. The Rust C ABI BinaryBuilder
         recipe is submitted in Yggdrasil PR #14292; JLL acceptance must precede
         the `bindings/julia` Registrator trigger and General merge.
+        SciCrunch registration now has a validated, release-bound answer and
+        evidence packet. The portal duplicate check, account-bound declarations,
+        submission, curation, and RRID assignment remain human or external.
     *   The authenticated arXiv account was rechecked on 26 July 2026:
         submission `7861466` is absent from the active-submission table.
         Replacement `7870358` is an incomplete start-stage draft expiring


### PR DESCRIPTION
## Summary

- add a copy-ready SciCrunch registration answer and evidence packet
- preserve account, submission, curation, and RRID-assignment boundaries
- add a fail-closed validator and regression contracts
- reconcile issue #298 and the active Conductor registry-readiness track

Closes the repository-owned preparation portion of #298; keep #298 open until
SciCrunch curation and RRID assignment are evidenced.

## Verification

- `uv run python scripts/validate_scicrunch_rrid.py`
- `uv run pytest tests/test_scicrunch_rrid_readiness.py tests/test_research_registry_readiness.py --no-cov -q`
- Ruff check and format: passed
- Vale: passed
- `tox`: lint, Vale, JOSS, harness, typecheck, Astro docs, frontier-contract,
  and version-sync passed; Python 3.12 was interrupted by a disappearing pytest
  temporary directory after 1,881 tests passed, producing setup-only
  `FileNotFoundError` failures unrelated to this documentation/validator change
