### PR TITLE
test(ingestion): cover verified replay policy branches

### DIFF
--- a/tests/test_source_policy_cache.py
+++ b/tests/test_source_policy_cache.py
@@ -45,6 +45,31 @@ def test_offline_materialize_replays_a_verified_cache_without_source(tmp_path) -
     assert offline.materialize("source.csv", sha256=digest).read_bytes() == payload
 
 
+def test_materialize_verifies_declared_byte_size_online_and_offline(tmp_path) -> None:
+    """Byte-size declarations constrain both source materialization and replay."""
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    digest = _digest(payload)
+    cache = tmp_path / "cache"
+    online = SourceAccessPolicy(tmp_path, cache_dir=cache)
+
+    with pytest.raises(IngestionError, match="byte size does not match"):
+        online.materialize("source.csv", sha256=digest, byte_size=len(payload) + 1)
+    online.materialize("source.csv", sha256=digest, byte_size=len(payload))
+    source.unlink()
+
+    with pytest.raises(IngestionError, match="byte size does not match"):
+        SourceAccessPolicy(tmp_path, cache_dir=cache, offline=True).materialize(
+            "source.csv", sha256=digest, byte_size=len(payload) + 1
+        )
+
+
+def test_materialize_rejects_negative_declared_byte_size(tmp_path) -> None:
+    with pytest.raises(IngestionError, match="byte size must be non-negative"):
+        SourceAccessPolicy(tmp_path).materialize("source.csv", byte_size=-1)
+
+
 def test_offline_materialize_requires_a_digest_and_never_refreshes(tmp_path) -> None:
     cache = tmp_path / "cache"
     policy = SourceAccessPolicy(tmp_path, cache_dir=cache, offline=True)

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -225,3 +225,49 @@ def test_ingest_cli_applies_explicit_resource_size_policy(tmp_path) -> None:
 
     assert result.exit_code == 2
     assert "exceeds configured size limit" in result.output
+
+
+def test_ingest_cli_replays_a_declared_resource_from_offline_cache(tmp_path) -> None:
+    """The CLI forwards its cache and offline policy flags to the provider."""
+    source = tmp_path / "samples.csv"
+    source.write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "croissant.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "distribution": [
+                    {
+                        "contentUrl": "samples.csv",
+                        "sha256": sha256(source.read_bytes()).hexdigest(),
+                    }
+                ],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    cache = tmp_path / "cache"
+    runner = CliRunner()
+
+    cached = runner.invoke(
+        app, ["ingest", "validate", str(descriptor), "--cache-dir", str(cache)]
+    )
+    source.unlink()
+    replayed = runner.invoke(
+        app,
+        [
+            "ingest",
+            "validate",
+            str(descriptor),
+            "--cache-dir",
+            str(cache),
+            "--offline",
+        ],
+    )
+
+    assert cached.exit_code == 0
+    assert replayed.exit_code == 0
+    assert json.loads(replayed.output)["valid"] is True

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -1160,6 +1160,62 @@ def test_croissant_provider_validates_declared_local_sha256(
         )
 
 
+def test_croissant_provider_preserves_non_checksum_ingestion_error(tmp_path) -> None:
+    """Only checksum failures are translated into Croissant integrity diagnostics."""
+    descriptor_path = tmp_path / "croissant.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "distribution": [{"contentUrl": "missing.csv", "sha256": "0" * 64}],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match="declared resource does not exist"):
+        CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("resource_update", "message"),
+    [
+        ({"checksum": "unsupported"}, "integrity declarations"),
+        ({"hash": 42}, "hash must be a SHA-256"),
+        ({"bytes": True}, "bytes must be a non-negative"),
+    ],
+)
+def test_frictionless_provider_rejects_unsupported_integrity_declarations(
+    tmp_path, resource_update, message
+) -> None:
+    """Only SHA-256 hash and integer byte-size declarations are accepted."""
+    _write_csv(tmp_path)
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                        **resource_update,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
 def test_dataframe_adapter_rejects_non_dataframe() -> None:
     with pytest.raises(ValueError, match="dataframe interchange"):
         from_dataframe(object(), dataset_id="bad")


### PR DESCRIPTION
## Summary
- cover online and offline declared-byte-size mismatch handling
- cover negative byte size, unsupported integrity declarations, and Croissant diagnostic translation paths

## Verification
- `uv run --extra ci --extra dev pytest tests/test_source_policy_cache.py tests/test_standardized_ingestion_providers.py tests/test_frictionless_offline_fixtures.py tests/test_croissant_offline_fixtures.py -q --no-cov`
- Ruff and ingestion-module type checks

Follow-up to #601: the implementation merged while its changed-line coverage gate had failed, so this PR supplies the missing adversarial coverage.