### PR TITLE
test(ingestion): add property conformance coverage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wired built-in Croissant and Frictionless providers through verified,
   content-addressed materialization so declared SHA-256 resources can replay
   offline; Frictionless now verifies supported `hash` and `bytes` declarations.
+- Added property-based cross-format conformance coverage proving that explicit
+  VOI bindings preserve normalized strategy order and EVPI when DataFrame and
+  direct producers emit decision columns in either order.
 - Added explicit offline, verified-cache, and resource-size policy flags to
   every standardized-ingestion CLI command while retaining local-only access.
 - Added a validated SciCrunch registration answer-and-evidence packet with

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -6,6 +6,8 @@ from hashlib import sha256
 import json
 from pathlib import Path
 
+from hypothesis import given, settings
+from hypothesis import strategies as st
 import numpy as np
 import polars as pl
 import pyarrow as pa
@@ -131,3 +133,55 @@ def test_canonical_decision_fixture_has_cross_format_evpi_parity(tmp_path) -> No
     assert {bundle.schema_fingerprint for bundle in bundles} == {
         direct.schema_fingerprint
     }
+
+
+@settings(max_examples=30, deadline=None)
+@given(
+    rows=st.lists(
+        st.tuples(
+            st.floats(
+                min_value=-1_000_000,
+                max_value=1_000_000,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+            st.floats(
+                min_value=-1_000_000,
+                max_value=1_000_000,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        ),
+        min_size=1,
+        max_size=20,
+    ),
+    column_order=st.permutations(("strategy_a", "strategy_b")),
+)
+def test_dataframe_and_direct_input_preserve_explicit_binding_under_column_order(
+    rows: list[tuple[float, float]], column_order: list[str]
+) -> None:
+    """Explicit bindings, not producer column order, define decision semantics."""
+    values = {
+        "strategy_a": [row[0] for row in rows],
+        "strategy_b": [row[1] for row in rows],
+    }
+    ordered_values = {field: values[field] for field in column_order}
+    direct = _direct_bundle(pa.table(ordered_values))
+    dataframe = from_dataframe(
+        pl.DataFrame(ordered_values),
+        dataset_id="property-fixture",
+        table_id="samples",
+        bindings=(_binding(),),
+    )
+
+    direct_prepared = prepare_analysis_inputs(direct)
+    dataframe_prepared = prepare_analysis_inputs(dataframe)
+    expected = np.asarray(
+        list(zip(values["strategy_a"], values["strategy_b"], strict=True))
+    )
+
+    assert direct_prepared.net_benefits.numpy_values.tolist() == expected.tolist()
+    assert dataframe_prepared.net_benefits.numpy_values.tolist() == expected.tolist()
+    assert evpi(direct_prepared.net_benefits.numpy_values) == pytest.approx(
+        evpi(dataframe_prepared.net_benefits.numpy_values)
+    )


### PR DESCRIPTION
## Summary
- add generated finite decision matrices and both producer column orders
- prove direct Arrow and DataFrame-interchange inputs preserve explicit binding strategy order and EVPI

## Verification
- `uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_conformance.py -q --no-cov`
- Ruff, formatting, and type checks

Advances Conductor P5-T5 property-based mapping evidence without claiming full Phase 5 completion.