### PR TITLE
feat(ingestion): expose CLI source policy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added explicit offline, verified-cache, and resource-size policy flags to
+  every standardized-ingestion CLI command while retaining local-only access.
 - Added a validated SciCrunch registration answer-and-evidence packet with
   explicit account-declaration, submission, curation, and RRID-assignment
   boundaries.

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -20,6 +20,17 @@ voiage ingest inspect croissant.json
 voiage ingest normalize datapackage.json --output normalized.arrow
 ```
 
+Every ingestion command accepts the same local source-policy controls. They
+never enable network access: use `--max-resource-bytes` to set a stricter
+resource cap, `--cache-dir` to select a verified materialization cache, and
+`--offline` to require replay rather than reading a source path. For example:
+
+```bash
+voiage ingest validate datapackage.json \
+  --max-resource-bytes 10485760 \
+  --cache-dir .voiage-cache
+```
+
 `croissant.json` is recognized from its Croissant context and
 `datapackage.json` from its Data Package resource list, not from the filename.
 `validate` resolves the descriptor and every declared local resource through

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -191,3 +191,37 @@ def test_normalize_and_calculate_return_safe_errors(tmp_path) -> None:
         ).exit_code
         == 2
     )
+
+
+def test_ingest_cli_applies_explicit_resource_size_policy(tmp_path) -> None:
+    """CLI policy flags constrain provider materialization without network opt-in."""
+    (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "datapackage.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "ingest",
+            "validate",
+            str(descriptor),
+            "--max-resource-bytes",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "exceeds configured size limit" in result.output

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -16,7 +16,7 @@ from voiage.contracts.normalized_input import (
     VOIBinding,
 )
 from voiage.contracts.preparation import prepare_analysis_inputs
-from voiage.ingestion.base import IngestionError
+from voiage.ingestion.base import IngestionError, SourceAccessPolicy
 from voiage.ingestion.registry import default_registry
 from voiage.methods.basic import evpi
 
@@ -68,12 +68,31 @@ def _inspection_binding(
     )
 
 
+def _source_policy(
+    descriptor: Path,
+    *,
+    offline: bool,
+    cache_dir: Path | None,
+    max_resource_bytes: int,
+) -> SourceAccessPolicy:
+    """Build an explicit, local-only policy for one CLI invocation."""
+    return SourceAccessPolicy(
+        descriptor.parent,
+        offline=offline,
+        cache_dir=cache_dir,
+        max_resource_bytes=max_resource_bytes,
+    )
+
+
 def _bundle_summary(
-    descriptor: Path, *, binding: VOIBinding | None = None
+    descriptor: Path,
+    *,
+    binding: VOIBinding | None = None,
+    policy: SourceAccessPolicy | None = None,
 ) -> dict[str, object]:
     """Return stable, non-secret metadata for a descriptor."""
     registry = default_registry()
-    bundle = registry.ingest(descriptor)
+    bundle = registry.ingest(descriptor, policy=policy)
     capabilities = registry.capabilities_for(bundle.manifest.provenance.provider_id)
     summary: dict[str, object] = {
         "capabilities": {
@@ -124,11 +143,35 @@ def _bundle_summary(
 @app.command("validate")
 def validate(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
+    offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
+    cache_dir: Path | None = typer.Option(
+        None, "--cache-dir", help="Verified materialization cache directory."
+    ),
+    max_resource_bytes: int = typer.Option(
+        512 * 1024 * 1024,
+        "--max-resource-bytes",
+        min=1,
+        help="Maximum accepted local resource size.",
+    ),
 ) -> None:
     """Validate a supported descriptor and its declared local resources."""
     try:
         typer.echo(
-            json.dumps({"valid": True, **_bundle_summary(descriptor)}, sort_keys=True)
+            json.dumps(
+                {
+                    "valid": True,
+                    **_bundle_summary(
+                        descriptor,
+                        policy=_source_policy(
+                            descriptor,
+                            offline=offline,
+                            cache_dir=cache_dir,
+                            max_resource_bytes=max_resource_bytes,
+                        ),
+                    ),
+                },
+                sort_keys=True,
+            )
         )
     except IngestionError as error:
         typer.echo(f"Error: {error}", err=True)
@@ -147,12 +190,31 @@ def inspect(
     strategy: list[str] = typer.Option(
         [], "--strategy", help="Optional strategy name; repeat in field order."
     ),
+    offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
+    cache_dir: Path | None = typer.Option(
+        None, "--cache-dir", help="Verified materialization cache directory."
+    ),
+    max_resource_bytes: int = typer.Option(
+        512 * 1024 * 1024, "--max-resource-bytes", min=1
+    ),
 ) -> None:
     """Inspect identity and optionally resolve one explicit EVPI binding."""
     try:
         binding = _inspection_binding(table, field, strategy)
         typer.echo(
-            json.dumps(_bundle_summary(descriptor, binding=binding), sort_keys=True)
+            json.dumps(
+                _bundle_summary(
+                    descriptor,
+                    binding=binding,
+                    policy=_source_policy(
+                        descriptor,
+                        offline=offline,
+                        cache_dir=cache_dir,
+                        max_resource_bytes=max_resource_bytes,
+                    ),
+                ),
+                sort_keys=True,
+            )
         )
     except (IngestionError, ValueError) as error:
         typer.echo(f"Error: {error}", err=True)
@@ -163,12 +225,27 @@ def inspect(
 def normalize(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
     output: Path = typer.Option(..., "--output", "-o"),
+    offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
+    cache_dir: Path | None = typer.Option(
+        None, "--cache-dir", help="Verified materialization cache directory."
+    ),
+    max_resource_bytes: int = typer.Option(
+        512 * 1024 * 1024, "--max-resource-bytes", min=1
+    ),
 ) -> None:
     """Normalize a descriptor into a deterministic Arrow IPC file."""
     try:
-        bundle = default_registry().ingest(descriptor)
+        policy = _source_policy(
+            descriptor,
+            offline=offline,
+            cache_dir=cache_dir,
+            max_resource_bytes=max_resource_bytes,
+        )
+        bundle = default_registry().ingest(descriptor, policy=policy)
         bundle.write_ipc(output)
-        typer.echo(json.dumps(_bundle_summary(descriptor), sort_keys=True))
+        typer.echo(
+            json.dumps(_bundle_summary(descriptor, policy=policy), sort_keys=True)
+        )
     except IngestionError as error:
         typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(2) from error
@@ -184,10 +261,25 @@ def calculate_from_dataset(
     strategy: list[str] = typer.Option(
         [], "--strategy", help="Optional strategy name; repeat in field order."
     ),
+    offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
+    cache_dir: Path | None = typer.Option(
+        None, "--cache-dir", help="Verified materialization cache directory."
+    ),
+    max_resource_bytes: int = typer.Option(
+        512 * 1024 * 1024, "--max-resource-bytes", min=1
+    ),
 ) -> None:
     """Calculate EVPI from explicitly selected normalized net-benefit fields."""
     try:
-        bundle = default_registry().ingest(descriptor)
+        bundle = default_registry().ingest(
+            descriptor,
+            policy=_source_policy(
+                descriptor,
+                offline=offline,
+                cache_dir=cache_dir,
+                max_resource_bytes=max_resource_bytes,
+            ),
+        )
         binding = VOIBinding(
             role="net_benefit",
             table_id=table,


### PR DESCRIPTION
## Summary
- expose explicit offline, verified-cache, and maximum-resource-size policy controls on all ingestion CLI commands
- retain local-only, fail-closed access; this PR does not enable remote fetches
- document the controls and add a resource-limit regression test

## Verification
- `uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_cli.py -q --no-cov`
- `uv run --extra ci --extra dev ruff check voiage/ingestion/cli.py tests/test_standardized_ingestion_cli.py`
- `uv run --extra ci --extra dev ty check voiage/ingestion/cli.py tests/test_standardized_ingestion_cli.py`

Advances Conductor `standardized-dataset-ingestion_20260723` P6-T3. It does not claim the remaining P6/P7 acceptance criteria are complete.