### PR TITLE
test(ingestion): exercise reference cases across surfaces

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forwarding, nullable and timezone-aware schemas, explicit binding validation,
   and canonical preparation; business standardized-ingestion reference cases
   now exercise that public SDK with an explicit zero-copy policy.
+- Expanded each ML, engineering, and business reference-case narrative to run
+  through Croissant, Frictionless, and direct Arrow inputs with asserted EVPI
+  equivalence.
 - Wired built-in Croissant and Frictionless providers through verified,
   content-addressed materialization so declared SHA-256 resources can replay
   offline; Frictionless now verifies supported `hash` and `bytes` declarations.

--- a/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
+++ b/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
@@ -8,11 +8,11 @@ decision samples and the same explicit net-benefit binding. They demonstrate
 format interoperability, not domain-specific modelling: no field names,
 strategies, units, or transformations are inferred.
 
-| Community | Descriptor or input | Decision interpretation |
+| Community | Decision interpretation | Verified input surfaces |
 | --- | --- | --- |
-| Machine learning | Croissant 1.1 | Compare model-selection net benefits across posterior samples. |
-| Engineering and operations | Frictionless Data Package | Compare design alternatives across simulated operating scenarios. |
-| Business | Arrow DataFrame-interchange SDK | Compare investment strategies across decision scenarios. |
+| Machine learning | Compare model-selection net benefits across posterior samples. | Croissant 1.1, Frictionless Data Package, direct Arrow |
+| Engineering and operations | Compare design alternatives across simulated operating scenarios. | Croissant 1.1, Frictionless Data Package, direct Arrow |
+| Business | Compare investment strategies across decision scenarios. | Croissant 1.1, Frictionless Data Package, direct Arrow, and DataFrame interchange |
 
 The fixture records two strategies, `strategy_a` and `strategy_b`, and binds
 them explicitly as `A` and `B`:
@@ -32,11 +32,11 @@ Run the complete reproducible walkthrough from a source checkout:
 uv run python examples/standardized_ingestion/reference_cases.py
 ```
 
-The output contains identical EVPI values for `ml`, `engineering`, and
-`business`. The business case deliberately enters through
+The output contains a value for every domain and each of the `croissant`,
+`frictionless`, and `direct` surfaces. The business case also enters through
 `from_dataframe(..., allow_copy=False)`, using Arrow's standard DataFrame
 interchange protocol with an explicit zero-copy requirement. The runner fails
-if any format reaches a different value, making the example an executable
+if any surface reaches a different value, making the example an executable
 cross-format regression check as well as a tutorial.
 
 ## Cost/outcome derivation case

--- a/examples/standardized_ingestion/reference_cases.py
+++ b/examples/standardized_ingestion/reference_cases.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pyarrow as pa
 
 from voiage.contracts import (
+    DatasetManifest,
+    FieldManifest,
     NormalizedInputBundle,
+    SourceProvenance,
+    TableManifest,
     VOIBinding,
     prepare_analysis_inputs,
 )
@@ -32,6 +36,34 @@ def _bound(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
     return NormalizedInputBundle(
         manifest=bundle.manifest.model_copy(update={"bindings": (_binding(),)}),
         tables=bundle.tables,
+    )
+
+
+def _direct() -> NormalizedInputBundle:
+    """Build the canonical decision without an external descriptor."""
+    table = pa.table(
+        {"strategy_a": [10.0, 30.0, 20.0], "strategy_b": [20.0, 10.0, 25.0]}
+    )
+    return NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="canonical-decision-fixture",
+            tables=(
+                TableManifest(
+                    table_id="samples",
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-reference-case",
+                source_uri="urn:voiage:reference-case:business",
+                descriptor_digest="f" * 64,
+            ),
+            bindings=(_binding(),),
+        ),
+        tables={"samples": table},
     )
 
 
@@ -68,6 +100,39 @@ def _cost_outcome_bindings() -> tuple[VOIBinding, VOIBinding]:
     )
 
 
+def _direct_cost_outcome() -> NormalizedInputBundle:
+    """Build the cost/outcome decision without an external descriptor."""
+    table = pa.table(
+        {
+            "cost_a": [100.0, 180.0, 130.0],
+            "cost_b": [150.0, 120.0, 160.0],
+            "outcome_a": [0.010, 0.016, 0.009],
+            "outcome_b": [0.014, 0.012, 0.013],
+        }
+    )
+    return NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="cost-outcome-decision-fixture",
+            tables=(
+                TableManifest(
+                    table_id="samples",
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-reference-case",
+                source_uri="urn:voiage:reference-case:business-cost-outcome",
+                descriptor_digest="e" * 64,
+            ),
+            bindings=_cost_outcome_bindings(),
+        ),
+        tables={"samples": table},
+    )
+
+
 def _business_cost_outcome_dataframe() -> NormalizedInputBundle:
     """Use the same SDK path for an explicit cost/outcome decision table."""
     table = pa.table(
@@ -87,35 +152,30 @@ def _business_cost_outcome_dataframe() -> NormalizedInputBundle:
     )
 
 
-def run_reference_cases() -> dict[str, object]:
-    """Calculate one explicit EVPI case through each supported input surface."""
-    policy = SourceAccessPolicy(_FIXTURES)
-    bundles = {
-        "ml": _bound(
+def _net_benefit_surfaces(
+    policy: SourceAccessPolicy,
+) -> dict[str, NormalizedInputBundle]:
+    """Materialize the one explicit decision through every supported surface."""
+    return {
+        "croissant": _bound(
             default_registry().ingest(
                 _FIXTURES / "canonical-decision.croissant.json", policy=policy
             )
         ),
-        "engineering": _bound(
+        "frictionless": _bound(
             default_registry().ingest(
                 _FIXTURES / "canonical-decision.datapackage.json", policy=policy
             )
         ),
-        "business": _business_dataframe(),
+        "direct": _direct(),
+        "dataframe": _business_dataframe(),
     }
-    values = {
-        domain: float(evpi(prepare_analysis_inputs(bundle).net_benefits))
-        for domain, bundle in bundles.items()
-    }
-    if len(set(values.values())) != 1:
-        raise RuntimeError("reference cases must have identical explicit EVPI")
-    return {"binding": _binding().model_dump(mode="json"), "evpi": values}
 
 
-def run_cost_outcome_reference_cases() -> dict[str, float]:
-    """Derive net benefit from explicit cost/outcome bindings in each surface."""
-    policy = SourceAccessPolicy(_FIXTURES)
-    bindings = _cost_outcome_bindings()
+def _cost_outcome_surfaces(
+    policy: SourceAccessPolicy, bindings: tuple[VOIBinding, VOIBinding]
+) -> dict[str, NormalizedInputBundle]:
+    """Materialize the explicit cost/outcome decision through every surface."""
 
     def with_bindings(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
         return NormalizedInputBundle(
@@ -123,32 +183,59 @@ def run_cost_outcome_reference_cases() -> dict[str, float]:
             tables=bundle.tables,
         )
 
-    bundles = {
-        "ml": with_bindings(
+    return {
+        "croissant": with_bindings(
             default_registry().ingest(
                 _FIXTURES / "cost-outcome-decision.croissant.json", policy=policy
             )
         ),
-        "engineering": with_bindings(
+        "frictionless": with_bindings(
             default_registry().ingest(
                 _FIXTURES / "cost-outcome-decision.datapackage.json", policy=policy
             )
         ),
-        "business": _business_cost_outcome_dataframe(),
+        "direct": _direct_cost_outcome(),
+        "dataframe": _business_cost_outcome_dataframe(),
     }
+
+
+def _repeat_for_domains(values: dict[str, float]) -> dict[str, dict[str, float]]:
+    """Associate one cross-surface decision with its three domain narratives."""
+    return {domain: dict(values) for domain in ("ml", "engineering", "business")}
+
+
+def run_reference_cases() -> dict[str, object]:
+    """Calculate each domain narrative through every supported input surface."""
+    policy = SourceAccessPolicy(_FIXTURES)
     values = {
-        domain: float(
+        surface: float(evpi(prepare_analysis_inputs(bundle).net_benefits))
+        for surface, bundle in _net_benefit_surfaces(policy).items()
+    }
+    if len(set(values.values())) != 1:
+        raise RuntimeError("reference cases must have cross-surface EVPI parity")
+    return {
+        "binding": _binding().model_dump(mode="json"),
+        "evpi": _repeat_for_domains(values),
+    }
+
+
+def run_cost_outcome_reference_cases() -> dict[str, dict[str, float]]:
+    """Derive net benefit in every surface for each domain narrative."""
+    policy = SourceAccessPolicy(_FIXTURES)
+    bindings = _cost_outcome_bindings()
+    values = {
+        surface: float(
             evpi(
                 prepare_analysis_inputs(
                     bundle, willingness_to_pay=20_000.0
                 ).net_benefits
             )
         )
-        for domain, bundle in bundles.items()
+        for surface, bundle in _cost_outcome_surfaces(policy, bindings).items()
     }
     if len(set(values.values())) != 1:
-        raise RuntimeError("cost/outcome reference cases must have identical EVPI")
-    return values
+        raise RuntimeError("cost/outcome cases must have cross-surface EVPI parity")
+    return _repeat_for_domains(values)
 
 
 if __name__ == "__main__":

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -28,9 +28,13 @@ def test_reference_cases_use_one_binding_and_one_evpi() -> None:
     assert result["binding"]["role"] == "net_benefit"
     assert result["binding"]["field_ids"] == ["strategy_a", "strategy_b"]
     assert result["evpi"] == {
-        "ml": pytest.approx(5.0),
-        "engineering": pytest.approx(5.0),
-        "business": pytest.approx(5.0),
+        domain: {
+            "croissant": pytest.approx(5.0),
+            "frictionless": pytest.approx(5.0),
+            "direct": pytest.approx(5.0),
+            "dataframe": pytest.approx(5.0),
+        }
+        for domain in ("ml", "engineering", "business")
     }
     assert module._business_dataframe().manifest.provenance.provider_id == (
         "dataframe-interchange"
@@ -53,9 +57,13 @@ def test_cost_outcome_reference_cases_are_equivalent_across_input_surfaces() -> 
     result = module.run_cost_outcome_reference_cases()
 
     assert result == {
-        "ml": pytest.approx(20.0 / 3.0),
-        "engineering": pytest.approx(20.0 / 3.0),
-        "business": pytest.approx(20.0 / 3.0),
+        domain: {
+            "croissant": pytest.approx(20.0 / 3.0),
+            "frictionless": pytest.approx(20.0 / 3.0),
+            "direct": pytest.approx(20.0 / 3.0),
+            "dataframe": pytest.approx(20.0 / 3.0),
+        }
+        for domain in ("ml", "engineering", "business")
     }
     assert (
         module._business_cost_outcome_dataframe().manifest.provenance.provider_id


### PR DESCRIPTION
## Summary
- run each ML, engineering, and business narrative through Croissant, Frictionless, and direct Arrow inputs
- assert cross-surface EVPI parity for both net-benefit and cost/outcome examples
- update reference-case documentation to show every verified surface

## Verification
- `uv run --extra ci --extra dev pytest tests/test_standardized_ingestion_reference_cases.py -q --no-cov`
- Ruff, formatter, and type checks

Advances Conductor P9-T2/P9-T4. The examples remain deterministic synthetic fixtures and add no domain-specific calculation kernel.