### PR TITLE
test(ingestion): preserve Croissant governance fixture

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -72,9 +72,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   identities, resources, record sets, fields, keys, references, splits,
   supported transformations, integrity failures, archives, nesting, and
   ambiguous semantics.
-- [ ] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
+- [~] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
   parser-feature gaps, live datasets, citations, PROV, usage information,
-  ODRL, and RAI metadata preservation.
+  ODRL, and RAI metadata preservation. Offline governance fixture added
+  (`9a5b45b7`); the authoritative live probe remains an explicit external gate.
 - [ ] **P4-T4 / AC-04:** Implement the lazy optional Croissant provider and
   publish separate standard-conformance and parser-capability profiles.
 - [ ] **P4-T5 / AC-04, AC-11:** Add Croissant inspection, diagnostics,

--- a/tests/fixtures/croissant_1_1/valid/governed-croissant.json
+++ b/tests/fixtures/croissant_1_1/valid/governed-croissant.json
@@ -1,0 +1,19 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
+  "name": "governed-decision-samples",
+  "license": "CC-BY-4.0",
+  "citation": "Example et al. (2026)",
+  "usageInfo": "Synthetic offline fixture only.",
+  "odrl": {"permission": "use"},
+  "provenance": {"wasGeneratedBy": "simulation"},
+  "rai": {"risk": "low"},
+  "distribution": [{
+    "contentUrl": "valid/data.csv",
+    "encodingFormat": "text/csv"
+  }],
+  "recordSet": [{
+    "name": "decision_samples",
+    "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+  }]
+}

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -67,3 +67,20 @@ def test_croissant_offline_identity_fixture_preserves_governance() -> None:
     assert bundle.manifest.extensions == {
         "mlcommons.org:croissant-governance": {"@id": "https://example.invalid/dataset"}
     }
+
+
+def test_croissant_offline_governance_fixture_preserves_metadata() -> None:
+    """Citation, PROV, usage, ODRL, and RAI metadata remain non-semantic."""
+    bundle = CroissantProvider().ingest(
+        _FIXTURE_ROOT / "valid" / "governed-croissant.json",
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert bundle.manifest.provenance.license == "CC-BY-4.0"
+    assert bundle.manifest.provenance.citation == "Example et al. (2026)"
+    governance = bundle.manifest.extensions["mlcommons.org:croissant-governance"]
+    assert governance["citation"] == "Example et al. (2026)"
+    assert governance["usageInfo"] == "Synthetic offline fixture only."
+    assert dict(governance["odrl"]) == {"permission": "use"}
+    assert dict(governance["provenance"]) == {"wasGeneratedBy": "simulation"}
+    assert dict(governance["rai"]) == {"risk": "low"}


### PR DESCRIPTION
## Summary
- add an offline Croissant 1.1 fixture with licence, citation, usage, ODRL, PROV-style provenance, and RAI metadata
- assert that metadata survives in immutable normalized provenance/extensions without semantic inference
- record P4-T3 as in progress while retaining the live interoperability probe as external

## Validation
- `uv run --extra ci --extra dev pytest tests/test_croissant_offline_fixtures.py tests/test_standardized_ingestion_providers.py -q --no-cov`
- `uv run --extra ci --extra dev ruff check tests/test_croissant_offline_fixtures.py`