### PR TITLE
fix(conductor): correct closeout lifecycle records

### DIFF
--- a/conductor/github-cross-references.json
+++ b/conductor/github-cross-references.json
@@ -741,7 +741,7 @@
     {
       "track_id": "conductor-github-cross-reference-reconciliation_20260724",
       "path": "conductor/tracks/conductor-github-cross-reference-reconciliation_20260724",
-      "lifecycle": "completed",
+      "lifecycle": "active",
       "issue": {
         "number": 462,
         "url": "https://github.com/edithatogo/voiage/issues/462",
@@ -765,11 +765,11 @@
       "track_id": "conductor-registry-normalization_20260727",
       "metadata_track_id": "conductor-registry-normalization_20260727",
       "path": "conductor/archive/conductor-registry-normalization_20260727",
-      "lifecycle": "active",
+      "lifecycle": "completed",
       "issue": {
         "number": 590,
         "url": "https://github.com/edithatogo/voiage/issues/590",
-        "state": "open"
+        "state": "closed"
       },
       "parent_issue_url": "https://github.com/edithatogo/voiage/issues/322",
       "subissues": [],


### PR DESCRIPTION
Correct the lifecycle fields in the adjacent cross-reference records: keep the still-active reconciliation track active, and record the archived normalization track and closed issue #590 as completed. This fixes the post-merge evidence reconciliation from #605.