### PR TITLE
ci: complete polyglot release assurance

### DIFF
--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -229,7 +229,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - uses: astral-sh/setup-uv@b75a909f75acd358c2191d546b4d3f95b5b76e30
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
       - name: Document retained runtime boundaries
         run: |
           printf '%s\n' \

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -1,6 +1,8 @@
 name: Retained Bindings CI
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     branches: [main]
     paths:
@@ -111,6 +113,8 @@ jobs:
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
         with:
           version: ${{ matrix.julia }}
+      - name: Record Julia package-quality contract
+        run: grep -F "Aqua.test_all" test/runtests.jl
       - name: Verify packaged EVPI fixture matches the canonical reference
         run: >-
           python -c
@@ -170,6 +174,8 @@ jobs:
       - uses: r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6
       - run: R CMD build .
       - run: Rscript tools/build-manual.R
+      - name: Run CRAN-style source-package checks
+        run: R CMD check --as-cran --no-manual voiageR_*.tar.gz
       - run: Rscript -e 'rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")'
         env:
           VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/rust/target/release/libvoiage_ffi.so
@@ -212,3 +218,32 @@ jobs:
           "library(voiageR);
           value <- evpi(matrix(c(0, 1, 2, 0), nrow = 2, byrow = TRUE));
           stopifnot(isTRUE(all.equal(value, 0.5, tolerance = 1e-12)))"
+
+  differential-conformance:
+    name: Cross-language differential conformance
+    needs: [rust, julia, r-native]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Document retained runtime boundaries
+        run: |
+          printf '%s\n' \
+            'Python public API' \
+            'Rust crate API' \
+            'C ABI' \
+            'R installed package' \
+            'Julia installed package'
+          test -f specs/numerical-reference/v1/evpi-cases.json
+      - name: Validate shared numerical reference corpus
+        run: >-
+          python -c
+          "import json, pathlib;
+          canonical=json.loads(pathlib.Path('specs/numerical-reference/v1/evpi-cases.json').read_text());
+          julia=json.loads(pathlib.Path('bindings/julia/test/fixtures/evpi-cases.json').read_text());
+          assert canonical == julia"
+      - name: Exercise Python reference corpus
+        run: python -m pytest tests/test_numerical_reference_cases.py --no-cov -q

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -166,6 +166,11 @@ jobs:
       - name: Build the Rust C ABI used by R
         working-directory: rust
         run: cargo build --release --locked --package voiage-ffi
+      - name: Set up Python for reticulate reference checks
+        id: r-python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.14"
       - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6
       - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6
         with:
@@ -176,9 +181,12 @@ jobs:
       - run: Rscript tools/build-manual.R
       - name: Run CRAN-style source-package checks
         run: R CMD check --as-cran --no-manual voiageR_*.tar.gz
+        env:
+          RETICULATE_PYTHON: ${{ steps.r-python.outputs.python-path }}
       - run: Rscript -e 'rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")'
         env:
           VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/rust/target/release/libvoiage_ffi.so
+          RETICULATE_PYTHON: ${{ steps.r-python.outputs.python-path }}
 
   r-native:
     name: R installed native smoke (${{ matrix.os }})

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -180,7 +180,14 @@ jobs:
       - run: R CMD build .
       - run: Rscript tools/build-manual.R
       - name: Run CRAN-style source-package checks
-        run: R CMD check --as-cran --no-manual voiageR_*.tar.gz
+        run: |
+          for attempt in 1 2 3; do
+            R CMD check --as-cran --no-manual voiageR_*.tar.gz && exit 0
+            if [ "${attempt}" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 15))
+          done
         env:
           RETICULATE_PYTHON: ${{ steps.r-python.outputs.python-path }}
       - run: Rscript -e 'rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")'

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -257,4 +257,4 @@ jobs:
           julia=json.loads(pathlib.Path('bindings/julia/test/fixtures/evpi-cases.json').read_text());
           assert canonical == julia"
       - name: Exercise Python reference corpus
-        run: uv run pytest tests/test_numerical_reference_cases.py --no-cov -q
+        run: uv run --extra ci pytest tests/test_numerical_reference_cases.py --no-cov -q

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -229,6 +229,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+      - uses: astral-sh/setup-uv@b75a909f75acd358c2191d546b4d3f95b5b76e30
       - name: Document retained runtime boundaries
         run: |
           printf '%s\n' \
@@ -246,4 +247,4 @@ jobs:
           julia=json.loads(pathlib.Path('bindings/julia/test/fixtures/evpi-cases.json').read_text());
           assert canonical == julia"
       - name: Exercise Python reference corpus
-        run: python -m pytest tests/test_numerical_reference_cases.py --no-cov -q
+        run: uv run pytest tests/test_numerical_reference_cases.py --no-cov -q

--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -10,8 +10,28 @@ on:
 permissions: {}
 
 jobs:
+  verify-base-release:
+    name: Verify shared immutable release manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download shared release identity
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#*-v}"
+          gh release download "v${version}" --repo "$GITHUB_REPOSITORY" \
+            --pattern release-manifest.json --pattern polyglot.sbom.cdx.json
+          jq -e --arg version "$version" \
+            '.schema_version == "1.0.0" and
+             any(.artifacts[]; .name | contains($version))' \
+            release-manifest.json
+
   julia:
     name: Release Julia package
+    needs: verify-base-release
     if: startsWith(github.ref_name, 'julia-v')
     runs-on: ubuntu-latest
     permissions:
@@ -37,6 +57,7 @@ jobs:
 
   r:
     name: Release R package
+    needs: verify-base-release
     if: startsWith(github.ref_name, 'r-v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Run profiling weekly on Monday
     - cron: '0 6 * * 1'
@@ -134,6 +136,11 @@ jobs:
 
     - name: Validate frontier contracts
       run: uv run python scripts/validate_frontier_contract.py
+
+    - name: Validate submission readiness contracts
+      run: |
+        uv run python scripts/validate_submission_readiness.py
+        uv run pytest tests/test_submission_readiness_contract.py --no-cov -q
 
     - name: Verify generated v2 contracts
       run: uv run python scripts/export_v2_contracts.py --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
         tested_head="$(git rev-parse HEAD)"
         echo "tested_head=${tested_head}"
         test "${tested_head}" = "${EXPECTED_SOURCE_HEAD}"
-        printf '### Exact source head\n\n`%s`\n' "${tested_head}" >> "${GITHUB_STEP_SUMMARY}"
+        printf '### Exact source head\n\n    %s\n' "${tested_head}" >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,8 @@ name: Dependency Review
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,10 @@ jobs:
       working-directory: docs/astro-site
       run: pnpm install --frozen-lockfile
 
+    - name: Type-check Astro and TypeScript
+      working-directory: docs/astro-site
+      run: pnpm run check
+
     - name: Validate repository-owned documentation links
       run: python scripts/validate_astro_docs.py .
 

--- a/.github/workflows/operational-assurance.yml
+++ b/.github/workflows/operational-assurance.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/polyglot-assurance.yml
+++ b/.github/workflows/polyglot-assurance.yml
@@ -1,0 +1,93 @@
+name: Polyglot Assurance Frontier
+
+on:
+  workflow_call:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 5 * * 2"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  arm64-observation:
+    name: ARM64 observation
+    runs-on: ubuntu-24.04-arm
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
+          enable-cache: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Install Rust MSRV
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: "1.85"
+      - name: Build and test native ARM64 wheel
+        run: |
+          uv sync --frozen --extra ci
+          uv run maturin build --locked --release --interpreter python3.12 --out dist
+          uv venv --python 3.12 .arm64-smoke
+          uv pip install --python .arm64-smoke dist/*.whl
+          uv run --python .arm64-smoke --no-project python -c \
+            "import platform, voiage; assert platform.machine() in {'aarch64', 'arm64'}"
+
+  dependency-submission:
+    name: Dependency submission
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
+          enable-cache: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.14"
+      - name: Generate resolved Python dependency inventory
+        run: |
+          uv export --frozen --no-dev --no-emit-project --format requirements-txt \
+            --output-file .polyglot-requirements.txt
+          uvx --from cyclonedx-bom==7.3.0 cyclonedx-py requirements \
+            .polyglot-requirements.txt --output-reproducible --of JSON \
+            -o python.sbom.cdx.json
+      - name: Compose mixed-language dependency inventory
+        run: >-
+          python scripts/compose_polyglot_sbom.py compose
+          --python-sbom python.sbom.cdx.json
+          --cargo-workspace rust
+          --r-description r-package/voiageR/DESCRIPTION
+          --julia-project bindings/julia/Project.toml
+          --source-version "0+${GITHUB_SHA::12}"
+          --source-commit "$GITHUB_SHA"
+          --source-tag ""
+          --output polyglot.sbom.cdx.json
+      - name: Submit resolved polyglot snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/github_dependency_snapshot.py \
+            polyglot.sbom.cdx.json dependency-snapshot.json
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/dependency-graph/snapshots" \
+            --input dependency-snapshot.json

--- a/.github/workflows/polyglot-assurance.yml
+++ b/.github/workflows/polyglot-assurance.yml
@@ -1,6 +1,15 @@
 name: Polyglot Assurance Frontier
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/polyglot-assurance.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/rust-crates-release.yml"
+      - "scripts/github_dependency_snapshot.py"
+      - "rust/**"
+      - "pyproject.toml"
+      - "uv.lock"
   workflow_call:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,25 @@
 name: Release
 
 on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing signed release tag to stage or publish"
+        required: true
+        type: string
+      publish:
+        description: "Publish the verified private draft"
+        required: false
+        type: boolean
+        default: false
+      expected_wheel_sha256:
+        description: "Reviewed comma-separated wheel SHA-256 values"
+        required: false
+        type: string
+      expected_sdist_sha256:
+        description: "Reviewed sdist SHA-256"
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -277,9 +296,59 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  polyglot-sbom:
+    name: Compose release-bound polyglot SBOM
+    needs: [resolve-tag, wheels, sdist]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check out immutable release commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag_sha }}
+          persist-credentials: false
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          version: "0.11.29"
+          enable-cache: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.14"
+      - name: Generate resolved Python inventory
+        run: |
+          uv export --frozen --no-dev --no-emit-project --format requirements-txt \
+            --output-file release-requirements.txt
+          uvx --from cyclonedx-bom==7.3.0 cyclonedx-py requirements \
+            release-requirements.txt --output-reproducible --of JSON \
+            -o python.sbom.cdx.json
+      - name: Compose mixed-language CycloneDX inventory
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+          TAG_SHA: ${{ needs.resolve-tag.outputs.tag_sha }}
+        run: >-
+          python scripts/compose_polyglot_sbom.py compose
+          --python-sbom python.sbom.cdx.json
+          --cargo-workspace rust
+          --r-description r-package/voiageR/DESCRIPTION
+          --julia-project bindings/julia/Project.toml
+          --source-version "${RELEASE_TAG#v}"
+          --source-commit "$TAG_SHA"
+          --source-tag "$RELEASE_TAG"
+          --output polyglot.sbom.cdx.json
+      - name: Upload release-bound SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voiage-polyglot-sbom
+          path: polyglot.sbom.cdx.json
+          if-no-files-found: error
+          retention-days: 7
+
   attest:
     name: Validate and attest release artifacts
-    needs: [resolve-tag, wheels, sdist]
+    needs: [resolve-tag, wheels, sdist, polyglot-sbom]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -328,6 +397,29 @@ jobs:
           test -s "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl"
         env:
           PROVENANCE_BUNDLE: ${{ steps.provenance.outputs.bundle-path }}
+      - name: Bind polyglot SBOM to release subjects
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
+          sbom-path: dist/polyglot.sbom.cdx.json
+      - name: Create digest-bound release manifest
+        shell: bash
+        run: |
+          cd dist
+          sha256sum -- *.whl *.tar.gz polyglot.sbom.cdx.json | LC_ALL=C sort > SHA256SUMS
+          python -c "import json, pathlib; rows=[line.split(maxsplit=1) for line in pathlib.Path('SHA256SUMS').read_text().splitlines()]; pathlib.Path('release-manifest.json').write_text(json.dumps({'schema_version':'1.0.0','source_commit':'${TAG_SHA}','artifacts':[{'sha256': digest, 'name': name.lstrip('*')} for digest, name in rows]}, sort_keys=True, indent=2)+'\n')"
+      - name: Verify build-provenance subjects
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          for artifact in dist/*.whl dist/*.tar.gz; do
+            gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
+            gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY" \
+              --predicate-type https://cyclonedx.org/bom
+          done
       - name: Upload attested release set
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -336,6 +428,9 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/*.intoto.jsonl
+            dist/polyglot.sbom.cdx.json
+            dist/release-manifest.json
+            dist/SHA256SUMS
           if-no-files-found: error
           retention-days: 7
 
@@ -478,12 +573,16 @@ jobs:
           verbose: true
           print-hash: true
           skip-existing: true
-          attestations: false
+          attestations: true
 
   test-pypi-smoke:
     name: Install and smoke TestPyPI release
     needs: [resolve-tag, test-pypi]
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.12", "3.13", "3.14"]
     timeout-minutes: 10
     permissions:
       contents: read
@@ -506,13 +605,48 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python }}
+      - name: Download reviewed release payload
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: reviewed-release-payload
+          path: reviewed-dist
+      - name: Compare TestPyPI bytes with reviewed payload
+        shell: bash
+        run: |
+          release_version="${RELEASE_TAG#v}"
+          mkdir testpypi-dist
+          python -m pip download --no-deps --only-binary=:all: \
+            --index-url https://test.pypi.org/simple/ \
+            --dest testpypi-dist "voiage==$release_version"
+          reviewed="$(find reviewed-dist -maxdepth 1 -name '*manylinux*x86_64.whl' -print -quit)"
+          downloaded="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$reviewed"
+          test -n "$downloaded"
+          test "$(sha256sum "$reviewed" | cut -d ' ' -f1)" = \
+            "$(sha256sum "$downloaded" | cut -d ' ' -f1)"
+      - name: Verify TestPyPI distribution attestations
+        shell: bash
+        run: |
+          distribution="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
+          release_version="${RELEASE_TAG#v}"
+          filename="$(basename "$distribution")"
+          distribution_url="$(
+            curl --fail --silent --show-error \
+              "https://test.pypi.org/pypi/voiage/${release_version}/json" |
+              jq --raw-output --arg filename "$filename" \
+                '.urls[] | select(.filename == $filename) | .url'
+          )"
+          test -n "$distribution_url"
+          uvx --from pypi-attestations pypi-attestations verify pypi --staging \
+            --repository "https://github.com/${GITHUB_REPOSITORY}" \
+            "$distribution_url"
       - name: Install TestPyPI artifact with bounded retry
         shell: bash
         run: |
           release_version="${RELEASE_TAG#v}"
           uv export --locked --extra ci --no-dev --no-emit-project --output-file locked-requirements.txt
-          uv venv --python 3.12 .testpypi-venv
+          uv venv --python "${{ matrix.python }}" .testpypi-venv
           uv pip install --python .testpypi-venv -r locked-requirements.txt
           for attempt in 1 2 3 4 5 6; do
             if uv pip install --python .testpypi-venv --no-deps --refresh-package voiage --index-url https://test.pypi.org/simple/ "voiage==$release_version"; then
@@ -569,7 +703,7 @@ jobs:
           packages-dir: dist/
           verbose: true
           print-hash: true
-          attestations: false
+          attestations: true
 
   github-release:
     name: Publish verified GitHub Release
@@ -600,6 +734,8 @@ jobs:
           name: voiage-attested-release
           path: dist
       - name: Publish verified GitHub Release
+        # The repository/organization should enable immutable releases so this
+        # draft-first publication locks its tag and final asset set.
         run: gh release edit "$RELEASE_TAG" --draft=false --latest
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/rust-crates-release.yml
+++ b/.github/workflows/rust-crates-release.yml
@@ -12,8 +12,10 @@ jobs:
   publish:
     name: Publish Rust core crates
     runs-on: ubuntu-latest
+    environment: crates-io
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -26,23 +28,26 @@ jobs:
       - name: Validate workspace packaging
         working-directory: rust
         run: cargo package --workspace --locked --allow-dirty --no-verify
+      - name: Obtain short-lived crates.io credential
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
       - name: Publish domain contracts
         working-directory: rust
         run: cargo publish --locked --package voiage-domain
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       - name: Publish diagnostics
         working-directory: rust
         run: cargo publish --locked --package voiage-diagnostics
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       - name: Publish numerical kernels
         working-directory: rust
         run: cargo publish --locked --package voiage-numerics
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       - name: Publish serialization
         working-directory: rust
         run: cargo publish --locked --package voiage-serialization
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -1,0 +1,7 @@
+# AI-assisted development
+
+AI-assisted development may be used for repository maintenance. Retained
+changes are reviewed by the maintainer, checked against the project
+requirements, and validated by the relevant automated tests and workflows.
+AI output is not treated as evidence of correctness or as a substitute for
+authorship, peer review, or maintainer accountability.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,9 @@ the required CI, security, coverage, documentation, and contract checks pass.
         ```bash
         tox -e frontier-contract
         ```
-    *   If you prefer the uv-backed runner, `nox` mirrors the same core sessions:
+    *   `tox is the required local CI authority`, together with the repository
+        harness. `nox is an optional developer interface` that mirrors
+        selected core sessions but is not a second required gate:
         ```bash
         uv run nox
         ```

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,10 @@
+# Governance
+
+`voiage` is maintained by its code owner. Pull requests and automated checks
+provide the auditable change boundary; the maintainer performs the final review
+and merge decision. Contributions, issue reports, and proposals are welcome
+through GitHub and are assessed against the project roadmap and documented
+quality and security requirements.
+
+External review, registry acceptance, and publication decisions remain with
+the relevant maintainers and editors.

--- a/conductor/github-cross-references.json
+++ b/conductor/github-cross-references.json
@@ -3136,7 +3136,12 @@
         "https://github.com/edithatogo/voiage/issues/298",
         "https://github.com/edithatogo/voiage/issues/299",
         "https://github.com/edithatogo/voiage/issues/312",
-        "https://github.com/edithatogo/voiage/issues/471"
+        "https://github.com/edithatogo/voiage/issues/471",
+        "https://github.com/edithatogo/voiage/issues/614",
+        "https://github.com/edithatogo/voiage/issues/615",
+        "https://github.com/edithatogo/voiage/issues/616",
+        "https://github.com/edithatogo/voiage/issues/617",
+        "https://github.com/edithatogo/voiage/issues/622"
       ],
       "pull_requests": [
         {

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -18,7 +18,8 @@
     "https://github.com/edithatogo/voiage/issues/614",
     "https://github.com/edithatogo/voiage/issues/615",
     "https://github.com/edithatogo/voiage/issues/616",
-    "https://github.com/edithatogo/voiage/issues/617"
+    "https://github.com/edithatogo/voiage/issues/617",
+    "https://github.com/edithatogo/voiage/issues/622"
   ],
   "external_evidence_required": true,
   "gates": [

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -14,7 +14,11 @@
     "https://github.com/edithatogo/voiage/issues/299",
     "https://github.com/edithatogo/voiage/issues/312",
     "https://github.com/edithatogo/voiage/issues/471",
-    "https://github.com/edithatogo/voiage/issues/555"
+    "https://github.com/edithatogo/voiage/issues/555",
+    "https://github.com/edithatogo/voiage/issues/614",
+    "https://github.com/edithatogo/voiage/issues/615",
+    "https://github.com/edithatogo/voiage/issues/616",
+    "https://github.com/edithatogo/voiage/issues/617"
   ],
   "external_evidence_required": true,
   "gates": [

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -84,6 +84,9 @@
   in Julia General with collision-free TagBot automation. BinaryBuilder,
   General registry bots, and registry maintainers remain external acceptance
   gates.
+- [~] Maintain the locally validated Spack/EasyBuild packaging handoff in
+  https://github.com/edithatogo/voiage/issues/622 before any HPC registry or
+  curation decision; registry acceptance remains external.
 
 ## Phase 2B: Independent simulated JOSS editorial review
 

--- a/conductor/tracks/research_software_registry_readiness_20260721/spec.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/spec.md
@@ -11,6 +11,13 @@ Make voiage's appropriate registry, archival, identifier, or research-software d
 - Record authoritative submission, acceptance, publication, archival, or identifier evidence when available.
 - Do not claim external completion from local preparation or a successful workflow alone.
 - Preserve existing repository contracts and rights constraints.
+- Maintain one machine-readable, fail-closed contract for every current and
+  potential submission destination. Each target must identify official
+  criteria, repository evidence, unresolved gates, action authority, and the
+  authoritative evidence required for acceptance.
+- Refresh external criteria before any action. A locally valid contract is
+  readiness evidence, not permission to inquire, upload, submit, register, or
+  apply.
 
 ## GitHub hierarchy
 
@@ -24,6 +31,16 @@ Parent: [#296](https://github.com/edithatogo/voiage/issues/296)
   - [#471](https://github.com/edithatogo/voiage/issues/471) — independent
     research-use, human community-engagement, or collaborative-input evidence
     before JOSS submission
+- [#614](https://github.com/edithatogo/voiage/issues/614) — cross-venue
+  submission-readiness contracts
+- [#615](https://github.com/edithatogo/voiage/issues/615) — possible rOpenSci
+  statistical-software review after R-package maturity gates
+- [#616](https://github.com/edithatogo/voiage/issues/616) — possible pyOpenSci
+  package review after the direct JOSS outcome
+- [#617](https://github.com/edithatogo/voiage/issues/617) — distinct post-JOSS
+  journal, sustainability, archival, and discoverability routes
+- [#622](https://github.com/edithatogo/voiage/issues/622) — locally validated
+  Spack/EasyBuild packaging before any HPC registry or curation decision
 
 ## Acceptance
 
@@ -38,3 +55,11 @@ pre-review signal rather than a hard pre-review gate. It does not count
 automated accounts or same-author repositories as human engagement. Individual
 registry deliverables close only with authoritative evidence or a documented
 ineligibility decision.
+
+The cross-venue contract covers existing releases and registrations as well as
+future considerations. It must reject missing evidence paths, unresolved
+requirements represented as ready, duplicate target identifiers, and any
+contract that grants repository automation authority over external acceptance.
+It must also map every required target to one or more GitHub-backed execution
+lanes so repository-controlled work is recoverable without treating human or
+external gates as implementation tasks.

--- a/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
@@ -64,6 +64,9 @@ immutable releases. Those deliberate exceptions should not be bypassed with
 bot approvals, alternate accounts, synthetic contributors, or placeholder
 releases.
 
+GitHub immutable releases should be enabled in hosted repository settings so
+published release assets and their tag cannot be modified.
+
 ## Owner and organization gates
 
 Some controls cannot be configured from this repository alone:

--- a/docs/release/pyopensci-readiness.md
+++ b/docs/release/pyopensci-readiness.md
@@ -1,0 +1,23 @@
+# pyOpenSci repository-readiness matrix
+
+This matrix records the repository-owned baseline for a possible future
+pyOpenSci review. It is not an inquiry, submission, or acceptance claim.
+
+The machine-readable matrix is
+`specs/submission-readiness/pyopensci-evidence.json`. The submission-readiness
+validator requires every repository-controlled criterion to have existing local
+evidence and requires the two non-repository gates to remain explicit:
+
+- the submitting maintainer's commitment to maintain the package; and
+- an author decision to open a pre-submission inquiry or review issue.
+
+The official criteria are refreshed on 2026-07-27. The current package provides
+published installation instructions, an importable wheel test, online quick
+starts and API reference, contribution and conduct documents, issue templates,
+CI-backed tests, release evidence, support and governance documentation, and an
+AI-use disclosure. Scope, overlap, and method provenance are documented in the
+README, methods documentation, and paper.
+
+Refresh the official guide and the evidence matrix immediately before any
+author-led inquiry. Do not treat this document as the maintainer commitment or
+as permission to contact pyOpenSci.

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
+    ":dependencyDashboard",
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":automergeMinor",
@@ -20,6 +21,9 @@
     "pip_setup"
   ],
   "schedule": ["every weekend"],
+  "minimumReleaseAge": "14 days",
+  "osvVulnerabilityAlerts": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "unresolved",
   "packageRules": [
     {
       "matchManagers": ["pep621", "pip_requirements", "pip_setup"],

--- a/roadmap.md
+++ b/roadmap.md
@@ -38,6 +38,19 @@ Research-software registry readiness follows that release in
 local preparation into external archival, identifier, submission, review, or
 acceptance evidence.
 
+The same track now owns a versioned cross-venue submission contract covering
+all retained package registries and archives plus potential pyOpenSci,
+rOpenSci, R Journal, Journal of Statistical Software, NumFOCUS, HPSF, and
+related routes. Issues #614--#617 own the contract and future decision lanes.
+The repository validates evidence paths, unresolved gates, and authority
+boundaries in tox and hosted CI. Passing that gate means the repository is
+prepared to evaluate a route; it does not authorize an inquiry or submission.
+The next execution sequence is issue-backed: #614 maintains all contract
+evidence; #616 closes Python community-review evidence; #615 closes the R
+installation/API/statistical-standards evidence; #622 prepares portable HPC
+recipes; and #617 makes explicit non-duplication decisions for distinct future
+routes. Author and external decisions remain outside these repository tasks.
+
 Conductor-to-GitHub traceability is being reconciled in
 `conductor-github-cross-reference-reconciliation_20260724`. Every completed
 track now has an individual issue, native parent, Project 28 item, and
@@ -270,6 +283,9 @@ evidence and is not reopened by this queue.
 2.  **Dependency Management:**
     *   **Status: `✅ Done`**
     *   uv for package management, Renovate for automated updates.
+    *   Renovate is the sole update-PR producer across supported managers;
+        GitHub vulnerability alerts remain an input and Dependabot update PRs
+        are not part of the automation architecture.
 3.  **Security & Quality:**
     *   **Status: `✅ Done / hosted controls applied`**
     *   CodeQL security scanning, Ruff linting/security rules, ty type checking,
@@ -282,6 +298,14 @@ evidence and is not reopened by this queue.
         now carry patched Python and Starlight documentation dependencies for
         the current advisory set; future update follow-up remains Renovate-owned
         follow-up work.
+    *   Polyglot CI modernization adds merge-queue event compatibility,
+        PEP 740 PyPI/TestPyPI attestations, exact-byte TestPyPI promotion,
+        release-bound CycloneDX attestations, a digest-bearing release
+        manifest, mixed-language dependency submission, shared numerical
+        corpus validation across Python/Rust/C/R/Julia, Astro type checking,
+        and a non-required Linux ARM64 observation lane. Hosted merge-queue,
+        immutable-release, environment, registry, and Trusted Publisher
+        settings remain external gates.
 4.  **Community Engagement:**
     *   **Status: `✅ Done`**
     *   Repository structured for contributions, Conductor workflow for AI-assisted development, and repository-level support, security, and community-health documents now provide a clear help path for users and contributors.

--- a/scripts/github_dependency_snapshot.py
+++ b/scripts/github_dependency_snapshot.py
@@ -1,0 +1,95 @@
+"""Convert the retained CycloneDX inventory to a GitHub dependency snapshot."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+def snapshot(document: dict[str, Any], *, sha: str, ref: str) -> dict[str, Any]:
+    """Build one GitHub dependency-submission payload."""
+    ref_to_purl = {
+        component.get("bom-ref"): component.get("purl")
+        for component in document.get("components", [])
+        if isinstance(component, dict)
+        and isinstance(component.get("bom-ref"), str)
+        and isinstance(component.get("purl"), str)
+    }
+    dependency_refs = {
+        dependency_ref
+        for relationship in document.get("dependencies", [])
+        if isinstance(relationship, dict)
+        for dependency_ref in relationship.get("dependsOn", [])
+        if isinstance(dependency_ref, str)
+    }
+    dependency_edges = {
+        relationship.get("ref"): [
+            ref_to_purl[dependency_ref]
+            for dependency_ref in relationship.get("dependsOn", [])
+            if dependency_ref in ref_to_purl
+        ]
+        for relationship in document.get("dependencies", [])
+        if isinstance(relationship, dict)
+        and isinstance(relationship.get("ref"), str)
+    }
+    resolved: dict[str, dict[str, Any]] = {}
+    for component in document.get("components", []):
+        if not isinstance(component, dict):
+            continue
+        purl = component.get("purl")
+        if not isinstance(purl, str) or not purl:
+            continue
+        resolved[purl] = {
+            "package_url": purl,
+            "relationship": (
+                "indirect" if component.get("bom-ref") in dependency_refs else "direct"
+            ),
+            "scope": "runtime",
+            "dependencies": dependency_edges.get(component.get("bom-ref"), []),
+        }
+    return {
+        "version": 0,
+        "sha": sha,
+        "ref": ref,
+        "job": {
+            "correlator": "polyglot-assurance_dependency-submission",
+            "id": os.environ.get("GITHUB_RUN_ID", "local"),
+        },
+        "detector": {
+            "name": "voiage-polyglot-cyclonedx",
+            "version": "1.0.0",
+            "url": "https://github.com/edithatogo/voiage",
+        },
+        "scanned": os.environ.get("GITHUB_RUN_STARTED_AT", "1970-01-01T00:00:00Z"),
+        "manifests": {
+            "polyglot.sbom.cdx.json": {
+                "name": "voiage mixed-language resolved dependencies",
+                "file": {"source_location": "polyglot.sbom.cdx.json"},
+                "resolved": resolved,
+            }
+        },
+    }
+
+
+def main() -> int:
+    """Write the dependency snapshot named by the command line."""
+    if len(sys.argv) != 3:
+        print("usage: github_dependency_snapshot.py SBOM OUTPUT", file=sys.stderr)
+        return 2
+    document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    payload = snapshot(
+        document,
+        sha=os.environ.get("GITHUB_SHA", "0" * 40),
+        ref=os.environ.get("GITHUB_REF", "refs/heads/local"),
+    )
+    Path(sys.argv[2]).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_submission_readiness.py
+++ b/scripts/validate_submission_readiness.py
@@ -18,6 +18,7 @@ TARGET_KINDS = {
     "sustainability",
 }
 PYOPENSCI_STATUSES = {"satisfied", "human_deferred"}
+ROPENSCI_STATUSES = {"satisfied", "repository_blocked", "human_deferred"}
 
 
 def _non_empty(value: Any, label: str) -> str:
@@ -213,6 +214,40 @@ def validate_pyopensci_evidence(path: Path, root: Path) -> dict[str, Any]:
     return {"criterion_count": len(criteria), "deferred": sorted(human_deferred)}
 
 
+def validate_ropensci_evidence(path: Path, root: Path) -> dict[str, Any]:
+    """Validate that rOpenSci readiness evidence preserves unmet gates."""
+    payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema_version") != "1.0":
+        raise ValueError("rOpenSci evidence must use schema_version 1.0")
+    criteria = payload.get("criteria")
+    if not isinstance(criteria, list) or not criteria:
+        raise ValueError("rOpenSci evidence criteria must be a non-empty array")
+    statuses: dict[str, str] = {}
+    for criterion in criteria:
+        identifier = _non_empty(criterion.get("id"), "rOpenSci criterion id")
+        if identifier in statuses:
+            raise ValueError(f"duplicate rOpenSci criterion: {identifier}")
+        status = criterion.get("status")
+        if status not in ROPENSCI_STATUSES:
+            raise ValueError(f"{identifier} has invalid rOpenSci status: {status}")
+        statuses[identifier] = status
+        evidence = criterion.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            raise ValueError(f"{identifier} evidence must be a non-empty array")
+        for relative in evidence:
+            relative_path = Path(_non_empty(relative, "rOpenSci evidence path"))
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise ValueError(f"unsafe rOpenSci evidence path: {relative}")
+            if not (root / relative_path).exists():
+                raise ValueError(f"rOpenSci evidence path does not exist: {relative}")
+    if {key for key, value in statuses.items() if value == "repository_blocked"} != {
+        "pkgcheck",
+        "self-contained-installation",
+    }:
+        raise ValueError("rOpenSci repository blockers must remain explicit")
+    return {"criterion_count": len(criteria), "statuses": statuses}
+
+
 def main() -> int:
     """Run validation from the command line."""
     parser = argparse.ArgumentParser()
@@ -229,10 +264,13 @@ def main() -> int:
     pyopensci = validate_pyopensci_evidence(
         root / "specs/submission-readiness/pyopensci-evidence.json", root
     )
+    ropensci = validate_ropensci_evidence(
+        root / "specs/submission-readiness/ropensci-evidence.json", root
+    )
     print(
         "Submission readiness contract: PASS "
         f"({summary['target_count']} targets; {pyopensci['criterion_count']} "
-        "pyOpenSci criteria)"
+        f"pyOpenSci criteria; {ropensci['criterion_count']} rOpenSci criteria)"
     )
     return 0
 

--- a/scripts/validate_submission_readiness.py
+++ b/scripts/validate_submission_readiness.py
@@ -17,6 +17,7 @@ TARGET_KINDS = {
     "package_registry",
     "sustainability",
 }
+PYOPENSCI_STATUSES = {"satisfied", "human_deferred"}
 
 
 def _non_empty(value: Any, label: str) -> str:
@@ -155,6 +156,63 @@ def validate_contract(path: Path, root: Path) -> dict[str, Any]:
     return {"target_count": len(targets), "targets": sorted(identifiers)}
 
 
+def validate_pyopensci_evidence(path: Path, root: Path) -> dict[str, Any]:
+    """Validate the repository-controlled pyOpenSci evidence matrix."""
+    payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema_version") != "1.0":
+        raise ValueError("pyOpenSci evidence must use schema_version 1.0")
+    _non_empty(payload.get("criteria_url"), "pyOpenSci criteria_url")
+    _non_empty(payload.get("reviewed_at"), "pyOpenSci reviewed_at")
+    criteria = payload.get("criteria")
+    if not isinstance(criteria, list) or not criteria:
+        raise ValueError("pyOpenSci evidence criteria must be a non-empty array")
+    criterion_ids: set[str] = set()
+    human_deferred: set[str] = set()
+    for criterion in criteria:
+        if not isinstance(criterion, dict):
+            raise TypeError("pyOpenSci criteria must be objects")
+        identifier = _non_empty(criterion.get("id"), "pyOpenSci criterion id")
+        if identifier in criterion_ids:
+            raise ValueError(f"duplicate pyOpenSci criterion: {identifier}")
+        criterion_ids.add(identifier)
+        status = criterion.get("status")
+        if status not in PYOPENSCI_STATUSES:
+            raise ValueError(f"{identifier} has invalid pyOpenSci status: {status}")
+        evidence = criterion.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            raise ValueError(f"{identifier} evidence must be a non-empty array")
+        for relative in evidence:
+            relative_path = Path(_non_empty(relative, "pyOpenSci evidence path"))
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise ValueError(f"unsafe pyOpenSci evidence path: {relative}")
+            if not (root / relative_path).exists():
+                raise ValueError(f"pyOpenSci evidence path does not exist: {relative}")
+        if status == "human_deferred":
+            human_deferred.add(identifier)
+    required = payload.get("repository_controlled_criteria")
+    if not isinstance(required, list) or not required:
+        raise ValueError("repository_controlled_criteria must be a non-empty array")
+    if any(
+        not isinstance(identifier, str) or not identifier for identifier in required
+    ):
+        raise ValueError("repository_controlled_criteria must contain non-empty ids")
+    if len(required) != len(set(required)) or not set(required) <= criterion_ids:
+        raise ValueError("repository_controlled_criteria must resolve to criteria")
+    unresolved_repository = {
+        criterion["id"]
+        for criterion in criteria
+        if criterion["id"] in required and criterion["status"] != "satisfied"
+    }
+    if unresolved_repository:
+        raise ValueError(
+            "repository-controlled pyOpenSci criteria remain unresolved: "
+            + ", ".join(sorted(unresolved_repository))
+        )
+    if human_deferred != {"maintainer-commitment", "external-inquiry"}:
+        raise ValueError("pyOpenSci human gates must remain explicit and bounded")
+    return {"criterion_count": len(criteria), "deferred": sorted(human_deferred)}
+
+
 def main() -> int:
     """Run validation from the command line."""
     parser = argparse.ArgumentParser()
@@ -166,8 +224,16 @@ def main() -> int:
     )
     parser.add_argument("--root", type=Path, default=Path.cwd())
     arguments = parser.parse_args()
-    summary = validate_contract(arguments.contract, arguments.root.resolve())
-    print(f"Submission readiness contract: PASS ({summary['target_count']} targets)")
+    root = arguments.root.resolve()
+    summary = validate_contract(arguments.contract, root)
+    pyopensci = validate_pyopensci_evidence(
+        root / "specs/submission-readiness/pyopensci-evidence.json", root
+    )
+    print(
+        "Submission readiness contract: PASS "
+        f"({summary['target_count']} targets; {pyopensci['criterion_count']} "
+        "pyOpenSci criteria)"
+    )
     return 0
 
 

--- a/scripts/validate_submission_readiness.py
+++ b/scripts/validate_submission_readiness.py
@@ -1,0 +1,175 @@
+"""Validate the repository-wide submission-readiness contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+READINESS = {"published", "ready", "conditional", "blocked", "consideration", "retired"}
+REQUIREMENT_STATUS = {"satisfied", "pending", "external", "not_applicable"}
+TARGET_KINDS = {
+    "archive",
+    "community_review",
+    "identifier",
+    "journal",
+    "package_registry",
+    "sustainability",
+}
+
+
+def _non_empty(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def validate_contract(path: Path, root: Path) -> dict[str, Any]:
+    """Validate target coverage, evidence paths, and authority boundaries."""
+    payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema_version") != "1.0":
+        raise ValueError("submission contract must use schema_version 1.0")
+    targets = payload.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise ValueError("submission contract targets must be a non-empty array")
+
+    identifiers: set[str] = set()
+    for target in targets:
+        if not isinstance(target, dict):
+            raise TypeError("submission target entries must be objects")
+        identifier = _non_empty(target.get("id"), "target id")
+        if identifier in identifiers:
+            raise ValueError(f"duplicate submission target: {identifier}")
+        identifiers.add(identifier)
+
+        kind = target.get("kind")
+        if kind not in TARGET_KINDS:
+            raise ValueError(f"{identifier} has invalid kind: {kind}")
+        readiness = target.get("readiness")
+        if readiness not in READINESS:
+            raise ValueError(f"{identifier} has invalid readiness: {readiness}")
+        _non_empty(target.get("criteria_url"), f"{identifier} criteria_url")
+        _non_empty(target.get("scope"), f"{identifier} scope")
+        _non_empty(target.get("next_decision"), f"{identifier} next_decision")
+
+        authority = target.get("authority")
+        if not isinstance(authority, dict):
+            raise TypeError(f"{identifier} authority must be an object")
+        if authority.get("prepare") != "repository":
+            raise ValueError(f"{identifier} preparation authority must be repository")
+        if authority.get("submit") not in {"human", "external-system"}:
+            raise ValueError(f"{identifier} submission authority must remain external")
+        if authority.get("accept") != "external":
+            raise ValueError(f"{identifier} acceptance authority must be external")
+
+        acceptance_evidence = target.get("acceptance_evidence")
+        if not isinstance(acceptance_evidence, list) or not acceptance_evidence:
+            raise ValueError(f"{identifier} acceptance_evidence must be non-empty")
+        for item in acceptance_evidence:
+            _non_empty(item, f"{identifier} acceptance evidence")
+
+        requirements = target.get("requirements")
+        if not isinstance(requirements, list) or not requirements:
+            raise ValueError(f"{identifier} requirements must be a non-empty array")
+        requirement_ids: set[str] = set()
+        unresolved = False
+        for requirement in requirements:
+            if not isinstance(requirement, dict):
+                raise TypeError(f"{identifier} requirement must be an object")
+            requirement_id = _non_empty(
+                requirement.get("id"), f"{identifier} requirement id"
+            )
+            if requirement_id in requirement_ids:
+                raise ValueError(
+                    f"{identifier} has duplicate requirement: {requirement_id}"
+                )
+            requirement_ids.add(requirement_id)
+            status = requirement.get("status")
+            if status not in REQUIREMENT_STATUS:
+                raise ValueError(
+                    f"{identifier}/{requirement_id} has invalid status: {status}"
+                )
+            unresolved |= status in {"pending", "external"}
+            evidence = requirement.get("evidence")
+            if not isinstance(evidence, list):
+                raise TypeError(
+                    f"{identifier}/{requirement_id} evidence must be an array"
+                )
+            for relative in evidence:
+                relative_path = Path(_non_empty(relative, "evidence path"))
+                if relative_path.is_absolute() or ".." in relative_path.parts:
+                    raise ValueError(f"unsafe evidence path: {relative}")
+                if not (root / relative_path).exists():
+                    raise ValueError(f"evidence path does not exist: {relative}")
+
+        if readiness in {"ready", "published"} and unresolved:
+            raise ValueError(f"{identifier} cannot be ready with an unmet gate")
+
+    required = payload.get("required_target_ids")
+    if not isinstance(required, list) or not set(required) <= identifiers:
+        raise ValueError("required_target_ids must resolve to declared targets")
+
+    criteria_refresh = payload.get("criteria_refresh")
+    if not isinstance(criteria_refresh, dict):
+        raise TypeError("criteria_refresh must be an object")
+    _non_empty(criteria_refresh.get("reviewed_at"), "criteria_refresh reviewed_at")
+    refresh_evidence = Path(
+        _non_empty(criteria_refresh.get("evidence"), "criteria_refresh evidence")
+    )
+    if refresh_evidence.is_absolute() or ".." in refresh_evidence.parts:
+        raise ValueError("criteria_refresh evidence path is unsafe")
+    if not (root / refresh_evidence).exists():
+        raise ValueError("criteria_refresh evidence path does not exist")
+    refreshed_targets = criteria_refresh.get("target_ids")
+    if not isinstance(refreshed_targets, list) or not set(required) <= set(
+        refreshed_targets
+    ):
+        raise ValueError("criteria_refresh must cover every required target")
+
+    lanes = payload.get("execution_lanes")
+    if not isinstance(lanes, list) or not lanes:
+        raise ValueError("execution_lanes must be a non-empty array")
+    lane_ids: set[str] = set()
+    planned_targets: set[str] = set()
+    for lane in lanes:
+        if not isinstance(lane, dict):
+            raise TypeError("submission execution lanes must be objects")
+        lane_id = _non_empty(lane.get("id"), "execution lane id")
+        if lane_id in lane_ids:
+            raise ValueError(f"duplicate execution lane: {lane_id}")
+        lane_ids.add(lane_id)
+        issue_url = _non_empty(lane.get("issue_url"), f"{lane_id} issue_url")
+        if not issue_url.startswith("https://github.com/edithatogo/voiage/issues/"):
+            raise ValueError(f"{lane_id} issue_url must be a voiage GitHub issue")
+        _non_empty(lane.get("repository_outcome"), f"{lane_id} repository_outcome")
+        lane_targets = lane.get("targets")
+        if not isinstance(lane_targets, list) or not lane_targets:
+            raise ValueError(f"{lane_id} targets must be a non-empty array")
+        unknown_targets = set(lane_targets) - identifiers
+        if unknown_targets:
+            raise ValueError(f"{lane_id} references unknown targets: {unknown_targets}")
+        planned_targets.update(lane_targets)
+    if not set(required) <= planned_targets:
+        raise ValueError("every required target must belong to an execution lane")
+    return {"target_count": len(targets), "targets": sorted(identifiers)}
+
+
+def main() -> int:
+    """Run validation from the command line."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "contract",
+        nargs="?",
+        type=Path,
+        default=Path("specs/submission-readiness/targets.json"),
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    arguments = parser.parse_args()
+    summary = validate_contract(arguments.contract, arguments.root.resolve())
+    print(f"Submission readiness contract: PASS ({summary['target_count']} targets)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/submission-readiness/README.md
+++ b/specs/submission-readiness/README.md
@@ -1,0 +1,47 @@
+# Submission readiness contracts
+
+`targets.json` is the authoritative cross-venue inventory for package
+registries, archives, identifiers, journals, community software review, and
+sustainability affiliations.
+
+The contract records repository evidence and outstanding gates without
+authorizing external action. Preparation, submission, review, acceptance,
+publication, and indexing are distinct states. Criteria URLs must be refreshed
+before an author decides to submit because external policies can change.
+
+## Execution plan
+
+Every retained target belongs to at least one repository-controlled execution
+lane in `targets.json`. The validator rejects a required target that has no
+lane or a lane without a `voiage` GitHub issue. The lanes deliberately close
+only repository work:
+
+- #614 maintains criteria, evidence, authority, and status boundaries for all
+  destinations;
+- #299 maintains the preprint/JOSS/RRID package while preserving author and
+  editorial decisions as external;
+- #616 prepares the Python package for a possible pyOpenSci decision;
+- #615 matures the R package for possible rOpenSci and R Journal routes;
+- #617 records whether a distinct JSS, NumFOCUS, or Zenodo outcome is justified;
+- #622 prepares portable Spack/EasyBuild recipes before any HPC upstream or
+  curation decision.
+
+No lane authorizes an inquiry, upload, submission, application, review, or
+acceptance claim. Those actions remain human or external even after all
+repository-controlled tasks are complete.
+
+Validate the inventory from the repository root:
+
+```sh
+uv run python scripts/validate_submission_readiness.py
+uv run pytest tests/test_submission_readiness_contract.py --no-cov
+```
+
+Specialised contracts remain authoritative within their domain:
+
+- JOSS: `paper/joss-readiness-manifest.json` and `scripts/validate_joss.py`;
+- language registries: `docs/release/binding-submission-checklist.md` and the
+  registry audit snapshot;
+- arXiv: `paper/readiness-manifest.json` and the non-submitting manuscript
+  assurance workflow;
+- Conductor: `research_software_registry_readiness_20260721`.

--- a/specs/submission-readiness/criteria-refresh-2026-07-27.md
+++ b/specs/submission-readiness/criteria-refresh-2026-07-27.md
@@ -1,0 +1,32 @@
+# Cross-venue criteria refresh — 2026-07-27
+
+This is repository-owned evidence that official eligibility, author, and
+packaging guidance was refreshed before any future action. It does not attest
+to a human commitment, a completed upload, an external review, or acceptance.
+The authoritative URLs remain in `targets.json` and must be refreshed again
+immediately before an inquiry, upload, submission, application, or release.
+
+| Target | Refresh outcome | Repository action |
+| --- | --- | --- |
+| arXiv | Author-selected category, licence, and upload remain required. | Keep the canonical source package auditable; defer author action. |
+| JOSS | Repository paper checks are distinct from author and editorial gates. | Keep local paper/metadata validation current. |
+| pyOpenSci | Maintainer commitment, packaging baseline, documentation, CI, fit/overlap, and AI disclosure remain relevant. | Build the evidence matrix in issue #616; defer commitment and inquiry. |
+| rOpenSci | Scope, lifecycle, documentation, stable tested API, and no concurrent review remain relevant. | Build R installation and standards evidence in issue #615. |
+| R Journal | Requires an appropriately distinct R-centred article. | Record a non-duplication decision before drafting. |
+| Journal of Statistical Software | Requires a substantial non-duplicative software/methodology article. | Record a non-duplication decision before drafting. |
+| NumFOCUS | Affiliation requires community and sustainability evidence. | Retain governance/adoption evidence; defer application. |
+| PyPI | Packaging/release evidence remains release-bound. | Maintain trusted release workflow and provenance. |
+| TestPyPI | Index upload and installation evidence remain promotion-bound. | Maintain release-candidate smoke evidence. |
+| conda-forge | Feedstock review and merge remain external. | Preserve recipe and build evidence only. |
+| CRAN | Upload, confirmation, and review remain author/external actions. | Preserve strict source-check evidence only. |
+| r-universe | Hosted build and package metadata remain the local evidence. | Maintain hosted-build evidence. |
+| crates.io | Registry publication remains release-bound. | Maintain synchronized package and release evidence. |
+| Julia General | Registrator and General review depend on the JLL. | Preserve Julia package contract; defer external dependency. |
+| Yggdrasil | BinaryBuilder acceptance remains external. | Preserve submitted-recipe evidence; respond only with maintainer authority. |
+| Software Heritage | Snapshot and citation are archival evidence. | Refresh for future release-bound archival needs. |
+| Zenodo | Deposition is optional unless a selected venue requires it. | Defer until a distinct DOI-bearing archive is needed. |
+| SciCrunch/RRID | Curation and RRID assignment remain external. | Maintain registration metadata. |
+| Spack | A tested package recipe is the repository-controlled prerequisite. | Implement through issue #622. |
+| EasyBuild | A tested easyconfig is the repository-controlled prerequisite. | Implement only if it is a distinct supported path (#622). |
+| HPSF | Adoption and governance precede any curation decision. | Retain evidence; defer application. |
+| E4S | Upstream HPC packaging and curation remain prerequisites. | Implement the upstream recipe path first (#622). |

--- a/specs/submission-readiness/pyopensci-evidence.json
+++ b/specs/submission-readiness/pyopensci-evidence.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "1.0",
+  "criteria_url": "https://www.pyopensci.org/software-peer-review/how-to/author-guide.html",
+  "reviewed_at": "2026-07-27",
+  "repository_controlled_criteria": [
+    "install-and-import",
+    "scope-and-overlap",
+    "online-documentation",
+    "required-community-files",
+    "issue-template-metadata",
+    "automated-tests-and-ci",
+    "stable-api-and-release-evidence",
+    "support-governance-and-ai-disclosure"
+  ],
+  "criteria": [
+    {
+      "id": "install-and-import",
+      "status": "satisfied",
+      "evidence": ["docs/astro-site/src/content/docs/getting-started/installation.mdx", "docs/release/joss-submission-readiness.md", "tests/packaging/test_wheel_black_box.py"]
+    },
+    {
+      "id": "scope-and-overlap",
+      "status": "satisfied",
+      "evidence": ["README.md", "paper.md", "docs/astro-site/src/content/docs/methods/index.mdx"]
+    },
+    {
+      "id": "online-documentation",
+      "status": "satisfied",
+      "evidence": ["docs/astro-site/src/content/docs/getting-started.mdx", "docs/astro-site/src/content/docs/api-reference/index.mdx", "docs/astro-site/src/content/docs/getting-started/installation.mdx"]
+    },
+    {
+      "id": "required-community-files",
+      "status": "satisfied",
+      "evidence": ["README.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE"]
+    },
+    {
+      "id": "issue-template-metadata",
+      "status": "satisfied",
+      "evidence": [".github/ISSUE_TEMPLATE/bug_report.md", ".github/ISSUE_TEMPLATE/feature_request.md", ".github/ISSUE_TEMPLATE/question.md"]
+    },
+    {
+      "id": "automated-tests-and-ci",
+      "status": "satisfied",
+      "evidence": [".github/workflows/ci.yml", "tox.ini", "tests/test_package_exports.py"]
+    },
+    {
+      "id": "stable-api-and-release-evidence",
+      "status": "satisfied",
+      "evidence": ["docs/astro-site/src/content/docs/user-guide/v1-release-readiness.mdx", "docs/release/release-evidence.md", "tests/test_v1_stable_api_contract.py"]
+    },
+    {
+      "id": "support-governance-and-ai-disclosure",
+      "status": "satisfied",
+      "evidence": ["SUPPORT.md", "GOVERNANCE.md", "AI_USAGE.md"]
+    },
+    {
+      "id": "maintainer-commitment",
+      "status": "human_deferred",
+      "evidence": ["GOVERNANCE.md", "SUPPORT.md"]
+    },
+    {
+      "id": "external-inquiry",
+      "status": "human_deferred",
+      "evidence": ["specs/submission-readiness/targets.json", "conductor/tracks/research_software_registry_readiness_20260721/plan.md"]
+    }
+  ]
+}

--- a/specs/submission-readiness/ropensci-evidence.json
+++ b/specs/submission-readiness/ropensci-evidence.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0",
+  "criteria_url": "https://devguide.ropensci.org/softwarereview_author.html",
+  "reviewed_at": "2026-07-27",
+  "criteria": [
+    {"id": "package-metadata", "status": "satisfied", "evidence": ["r-package/voiageR/DESCRIPTION", "r-package/voiageR/NAMESPACE"]},
+    {"id": "documented-bounded-api", "status": "satisfied", "evidence": ["r-package/voiageR/README.md", "r-package/voiageR/vignettes/voiageR-getting-started.Rmd", "r-package/voiageR/tests/testthat/test-voiageR.R"]},
+    {"id": "prior-art-and-overlap", "status": "satisfied", "evidence": ["r-package/voiageR/README.md", "paper.md"]},
+    {"id": "tests-and-ci", "status": "satisfied", "evidence": ["r-package/voiageR/tests/testthat/test-voiageR.R", ".github/workflows/bindings-ci.yml"]},
+    {"id": "reference-comparisons", "status": "satisfied", "evidence": ["r-package/voiageR/tests/testthat/test-zz-numerical-reference.R", "specs/numerical-reference/v1/evpi-cases.json"]},
+    {"id": "input-error-and-seed-contract", "status": "satisfied", "evidence": ["r-package/voiageR/R/voiageR.R", "r-package/voiageR/tests/testthat/test-voiageR.R"]},
+    {"id": "self-contained-installation", "status": "repository_blocked", "evidence": ["r-package/voiageR/DESCRIPTION", "r-package/voiageR/README.md"]},
+    {"id": "pkgcheck", "status": "repository_blocked", "evidence": ["docs/release/binding-submission-checklist.md"]},
+    {"id": "maintainer-lifecycle-and-scope", "status": "human_deferred", "evidence": ["r-package/voiageR/README.md", "conductor/tracks/research_software_registry_readiness_20260721/plan.md"]},
+    {"id": "concurrent-review-and-inquiry", "status": "human_deferred", "evidence": ["specs/submission-readiness/targets.json", "conductor/tracks/research_software_registry_readiness_20260721/plan.md"]}
+  ]
+}

--- a/specs/submission-readiness/targets.json
+++ b/specs/submission-readiness/targets.json
@@ -110,8 +110,8 @@
       "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
       "requirements": [
         {"id": "r-package-baseline", "status": "satisfied", "evidence": ["r-package/voiageR/DESCRIPTION", "r-package/voiageR/README.md", "r-package/voiageR/vignettes/voiageR-intro.Rmd"]},
-        {"id": "self-contained-installation", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]},
-        {"id": "statistical-standards-map", "status": "pending", "evidence": ["r-package/voiageR/tests/testthat/test-zz-numerical-reference.R"]}
+        {"id": "self-contained-installation", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md", "specs/submission-readiness/ropensci-evidence.json"]},
+        {"id": "statistical-standards-map", "status": "pending", "evidence": ["specs/submission-readiness/ropensci-evidence.json", "r-package/voiageR/tests/testthat/test-zz-numerical-reference.R"]}
       ],
       "acceptance_evidence": ["rOpenSci pre-submission or review issue", "rOpenSci acceptance and onboarding record"],
       "next_decision": "Reconsider only after self-contained installation, bounded R scope, distribution, and srr standards evidence."

--- a/specs/submission-readiness/targets.json
+++ b/specs/submission-readiness/targets.json
@@ -1,0 +1,372 @@
+{
+  "schema_version": "1.0",
+  "reviewed_at": "2026-07-27",
+  "policy": {
+    "states_are_distinct": ["prepared", "submitted", "under_review", "accepted", "published", "indexed"],
+    "no_external_action_from_contract": true,
+    "refresh_before_action": true,
+    "concurrency_rule": "Do not place the same package or an associated manuscript under simultaneous review where either venue prohibits or discourages it."
+  },
+  "criteria_refresh": {
+    "reviewed_at": "2026-07-27",
+    "evidence": "specs/submission-readiness/criteria-refresh-2026-07-27.md",
+    "target_ids": ["arxiv", "joss", "pyopensci", "ropensci", "r-journal", "journal-of-statistical-software", "numfocus", "pypi", "testpypi", "conda-forge", "cran", "r-universe", "crates-io", "julia-general", "yggdrasil", "software-heritage", "zenodo", "scicrunch-rrid", "spack", "easybuild", "hpsf", "e4s"]
+  },
+  "execution_lanes": [
+    {
+      "id": "contract-maintenance",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/614",
+      "targets": ["arxiv", "joss", "pyopensci", "ropensci", "r-journal", "journal-of-statistical-software", "numfocus", "pypi", "testpypi", "conda-forge", "cran", "r-universe", "crates-io", "julia-general", "yggdrasil", "software-heritage", "zenodo", "scicrunch-rrid", "spack", "easybuild", "hpsf", "e4s"],
+      "repository_outcome": "Keep criteria, evidence paths, authority boundaries, and evidence refreshes valid for every target."
+    },
+    {
+      "id": "paper-and-author-boundaries",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/299",
+      "targets": ["arxiv", "joss", "scicrunch-rrid"],
+      "repository_outcome": "Maintain the locally validated manuscript and metadata package while leaving author attestations, upload, curation, and editorial decisions external."
+    },
+    {
+      "id": "python-community-review",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/616",
+      "targets": ["pyopensci"],
+      "repository_outcome": "Maintain a current criteria-to-evidence matrix and complete all repository-controlled Python-package expectations before an author decides whether to inquire."
+    },
+    {
+      "id": "r-community-and-journal-readiness",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/615",
+      "targets": ["ropensci", "r-journal"],
+      "repository_outcome": "Deliver self-contained R installation, bounded API, statistical-software evidence, and an R-centred contribution assessment."
+    },
+    {
+      "id": "distinct-publication-and-sustainability-assessment",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/617",
+      "targets": ["journal-of-statistical-software", "numfocus", "zenodo"],
+      "repository_outcome": "Record a non-duplication and eligibility decision before creating any venue-specific manuscript, application, or deposition package."
+    },
+    {
+      "id": "hpc-distribution-readiness",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/622",
+      "targets": ["spack", "easybuild", "hpsf", "e4s"],
+      "repository_outcome": "Create locally validated portable package recipes before any upstream HPC packaging or curation decision."
+    }
+  ],
+  "required_target_ids": [
+    "arxiv", "joss", "pyopensci", "ropensci", "r-journal",
+    "journal-of-statistical-software", "numfocus", "pypi", "testpypi",
+    "conda-forge", "cran", "r-universe", "crates-io", "julia-general",
+    "yggdrasil", "software-heritage", "zenodo", "scicrunch-rrid",
+    "spack", "easybuild", "hpsf", "e4s"
+  ],
+  "targets": [
+    {
+      "id": "arxiv",
+      "kind": "archive",
+      "readiness": "blocked",
+      "scope": "Canonical LaTeX research preprint.",
+      "criteria_url": "https://info.arxiv.org/help/submit/index.html",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "canonical-source", "status": "satisfied", "evidence": ["paper/main.tex", "paper/readiness-manifest.json"]},
+        {"id": "author-category-licence-upload", "status": "pending", "evidence": ["paper/readiness-manifest.json"]}
+      ],
+      "acceptance_evidence": ["Authenticated arXiv submission state", "Permanent announced arXiv identifier"],
+      "next_decision": "Author completes category, licence, source upload, metadata, and submission after final review."
+    },
+    {
+      "id": "joss",
+      "kind": "journal",
+      "readiness": "blocked",
+      "scope": "Rust-centred polyglot research software and short software paper.",
+      "criteria_url": "https://joss.readthedocs.io/en/latest/submitting.html",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "paper-and-validator", "status": "satisfied", "evidence": ["paper.md", "paper/joss-readiness-manifest.json", "scripts/validate_joss.py"]},
+        {"id": "research-use-human-attestation", "status": "pending", "evidence": ["docs/release/joss-independent-validation.md"]}
+      ],
+      "acceptance_evidence": ["JOSS submission identifier", "Public review issue", "Acceptance decision and DOI"],
+      "next_decision": "Direct submission remains after demonstrated use, human engagement evidence, AI affirmation, and author-selected arXiv sequence."
+    },
+    {
+      "id": "pyopensci",
+      "kind": "community_review",
+      "readiness": "conditional",
+      "scope": "Maintained scientific Python package and packaging practice.",
+      "criteria_url": "https://www.pyopensci.org/software-peer-review/how-to/author-guide.html",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "package-baseline", "status": "satisfied", "evidence": ["README.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", "pyproject.toml"]},
+        {"id": "method-provenance-and-overlap", "status": "satisfied", "evidence": ["README.md", "paper.md", "docs/astro-site/src/content/docs/methods/index.mdx"]},
+        {"id": "maintenance-and-ai-affirmation", "status": "pending", "evidence": ["SUPPORT.md", "GOVERNANCE.md", "AI_USAGE.md", "paper.md"]}
+      ],
+      "acceptance_evidence": ["pyOpenSci review issue", "pyOpenSci approval label and catalogue entry"],
+      "next_decision": "After the JOSS outcome, refresh criteria and decide whether to open a pre-submission inquiry."
+    },
+    {
+      "id": "ropensci",
+      "kind": "community_review",
+      "readiness": "blocked",
+      "scope": "Independently reviewable R statistical-software package.",
+      "criteria_url": "https://devguide.ropensci.org/softwarereview_author.html",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "r-package-baseline", "status": "satisfied", "evidence": ["r-package/voiageR/DESCRIPTION", "r-package/voiageR/README.md", "r-package/voiageR/vignettes/voiageR-intro.Rmd"]},
+        {"id": "self-contained-installation", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]},
+        {"id": "statistical-standards-map", "status": "pending", "evidence": ["r-package/voiageR/tests/testthat/test-zz-numerical-reference.R"]}
+      ],
+      "acceptance_evidence": ["rOpenSci pre-submission or review issue", "rOpenSci acceptance and onboarding record"],
+      "next_decision": "Reconsider only after self-contained installation, bounded R scope, distribution, and srr standards evidence."
+    },
+    {
+      "id": "r-journal",
+      "kind": "journal",
+      "readiness": "consideration",
+      "scope": "A distinct article centred on the mature R package and its R ecosystem contribution.",
+      "criteria_url": "https://rjournal.github.io/submissions.html",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "distinct-contribution", "status": "pending", "evidence": ["r-package/voiageR/README.md", "paper.md"]},
+        {"id": "mature-r-package", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]}
+      ],
+      "acceptance_evidence": ["R Journal manuscript identifier", "Editorial acceptance and publication record"],
+      "next_decision": "Assess only when the R surface supports a non-duplicative article."
+    },
+    {
+      "id": "journal-of-statistical-software",
+      "kind": "journal",
+      "readiness": "consideration",
+      "scope": "Full statistical-software and methodology article distinct from JOSS.",
+      "criteria_url": "https://www.jstatsoft.org/about/submissions",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "distinct-full-article", "status": "pending", "evidence": ["paper/main.tex", "paper.md"]},
+        {"id": "methodological-evaluation", "status": "pending", "evidence": ["paper/health-example-methods.md"]}
+      ],
+      "acceptance_evidence": ["JSS manuscript identifier", "Editorial acceptance and DOI"],
+      "next_decision": "Consider only if a substantial, non-overlapping statistical contribution remains after JOSS."
+    },
+    {
+      "id": "numfocus",
+      "kind": "sustainability",
+      "readiness": "consideration",
+      "scope": "Future sustainability affiliation rather than software peer review.",
+      "criteria_url": "https://numfocus.org/projects-overview",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "community-and-governance", "status": "pending", "evidence": ["GOVERNANCE.md", "CONTRIBUTING.md"]},
+        {"id": "adoption-and-sustainability", "status": "pending", "evidence": ["docs/astro-site/src/content/docs/developer-guide/community-support.mdx"]}
+      ],
+      "acceptance_evidence": ["NumFOCUS application record", "Formal affiliation decision"],
+      "next_decision": "Reassess after demonstrated adoption and multi-person governance."
+    },
+    {
+      "id": "pypi",
+      "kind": "package_registry",
+      "readiness": "published",
+      "scope": "Primary Python package distribution.",
+      "criteria_url": "https://packaging.python.org/en/latest/tutorials/packaging-projects/",
+      "authority": {"prepare": "repository", "submit": "external-system", "accept": "external"},
+      "requirements": [
+        {"id": "release-workflow", "status": "satisfied", "evidence": [".github/workflows/release.yml"]},
+        {"id": "published-release", "status": "satisfied", "evidence": ["docs/release/release-evidence.md"]}
+      ],
+      "acceptance_evidence": ["PyPI version page", "Trusted-publishing provenance"],
+      "next_decision": "Maintain tag-driven release and provenance contracts."
+    },
+    {
+      "id": "testpypi",
+      "kind": "package_registry",
+      "readiness": "published",
+      "scope": "Pre-release Python package validation.",
+      "criteria_url": "https://packaging.python.org/en/latest/guides/using-testpypi/",
+      "authority": {"prepare": "repository", "submit": "external-system", "accept": "external"},
+      "requirements": [
+        {"id": "test-release-workflow", "status": "satisfied", "evidence": [".github/workflows/release.yml"]},
+        {"id": "install-smoke", "status": "satisfied", "evidence": ["docs/release/release-evidence.md"]}
+      ],
+      "acceptance_evidence": ["TestPyPI version page", "Workflow upload evidence"],
+      "next_decision": "Keep as the release-candidate gate before PyPI."
+    },
+    {
+      "id": "conda-forge",
+      "kind": "package_registry",
+      "readiness": "conditional",
+      "scope": "Compiled Python/Rust distribution through conda-forge.",
+      "criteria_url": "https://github.com/conda-forge/staged-recipes",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "recipe-and-builds", "status": "satisfied", "evidence": ["conda-recipe/meta.yaml", "docs/release/binding-submission-checklist.md"]},
+        {"id": "maintainer-merge-indexing", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+      ],
+      "acceptance_evidence": ["Merged conda-forge feedstock PR", "Installable indexed package"],
+      "next_decision": "Monitor staged-recipes review and record merge and indexing separately."
+    },
+    {
+      "id": "cran",
+      "kind": "package_registry",
+      "readiness": "conditional",
+      "scope": "Canonical R package distribution.",
+      "criteria_url": "https://cran.r-project.org/web/packages/policies.html",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "source-check", "status": "satisfied", "evidence": ["r-package/voiageR/DESCRIPTION", "docs/release/binding-submission-checklist.md"]},
+        {"id": "upload-confirmation-review", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+      ],
+      "acceptance_evidence": ["CRAN incoming confirmation", "CRAN package index page"],
+      "next_decision": "Author-controlled upload and confirmation remain separate from CRAN review and acceptance."
+    },
+    {
+      "id": "r-universe",
+      "kind": "package_registry",
+      "readiness": "published",
+      "scope": "Hosted R source and binary distribution.",
+      "criteria_url": "https://ropensci.org/r-universe/",
+      "authority": {"prepare": "repository", "submit": "external-system", "accept": "external"},
+      "requirements": [
+        {"id": "hosted-build", "status": "satisfied", "evidence": ["docs/release/registry_audit_snapshot.json"]},
+        {"id": "package-metadata", "status": "satisfied", "evidence": ["r-package/voiageR/DESCRIPTION"]}
+      ],
+      "acceptance_evidence": ["r-universe package page", "Hosted platform build matrix"],
+      "next_decision": "Maintain successful builds while CRAN remains separate."
+    },
+    {
+      "id": "crates-io",
+      "kind": "package_registry",
+      "readiness": "published",
+      "scope": "Binding-independent Rust core crates.",
+      "criteria_url": "https://doc.rust-lang.org/cargo/reference/publishing.html",
+      "authority": {"prepare": "repository", "submit": "external-system", "accept": "external"},
+      "requirements": [
+        {"id": "publishable-crates", "status": "satisfied", "evidence": ["rust/Cargo.toml", ".github/workflows/rust-crates-release.yml"]},
+        {"id": "published-v2", "status": "satisfied", "evidence": ["docs/release/release-evidence.md"]}
+      ],
+      "acceptance_evidence": ["crates.io crate version pages"],
+      "next_decision": "Maintain synchronized versions and dependency order."
+    },
+    {
+      "id": "julia-general",
+      "kind": "package_registry",
+      "readiness": "blocked",
+      "scope": "Julia source package registration.",
+      "criteria_url": "https://pkgdocs.julialang.org/dev/creating-packages/",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "package-contract", "status": "satisfied", "evidence": ["bindings/julia/Project.toml", "bindings/julia/test/runtests.jl"]},
+        {"id": "jll-dependency", "status": "external", "evidence": ["docs/release/binding-submission-checklist.md"]}
+      ],
+      "acceptance_evidence": ["Registrator PR", "General registry merge", "TagBot release"],
+      "next_decision": "Wait for the JLL, then run clean-depot tests before Registrator."
+    },
+    {
+      "id": "yggdrasil",
+      "kind": "package_registry",
+      "readiness": "conditional",
+      "scope": "Cross-platform voiage_ffi_jll native-library recipe.",
+      "criteria_url": "https://docs.binarybuilder.org/stable/",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "recipe-submitted", "status": "satisfied", "evidence": ["docs/release/binding-submission-checklist.md"]},
+        {"id": "binarybuilder-acceptance", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+      ],
+      "acceptance_evidence": ["Merged Yggdrasil recipe", "Registered JLL package and artifacts"],
+      "next_decision": "Respond to BinaryBuilder review; JLL acceptance precedes Julia General."
+    },
+    {
+      "id": "software-heritage",
+      "kind": "archive",
+      "readiness": "published",
+      "scope": "Immutable source history and release snapshot.",
+      "criteria_url": "https://docs.softwareheritage.org/user/getting-started/save-code-now.html",
+      "authority": {"prepare": "repository", "submit": "external-system", "accept": "external"},
+      "requirements": [
+        {"id": "snapshot", "status": "satisfied", "evidence": ["docs/release/release-evidence.md"]},
+        {"id": "citation", "status": "satisfied", "evidence": ["CITATION.cff"]}
+      ],
+      "acceptance_evidence": ["Software Heritage snapshot SWHID and completed visit"],
+      "next_decision": "Refresh only for release-bound archival needs."
+    },
+    {
+      "id": "zenodo",
+      "kind": "archive",
+      "readiness": "consideration",
+      "scope": "Optional DOI-bearing release archive where a venue requires it.",
+      "criteria_url": "https://help.zenodo.org/docs/github/",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "release-metadata", "status": "satisfied", "evidence": ["CITATION.cff", "codemeta.json"]},
+        {"id": "need-and-deposition", "status": "pending", "evidence": ["docs/release/release-evidence.md"]}
+      ],
+      "acceptance_evidence": ["Zenodo deposition record and DOI"],
+      "next_decision": "Use only when a selected venue requires a DOI-bearing archive not supplied elsewhere."
+    },
+    {
+      "id": "scicrunch-rrid",
+      "kind": "identifier",
+      "readiness": "conditional",
+      "scope": "Research Resource Identifier registration and curation.",
+      "criteria_url": "https://scicrunch.org/resources",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "registration-metadata", "status": "satisfied", "evidence": ["CITATION.cff", "codemeta.json"]},
+        {"id": "curation-assignment", "status": "external", "evidence": ["conductor/tracks/research_software_registry_readiness_20260721/handoff/registry-readiness.json"]}
+      ],
+      "acceptance_evidence": ["SciCrunch resource record", "Assigned RRID"],
+      "next_decision": "Track registration, curation, and RRID assignment separately."
+    },
+    {
+      "id": "spack",
+      "kind": "package_registry",
+      "readiness": "blocked",
+      "scope": "HPC source-build package.",
+      "criteria_url": "https://spack.readthedocs.io/en/latest/package_review_guide.html",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "recipe", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]},
+        {"id": "platform-build-review", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+      ],
+      "acceptance_evidence": ["Spack package PR", "Maintainer approval and merge", "Indexed package"],
+      "next_decision": "Prepare only when the retained distribution design has a tested package recipe."
+    },
+    {
+      "id": "easybuild",
+      "kind": "package_registry",
+      "readiness": "blocked",
+      "scope": "HPC easyconfig distribution.",
+      "criteria_url": "https://docs.easybuild.io/contributing/",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "easyconfig", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]},
+        {"id": "upstream-review", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+      ],
+      "acceptance_evidence": ["EasyBuild easyconfigs PR", "Maintainer merge and indexed easyconfig"],
+      "next_decision": "Prepare after a stable HPC installation contract exists."
+    },
+    {
+      "id": "hpsf",
+      "kind": "sustainability",
+      "readiness": "consideration",
+      "scope": "Potential HPC ecosystem curation or project path.",
+      "criteria_url": "https://hpsf.io/projects/",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "governance-adoption", "status": "pending", "evidence": ["GOVERNANCE.md", "docs/release/binding-submission-checklist.md"]},
+        {"id": "curation-decision", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+      ],
+      "acceptance_evidence": ["HPSF application or curation record", "Formal project decision"],
+      "next_decision": "Reassess after production HPC adoption and governance evidence."
+    },
+    {
+      "id": "e4s",
+      "kind": "package_registry",
+      "readiness": "consideration",
+      "scope": "Curated HPC software-stack inclusion.",
+      "criteria_url": "https://e4s.io/",
+      "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
+      "requirements": [
+        {"id": "upstream-hpc-package", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]},
+        {"id": "curation", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+      ],
+      "acceptance_evidence": ["E4S curation record", "Release inclusion evidence"],
+      "next_decision": "Reassess after Spack or equivalent upstream packaging and production evidence."
+    }
+  ]
+}

--- a/specs/submission-readiness/targets.json
+++ b/specs/submission-readiness/targets.json
@@ -96,7 +96,7 @@
       "requirements": [
         {"id": "package-baseline", "status": "satisfied", "evidence": ["README.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", "pyproject.toml"]},
         {"id": "method-provenance-and-overlap", "status": "satisfied", "evidence": ["README.md", "paper.md", "docs/astro-site/src/content/docs/methods/index.mdx"]},
-        {"id": "maintenance-and-ai-affirmation", "status": "pending", "evidence": ["SUPPORT.md", "GOVERNANCE.md", "AI_USAGE.md", "paper.md"]}
+        {"id": "maintenance-and-ai-affirmation", "status": "pending", "evidence": ["SUPPORT.md", "GOVERNANCE.md", "AI_USAGE.md", "paper.md", "specs/submission-readiness/pyopensci-evidence.json"]}
       ],
       "acceptance_evidence": ["pyOpenSci review issue", "pyOpenSci approval label and catalogue entry"],
       "next_decision": "After the JOSS outcome, refresh criteria and decide whether to open a pre-submission inquiry."

--- a/tests/test_julia_release_workflow.py
+++ b/tests/test_julia_release_workflow.py
@@ -14,7 +14,7 @@ def test_julia_release_workflow_and_checklist_align() -> None:
     assert "Project.toml version" in workflow_text
     assert "Pkg.test()" in workflow_text
     assert 'gh release create "${GITHUB_REF_NAME}"' not in workflow_text
-    assert "GH_TOKEN: ${{ github.token }}" not in workflow_text
+    assert "permissions:\n      contents: read" in workflow_text
     assert "contents: read" in workflow_text
 
     assert (

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -80,6 +80,7 @@ def test_each_retained_language_has_native_assurance() -> None:
         "bash scripts/run_ffi_sanitizers.sh",
         "R CMD check --as-cran",
         "rcmdcheck::rcmdcheck",
+        "RETICULATE_PYTHON",
         "Aqua.test_all",
         "julia --project=.",
         "pnpm run check",

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -117,6 +117,7 @@ def test_shared_numerical_corpus_crosses_every_runtime_boundary() -> None:
         "C ABI",
         "R installed package",
         "Julia installed package",
+        "uv run --extra ci pytest tests/test_numerical_reference_cases.py",
     ):
         assert marker in workflow
 

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -1,0 +1,188 @@
+"""Fail-closed contract for the repository's polyglot CI/CD architecture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.github_dependency_snapshot import snapshot
+
+ROOT = Path(__file__).parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _text(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def _workflow(name: str) -> dict[str, object]:
+    loaded = yaml.safe_load(_text(name))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_required_pr_workflows_support_merge_queue() -> None:
+    """Required checks must run against GitHub's synthesized merge commit."""
+    for name in (
+        "ci.yml",
+        "bindings-ci.yml",
+        "codeql.yml",
+        "dependency-review.yml",
+        "operational-assurance.yml",
+    ):
+        assert "merge_group:" in _text(name), name
+
+
+def test_release_uses_pep740_and_exact_testpypi_promotion() -> None:
+    """TestPyPI is an attested multi-version promotion gate, not a token smoke."""
+    release = _text("release.yml")
+    assert "attestations: false" not in release
+    assert "Verify TestPyPI distribution attestations" in release
+    assert "pypi-attestations" in release
+    assert "verify pypi --staging" in release
+    assert 'python: ["3.12", "3.13", "3.14"]' in release
+    assert "Download reviewed release payload" in release
+    assert "Compare TestPyPI bytes with reviewed payload" in release
+    assert release.index("Publish Reviewed Draft to TestPyPI") < release.index(
+        "Publish to PyPI"
+    )
+
+
+def test_release_attests_build_and_polyglot_sbom_subjects() -> None:
+    """Every promoted subject carries both provenance and its polyglot SBOM."""
+    release = _text("release.yml")
+    assert "workflow_call:" in release
+    assert "actions/attest-build-provenance@" in release
+    assert "actions/attest-sbom@" in release
+    assert "polyglot.sbom.cdx.json" in release
+    assert "release-manifest.json" in release
+    assert "gh attestation verify" in release
+
+
+def test_each_retained_language_has_native_assurance() -> None:
+    """Python, Rust/C, R, Julia, and Astro/TypeScript remain explicit."""
+    combined = "\n".join(
+        _text(name)
+        for name in (
+            "ci.yml",
+            "bindings-ci.yml",
+            "ffi-sanitizers.yml",
+            "rust-security.yml",
+            "docs.yml",
+        )
+    )
+    required = (
+        'python: ["3.12", "3.13", "3.14"]',
+        "cargo clippy --workspace --all-targets --all-features --locked",
+        "cargo test --workspace --all-features --locked",
+        "bash scripts/run_ffi_sanitizers.sh",
+        "R CMD check --as-cran",
+        "rcmdcheck::rcmdcheck",
+        "Aqua.test_all",
+        "julia --project=.",
+        "pnpm run check",
+        "pnpm run build",
+    )
+    for marker in required:
+        assert marker in combined, marker
+
+
+def test_rust_publication_uses_short_lived_trusted_publishing() -> None:
+    """crates.io publication must not depend on a stored registry token."""
+    workflow = _text("rust-crates-release.yml")
+    assert "rust-lang/crates-io-auth-action@" in workflow
+    assert "id-token: write" in workflow
+    assert "secrets.CARGO_REGISTRY_TOKEN" not in workflow
+
+
+def test_binding_releases_consume_the_shared_release_identity() -> None:
+    """R and Julia release validation is anchored to the common manifest."""
+    workflow = _text("bindings-release.yml")
+    assert "Verify shared immutable release manifest" in workflow
+    assert "release-manifest.json" in workflow
+    assert workflow.count("needs: verify-base-release") == 2
+
+
+def test_shared_numerical_corpus_crosses_every_runtime_boundary() -> None:
+    """The same reference corpus must reach every retained callable surface."""
+    workflow = _text("bindings-ci.yml")
+    for marker in (
+        "Cross-language differential conformance",
+        "specs/numerical-reference/v1/evpi-cases.json",
+        "Python public API",
+        "Rust crate API",
+        "C ABI",
+        "R installed package",
+        "Julia installed package",
+    ):
+        assert marker in workflow
+
+
+def test_arm64_is_observed_before_release_promotion() -> None:
+    """Preview ARM64 coverage stays non-required until evidence supports it."""
+    workflow = _text("polyglot-assurance.yml")
+    assert "ubuntu-24.04-arm" in workflow
+    assert "continue-on-error: true" in workflow
+    assert "ARM64 observation" in workflow
+
+
+def test_renovate_is_the_only_update_pr_producer() -> None:
+    """GitHub alerts may remain inputs, but Dependabot must not open PRs."""
+    assert not (ROOT / ".github" / "dependabot.yml").exists()
+    renovate = json.loads((ROOT / "renovate.json").read_text(encoding="utf-8"))
+    assert "config:best-practices" in renovate["extends"]
+    assert ":dependencyDashboard" in renovate["extends"]
+    assert renovate["osvVulnerabilityAlerts"] is True
+    assert {"cargo", "github-actions", "npm", "pep621"} <= set(
+        renovate["enabledManagers"]
+    )
+    assert renovate["minimumReleaseAge"] == "14 days"
+
+
+def test_dependency_graph_and_immutable_release_contracts_are_explicit() -> None:
+    """Resolved dependencies and final assets have hosted integrity controls."""
+    assurance = _text("polyglot-assurance.yml")
+    release = _text("release.yml")
+    quality = (
+        ROOT
+        / "docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx"
+    ).read_text(encoding="utf-8")
+    assert "Dependency submission" in assurance
+    assert "contents: write" in assurance
+    assert "immutable release" in release.lower()
+    assert "immutable releases" in quality.lower()
+
+
+def test_ci_has_one_required_local_authority() -> None:
+    """Tox and the harness are authoritative; nox remains a convenience."""
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "tox is the required local CI authority" in contributing
+    assert "nox is an optional developer interface" in contributing
+
+
+def test_dependency_snapshot_preserves_polyglot_package_urls() -> None:
+    """Submitted snapshots retain every package ecosystem represented by purl."""
+    document = {
+        "components": [
+            {"bom-ref": "numpy", "purl": "pkg:pypi/numpy@2.3.0"},
+            {"bom-ref": "serde", "purl": "pkg:cargo/serde@1.0.0"},
+            {"purl": "pkg:cran/testthat@3.2.0"},
+            {"purl": "pkg:julia/JSON@0.21.4"},
+            {"name": "component-without-purl"},
+        ],
+        "dependencies": [{"ref": "numpy", "dependsOn": ["serde"]}],
+    }
+    payload = snapshot(document, sha="a" * 40, ref="refs/heads/main")
+    manifests = payload["manifests"]
+    assert isinstance(manifests, dict)
+    resolved = manifests["polyglot.sbom.cdx.json"]["resolved"]
+    assert set(resolved) == {
+        "pkg:pypi/numpy@2.3.0",
+        "pkg:cargo/serde@1.0.0",
+        "pkg:cran/testthat@3.2.0",
+        "pkg:julia/JSON@0.21.4",
+    }
+    assert resolved["pkg:pypi/numpy@2.3.0"]["dependencies"] == ["pkg:cargo/serde@1.0.0"]
+    assert resolved["pkg:cargo/serde@1.0.0"]["relationship"] == "indirect"

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -79,6 +79,7 @@ def test_each_retained_language_has_native_assurance() -> None:
         "cargo test --workspace --all-features --locked",
         "bash scripts/run_ffi_sanitizers.sh",
         "R CMD check --as-cran",
+        "for attempt in 1 2 3",
         "rcmdcheck::rcmdcheck",
         "RETICULATE_PYTHON",
         "Aqua.test_all",

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -222,7 +222,7 @@ def test_python_release_keeps_staging_separate_from_publication() -> None:
         "reviewed-payload:\n    name: Validate Reviewed Private Draft"
         in release_workflow
     )
-    assert release_workflow.count("name: reviewed-release-payload") == 3
+    assert release_workflow.count("name: reviewed-release-payload") == 4
     assert (
         'gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft'
         in release_workflow

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -33,12 +33,22 @@ def test_registry_track_records_native_paper_issue_hierarchy() -> None:
 
     arxiv_issue = "https://github.com/edithatogo/voiage/issues/312"
     independent_validation_issue = "https://github.com/edithatogo/voiage/issues/471"
+    submission_contract_issues = {
+        f"https://github.com/edithatogo/voiage/issues/{number}"
+        for number in range(614, 618)
+    }
+    hpc_packaging_issue = "https://github.com/edithatogo/voiage/issues/622"
     assert arxiv_issue in metadata["github_subissues"]
     assert independent_validation_issue in metadata["github_subissues"]
+    assert submission_contract_issues <= set(metadata["github_subissues"])
+    assert hpc_packaging_issue in metadata["github_subissues"]
     assert arxiv_issue in plan
     assert independent_validation_issue in plan
     assert arxiv_issue in specification
     assert independent_validation_issue in specification
+    assert all(issue in specification for issue in submission_contract_issues)
+    assert hpc_packaging_issue in plan
+    assert hpc_packaging_issue in specification
     assert handoff["arxiv_preprint_evidence"]["review_pr"].endswith("/pull/311")
     assert handoff["arxiv_preprint_evidence"]["prior_submission_id"] == "7861466"
     assert handoff["arxiv_preprint_evidence"]["submission_id"] == "7870358"

--- a/tests/test_submission_readiness_contract.py
+++ b/tests/test_submission_readiness_contract.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 import pytest
 
-from scripts.validate_submission_readiness import validate_contract
+from scripts.validate_submission_readiness import (
+    validate_contract,
+    validate_pyopensci_evidence,
+)
 
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "specs" / "submission-readiness" / "targets.json"
@@ -63,6 +66,15 @@ def test_submission_contract_requires_current_criteria_refresh_evidence() -> Non
 
     assert set(contract["required_target_ids"]) <= set(refresh["target_ids"])
     assert (ROOT / refresh["evidence"]).is_file()
+
+
+def test_pyopensci_matrix_closes_repository_criteria_only() -> None:
+    summary = validate_pyopensci_evidence(
+        ROOT / "specs" / "submission-readiness" / "pyopensci-evidence.json", ROOT
+    )
+
+    assert summary["criterion_count"] >= 10
+    assert summary["deferred"] == ["external-inquiry", "maintainer-commitment"]
 
 
 def test_submission_contract_rejects_ready_target_with_unmet_gate(

--- a/tests/test_submission_readiness_contract.py
+++ b/tests/test_submission_readiness_contract.py
@@ -1,0 +1,88 @@
+"""Tests for the cross-venue submission-readiness contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_submission_readiness import validate_contract
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "specs" / "submission-readiness" / "targets.json"
+
+
+def test_submission_contract_covers_current_and_future_targets() -> None:
+    summary = validate_contract(CONTRACT, ROOT)
+
+    assert summary["target_count"] >= 20
+    assert {
+        "arxiv",
+        "joss",
+        "pyopensci",
+        "ropensci",
+        "r-journal",
+        "journal-of-statistical-software",
+        "numfocus",
+        "pypi",
+        "cran",
+        "julia-general",
+        "conda-forge",
+        "software-heritage",
+        "scicrunch-rrid",
+    } <= set(summary["targets"])
+
+
+def test_submission_contract_preserves_external_authority() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+    for target in contract["targets"]:
+        assert target["authority"]["prepare"] == "repository"
+        assert target["authority"]["submit"] in {"human", "external-system"}
+        assert target["authority"]["accept"] == "external"
+        assert target["acceptance_evidence"]
+
+
+def test_submission_contract_routes_every_target_to_a_github_execution_lane() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    planned_targets = {
+        target for lane in contract["execution_lanes"] for target in lane["targets"]
+    }
+
+    assert set(contract["required_target_ids"]) <= planned_targets
+    assert all(
+        lane["issue_url"].startswith("https://github.com/edithatogo/voiage/issues/")
+        for lane in contract["execution_lanes"]
+    )
+
+
+def test_submission_contract_requires_current_criteria_refresh_evidence() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    refresh = contract["criteria_refresh"]
+
+    assert set(contract["required_target_ids"]) <= set(refresh["target_ids"])
+    assert (ROOT / refresh["evidence"]).is_file()
+
+
+def test_submission_contract_rejects_ready_target_with_unmet_gate(
+    tmp_path: Path,
+) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    contract["targets"][0]["readiness"] = "ready"
+    contract["targets"][0]["requirements"][0]["status"] = "pending"
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cannot be ready"):
+        validate_contract(invalid, ROOT)
+
+
+def test_submission_contract_rejects_missing_evidence_path(tmp_path: Path) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    contract["targets"][0]["requirements"][0]["evidence"] = ["docs/does-not-exist.md"]
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="evidence path"):
+        validate_contract(invalid, ROOT)

--- a/tests/test_submission_readiness_contract.py
+++ b/tests/test_submission_readiness_contract.py
@@ -10,6 +10,7 @@ import pytest
 from scripts.validate_submission_readiness import (
     validate_contract,
     validate_pyopensci_evidence,
+    validate_ropensci_evidence,
 )
 
 ROOT = Path(__file__).parents[1]
@@ -75,6 +76,15 @@ def test_pyopensci_matrix_closes_repository_criteria_only() -> None:
 
     assert summary["criterion_count"] >= 10
     assert summary["deferred"] == ["external-inquiry", "maintainer-commitment"]
+
+
+def test_ropensci_matrix_keeps_repository_blockers_explicit() -> None:
+    summary = validate_ropensci_evidence(
+        ROOT / "specs" / "submission-readiness" / "ropensci-evidence.json", ROOT
+    )
+
+    assert summary["criterion_count"] >= 10
+    assert summary["statuses"]["self-contained-installation"] == "repository_blocked"
 
 
 def test_submission_contract_rejects_ready_target_with_unmet_gate(


### PR DESCRIPTION
## CI/CD and readiness hardening

- validates Python, Rust, R, Julia, and ARM64 release assurance
- restores the submission-readiness validator and evidence contract required by CI
- uses Renovate and trusted publishing safeguards
- keeps ARM64 advisory pending longer observation

Self-reviewed. Focused readiness, workflow-contract, release-workflow, and exact-head tests pass locally; hosted CI remains the merge authority.