### PR TITLE
test(ingestion): add Frictionless offline fixture corpus

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -85,10 +85,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 
 - [x] **P4-T6 / AC-05:** Review and record the Frictionless dependency and
   supported-profile decision through the same dependency-frontier evidence. (`frictionless==5.19.0` decision)
-- [ ] **P4-T7 / AC-05:** Write failing offline fixtures/tests for package and
+- [~] **P4-T7 / AC-05:** Write failing offline fixtures/tests for package and
   data validation, resources, schemas, dialects, types, constraints, missing
   values, keys, integrity, governance metadata, supported tabular formats, and
-  ambiguous resources.
+  ambiguous resources. File-backed baseline and fail-closed format/integrity
+  coverage added (`d0c1b238`); remaining acceptance evidence is tracked below.
 - [ ] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
   documented supported profile.
 - [ ] **P4-T9 / AC-05, AC-11:** Add Frictionless inspection, diagnostics,

--- a/tests/fixtures/frictionless_v1/unsupported/duplicate-primary-key.csv
+++ b/tests/fixtures/frictionless_v1/unsupported/duplicate-primary-key.csv
@@ -1,0 +1,3 @@
+scenario_id,net_benefit
+1,100.0
+1,80.0

--- a/tests/fixtures/frictionless_v1/unsupported/duplicate-primary-key.json
+++ b/tests/fixtures/frictionless_v1/unsupported/duplicate-primary-key.json
@@ -1,0 +1,7 @@
+{
+  "resources": [{
+    "name": "samples",
+    "path": "unsupported/duplicate-primary-key.csv",
+    "schema": {"primaryKey": "scenario_id", "fields": [{"name": "scenario_id"}, {"name": "net_benefit"}]}
+  }]
+}

--- a/tests/fixtures/frictionless_v1/unsupported/integrity-declaration.json
+++ b/tests/fixtures/frictionless_v1/unsupported/integrity-declaration.json
@@ -1,0 +1,8 @@
+{
+  "resources": [{
+    "name": "samples",
+    "path": "valid/data.csv",
+    "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "schema": {"fields": [{"name": "scenario_id"}, {"name": "net_benefit"}]}
+  }]
+}

--- a/tests/fixtures/frictionless_v1/unsupported/multiple-resources.json
+++ b/tests/fixtures/frictionless_v1/unsupported/multiple-resources.json
@@ -1,0 +1,6 @@
+{
+  "resources": [
+    {"name": "first", "path": "valid/data.csv", "schema": {"fields": [{"name": "scenario_id"}, {"name": "net_benefit"}]}},
+    {"name": "second", "path": "valid/data.csv", "schema": {"fields": [{"name": "scenario_id"}, {"name": "net_benefit"}]}}
+  ]
+}

--- a/tests/fixtures/frictionless_v1/unsupported/non-comma-dialect.json
+++ b/tests/fixtures/frictionless_v1/unsupported/non-comma-dialect.json
@@ -1,0 +1,8 @@
+{
+  "resources": [{
+    "name": "samples",
+    "path": "valid/data.csv",
+    "dialect": {"delimiter": ";"},
+    "schema": {"fields": [{"name": "scenario_id"}, {"name": "net_benefit"}]}
+  }]
+}

--- a/tests/fixtures/frictionless_v1/unsupported/non-csv-format.json
+++ b/tests/fixtures/frictionless_v1/unsupported/non-csv-format.json
@@ -1,0 +1,8 @@
+{
+  "resources": [{
+    "name": "samples",
+    "path": "valid/data.csv",
+    "format": "parquet",
+    "schema": {"fields": [{"name": "scenario_id"}, {"name": "net_benefit"}]}
+  }]
+}

--- a/tests/fixtures/frictionless_v1/unsupported/required-null.csv
+++ b/tests/fixtures/frictionless_v1/unsupported/required-null.csv
@@ -1,0 +1,2 @@
+scenario_id,net_benefit
+,100.0

--- a/tests/fixtures/frictionless_v1/unsupported/required-null.json
+++ b/tests/fixtures/frictionless_v1/unsupported/required-null.json
@@ -1,0 +1,7 @@
+{
+  "resources": [{
+    "name": "samples",
+    "path": "unsupported/required-null.csv",
+    "schema": {"fields": [{"name": "scenario_id", "constraints": {"required": true}}, {"name": "net_benefit"}]}
+  }]
+}

--- a/tests/fixtures/frictionless_v1/unsupported/unknown-primary-key.json
+++ b/tests/fixtures/frictionless_v1/unsupported/unknown-primary-key.json
@@ -1,0 +1,7 @@
+{
+  "resources": [{
+    "name": "samples",
+    "path": "valid/data.csv",
+    "schema": {"primaryKey": "missing", "fields": [{"name": "scenario_id"}, {"name": "net_benefit"}]}
+  }]
+}

--- a/tests/fixtures/frictionless_v1/unsupported/unsupported-type.json
+++ b/tests/fixtures/frictionless_v1/unsupported/unsupported-type.json
@@ -1,0 +1,7 @@
+{
+  "resources": [{
+    "name": "samples",
+    "path": "valid/data.csv",
+    "schema": {"fields": [{"name": "scenario_id", "type": "date"}, {"name": "net_benefit"}]}
+  }]
+}

--- a/tests/fixtures/frictionless_v1/valid/data.csv
+++ b/tests/fixtures/frictionless_v1/valid/data.csv
@@ -1,0 +1,3 @@
+scenario_id,net_benefit
+1,100.0
+2,80.0

--- a/tests/fixtures/frictionless_v1/valid/datapackage.json
+++ b/tests/fixtures/frictionless_v1/valid/datapackage.json
@@ -1,0 +1,16 @@
+{
+  "name": "operations-fixture",
+  "profile": "tabular-data-package",
+  "licenses": [{"name": "CC-BY-4.0", "path": "https://example.invalid/license"}],
+  "resources": [{
+    "name": "operations_samples",
+    "path": "valid/data.csv",
+    "schema": {
+      "primaryKey": "scenario_id",
+      "fields": [
+        {"name": "scenario_id", "type": "integer", "constraints": {"required": true, "unique": true}},
+        {"name": "net_benefit", "type": "number"}
+      ]
+    }
+  }]
+}

--- a/tests/test_frictionless_offline_fixtures.py
+++ b/tests/test_frictionless_offline_fixtures.py
@@ -1,0 +1,53 @@
+"""File-backed Frictionless Data Package profile conformance fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voiage.ingestion.base import IngestionError, SourceAccessPolicy
+from voiage.ingestion.frictionless import FrictionlessProvider
+
+_FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "frictionless_v1"
+
+
+@pytest.mark.parametrize(
+    ("fixture", "message"),
+    [
+        ("unsupported/multiple-resources.json", "exactly one resource"),
+        ("unsupported/non-comma-dialect.json", "only CSV comma dialect"),
+        ("unsupported/non-csv-format.json", "requires CSV format"),
+        ("unsupported/integrity-declaration.json", "integrity declarations"),
+        ("unsupported/unsupported-type.json", "unsupported Data Package field type"),
+        ("unsupported/required-null.json", "required field contains null"),
+        ("unsupported/duplicate-primary-key.json", "primaryKey contains duplicate"),
+        ("unsupported/unknown-primary-key.json", "primaryKey references an unknown"),
+    ],
+)
+def test_frictionless_offline_unsupported_profile_fixtures_fail_closed(
+    fixture: str, message: str
+) -> None:
+    """Every retained unsupported feature has a stable offline fixture."""
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            _FIXTURE_ROOT / fixture, policy=SourceAccessPolicy(_FIXTURE_ROOT)
+        )
+
+
+def test_frictionless_offline_valid_profile_fixture_materializes() -> None:
+    """The supported fixture preserves schema, key, and governance metadata."""
+    bundle = FrictionlessProvider().ingest(
+        _FIXTURE_ROOT / "valid" / "datapackage.json",
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert bundle.manifest.tables[0].primary_key == ("scenario_id",)
+    assert bundle.table("operations_samples").to_pylist() == [
+        {"scenario_id": 1, "net_benefit": 100.0},
+        {"scenario_id": 2, "net_benefit": 80.0},
+    ]
+    assert bundle.manifest.provenance.license == "CC-BY-4.0"
+    assert bundle.manifest.extensions["frictionlessdata.org:profile"] == (
+        "tabular-data-package"
+    )

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -77,6 +77,13 @@ class FrictionlessProvider:
         if not isinstance(fields, list):
             raise IngestionError("Data Package schema requires fields")
         fields = cast("list[object]", fields)
+        resource_format = resource.get("format")
+        if resource_format not in (None, "csv"):
+            raise IngestionError("supported Data Package profile requires CSV format")
+        if any(key in resource for key in ("hash", "bytes", "checksum")):
+            raise IngestionError(
+                "supported Data Package profile does not support integrity declarations"
+            )
         dialect = resource.get("dialect")
         if dialect not in (None, {"delimiter": ","}):
             raise IngestionError(


### PR DESCRIPTION
## Summary
- add portable Data Package v1 CSV fixtures for valid and invalid supported-profile cases
- reject declared non-CSV formats and integrity declarations that the built-in profile cannot safely verify
- record P4-T7 as in progress rather than claiming its remaining acceptance evidence complete

## Validation
- `uv run --extra ci --extra dev pytest tests/test_frictionless_offline_fixtures.py tests/test_standardized_ingestion_providers.py -q --no-cov`
- `uv run --extra ci --extra dev ruff check voiage/ingestion/frictionless.py tests/test_frictionless_offline_fixtures.py`