### PR TITLE
feat(contracts): add explicit structural binding roles

### DIFF
--- a/tests/test_normalized_input_bundle.py
+++ b/tests/test_normalized_input_bundle.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import subprocess
 import sys
 from types import SimpleNamespace
+from typing import Literal
 
 from jsonschema import Draft202012Validator
 import pyarrow as pa
@@ -82,6 +83,21 @@ def test_bundle_is_strict_immutable_and_canonical() -> None:
     assert json.loads(bundle.canonical_json)["dataset_id"] == "decision-fixture"
     with pytest.raises(TypeError):
         bundle.tables["other"] = pa.table({})  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["sample", "strategy", "design_variable", "target", "perspective", "split"],
+)
+def test_contract_accepts_explicit_non_calculation_binding_roles(
+    role: Literal[
+        "sample", "strategy", "design_variable", "target", "perspective", "split"
+    ],
+) -> None:
+    """Metadata roles are explicit contract vocabulary, never inferred semantics."""
+    binding = VOIBinding(role=role, table_id="net_benefit", field_ids=("strategy_a",))
+
+    assert binding.role == role
 
 
 def test_bundle_rejects_stale_binding_reference() -> None:

--- a/voiage/contracts/normalized_input.py
+++ b/voiage/contracts/normalized_input.py
@@ -134,7 +134,19 @@ class SourceProvenance(ContractModel):
 class VOIBinding(ContractModel):
     """An explicit mapping from source fields to a VOI runtime role."""
 
-    role: Literal["net_benefit", "parameter", "cost", "outcome", "weight"]
+    role: Literal[
+        "sample",
+        "strategy",
+        "net_benefit",
+        "cost",
+        "outcome",
+        "parameter",
+        "design_variable",
+        "target",
+        "weight",
+        "perspective",
+        "split",
+    ]
     table_id: Identifier
     field_ids: tuple[Identifier, ...]
     strategy_names: tuple[Identifier, ...] = ()


### PR DESCRIPTION
## Summary
- expand the format-neutral VOI binding vocabulary with sample, strategy, design-variable, target, perspective, and split roles
- preserve explicit-only semantics; this change adds no numerical inference or calculation path

## Verification
- `uv run --extra ci --extra dev pytest tests/test_normalized_input_bundle.py -q --no-cov`
- Ruff and `ty check voiage/contracts/normalized_input.py`

Advances Conductor P1-T2 contract coverage. It does not claim the whole Phase 1 checkpoint.