### PR TITLE
test(ingestion): add malformed Frictionless fixture

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for integrity declarations, non-CSV media types, and field sources.
 - Reject malformed Croissant distribution and record-set entries through the
   stable ingestion error boundary rather than leaking implementation exceptions.
+- Add a file-backed Frictionless malformed-resource fixture to the fail-closed
+  ingestion conformance corpus.
 - Export future GitHub release attestations as discoverable SLSA
   `.intoto.jsonl` assets and add time-bounded OSV exceptions for two Pydantic
   advisories that do not affect the required and locked Pydantic 2.13.4.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -94,7 +94,8 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   data validation, resources, schemas, dialects, types, constraints, missing
   values, keys, integrity, governance metadata, supported tabular formats, and
   ambiguous resources. File-backed baseline and fail-closed format/integrity
-  coverage added (`d0c1b238`); remaining acceptance evidence is tracked below.
+  coverage added (`d0c1b238`); malformed-resource coverage is also file-backed.
+  (`6c57a7a8`, partial). Remaining acceptance evidence is tracked below.
 - [ ] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
   documented supported profile.
 - [ ] **P4-T9 / AC-05, AC-11:** Add Frictionless inspection, diagnostics,

--- a/tests/fixtures/frictionless_v1/unsupported/malformed-resource.json
+++ b/tests/fixtures/frictionless_v1/unsupported/malformed-resource.json
@@ -1,0 +1,4 @@
+{
+  "name": "malformed-resource",
+  "resources": ["valid/data.csv"]
+}

--- a/tests/test_frictionless_offline_fixtures.py
+++ b/tests/test_frictionless_offline_fixtures.py
@@ -16,6 +16,7 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "frictionless_v1"
 @pytest.mark.parametrize(
     ("fixture", "message"),
     [
+        ("unsupported/malformed-resource.json", "resources must be objects"),
         ("unsupported/non-comma-dialect.json", "only CSV comma dialect"),
         ("unsupported/non-csv-format.json", "requires CSV format"),
         ("unsupported/integrity-declaration.json", "hash must be a SHA-256"),


### PR DESCRIPTION
Adds a retained file-backed Data Package fixture for malformed resource entries, extending the partial P4-T7 fail-closed corpus. No parser behavior, issue status, or track archival is changed.