### PR TITLE
feat(ingestion): retain Croissant field data types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Published executable ML, engineering/operations, and business reference-case
   evidence across Croissant, Frictionless, and direct DataFrame inputs, with
   normalized-schema, pinned-resource, provenance-digest, and EVPI equivalence.
+- Preserved scalar Croissant field `dataType` declarations as descriptive
+  normalized metadata, while rejecting structured declarations that could
+  introduce unsupported semantics.
 - Wired built-in Croissant and Frictionless providers through verified,
   content-addressed materialization so declared SHA-256 resources can replay
   offline; Frictionless now verifies supported `hash` and `bytes` declarations.

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -63,6 +63,35 @@ def test_croissant_offline_valid_profile_fixture_materializes() -> None:
     ]
 
 
+def test_croissant_preserves_declared_field_data_type_as_descriptive_metadata(
+    tmp_path,
+) -> None:
+    """A declared ML data type remains descriptive until a binding uses it."""
+    (tmp_path / "samples.csv").write_text("score\n1.5\n", encoding="utf-8")
+    descriptor = tmp_path / "croissant.json"
+    descriptor.write_text(
+        '{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"samples.csv"}],"recordSet":[{"name":"samples","field":[{"name":"score","dataType":"sc:Float"}]}]}',
+        encoding="utf-8",
+    )
+
+    bundle = CroissantProvider().ingest(descriptor, policy=SourceAccessPolicy(tmp_path))
+
+    assert bundle.manifest.tables[0].fields[0].semantic_type == "sc:Float"
+
+
+def test_croissant_rejects_a_non_scalar_declared_field_data_type(tmp_path) -> None:
+    """Descriptor metadata cannot smuggle structured field semantics downstream."""
+    (tmp_path / "samples.csv").write_text("score\n1.5\n", encoding="utf-8")
+    descriptor = tmp_path / "croissant.json"
+    descriptor.write_text(
+        '{"@context":"https://mlcommons.org/croissant/1.1","distribution":[{"contentUrl":"samples.csv"}],"recordSet":[{"name":"samples","field":[{"name":"score","dataType":{"@id":"sc:Float"}}]}]}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match="dataType must be a string"):
+        CroissantProvider().ingest(descriptor, policy=SourceAccessPolicy(tmp_path))
+
+
 def test_croissant_offline_identity_fixture_preserves_governance() -> None:
     """Croissant identities are retained as metadata, not VOI semantics."""
     bundle = CroissantProvider().ingest(

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -100,7 +100,11 @@ class CroissantProvider:
                 ) from error
             raise
         manifest_fields = tuple(
-            FieldManifest(field_id=name, dtype=str(table.schema.field(name).type))
+            FieldManifest(
+                field_id=name,
+                dtype=str(table.schema.field(name).type),
+                semantic_type=_declared_data_type(cast("dict[str, object]", item)),
+            )
             for item in fields
             if isinstance(item, dict)
             for name in [item.get("name")]
@@ -183,6 +187,14 @@ class CroissantProvider:
 def _scalar_metadata(value: object) -> str | None:
     """Expose scalar metadata in provenance without coercing structured values."""
     return value if isinstance(value, str) else None
+
+
+def _declared_data_type(field: dict[str, object]) -> str | None:
+    """Retain a declared Croissant data type without giving it VOI meaning."""
+    value = field.get("dataType")
+    if value is None or isinstance(value, str):
+        return value
+    raise IngestionError("Croissant field dataType must be a string")
 
 
 def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
Clean main-based successor for #610, rebased onto current main after the ingestion reference-evidence merge. Full hosted checks required before merge.