### PR TITLE
feat(ingestion): freeze provider SDK v1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Phase 7 standardized-ingestion assurance coverage for rejected remote
   URI schemes and secret-safe errors, plus comparable Croissant and
   Frictionless parse-to-Arrow, normalization, EVPI, and peak-memory benchmarks.
+- Froze the v1 ingestion-provider SDK with capability-identity validation and
+  a published compatibility/publication contract; expanded DataFrame consumer
+  validation for categorical nullable columns and index exclusion.
 - Wired built-in Croissant and Frictionless providers through verified,
   content-addressed materialization so declared SHA-256 resources can replay
   offline; Frictionless now verifies supported `hash` and `bytes` declarations.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -175,20 +175,20 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 
 ## Phase 8 — Publish the provider SDK and DataFrame adapter (#467)
 
-- [ ] **P8-T1 / AC-12:** Freeze the supported provider-SDK surface only after
+- [~] **P8-T1 / AC-12:** Freeze the supported provider-SDK surface only after
   phases 1–5 establish stable core contracts and conformance evidence.
-- [ ] **P8-T2 / AC-12:** Add typed protocol stubs, a minimal example provider,
+- [~] **P8-T2 / AC-12:** Add typed protocol stubs, a minimal example provider,
   reusable contract tests, capability manifests, compatibility rules, and an
   opt-in entry-point publication checklist.
-- [ ] **P8-T3 / AC-12:** Write failing DataFrame-interchange tests covering
+- [~] **P8-T3 / AC-12:** Write failing DataFrame-interchange tests covering
   pandas, Polars, dtype/null/category/timezone/index handling, copy diagnostics,
   and clean optional environments.
-- [ ] **P8-T4 / AC-12:** Implement the generic `__dataframe__` adapter through
+- [~] **P8-T4 / AC-12:** Implement the generic `__dataframe__` adapter through
   Arrow and `NormalizedInputBundle`, with no alternate preparation or numerical
   path.
-- [ ] **P8-T5 / AC-12:** Assess Hugging Face and OpenML Croissant support and
+- [~] **P8-T5 / AC-12:** Assess Hugging Face and OpenML Croissant support and
   create registry-specific providers only for documented, tested gaps.
-- [ ] **P8-T6 / AC-12:** Run SDK consumer tests, conformance, numerical
+- [~] **P8-T6 / AC-12:** Run SDK consumer tests, conformance, numerical
   equivalence, import isolation, security review, full tox, and hosted checks.
 
 ## Phase 9 — Ship cross-domain reference cases (#468)

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -160,6 +160,11 @@ not resolve resources, access the network, or import optional parser stacks.
 `ingest` must return a `NormalizedInputBundle` and must resolve every declared
 resource through the supplied `SourceAccessPolicy`.
 
+The frozen v1 SDK additionally requires `capabilities.provider_id` to equal the
+provider's `provider_id`; registration rejects mismatches. Its versioned
+compatibility and publication rules live in
+`specs/core-api/ingestion-provider-sdk-v1.md`.
+
 Publish an initialized provider instance under the
 `voiage.ingestion.providers` entry-point group. The entry-point name is the
 deployment identifier that applications add to their allow-list; it need not

--- a/specs/core-api/ingestion-provider-sdk-v1.md
+++ b/specs/core-api/ingestion-provider-sdk-v1.md
@@ -1,0 +1,57 @@
+# Ingestion Provider SDK v1
+
+`INGESTION_PROVIDER_SDK_VERSION == "1"` freezes the public provider boundary.
+It is intentionally small so external parser packages remain decoupled from the
+VOI calculation runtime.
+
+## Required provider surface
+
+An entry point in the `voiage.ingestion.providers` group exports one initialized
+object with:
+
+- a non-empty `provider_id` string;
+- a `ProviderCapabilities` instance whose `provider_id` is identical;
+- `can_handle(descriptor: dict[str, object]) -> bool`, a side-effect-free
+  recognizer; and
+- `ingest(descriptor_path: Path, *, policy: SourceAccessPolicy) ->
+  NormalizedInputBundle`.
+
+`can_handle` must not access resources, import parser stacks, or perform network
+I/O. `ingest` must resolve every declared resource through the supplied policy
+and return a valid normalized bundle. Providers must not infer VOI roles,
+strategies, outcomes, or decision semantics.
+
+## Capability and compatibility rules
+
+`ProviderCapabilities` is the provider's conservative support declaration:
+format versions, media types, transformations, projection, filtering,
+streaming, and random access. A provider must declare unsupported operations as
+false or empty. Adding an optional capability is compatible only when the
+existing profile remains unchanged; changing a declared capability, provider
+identifier, error category, or normalized manifest meaning requires a new SDK
+major version.
+
+Discovery is opt-in and allow-listed. Base imports and descriptor probing never
+load third-party entry points. A provider must be tested in a clean base install
+and with only its named optional extra installed.
+
+## Consumer contract
+
+`from_dataframe` is the supported generic DataFrame entry point. It accepts a
+producer that Arrow can convert through `__dataframe__`, preserves the resulting
+Arrow column schema, excludes producer-specific indexes, honours `allow_copy`,
+and returns the same `NormalizedInputBundle` preparation path as providers.
+Nullable values, categories, and timezone-aware values are supported when Arrow
+can materialize them. Nested values and conversions requiring a disallowed copy
+fail with a stable `ValueError`; no alternate calculation path is used.
+
+## Publication checklist
+
+1. Declare an entry point that returns an initialized provider instance.
+2. Add supported and rejected descriptor fixtures, source-policy tests, and
+   deterministic provenance/receipt assertions.
+3. Verify capability identity, import isolation, and explicit allow-listed
+   discovery.
+4. Document parser dependencies behind a named optional extra; never add them
+   to the base install.
+5. Publish the supported profile and unsupported boundaries before release.

--- a/tests/test_dataframe_interchange_sdk.py
+++ b/tests/test_dataframe_interchange_sdk.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 import pytest
 
 from voiage.contracts import VOIBinding, prepare_analysis_inputs
-from voiage.ingestion import from_dataframe
+from voiage.ingestion import INGESTION_PROVIDER_SDK_VERSION, from_dataframe
 
 
 class _RecordingFrame:
@@ -90,3 +90,25 @@ def test_dataframe_sdk_rejects_a_binding_outside_the_declared_table() -> None:
             dataset_id="business-scenarios",
             bindings=(invalid,),
         )
+
+
+def test_dataframe_sdk_v1_preserves_index_exclusion_and_category_values() -> None:
+    """The interchange contract retains columns, not producer-specific indexes."""
+    pandas = pytest.importorskip("pandas")
+    index = pandas.Index(["one", "two"], name="scenario")
+    frame = pandas.DataFrame(
+        {
+            "tier": pandas.Series(["standard", None], dtype="category", index=index),
+            "net_benefit": pandas.Series([10, None], dtype="Int64", index=index),
+        },
+        index=index,
+    )
+
+    bundle = from_dataframe(frame, dataset_id="consumer-v1")
+
+    assert INGESTION_PROVIDER_SDK_VERSION == "1"
+    assert bundle.table("data").column_names == ["tier", "net_benefit"]
+    assert bundle.table("data").to_pylist() == [
+        {"tier": "standard", "net_benefit": 10},
+        {"tier": None, "net_benefit": None},
+    ]

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -679,6 +679,29 @@ def test_public_provider_protocol_supports_consumer_runtime_validation() -> None
     assert not isinstance(object(), IngestionProvider)
 
 
+def test_registry_rejects_a_provider_with_mismatched_capability_identity() -> None:
+    """A published provider cannot claim a capability manifest for another ID."""
+
+    class MismatchedProvider:
+        provider_id = "consumer"
+        capabilities = ProviderCapabilities(
+            provider_id="different",
+            format_versions=("1",),
+            media_types=("application/json",),
+        )
+
+        def can_handle(self, descriptor: dict[str, object]) -> bool:
+            return bool(descriptor)
+
+        def ingest(
+            self, descriptor_path, *, policy: SourceAccessPolicy
+        ) -> NormalizedInputBundle:
+            raise AssertionError("not called")
+
+    with pytest.raises(IngestionError, match="provider contract"):
+        ProviderRegistry((MismatchedProvider(),))
+
+
 def test_base_import_does_not_load_builtin_provider_modules() -> None:
     script = "; ".join(
         (

--- a/voiage/ingestion/__init__.py
+++ b/voiage/ingestion/__init__.py
@@ -1,6 +1,7 @@
 """Optional source-format adapters for the normalized VOI input contract."""
 
 from .base import (
+    INGESTION_PROVIDER_SDK_VERSION,
     IngestionError,
     IngestionProvider,
     ProviderCapabilities,
@@ -12,6 +13,7 @@ from .frictionless import FrictionlessProvider
 from .registry import ProviderRegistry, default_registry, discover_entry_point_providers
 
 __all__ = [
+    "INGESTION_PROVIDER_SDK_VERSION",
     "CroissantProvider",
     "FrictionlessProvider",
     "IngestionError",

--- a/voiage/ingestion/base.py
+++ b/voiage/ingestion/base.py
@@ -17,6 +17,10 @@ class IngestionError(ValueError):
     """Stable, safe error raised when an external source cannot be ingested."""
 
 
+INGESTION_PROVIDER_SDK_VERSION = "1"
+"""Major version of the frozen public provider-SDK contract."""
+
+
 @dataclass(frozen=True)
 class ProviderCapabilities:
     """Conservative, source-neutral statement of a provider's support surface."""

--- a/voiage/ingestion/registry.py
+++ b/voiage/ingestion/registry.py
@@ -26,11 +26,13 @@ _ENTRY_POINT_GROUP = "voiage.ingestion.providers"
 
 def _validate_provider(provider: object) -> IngestionProvider:
     """Validate an explicitly loaded provider without importing its package."""
+    capabilities = getattr(provider, "capabilities", None)
     if not (
         isinstance(getattr(provider, "provider_id", None), str)
         and callable(getattr(provider, "can_handle", None))
         and callable(getattr(provider, "ingest", None))
-        and getattr(provider, "capabilities", None) is not None
+        and isinstance(capabilities, ProviderCapabilities)
+        and capabilities.provider_id == provider.provider_id
     ):
         raise IngestionError(
             "entry-point provider does not satisfy the provider contract"
@@ -74,7 +76,7 @@ class ProviderRegistry:
     """A deterministic registry populated only by the application caller."""
 
     def __init__(self, providers: tuple[IngestionProvider, ...] = ()) -> None:
-        self._providers = providers
+        self._providers = tuple(_validate_provider(provider) for provider in providers)
 
     def ingest(
         self, descriptor_path: Path, *, policy: SourceAccessPolicy | None = None


### PR DESCRIPTION
Reopens the provider-SDK change after #628 was automatically closed when its temporary base branch was deleted by the #627 merge. The branch is based on current main; focused provider tests passed locally. Full hosted checks are now required before merge.