### PR TITLE
feat(ingestion): add gated authoritative probe harness

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a fail-closed, opt-in authoritative-provider probe helper that verifies
+  separately staged descriptor and materialization digests without network I/O.
 - Export future GitHub release attestations as discoverable SLSA
   `.intoto.jsonl` assets and add time-bounded OSV exceptions for two Pydantic
   advisories that do not affect the required and locked Pydantic 2.13.4.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -78,9 +78,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   (`9a5b45b7`); the authoritative live probe remains an explicit external gate.
 - [ ] **P4-T4 / AC-04:** Implement the lazy optional Croissant provider and
   publish separate standard-conformance and parser-capability profiles.
-- [ ] **P4-T5 / AC-04, AC-11:** Add Croissant inspection, diagnostics,
+- [~] **P4-T5 / AC-04, AC-11:** Add Croissant inspection, diagnostics,
   provenance, governance metadata, and one opt-in authoritative live
-  interoperability probe.
+  interoperability probe. The fail-closed local probe harness is implemented;
+  an approved authoritative source and digest-bound external execution remain
+  required before this task can be marked complete.
 
 ### Frictionless Data
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -104,6 +104,16 @@ profiles fail with a stable `IngestionError`; they are not partially loaded or
 silently transformed. Compatibility will expand only with new fixtures,
 source-policy evidence, and a documented provider capability change.
 
+## Authoritative interoperability probes
+
+`run_authoritative_probe` is a deliberately gated evidence helper, not a
+downloader. It requires an explicit enablement flag, a separately staged local
+source root, and approved SHA-256 digests for both descriptor and resource. It
+performs no network I/O and returns only provider and digest receipt data.
+Consequently, a successful local fixture test does not establish authoritative
+interoperability: the selected external source, rights, approval, and pinned
+digest remain an explicit Conductor gate.
+
 ## Worked examples
 
 The same contract supports more than one community-facing example:

--- a/tests/test_standardized_ingestion_live_probe.py
+++ b/tests/test_standardized_ingestion_live_probe.py
@@ -1,0 +1,62 @@
+"""Fail-closed evidence for manually authorized provider interoperability probes."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from voiage.ingestion.live_probe import (
+    AuthoritativeProbeGateError,
+    run_authoritative_probe,
+)
+
+_FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
+_DESCRIPTOR = _FIXTURE_ROOT / "valid" / "croissant.json"
+_RESOURCE = _FIXTURE_ROOT / "valid" / "data.csv"
+
+
+def test_authoritative_probe_requires_explicit_opt_in() -> None:
+    """The gate rejects before reading a descriptor or materializing a resource."""
+    with pytest.raises(AuthoritativeProbeGateError, match="explicitly enabled"):
+        run_authoritative_probe(
+            _DESCRIPTOR,
+            source_root=_FIXTURE_ROOT,
+            expected_descriptor_sha256="0" * 64,
+            expected_resource_sha256="0" * 64,
+            enabled=False,
+        )
+
+
+def test_authoritative_probe_records_pinned_provider_receipt() -> None:
+    """An enabled, separately approved descriptor returns only stable evidence."""
+    descriptor = _DESCRIPTOR
+    resource = _RESOURCE
+
+    evidence = run_authoritative_probe(
+        descriptor,
+        expected_descriptor_sha256=sha256(descriptor.read_bytes()).hexdigest(),
+        expected_resource_sha256=sha256(resource.read_bytes()).hexdigest(),
+        enabled=True,
+        source_root=_FIXTURE_ROOT,
+    )
+
+    assert evidence == {
+        "descriptor_sha256": sha256(descriptor.read_bytes()).hexdigest(),
+        "provider_id": "croissant",
+        "resource_sha256": sha256(resource.read_bytes()).hexdigest(),
+    }
+
+
+def test_authoritative_probe_rejects_unpinned_resource_content() -> None:
+    """A source substitution cannot produce an authoritative-looking receipt."""
+    descriptor = _DESCRIPTOR
+    with pytest.raises(AuthoritativeProbeGateError, match="resource digest"):
+        run_authoritative_probe(
+            descriptor,
+            expected_descriptor_sha256=sha256(descriptor.read_bytes()).hexdigest(),
+            expected_resource_sha256="0" * 64,
+            enabled=True,
+            source_root=_FIXTURE_ROOT,
+        )

--- a/voiage/ingestion/__init__.py
+++ b/voiage/ingestion/__init__.py
@@ -9,10 +9,12 @@ from .base import (
 from .croissant import CroissantProvider
 from .dataframe import from_dataframe
 from .frictionless import FrictionlessProvider
+from .live_probe import AuthoritativeProbeGateError, run_authoritative_probe
 from .registry import ProviderRegistry, default_registry, discover_entry_point_providers
 
 __all__ = [
     "CroissantProvider",
+    "AuthoritativeProbeGateError",
     "FrictionlessProvider",
     "IngestionError",
     "IngestionProvider",
@@ -22,4 +24,5 @@ __all__ = [
     "default_registry",
     "discover_entry_point_providers",
     "from_dataframe",
+    "run_authoritative_probe",
 ]

--- a/voiage/ingestion/live_probe.py
+++ b/voiage/ingestion/live_probe.py
@@ -1,0 +1,61 @@
+"""Fail-closed evidence helper for manually authorized provider probes."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from typing import TYPE_CHECKING
+
+from voiage.ingestion.base import IngestionError, SourceAccessPolicy
+from voiage.ingestion.registry import default_registry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class AuthoritativeProbeGateError(IngestionError):
+    """Raised when authoritative interoperability evidence is not fully pinned."""
+
+
+def _digest(path: Path) -> str:
+    """Return the SHA-256 digest of one locally staged probe artifact."""
+    return sha256(path.read_bytes()).hexdigest()
+
+
+def run_authoritative_probe(
+    descriptor: Path,
+    *,
+    source_root: Path,
+    expected_descriptor_sha256: str,
+    expected_resource_sha256: str,
+    enabled: bool,
+) -> dict[str, str]:
+    """Validate one approved local descriptor without performing network I/O.
+
+    Callers must acquire and approve the source separately. The probe is disabled
+    by default and checks descriptor and materialization digests before emitting
+    a compact receipt suitable for evidence ledgers.
+    """
+    if not enabled:
+        raise AuthoritativeProbeGateError(
+            "authoritative live probe must be explicitly enabled"
+        )
+    if _digest(descriptor) != expected_descriptor_sha256:
+        raise AuthoritativeProbeGateError("descriptor digest does not match approval")
+    try:
+        bundle = default_registry().ingest(
+            descriptor, policy=SourceAccessPolicy(source_root)
+        )
+    except IngestionError as error:
+        raise AuthoritativeProbeGateError(
+            "approved descriptor did not materialize"
+        ) from error
+    if len(bundle.manifest.resources) != 1:
+        raise AuthoritativeProbeGateError("probe requires exactly one resource receipt")
+    resource = bundle.manifest.resources[0]
+    if resource.sha256 != expected_resource_sha256:
+        raise AuthoritativeProbeGateError("resource digest does not match approval")
+    return {
+        "descriptor_sha256": expected_descriptor_sha256,
+        "provider_id": bundle.manifest.provenance.provider_id,
+        "resource_sha256": resource.sha256,
+    }


### PR DESCRIPTION
## Summary

- add a fail-closed, local-only authoritative provider probe harness
- require explicit enablement and approved descriptor/resource SHA-256 values
- document the external source, rights, and digest-approval gate

## Validation

- ........................................................................ [ 66%]
.....................................                                    [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
  /private/tmp/voiage-provider-conformance/.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
    NAT_TYPES = {np.datetime64("NaT").dtype, np.timedelta64("NaT").dtype}

tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_adapter_does_not_require_a_specific_frame_library
tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_preserves_supported_nullable_and_temporal_values
tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_reports_a_disallowed_copy
tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_rejects_unsupported_nested_values_with_stable_error
tests/test_standardized_ingestion_providers.py::test_registry_supports_a_fake_provider_with_injected_source_policy
  /private/tmp/voiage-provider-conformance/.venv/lib/python3.14/site-packages/pyarrow/interchange/from_dataframe.py:88: DeprecationWarning: Support for the dataframe interchange protocol is deprecated since version 1.40.0
    return _from_dataframe(df.__dataframe__(allow_copy=allow_copy),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- Conductor GitHub cross-references valid: /private/tmp/voiage-provider-conformance/conductor/github-cross-references.json
- vale: commands[0]> bash scripts/vale_prose.sh
✔ 0 errors, 0 warnings and 0 suggestions in 591 files.
  vale: OK (0.60=setup[0.01]+cmd[0.59] seconds)
  congratulations :) (0.70 seconds)

The PR intentionally does not claim an authoritative live source has been selected or executed.