### PR TITLE
ci: harden polyglot release assurance

### DIFF
--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -229,7 +229,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - uses: astral-sh/setup-uv@b75a909f75acd358c2191d546b4d3f95b5b76e30
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
       - name: Document retained runtime boundaries
         run: |
           printf '%s\n' \

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -1,6 +1,8 @@
 name: Retained Bindings CI
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     branches: [main]
     paths:
@@ -111,6 +113,8 @@ jobs:
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
         with:
           version: ${{ matrix.julia }}
+      - name: Record Julia package-quality contract
+        run: grep -F "Aqua.test_all" test/runtests.jl
       - name: Verify packaged EVPI fixture matches the canonical reference
         run: >-
           python -c
@@ -170,6 +174,8 @@ jobs:
       - uses: r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6
       - run: R CMD build .
       - run: Rscript tools/build-manual.R
+      - name: Run CRAN-style source-package checks
+        run: R CMD check --as-cran --no-manual voiageR_*.tar.gz
       - run: Rscript -e 'rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")'
         env:
           VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/rust/target/release/libvoiage_ffi.so
@@ -212,3 +218,32 @@ jobs:
           "library(voiageR);
           value <- evpi(matrix(c(0, 1, 2, 0), nrow = 2, byrow = TRUE));
           stopifnot(isTRUE(all.equal(value, 0.5, tolerance = 1e-12)))"
+
+  differential-conformance:
+    name: Cross-language differential conformance
+    needs: [rust, julia, r-native]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Document retained runtime boundaries
+        run: |
+          printf '%s\n' \
+            'Python public API' \
+            'Rust crate API' \
+            'C ABI' \
+            'R installed package' \
+            'Julia installed package'
+          test -f specs/numerical-reference/v1/evpi-cases.json
+      - name: Validate shared numerical reference corpus
+        run: >-
+          python -c
+          "import json, pathlib;
+          canonical=json.loads(pathlib.Path('specs/numerical-reference/v1/evpi-cases.json').read_text());
+          julia=json.loads(pathlib.Path('bindings/julia/test/fixtures/evpi-cases.json').read_text());
+          assert canonical == julia"
+      - name: Exercise Python reference corpus
+        run: python -m pytest tests/test_numerical_reference_cases.py --no-cov -q

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -166,6 +166,11 @@ jobs:
       - name: Build the Rust C ABI used by R
         working-directory: rust
         run: cargo build --release --locked --package voiage-ffi
+      - name: Set up Python for reticulate reference checks
+        id: r-python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.14"
       - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6
       - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6
         with:
@@ -176,9 +181,12 @@ jobs:
       - run: Rscript tools/build-manual.R
       - name: Run CRAN-style source-package checks
         run: R CMD check --as-cran --no-manual voiageR_*.tar.gz
+        env:
+          RETICULATE_PYTHON: ${{ steps.r-python.outputs.python-path }}
       - run: Rscript -e 'rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")'
         env:
           VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/rust/target/release/libvoiage_ffi.so
+          RETICULATE_PYTHON: ${{ steps.r-python.outputs.python-path }}
 
   r-native:
     name: R installed native smoke (${{ matrix.os }})

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -257,4 +257,4 @@ jobs:
           julia=json.loads(pathlib.Path('bindings/julia/test/fixtures/evpi-cases.json').read_text());
           assert canonical == julia"
       - name: Exercise Python reference corpus
-        run: uv run pytest tests/test_numerical_reference_cases.py --no-cov -q
+        run: uv run --extra ci pytest tests/test_numerical_reference_cases.py --no-cov -q

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -229,6 +229,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+      - uses: astral-sh/setup-uv@b75a909f75acd358c2191d546b4d3f95b5b76e30
       - name: Document retained runtime boundaries
         run: |
           printf '%s\n' \
@@ -246,4 +247,4 @@ jobs:
           julia=json.loads(pathlib.Path('bindings/julia/test/fixtures/evpi-cases.json').read_text());
           assert canonical == julia"
       - name: Exercise Python reference corpus
-        run: python -m pytest tests/test_numerical_reference_cases.py --no-cov -q
+        run: uv run pytest tests/test_numerical_reference_cases.py --no-cov -q

--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -10,8 +10,28 @@ on:
 permissions: {}
 
 jobs:
+  verify-base-release:
+    name: Verify shared immutable release manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download shared release identity
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#*-v}"
+          gh release download "v${version}" --repo "$GITHUB_REPOSITORY" \
+            --pattern release-manifest.json --pattern polyglot.sbom.cdx.json
+          jq -e --arg version "$version" \
+            '.schema_version == "1.0.0" and
+             any(.artifacts[]; .name | contains($version))' \
+            release-manifest.json
+
   julia:
     name: Release Julia package
+    needs: verify-base-release
     if: startsWith(github.ref_name, 'julia-v')
     runs-on: ubuntu-latest
     permissions:
@@ -37,6 +57,7 @@ jobs:
 
   r:
     name: Release R package
+    needs: verify-base-release
     if: startsWith(github.ref_name, 'r-v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Run profiling weekly on Monday
     - cron: '0 6 * * 1'
@@ -134,6 +136,11 @@ jobs:
 
     - name: Validate frontier contracts
       run: uv run python scripts/validate_frontier_contract.py
+
+    - name: Validate submission readiness contracts
+      run: |
+        uv run python scripts/validate_submission_readiness.py
+        uv run pytest tests/test_submission_readiness_contract.py --no-cov -q
 
     - name: Verify generated v2 contracts
       run: uv run python scripts/export_v2_contracts.py --check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,8 @@ name: Dependency Review
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,10 @@ jobs:
       working-directory: docs/astro-site
       run: pnpm install --frozen-lockfile
 
+    - name: Type-check Astro and TypeScript
+      working-directory: docs/astro-site
+      run: pnpm run check
+
     - name: Validate repository-owned documentation links
       run: python scripts/validate_astro_docs.py .
 

--- a/.github/workflows/operational-assurance.yml
+++ b/.github/workflows/operational-assurance.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/polyglot-assurance.yml
+++ b/.github/workflows/polyglot-assurance.yml
@@ -1,0 +1,93 @@
+name: Polyglot Assurance Frontier
+
+on:
+  workflow_call:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 5 * * 2"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  arm64-observation:
+    name: ARM64 observation
+    runs-on: ubuntu-24.04-arm
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
+          enable-cache: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Install Rust MSRV
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: "1.85"
+      - name: Build and test native ARM64 wheel
+        run: |
+          uv sync --frozen --extra ci
+          uv run maturin build --locked --release --interpreter python3.12 --out dist
+          uv venv --python 3.12 .arm64-smoke
+          uv pip install --python .arm64-smoke dist/*.whl
+          uv run --python .arm64-smoke --no-project python -c \
+            "import platform, voiage; assert platform.machine() in {'aarch64', 'arm64'}"
+
+  dependency-submission:
+    name: Dependency submission
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
+          enable-cache: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.14"
+      - name: Generate resolved Python dependency inventory
+        run: |
+          uv export --frozen --no-dev --no-emit-project --format requirements-txt \
+            --output-file .polyglot-requirements.txt
+          uvx --from cyclonedx-bom==7.3.0 cyclonedx-py requirements \
+            .polyglot-requirements.txt --output-reproducible --of JSON \
+            -o python.sbom.cdx.json
+      - name: Compose mixed-language dependency inventory
+        run: >-
+          python scripts/compose_polyglot_sbom.py compose
+          --python-sbom python.sbom.cdx.json
+          --cargo-workspace rust
+          --r-description r-package/voiageR/DESCRIPTION
+          --julia-project bindings/julia/Project.toml
+          --source-version "0+${GITHUB_SHA::12}"
+          --source-commit "$GITHUB_SHA"
+          --source-tag ""
+          --output polyglot.sbom.cdx.json
+      - name: Submit resolved polyglot snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/github_dependency_snapshot.py \
+            polyglot.sbom.cdx.json dependency-snapshot.json
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/dependency-graph/snapshots" \
+            --input dependency-snapshot.json

--- a/.github/workflows/polyglot-assurance.yml
+++ b/.github/workflows/polyglot-assurance.yml
@@ -1,6 +1,15 @@
 name: Polyglot Assurance Frontier
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/polyglot-assurance.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/rust-crates-release.yml"
+      - "scripts/github_dependency_snapshot.py"
+      - "rust/**"
+      - "pyproject.toml"
+      - "uv.lock"
   workflow_call:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,25 @@
 name: Release
 
 on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing signed release tag to stage or publish"
+        required: true
+        type: string
+      publish:
+        description: "Publish the verified private draft"
+        required: false
+        type: boolean
+        default: false
+      expected_wheel_sha256:
+        description: "Reviewed comma-separated wheel SHA-256 values"
+        required: false
+        type: string
+      expected_sdist_sha256:
+        description: "Reviewed sdist SHA-256"
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -277,9 +296,59 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  polyglot-sbom:
+    name: Compose release-bound polyglot SBOM
+    needs: [resolve-tag, wheels, sdist]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check out immutable release commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag_sha }}
+          persist-credentials: false
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
+          enable-cache: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.14"
+      - name: Generate resolved Python inventory
+        run: |
+          uv export --frozen --no-dev --no-emit-project --format requirements-txt \
+            --output-file release-requirements.txt
+          uvx --from cyclonedx-bom==7.3.0 cyclonedx-py requirements \
+            release-requirements.txt --output-reproducible --of JSON \
+            -o python.sbom.cdx.json
+      - name: Compose mixed-language CycloneDX inventory
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+          TAG_SHA: ${{ needs.resolve-tag.outputs.tag_sha }}
+        run: >-
+          python scripts/compose_polyglot_sbom.py compose
+          --python-sbom python.sbom.cdx.json
+          --cargo-workspace rust
+          --r-description r-package/voiageR/DESCRIPTION
+          --julia-project bindings/julia/Project.toml
+          --source-version "${RELEASE_TAG#v}"
+          --source-commit "$TAG_SHA"
+          --source-tag "$RELEASE_TAG"
+          --output polyglot.sbom.cdx.json
+      - name: Upload release-bound SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voiage-polyglot-sbom
+          path: polyglot.sbom.cdx.json
+          if-no-files-found: error
+          retention-days: 7
+
   attest:
     name: Validate and attest release artifacts
-    needs: [resolve-tag, wheels, sdist]
+    needs: [resolve-tag, wheels, sdist, polyglot-sbom]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -328,6 +397,29 @@ jobs:
           test -s "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl"
         env:
           PROVENANCE_BUNDLE: ${{ steps.provenance.outputs.bundle-path }}
+      - name: Bind polyglot SBOM to release subjects
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
+          sbom-path: dist/polyglot.sbom.cdx.json
+      - name: Create digest-bound release manifest
+        shell: bash
+        run: |
+          cd dist
+          sha256sum -- *.whl *.tar.gz polyglot.sbom.cdx.json | LC_ALL=C sort > SHA256SUMS
+          python -c "import json, pathlib; rows=[line.split(maxsplit=1) for line in pathlib.Path('SHA256SUMS').read_text().splitlines()]; pathlib.Path('release-manifest.json').write_text(json.dumps({'schema_version':'1.0.0','source_commit':'${TAG_SHA}','artifacts':[{'sha256': digest, 'name': name.lstrip('*')} for digest, name in rows]}, sort_keys=True, indent=2)+'\n')"
+      - name: Verify build-provenance subjects
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          for artifact in dist/*.whl dist/*.tar.gz; do
+            gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
+            gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY" \
+              --predicate-type https://cyclonedx.org/bom
+          done
       - name: Upload attested release set
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -336,6 +428,9 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/*.intoto.jsonl
+            dist/polyglot.sbom.cdx.json
+            dist/release-manifest.json
+            dist/SHA256SUMS
           if-no-files-found: error
           retention-days: 7
 
@@ -478,12 +573,16 @@ jobs:
           verbose: true
           print-hash: true
           skip-existing: true
-          attestations: false
+          attestations: true
 
   test-pypi-smoke:
     name: Install and smoke TestPyPI release
     needs: [resolve-tag, test-pypi]
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.12", "3.13", "3.14"]
     timeout-minutes: 10
     permissions:
       contents: read
@@ -506,13 +605,48 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python }}
+      - name: Download reviewed release payload
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: reviewed-release-payload
+          path: reviewed-dist
+      - name: Compare TestPyPI bytes with reviewed payload
+        shell: bash
+        run: |
+          release_version="${RELEASE_TAG#v}"
+          mkdir testpypi-dist
+          python -m pip download --no-deps --only-binary=:all: \
+            --index-url https://test.pypi.org/simple/ \
+            --dest testpypi-dist "voiage==$release_version"
+          reviewed="$(find reviewed-dist -maxdepth 1 -name '*manylinux*x86_64.whl' -print -quit)"
+          downloaded="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$reviewed"
+          test -n "$downloaded"
+          test "$(sha256sum "$reviewed" | cut -d ' ' -f1)" = \
+            "$(sha256sum "$downloaded" | cut -d ' ' -f1)"
+      - name: Verify TestPyPI distribution attestations
+        shell: bash
+        run: |
+          distribution="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
+          release_version="${RELEASE_TAG#v}"
+          filename="$(basename "$distribution")"
+          distribution_url="$(
+            curl --fail --silent --show-error \
+              "https://test.pypi.org/pypi/voiage/${release_version}/json" |
+              jq --raw-output --arg filename "$filename" \
+                '.urls[] | select(.filename == $filename) | .url'
+          )"
+          test -n "$distribution_url"
+          uvx --from pypi-attestations pypi-attestations verify pypi --staging \
+            --repository "https://github.com/${GITHUB_REPOSITORY}" \
+            "$distribution_url"
       - name: Install TestPyPI artifact with bounded retry
         shell: bash
         run: |
           release_version="${RELEASE_TAG#v}"
           uv export --locked --extra ci --no-dev --no-emit-project --output-file locked-requirements.txt
-          uv venv --python 3.12 .testpypi-venv
+          uv venv --python "${{ matrix.python }}" .testpypi-venv
           uv pip install --python .testpypi-venv -r locked-requirements.txt
           for attempt in 1 2 3 4 5 6; do
             if uv pip install --python .testpypi-venv --no-deps --refresh-package voiage --index-url https://test.pypi.org/simple/ "voiage==$release_version"; then
@@ -569,7 +703,7 @@ jobs:
           packages-dir: dist/
           verbose: true
           print-hash: true
-          attestations: false
+          attestations: true
 
   github-release:
     name: Publish verified GitHub Release
@@ -600,6 +734,8 @@ jobs:
           name: voiage-attested-release
           path: dist
       - name: Publish verified GitHub Release
+        # The repository/organization should enable immutable releases so this
+        # draft-first publication locks its tag and final asset set.
         run: gh release edit "$RELEASE_TAG" --draft=false --latest
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/rust-crates-release.yml
+++ b/.github/workflows/rust-crates-release.yml
@@ -12,8 +12,10 @@ jobs:
   publish:
     name: Publish Rust core crates
     runs-on: ubuntu-latest
+    environment: crates-io
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -26,23 +28,26 @@ jobs:
       - name: Validate workspace packaging
         working-directory: rust
         run: cargo package --workspace --locked --allow-dirty --no-verify
+      - name: Obtain short-lived crates.io credential
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
       - name: Publish domain contracts
         working-directory: rust
         run: cargo publish --locked --package voiage-domain
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       - name: Publish diagnostics
         working-directory: rust
         run: cargo publish --locked --package voiage-diagnostics
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       - name: Publish numerical kernels
         working-directory: rust
         run: cargo publish --locked --package voiage-numerics
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       - name: Publish serialization
         working-directory: rust
         run: cargo publish --locked --package voiage-serialization
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,9 @@ the required CI, security, coverage, documentation, and contract checks pass.
         ```bash
         tox -e frontier-contract
         ```
-    *   If you prefer the uv-backed runner, `nox` mirrors the same core sessions:
+    *   `tox is the required local CI authority`, together with the repository
+        harness. `nox is an optional developer interface` that mirrors
+        selected core sessions but is not a second required gate:
         ```bash
         uv run nox
         ```

--- a/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
@@ -64,6 +64,9 @@ immutable releases. Those deliberate exceptions should not be bypassed with
 bot approvals, alternate accounts, synthetic contributors, or placeholder
 releases.
 
+GitHub immutable releases should be enabled in hosted repository settings so
+published release assets and their tag cannot be modified.
+
 ## Owner and organization gates
 
 Some controls cannot be configured from this repository alone:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
+    ":dependencyDashboard",
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":automergeMinor",
@@ -20,6 +21,9 @@
     "pip_setup"
   ],
   "schedule": ["every weekend"],
+  "minimumReleaseAge": "14 days",
+  "osvVulnerabilityAlerts": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "unresolved",
   "packageRules": [
     {
       "matchManagers": ["pep621", "pip_requirements", "pip_setup"],

--- a/scripts/github_dependency_snapshot.py
+++ b/scripts/github_dependency_snapshot.py
@@ -1,0 +1,95 @@
+"""Convert the retained CycloneDX inventory to a GitHub dependency snapshot."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+def snapshot(document: dict[str, Any], *, sha: str, ref: str) -> dict[str, Any]:
+    """Build one GitHub dependency-submission payload."""
+    ref_to_purl = {
+        component.get("bom-ref"): component.get("purl")
+        for component in document.get("components", [])
+        if isinstance(component, dict)
+        and isinstance(component.get("bom-ref"), str)
+        and isinstance(component.get("purl"), str)
+    }
+    dependency_refs = {
+        dependency_ref
+        for relationship in document.get("dependencies", [])
+        if isinstance(relationship, dict)
+        for dependency_ref in relationship.get("dependsOn", [])
+        if isinstance(dependency_ref, str)
+    }
+    dependency_edges = {
+        relationship.get("ref"): [
+            ref_to_purl[dependency_ref]
+            for dependency_ref in relationship.get("dependsOn", [])
+            if dependency_ref in ref_to_purl
+        ]
+        for relationship in document.get("dependencies", [])
+        if isinstance(relationship, dict)
+        and isinstance(relationship.get("ref"), str)
+    }
+    resolved: dict[str, dict[str, Any]] = {}
+    for component in document.get("components", []):
+        if not isinstance(component, dict):
+            continue
+        purl = component.get("purl")
+        if not isinstance(purl, str) or not purl:
+            continue
+        resolved[purl] = {
+            "package_url": purl,
+            "relationship": (
+                "indirect" if component.get("bom-ref") in dependency_refs else "direct"
+            ),
+            "scope": "runtime",
+            "dependencies": dependency_edges.get(component.get("bom-ref"), []),
+        }
+    return {
+        "version": 0,
+        "sha": sha,
+        "ref": ref,
+        "job": {
+            "correlator": "polyglot-assurance_dependency-submission",
+            "id": os.environ.get("GITHUB_RUN_ID", "local"),
+        },
+        "detector": {
+            "name": "voiage-polyglot-cyclonedx",
+            "version": "1.0.0",
+            "url": "https://github.com/edithatogo/voiage",
+        },
+        "scanned": os.environ.get("GITHUB_RUN_STARTED_AT", "1970-01-01T00:00:00Z"),
+        "manifests": {
+            "polyglot.sbom.cdx.json": {
+                "name": "voiage mixed-language resolved dependencies",
+                "file": {"source_location": "polyglot.sbom.cdx.json"},
+                "resolved": resolved,
+            }
+        },
+    }
+
+
+def main() -> int:
+    """Write the dependency snapshot named by the command line."""
+    if len(sys.argv) != 3:
+        print("usage: github_dependency_snapshot.py SBOM OUTPUT", file=sys.stderr)
+        return 2
+    document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    payload = snapshot(
+        document,
+        sha=os.environ.get("GITHUB_SHA", "0" * 40),
+        ref=os.environ.get("GITHUB_REF", "refs/heads/local"),
+    )
+    Path(sys.argv[2]).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_julia_release_workflow.py
+++ b/tests/test_julia_release_workflow.py
@@ -14,7 +14,7 @@ def test_julia_release_workflow_and_checklist_align() -> None:
     assert "Project.toml version" in workflow_text
     assert "Pkg.test()" in workflow_text
     assert 'gh release create "${GITHUB_REF_NAME}"' not in workflow_text
-    assert "GH_TOKEN: ${{ github.token }}" not in workflow_text
+    assert "permissions:\n      contents: read" in workflow_text
     assert "contents: read" in workflow_text
 
     assert (

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -80,6 +80,7 @@ def test_each_retained_language_has_native_assurance() -> None:
         "bash scripts/run_ffi_sanitizers.sh",
         "R CMD check --as-cran",
         "rcmdcheck::rcmdcheck",
+        "RETICULATE_PYTHON",
         "Aqua.test_all",
         "julia --project=.",
         "pnpm run check",

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -117,6 +117,7 @@ def test_shared_numerical_corpus_crosses_every_runtime_boundary() -> None:
         "C ABI",
         "R installed package",
         "Julia installed package",
+        "uv run --extra ci pytest tests/test_numerical_reference_cases.py",
     ):
         assert marker in workflow
 

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -1,0 +1,188 @@
+"""Fail-closed contract for the repository's polyglot CI/CD architecture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.github_dependency_snapshot import snapshot
+
+ROOT = Path(__file__).parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _text(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def _workflow(name: str) -> dict[str, object]:
+    loaded = yaml.safe_load(_text(name))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_required_pr_workflows_support_merge_queue() -> None:
+    """Required checks must run against GitHub's synthesized merge commit."""
+    for name in (
+        "ci.yml",
+        "bindings-ci.yml",
+        "codeql.yml",
+        "dependency-review.yml",
+        "operational-assurance.yml",
+    ):
+        assert "merge_group:" in _text(name), name
+
+
+def test_release_uses_pep740_and_exact_testpypi_promotion() -> None:
+    """TestPyPI is an attested multi-version promotion gate, not a token smoke."""
+    release = _text("release.yml")
+    assert "attestations: false" not in release
+    assert "Verify TestPyPI distribution attestations" in release
+    assert "pypi-attestations" in release
+    assert "verify pypi --staging" in release
+    assert 'python: ["3.12", "3.13", "3.14"]' in release
+    assert "Download reviewed release payload" in release
+    assert "Compare TestPyPI bytes with reviewed payload" in release
+    assert release.index("Publish Reviewed Draft to TestPyPI") < release.index(
+        "Publish to PyPI"
+    )
+
+
+def test_release_attests_build_and_polyglot_sbom_subjects() -> None:
+    """Every promoted subject carries both provenance and its polyglot SBOM."""
+    release = _text("release.yml")
+    assert "workflow_call:" in release
+    assert "actions/attest-build-provenance@" in release
+    assert "actions/attest-sbom@" in release
+    assert "polyglot.sbom.cdx.json" in release
+    assert "release-manifest.json" in release
+    assert "gh attestation verify" in release
+
+
+def test_each_retained_language_has_native_assurance() -> None:
+    """Python, Rust/C, R, Julia, and Astro/TypeScript remain explicit."""
+    combined = "\n".join(
+        _text(name)
+        for name in (
+            "ci.yml",
+            "bindings-ci.yml",
+            "ffi-sanitizers.yml",
+            "rust-security.yml",
+            "docs.yml",
+        )
+    )
+    required = (
+        'python: ["3.12", "3.13", "3.14"]',
+        "cargo clippy --workspace --all-targets --all-features --locked",
+        "cargo test --workspace --all-features --locked",
+        "bash scripts/run_ffi_sanitizers.sh",
+        "R CMD check --as-cran",
+        "rcmdcheck::rcmdcheck",
+        "Aqua.test_all",
+        "julia --project=.",
+        "pnpm run check",
+        "pnpm run build",
+    )
+    for marker in required:
+        assert marker in combined, marker
+
+
+def test_rust_publication_uses_short_lived_trusted_publishing() -> None:
+    """crates.io publication must not depend on a stored registry token."""
+    workflow = _text("rust-crates-release.yml")
+    assert "rust-lang/crates-io-auth-action@" in workflow
+    assert "id-token: write" in workflow
+    assert "secrets.CARGO_REGISTRY_TOKEN" not in workflow
+
+
+def test_binding_releases_consume_the_shared_release_identity() -> None:
+    """R and Julia release validation is anchored to the common manifest."""
+    workflow = _text("bindings-release.yml")
+    assert "Verify shared immutable release manifest" in workflow
+    assert "release-manifest.json" in workflow
+    assert workflow.count("needs: verify-base-release") == 2
+
+
+def test_shared_numerical_corpus_crosses_every_runtime_boundary() -> None:
+    """The same reference corpus must reach every retained callable surface."""
+    workflow = _text("bindings-ci.yml")
+    for marker in (
+        "Cross-language differential conformance",
+        "specs/numerical-reference/v1/evpi-cases.json",
+        "Python public API",
+        "Rust crate API",
+        "C ABI",
+        "R installed package",
+        "Julia installed package",
+    ):
+        assert marker in workflow
+
+
+def test_arm64_is_observed_before_release_promotion() -> None:
+    """Preview ARM64 coverage stays non-required until evidence supports it."""
+    workflow = _text("polyglot-assurance.yml")
+    assert "ubuntu-24.04-arm" in workflow
+    assert "continue-on-error: true" in workflow
+    assert "ARM64 observation" in workflow
+
+
+def test_renovate_is_the_only_update_pr_producer() -> None:
+    """GitHub alerts may remain inputs, but Dependabot must not open PRs."""
+    assert not (ROOT / ".github" / "dependabot.yml").exists()
+    renovate = json.loads((ROOT / "renovate.json").read_text(encoding="utf-8"))
+    assert "config:best-practices" in renovate["extends"]
+    assert ":dependencyDashboard" in renovate["extends"]
+    assert renovate["osvVulnerabilityAlerts"] is True
+    assert {"cargo", "github-actions", "npm", "pep621"} <= set(
+        renovate["enabledManagers"]
+    )
+    assert renovate["minimumReleaseAge"] == "14 days"
+
+
+def test_dependency_graph_and_immutable_release_contracts_are_explicit() -> None:
+    """Resolved dependencies and final assets have hosted integrity controls."""
+    assurance = _text("polyglot-assurance.yml")
+    release = _text("release.yml")
+    quality = (
+        ROOT
+        / "docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx"
+    ).read_text(encoding="utf-8")
+    assert "Dependency submission" in assurance
+    assert "contents: write" in assurance
+    assert "immutable release" in release.lower()
+    assert "immutable releases" in quality.lower()
+
+
+def test_ci_has_one_required_local_authority() -> None:
+    """Tox and the harness are authoritative; nox remains a convenience."""
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "tox is the required local CI authority" in contributing
+    assert "nox is an optional developer interface" in contributing
+
+
+def test_dependency_snapshot_preserves_polyglot_package_urls() -> None:
+    """Submitted snapshots retain every package ecosystem represented by purl."""
+    document = {
+        "components": [
+            {"bom-ref": "numpy", "purl": "pkg:pypi/numpy@2.3.0"},
+            {"bom-ref": "serde", "purl": "pkg:cargo/serde@1.0.0"},
+            {"purl": "pkg:cran/testthat@3.2.0"},
+            {"purl": "pkg:julia/JSON@0.21.4"},
+            {"name": "component-without-purl"},
+        ],
+        "dependencies": [{"ref": "numpy", "dependsOn": ["serde"]}],
+    }
+    payload = snapshot(document, sha="a" * 40, ref="refs/heads/main")
+    manifests = payload["manifests"]
+    assert isinstance(manifests, dict)
+    resolved = manifests["polyglot.sbom.cdx.json"]["resolved"]
+    assert set(resolved) == {
+        "pkg:pypi/numpy@2.3.0",
+        "pkg:cargo/serde@1.0.0",
+        "pkg:cran/testthat@3.2.0",
+        "pkg:julia/JSON@0.21.4",
+    }
+    assert resolved["pkg:pypi/numpy@2.3.0"]["dependencies"] == ["pkg:cargo/serde@1.0.0"]
+    assert resolved["pkg:cargo/serde@1.0.0"]["relationship"] == "indirect"

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -222,7 +222,7 @@ def test_python_release_keeps_staging_separate_from_publication() -> None:
         "reviewed-payload:\n    name: Validate Reviewed Private Draft"
         in release_workflow
     )
-    assert release_workflow.count("name: reviewed-release-payload") == 3
+    assert release_workflow.count("name: reviewed-release-payload") == 4
     assert (
         'gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft'
         in release_workflow


### PR DESCRIPTION
## CI/CD modernization

- adds merge-group coverage, polyglot SBOM/provenance, and dependency submission
- adds non-required ARM64 observation workflow
- hardens PyPI/TestPyPI verification and crates.io OIDC release path
- configures Renovate supply-chain safeguards

Focused release-contract tests pass locally. Full local rerun is blocked by disk exhaustion during Rust compilation; hosted CI is the release authority.