### PR TITLE
ci(security): update OpenSSF Scorecard action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc
         with:
           results_file: scorecard-results.json
           results_format: sarif

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export future GitHub release attestations as discoverable SLSA
   `.intoto.jsonl` assets and add time-bounded OSV exceptions for two Pydantic
   advisories that do not affect the required and locked Pydantic 2.13.4.
+- Update the pinned OpenSSF Scorecard action to v2.4.4 so its v5.5 scanner
+  applies the repository's documented OSV exceptions.
 - Wired built-in Croissant and Frictionless providers through verified,
   content-addressed materialization so declared SHA-256 resources can replay
   offline; Frictionless now verifies supported `hash` and `bytes` declarations.


### PR DESCRIPTION
## Summary
- update the immutable official Scorecard action pin from v2.4.3 to signed v2.4.4
- consume Scorecard v5.5.0, which correctly applies the repository OSV exception evidence

## Evidence
- the v2.4.4 annotated tag is signature-verified and resolves to `2d1146689b8cda280b9bc96326124645441f03bc`
- its `go.mod` pins `github.com/ossf/scorecard/v5 v5.5.0`
- a local v5.5.0 scan reports Vulnerabilities 10/10 with zero existing vulnerabilities

## Validation
- `actionlint .github/workflows/scorecard.yml`
- `uv run python scripts/repo_harness.py` (0 findings, 27 workflows)
- focused code-scanning gate tests pass