### PR TITLE
fix(ingestion): reject non-object descriptor roots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stable ingestion error boundary rather than leaking implementation exceptions.
 - Add a file-backed Frictionless malformed-resource fixture to the fail-closed
   ingestion conformance corpus.
+- Reject non-object Croissant and Frictionless descriptor roots through the
+  stable ingestion error boundary before provider-specific parsing.
 - Export future GitHub release attestations as discoverable SLSA
   `.intoto.jsonl` assets and add time-bounded OSV exceptions for two Pydantic
   advisories that do not affect the required and locked Pydantic 2.13.4.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -75,7 +75,8 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   field-source, and malformed collection-entry corpus coverage. Focused corpus
   and provider validation pass; full tox remains blocked by the pre-existing
   missing source-provenance and JOSS contract files in this clean worktree.
-  (`333ee68f`, `d745d2d6`, partial)
+  Non-object descriptor-root handling is covered by the shared provider guard
+  (`333ee68f`, `d745d2d6`, `1e4e6bd7`, partial).
 - [~] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
   parser-feature gaps, live datasets, citations, PROV, usage information,
   ODRL, and RAI metadata preservation. Offline governance fixture added
@@ -95,7 +96,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   values, keys, integrity, governance metadata, supported tabular formats, and
   ambiguous resources. File-backed baseline and fail-closed format/integrity
   coverage added (`d0c1b238`); malformed-resource coverage is also file-backed.
-  (`6c57a7a8`, partial). Remaining acceptance evidence is tracked below.
+  Non-object descriptor-root handling is covered by the shared provider guard
+  (`0c19fe1b`, `1e4e6bd7`, partial). Remaining acceptance evidence is tracked
+  below.
 - [ ] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
   documented supported profile.
 - [ ] **P4-T9 / AC-05, AC-11:** Add Frictionless inspection, diagnostics,

--- a/tests/fixtures/croissant_1_1/unsupported/non-object-root.json
+++ b/tests/fixtures/croissant_1_1/unsupported/non-object-root.json
@@ -1,0 +1,3 @@
+[
+  "not-a-croissant-descriptor"
+]

--- a/tests/fixtures/frictionless_v1/unsupported/non-object-root.json
+++ b/tests/fixtures/frictionless_v1/unsupported/non-object-root.json
@@ -1,0 +1,3 @@
+[
+  "not-a-data-package"
+]

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -15,6 +15,7 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
 @pytest.mark.parametrize(
     ("fixture", "message"),
     [
+        ("unsupported/non-object-root.json", "descriptor root must be a JSON object"),
         ("unsupported/archive.json", "archives"),
         ("unsupported/checksum-mismatch.json", "SHA-256"),
         ("unsupported/integrity-declaration.json", "integrity declarations"),

--- a/tests/test_frictionless_offline_fixtures.py
+++ b/tests/test_frictionless_offline_fixtures.py
@@ -17,6 +17,7 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "frictionless_v1"
     ("fixture", "message"),
     [
         ("unsupported/malformed-resource.json", "resources must be objects"),
+        ("unsupported/non-object-root.json", "descriptor root must be a JSON object"),
         ("unsupported/non-comma-dialect.json", "only CSV comma dialect"),
         ("unsupported/non-csv-format.json", "requires CSV format"),
         ("unsupported/integrity-declaration.json", "hash must be a SHA-256"),

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -42,6 +42,8 @@ class CroissantProvider:
     ) -> NormalizedInputBundle:
         """Materialize the supported, unambiguous one-resource Croissant profile."""
         raw = json.loads(descriptor_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise IngestionError("descriptor root must be a JSON object")
         descriptor = cast("dict[str, object]", raw)
         context = descriptor.get("@context")
         if not (isinstance(context, str) and "mlcommons.org/croissant/1.1" in context):

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -50,6 +50,8 @@ class FrictionlessProvider:
     ) -> NormalizedInputBundle:
         """Materialize the supported explicit-schema Data Package profile."""
         raw = json.loads(descriptor_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise IngestionError("descriptor root must be a JSON object")
         descriptor = cast("dict[str, object]", raw)
         resources = descriptor.get("resources")
         if not isinstance(resources, list) or not resources:


### PR DESCRIPTION
Hardens the Croissant and Frictionless adapters: non-object JSON descriptor roots now fail through the stable IngestionError boundary before provider-specific parsing. Adds retained offline fixtures for both profiles. P4-T2 and P4-T7 remain partial; no issue closure or track archival.