### PR TITLE
ci(security): expose release provenance to Scorecard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,9 +316,18 @@ jobs:
           python -c "import os; from pathlib import Path; version=os.environ['RELEASE_VERSION']; abi=os.environ['VOIAGE_PYTHON_ABI']; expected=set(os.environ['EXPECTED_NATIVE_ARCHITECTURES'].split(',')); wheels=list(Path('dist').glob('*.whl')); manifests=list(Path('dist').glob('wheel-manifest-*.txt')); actual={m.stem.removeprefix('wheel-manifest-') for m in manifests}; assert actual==expected, f'expected native architectures {expected}, found {actual}'; assert len(wheels)==len(manifests)>0, f'expected one wheel per architecture manifest: {wheels=} {manifests=}'; declared={m.read_text(encoding='utf-8').strip() for m in manifests}; assert declared=={w.name for w in wheels}; assert all(f'voiage-{version}-{abi}-' in w.name for w in wheels)"
           python -c "import os; from pathlib import Path; version=os.environ['RELEASE_VERSION']; sdists=list(Path('dist').glob('*.tar.gz')); assert len(sdists)==1, f'expected exactly one source distribution, found {sdists}'; assert sdists[0].name==f'voiage-{version}.tar.gz'"
       - name: Attest release artifacts
+        id: provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
         with:
           subject-path: "dist/*"
+      - name: Export detectable SLSA provenance
+        shell: bash
+        run: |
+          test -s "$PROVENANCE_BUNDLE"
+          cp "$PROVENANCE_BUNDLE" "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl"
+          test -s "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl"
+        env:
+          PROVENANCE_BUNDLE: ${{ steps.provenance.outputs.bundle-path }}
       - name: Upload attested release set
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -326,6 +335,7 @@ jobs:
           path: |
             dist/*.whl
             dist/*.tar.gz
+            dist/*.intoto.jsonl
           if-no-files-found: error
           retention-days: 7
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Export future GitHub release attestations as discoverable SLSA
+  `.intoto.jsonl` assets and add time-bounded OSV exceptions for two Pydantic
+  advisories that do not affect the required and locked Pydantic 2.13.4.
 - Wired built-in Croissant and Frictionless providers through verified,
   content-addressed materialization so declared SHA-256 resources can replay
   offline; Frictionless now verifies supported `hash` and `bytes` declarations.

--- a/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
@@ -43,7 +43,10 @@ than a release or performance claim.
 The hosted repository runs CodeQL, OpenSSF Scorecard, Dependency Review, and
 Zizmor. Workflows also enforce SHA-pinned actions, least-privilege
 permissions, disabled credential persistence on security-sensitive checkouts,
-and release artifact provenance attestations.
+and release artifact provenance attestations. The release workflow also
+publishes the signed SLSA bundle as a `.intoto.jsonl` release asset so
+independent tools can discover provenance without privileged access to
+GitHub's attestation store.
 
 The protected `main` ruleset requires pull requests, resolved review threads,
 successful required checks, signed commits, and linear history. The required
@@ -51,6 +54,15 @@ approval count is zero for the single-maintainer operating model; CODEOWNERS
 still routes review responsibility without creating an impossible independent
 approval gate. Hosted settings must be verified through the GitHub API because
 they are not represented by files in the checkout.
+
+OpenSSF's aggregate Scorecard is interpreted check by check. Independent human
+review and multi-organisation contributor diversity are useful signals, but a
+single-maintainer project cannot manufacture either signal. The repository
+therefore retains zero required approvals while requiring the complete
+automated matrix, signed commits, current branches, resolved threads, and
+immutable releases. Those deliberate exceptions should not be bypassed with
+bot approvals, alternate accounts, synthetic contributors, or placeholder
+releases.
 
 ## Owner and organization gates
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,14 @@
+# Scorecard's OSV integration reports both aliases against Pydantic even
+# though every supported and locked environment uses Pydantic 2.13.4. That
+# version is outside both affected ranges. Keep the exceptions narrow,
+# documented, and time-bounded so unrelated or future advisories still fail.
+
+[[IgnoredVulns]]
+id = "GHSA-5jqp-qgf6-3pvh"
+ignoreUntil = 2026-10-31
+reason = "False positive: voiage requires and locks Pydantic 2.13.4; this advisory affects Pydantic before 1.8.2."
+
+[[IgnoredVulns]]
+id = "GHSA-mr82-8j83-vxmv"
+ignoreUntil = 2026-10-31
+reason = "False positive: voiage requires and locks Pydantic 2.13.4; this advisory affects Pydantic 2.0.0 through 2.4.2."

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -84,6 +84,10 @@ def test_python_release_workflow_builds_and_publishes_aggregated_artifacts() -> 
         "actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373"
         in release_workflow
     )
+    assert "id: provenance" in release_workflow
+    assert "${{ steps.provenance.outputs.bundle-path }}" in release_workflow
+    assert "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl" in release_workflow
+    assert "dist/*.intoto.jsonl" in release_workflow
     assert (
         "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"
         in release_workflow


### PR DESCRIPTION
## Summary
- publish future SLSA bundles as discoverable `.intoto.jsonl` release assets
- add narrow, expiring OSV exceptions for two Pydantic false positives
- document the legitimate solo-maintainer limits of review and contributor heuristics

## Validation
- `uv run --extra ci --extra dev pytest tests/test_python_release_workflow.py tests/test_code_scanning_gate.py --no-cov -q`
- `uv run python scripts/repo_harness.py` (0 findings, 27 workflows)
- `actionlint .github/workflows/release.yml`
- `uvx ruff check tests/test_python_release_workflow.py`
- TOML/YAML parse and `git diff --check`

## External metric boundaries
The published releases are immutable, so existing attestations cannot be added as release assets retroactively. Scorecard also requires real independent human review and recent contributors from three organisations for 10/10; those signals cannot be manufactured in a solo-maintainer repository.