### PR TITLE
feat(ingestion): replay verified provider resources offline

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Wired built-in Croissant and Frictionless providers through verified,
+  content-addressed materialization so declared SHA-256 resources can replay
+  offline; Frictionless now verifies supported `hash` and `bytes` declarations.
 - Added explicit offline, verified-cache, and resource-size policy flags to
   every standardized-ingestion CLI command while retaining local-only access.
 - Added a validated SciCrunch registration answer-and-evidence packet with

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -54,6 +54,14 @@ digest into a policy-scoped content-addressed cache. Later, an `offline=True`
 policy can replay only that verified digest; it never falls back to a changed or
 missing source file and never performs a network refresh.
 
+The built-in providers use this path directly. A Croissant distribution may
+declare `sha256`; a Frictionless CSV resource may declare a 64-character
+SHA-256 `hash` and non-negative `bytes`. With those declarations, ingesting
+once with `cache_dir` creates the verified cache entry, and a later
+`voiage ingest ... --offline --cache-dir .voiage-cache` replays it even when
+the original local CSV is no longer present. Other hash algorithms and
+unverifiable integrity declarations are rejected.
+
 ```python
 from pathlib import Path
 
@@ -88,7 +96,7 @@ complete implementation of either upstream standard.
 | Input family | Supported profile | Explicitly not supported in the built-in provider |
 | --- | --- | --- |
 | Croissant ML | Croissant 1.1 descriptor, one declared local CSV distribution, one `recordSet`, explicit fields, local SHA-256 when declared | Remote downloads, archives, transformations, multiple resources, executable metadata, implicit schema inference |
-| Frictionless Data Package | Data Package v1-style descriptor, one local CSV resource with an explicit field schema | Remote URLs, archives, transformations, multiple resources, implicit schema inference |
+| Frictionless Data Package | Data Package v1-style descriptor, one local CSV resource with an explicit field schema; optional SHA-256 `hash` and `bytes` verification | Remote URLs, archives, transformations, multiple resources, other integrity algorithms, implicit schema inference |
 | DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | Inferred decision semantics and nested values that Arrow interchange cannot safely materialize |
 
 All providers default to local-only access. Inputs that fall outside these

--- a/tests/test_frictionless_offline_fixtures.py
+++ b/tests/test_frictionless_offline_fixtures.py
@@ -18,7 +18,7 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "frictionless_v1"
         ("unsupported/multiple-resources.json", "exactly one resource"),
         ("unsupported/non-comma-dialect.json", "only CSV comma dialect"),
         ("unsupported/non-csv-format.json", "requires CSV format"),
-        ("unsupported/integrity-declaration.json", "integrity declarations"),
+        ("unsupported/integrity-declaration.json", "hash must be a SHA-256"),
         ("unsupported/unsupported-type.json", "unsupported Data Package field type"),
         ("unsupported/required-null.json", "required field contains null"),
         ("unsupported/duplicate-primary-key.json", "primaryKey contains duplicate"),

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -94,6 +94,54 @@ def test_built_in_providers_normalize_supported_csv_profile(
     )
 
 
+@pytest.mark.parametrize("provider", ["croissant", "frictionless"])
+def test_built_in_provider_replays_a_verified_cached_resource_offline(
+    tmp_path, provider
+) -> None:
+    """Built-ins consume the verified cache rather than bypassing it on replay."""
+    _write_csv(tmp_path)
+    source = tmp_path / "samples.csv"
+    digest = digest_file(source)
+    if provider == "croissant":
+        descriptor = {
+            "@context": "https://mlcommons.org/croissant/1.1",
+            "distribution": [{"contentUrl": "samples.csv", "sha256": digest}],
+            "recordSet": [{"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}],
+        }
+        descriptor_path = tmp_path / "croissant.json"
+    else:
+        descriptor = {
+            "resources": [
+                {
+                    "name": "samples",
+                    "path": "samples.csv",
+                    "hash": digest,
+                    "bytes": source.stat().st_size,
+                    "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                }
+            ]
+        }
+        descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+    cache = tmp_path / "cache"
+
+    default_registry().ingest(
+        descriptor_path,
+        policy=SourceAccessPolicy(tmp_path, cache_dir=cache, cache_namespace="test"),
+    )
+    source.unlink()
+
+    bundle = default_registry().ingest(
+        descriptor_path,
+        policy=SourceAccessPolicy(
+            tmp_path, cache_dir=cache, cache_namespace="test", offline=True
+        ),
+    )
+
+    assert bundle.table("samples").num_rows == 2
+    assert bundle.manifest.resources[0].uri == source.as_uri()
+
+
 def test_frictionless_provider_validates_declared_types_constraints_and_primary_key(
     tmp_path,
 ) -> None:

--- a/voiage/ingestion/_tabular.py
+++ b/voiage/ingestion/_tabular.py
@@ -17,11 +17,17 @@ def digest_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def read_csv(reference: str, policy: SourceAccessPolicy) -> pa.Table:
+def read_csv(
+    reference: str,
+    policy: SourceAccessPolicy,
+    *,
+    sha256: str | None = None,
+    byte_size: int | None = None,
+) -> pa.Table:
     """Read a declared CSV file after policy enforcement."""
-    path = policy.resolve(reference)
-    if path.suffix.lower() != ".csv":
+    if not reference.lower().endswith(".csv"):
         raise IngestionError("built-in providers currently support CSV resources only")
+    path = policy.materialize(reference, sha256=sha256, byte_size=byte_size)
     try:
         return csv.read_csv(path)
     except pa.ArrowException as error:
@@ -29,13 +35,18 @@ def read_csv(reference: str, policy: SourceAccessPolicy) -> pa.Table:
 
 
 def materialization_receipt(
-    reference: str, resource_id: str, policy: SourceAccessPolicy
+    reference: str,
+    resource_id: str,
+    policy: SourceAccessPolicy,
+    *,
+    sha256: str | None = None,
+    byte_size: int | None = None,
 ) -> ResourceManifest:
     """Return immutable local-resource identity after policy resolution."""
-    path = policy.resolve(reference)
+    path = policy.materialize(reference, sha256=sha256, byte_size=byte_size)
     return ResourceManifest(
         resource_id=resource_id,
-        uri=path.as_uri(),
+        uri=policy.source_uri(reference),
         sha256=digest_file(path),
         media_type="text/csv",
         byte_size=path.stat().st_size,

--- a/voiage/ingestion/base.py
+++ b/voiage/ingestion/base.py
@@ -56,20 +56,20 @@ class SourceAccessPolicy:
 
     def resolve(self, reference: str) -> Path:
         """Resolve a relative local reference without allowing path traversal."""
-        if "://" in reference:
-            if not self.allow_network:
-                raise IngestionError("network resource access is disabled by policy")
-            raise IngestionError("network resource access is not implemented")
-        candidate = (self.root / reference).resolve()
-        if candidate != self.root and self.root not in candidate.parents:
-            raise IngestionError("resource path escapes the configured source root")
+        candidate = self._local_candidate(reference)
         if not candidate.is_file():
             raise IngestionError("declared resource does not exist")
         if candidate.stat().st_size > self.max_resource_bytes:
             raise IngestionError("declared resource exceeds configured size limit")
         return candidate
 
-    def materialize(self, reference: str, *, sha256: str | None = None) -> Path:
+    def materialize(
+        self,
+        reference: str,
+        *,
+        sha256: str | None = None,
+        byte_size: int | None = None,
+    ) -> Path:
         """Return a digest-verified local materialization, optionally from cache.
 
         This method never performs network I/O.  Offline replay is intentionally
@@ -77,6 +77,11 @@ class SourceAccessPolicy:
         silently substituted for a previously reviewed materialization.
         """
         expected = self._validate_digest(sha256) if sha256 is not None else None
+        if byte_size is not None and byte_size < 0:
+            raise IngestionError("expected resource byte size must be non-negative")
+        # Validate the descriptor reference even when an offline cache hit means
+        # the original source is intentionally unavailable.
+        self._local_candidate(reference)
         if self.offline:
             if expected is None:
                 raise IngestionError(
@@ -87,9 +92,13 @@ class SourceAccessPolicy:
                 raise IngestionError("no verified offline materialization is available")
             if self._digest(cached) != expected:
                 raise IngestionError("cached materialization checksum does not match")
+            if byte_size is not None and cached.stat().st_size != byte_size:
+                raise IngestionError("cached materialization byte size does not match")
             return cached
 
         source = self.resolve(reference)
+        if byte_size is not None and source.stat().st_size != byte_size:
+            raise IngestionError("materialized resource byte size does not match")
         actual = self._digest(source)
         if expected is not None and actual != expected:
             raise IngestionError("materialized resource checksum does not match")
@@ -112,10 +121,25 @@ class SourceAccessPolicy:
             raise IngestionError("cached materialization checksum does not match")
         return cached
 
+    def source_uri(self, reference: str) -> str:
+        """Return the validated logical local URI without requiring the source."""
+        return self._local_candidate(reference).as_uri()
+
     def _cache_path(self, digest: str) -> Path | None:
         if self.cache_dir is None:
             return None
         return self.cache_dir / self._cache_context / digest[:2] / digest
+
+    def _local_candidate(self, reference: str) -> Path:
+        """Validate a descriptor-relative local path before any file operation."""
+        if "://" in reference:
+            if not self.allow_network:
+                raise IngestionError("network resource access is disabled by policy")
+            raise IngestionError("network resource access is not implemented")
+        candidate = (self.root / reference).resolve()
+        if candidate != self.root and self.root not in candidate.parents:
+            raise IngestionError("resource path escapes the configured source root")
+        return candidate
 
     @staticmethod
     def _validate_digest(digest: str) -> str:

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -14,7 +14,7 @@ from voiage.contracts.normalized_input import (
     SourceProvenance,
     TableManifest,
 )
-from voiage.ingestion._tabular import digest_file, materialization_receipt, read_csv
+from voiage.ingestion._tabular import materialization_receipt, read_csv
 from voiage.ingestion.base import (
     IngestionError,
     ProviderCapabilities,
@@ -79,14 +79,16 @@ class CroissantProvider:
                 "supported Croissant profile does not support transformations"
             )
         declared_sha256 = distribution.get("sha256")
-        if declared_sha256 is not None and (
-            not isinstance(declared_sha256, str)
-            or digest_file(policy.resolve(reference)).lower() != declared_sha256.lower()
-        ):
-            raise IngestionError(
-                "declared Croissant SHA-256 does not match local content"
-            )
-        table = read_csv(reference, policy)
+        if declared_sha256 is not None and not isinstance(declared_sha256, str):
+            raise IngestionError("declared Croissant SHA-256 must be a string")
+        try:
+            table = read_csv(reference, policy, sha256=declared_sha256)
+        except IngestionError as error:
+            if declared_sha256 is not None and "checksum" in str(error):
+                raise IngestionError(
+                    "declared Croissant SHA-256 does not match local content"
+                ) from error
+            raise
         manifest_fields = tuple(
             FieldManifest(field_id=name, dtype=str(table.schema.field(name).type))
             for item in fields
@@ -105,7 +107,11 @@ class CroissantProvider:
             manifest=DatasetManifest(
                 dataset_id=str(descriptor.get("name", table_id)),
                 tables=(TableManifest(table_id=table_id, fields=manifest_fields),),
-                resources=(materialization_receipt(reference, table_id, policy),),
+                resources=(
+                    materialization_receipt(
+                        reference, table_id, policy, sha256=declared_sha256
+                    ),
+                ),
                 provenance=SourceProvenance(
                     provider_id=self.provider_id,
                     source_uri=descriptor_path.resolve().as_uri(),

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -80,16 +80,23 @@ class FrictionlessProvider:
         resource_format = resource.get("format")
         if resource_format not in (None, "csv"):
             raise IngestionError("supported Data Package profile requires CSV format")
-        if any(key in resource for key in ("hash", "bytes", "checksum")):
+        if "checksum" in resource:
             raise IngestionError(
                 "supported Data Package profile does not support integrity declarations"
             )
+        declared_sha256 = _sha256(resource.get("hash"))
+        declared_byte_size = _byte_size(resource.get("bytes"))
         dialect = resource.get("dialect")
         if dialect not in (None, {"delimiter": ","}):
             raise IngestionError(
                 "supported Data Package profile accepts only CSV comma dialect"
             )
-        table = read_csv(reference, policy)
+        table = read_csv(
+            reference,
+            policy,
+            sha256=declared_sha256,
+            byte_size=declared_byte_size,
+        )
         self._validate_schema(table, fields)
         primary_key = self._primary_key(schema)
         self._validate_primary_key(table, primary_key)
@@ -117,7 +124,15 @@ class FrictionlessProvider:
                         primary_key=primary_key,
                     ),
                 ),
-                resources=(materialization_receipt(reference, table_id, policy),),
+                resources=(
+                    materialization_receipt(
+                        reference,
+                        table_id,
+                        policy,
+                        sha256=declared_sha256,
+                        byte_size=declared_byte_size,
+                    ),
+                ),
                 provenance=SourceProvenance(
                     provider_id=self.provider_id,
                     source_uri=descriptor_path.resolve().as_uri(),
@@ -223,6 +238,31 @@ def _license_label(value: object) -> str | None:
 def _citation_label(value: object) -> str | None:
     """Accept only an explicit scalar citation for the compact provenance field."""
     return value if isinstance(value, str) else None
+
+
+def _sha256(value: object) -> str | None:
+    """Accept only an explicit SHA-256 Data Package resource hash."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise IngestionError("Data Package resource hash must be a SHA-256 string")
+    candidate = value.lower()
+    if len(candidate) != 64 or any(
+        char not in "0123456789abcdef" for char in candidate
+    ):
+        raise IngestionError("Data Package resource hash must be a SHA-256 string")
+    return candidate
+
+
+def _byte_size(value: object) -> int | None:
+    """Accept only a non-negative Data Package byte-size declaration."""
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise IngestionError(
+            "Data Package resource bytes must be a non-negative integer"
+        )
+    return value
 
 
 def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- route built-in Croissant and Frictionless CSV reads through verified content-addressed materialization
- support Frictionless SHA-256 `hash` and `bytes` verification in the conservative CSV profile
- prove both providers can ingest from a verified cache after the original local resource is removed

## Verification
- `uv run --extra ci --extra dev pytest tests/test_source_policy_cache.py tests/test_standardized_ingestion_providers.py tests/test_frictionless_offline_fixtures.py tests/test_croissant_offline_fixtures.py tests/test_standardized_ingestion_cli.py -q --no-cov`
- `uv run --extra ci --extra dev ruff check ...`
- `uv run --extra ci --extra dev ty check voiage/ingestion/base.py voiage/ingestion/_tabular.py voiage/ingestion/croissant.py voiage/ingestion/frictionless.py`

Advances Conductor P4 and P7 verified materialization/replay evidence. It does not claim remote source support, archive handling, or Phase 7 completion.