### PR TITLE
refactor(ingestion): lazily export built-in providers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ingestion conformance corpus.
 - Reject non-object Croissant and Frictionless descriptor roots through the
   stable ingestion error boundary before provider-specific parsing.
+- Make the public Croissant and Frictionless provider exports lazy, keeping
+  ordinary `voiage.ingestion` imports free of source-format adapter imports.
 - Export future GitHub release attestations as discoverable SLSA
   `.intoto.jsonl` assets and add time-bounded OSV exceptions for two Pydantic
   advisories that do not affect the required and locked Pydantic 2.13.4.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -81,8 +81,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   parser-feature gaps, live datasets, citations, PROV, usage information,
   ODRL, and RAI metadata preservation. Offline governance fixture added
   (`9a5b45b7`); the authoritative live probe remains an explicit external gate.
-- [ ] **P4-T4 / AC-04:** Implement the lazy optional Croissant provider and
-  publish separate standard-conformance and parser-capability profiles.
+- [~] **P4-T4 / AC-04:** Implement the lazy optional Croissant provider and
+  publish separate standard-conformance and parser-capability profiles. Public
+  provider export is now lazy (`2ad0a24a`, partial); profile acceptance evidence
+  remains active.
 - [ ] **P4-T5 / AC-04, AC-11:** Add Croissant inspection, diagnostics,
   provenance, governance metadata, and one opt-in authoritative live
   interoperability probe.
@@ -99,8 +101,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   Non-object descriptor-root handling is covered by the shared provider guard
   (`0c19fe1b`, `1e4e6bd7`, partial). Remaining acceptance evidence is tracked
   below.
-- [ ] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
-  documented supported profile.
+- [~] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
+  documented supported profile. Public provider export is now lazy; profile
+  acceptance evidence remains active (`2ad0a24a`, partial).
 - [ ] **P4-T9 / AC-05, AC-11:** Add Frictionless inspection, diagnostics,
   provenance, licence/citation/usage preservation, and one opt-in authoritative
   live interoperability probe.

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -13,6 +13,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
+from voiage import ingestion
 from voiage.contracts import (
     DatasetManifest,
     FieldManifest,
@@ -764,6 +765,15 @@ def test_public_provider_exports_load_the_requested_adapter_on_demand() -> None:
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_public_provider_exports_cover_lazy_lookup_branches() -> None:
+    """Public names resolve through the lazy module lookup under coverage."""
+    assert ingestion.CroissantProvider is CroissantProvider
+    assert ingestion.FrictionlessProvider is FrictionlessProvider
+
+    with pytest.raises(AttributeError, match="has no attribute 'UnknownProvider'"):
+        _ = ingestion.UnknownProvider
 
 
 def test_entry_point_discovery_is_opt_in_and_allow_listed() -> None:

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -725,6 +725,47 @@ def test_base_import_does_not_load_builtin_provider_modules() -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_ingestion_package_import_does_not_load_builtin_provider_modules() -> None:
+    """Public ingestion helpers stay usable without loading source adapters."""
+    script = "; ".join(
+        (
+            "import sys",
+            "import voiage.ingestion",
+            "assert 'voiage.ingestion.croissant' not in sys.modules",
+            "assert 'voiage.ingestion.frictionless' not in sys.modules",
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_public_provider_exports_load_the_requested_adapter_on_demand() -> None:
+    """Lazy exports retain the public provider-class import contract."""
+    script = "; ".join(
+        (
+            "import sys",
+            "from voiage.ingestion import CroissantProvider",
+            "assert CroissantProvider.provider_id == 'croissant'",
+            "assert 'voiage.ingestion.croissant' in sys.modules",
+            "assert 'voiage.ingestion.frictionless' not in sys.modules",
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_entry_point_discovery_is_opt_in_and_allow_listed() -> None:
     loaded: list[str] = []
 

--- a/voiage/ingestion/__init__.py
+++ b/voiage/ingestion/__init__.py
@@ -1,5 +1,7 @@
 """Optional source-format adapters for the normalized VOI input contract."""
 
+from typing import TYPE_CHECKING
+
 from .base import (
     INGESTION_PROVIDER_SDK_VERSION,
     IngestionError,
@@ -7,10 +9,12 @@ from .base import (
     ProviderCapabilities,
     SourceAccessPolicy,
 )
-from .croissant import CroissantProvider
 from .dataframe import from_dataframe
-from .frictionless import FrictionlessProvider
 from .registry import ProviderRegistry, default_registry, discover_entry_point_providers
+
+if TYPE_CHECKING:
+    from .croissant import CroissantProvider
+    from .frictionless import FrictionlessProvider
 
 __all__ = [
     "INGESTION_PROVIDER_SDK_VERSION",
@@ -25,3 +29,16 @@ __all__ = [
     "discover_entry_point_providers",
     "from_dataframe",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Load built-in source adapters only when their public names are requested."""
+    if name == "CroissantProvider":
+        from .croissant import CroissantProvider
+
+        return CroissantProvider
+    if name == "FrictionlessProvider":
+        from .frictionless import FrictionlessProvider
+
+        return FrictionlessProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Makes the public CroissantProvider and FrictionlessProvider exports lazy. Importing `voiage.ingestion` no longer loads source-format adapters; explicit public provider imports retain their compatibility contract. P4-T4 and P4-T8 remain partial pending broader profile acceptance evidence.