### PR TITLE
fix(ingestion): reject malformed Croissant collection entries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expanded the offline Croissant 1.1 fixture corpus with fail-closed coverage
   for integrity declarations, non-CSV media types, and field sources.
+- Reject malformed Croissant distribution and record-set entries through the
+  stable ingestion error boundary rather than leaking implementation exceptions.
 - Export future GitHub release attestations as discoverable SLSA
   `.intoto.jsonl` assets and add time-bounded OSV exceptions for two Pydantic
   advisories that do not affect the required and locked Pydantic 2.13.4.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -72,9 +72,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   identities, resources, record sets, fields, keys, references, splits,
   supported transformations, integrity failures, archives, nesting, and
   ambiguous semantics. Expanded integrity-declaration, non-CSV-media-type,
-  and field-source corpus coverage. (`333ee68f`, partial). Focused corpus and
-  provider validation pass; full tox remains blocked by the pre-existing
+  field-source, and malformed collection-entry corpus coverage. Focused corpus
+  and provider validation pass; full tox remains blocked by the pre-existing
   missing source-provenance and JOSS contract files in this clean worktree.
+  (`333ee68f`, `d745d2d6`, partial)
 - [~] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
   parser-feature gaps, live datasets, citations, PROV, usage information,
   ODRL, and RAI metadata preservation. Offline governance fixture added

--- a/tests/fixtures/croissant_1_1/unsupported/malformed-distribution.json
+++ b/tests/fixtures/croissant_1_1/unsupported/malformed-distribution.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "name": "malformed-distribution",
+  "distribution": ["valid/data.csv"],
+  "recordSet": [{
+    "name": "decision_samples",
+    "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+  }]
+}

--- a/tests/fixtures/croissant_1_1/unsupported/malformed-record-set.json
+++ b/tests/fixtures/croissant_1_1/unsupported/malformed-record-set.json
@@ -1,0 +1,6 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "name": "malformed-record-set",
+  "distribution": [{"contentUrl": "valid/data.csv"}],
+  "recordSet": ["decision_samples"]
+}

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -25,6 +25,8 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
         ("unsupported/nested-field.json", "nested fields"),
         ("unsupported/references.json", "field references"),
         ("unsupported/field-source.json", "field sources"),
+        ("unsupported/malformed-distribution.json", "distribution object"),
+        ("unsupported/malformed-record-set.json", "recordSet object"),
         ("unsupported/split.json", "splits"),
         ("unsupported/transform.json", "transformations"),
         ("unsupported/version-1-0.json", "version 1.1"),

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -56,6 +56,14 @@ class CroissantProvider:
             raise IngestionError(
                 "supported Croissant profile requires exactly one distribution"
             )
+        if not isinstance(record_sets[0], dict):
+            raise IngestionError(
+                "supported Croissant profile requires a recordSet object"
+            )
+        if not isinstance(distributions[0], dict):
+            raise IngestionError(
+                "supported Croissant profile requires a distribution object"
+            )
         record_set = cast("dict[str, object]", record_sets[0])
         distribution = cast("dict[str, object]", distributions[0])
         self._reject_unsupported_semantics(descriptor, distribution, record_set)


### PR DESCRIPTION
Extends the offline Croissant 1.1 fixture corpus with malformed distribution and record-set entries. The provider now rejects both through the public IngestionError boundary instead of leaking AttributeError. P4-T2 remains partial; this does not close any issue or archive the track.