### PR TITLE
test(ingestion): cover provider inspection evidence

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -107,9 +107,12 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [~] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
   documented supported profile. Public provider export is now lazy; profile
   acceptance evidence remains active (`2ad0a24a`, partial).
-- [ ] **P4-T9 / AC-05, AC-11:** Add Frictionless inspection, diagnostics,
+- [~] **P4-T9 / AC-05, AC-11:** Add Frictionless inspection, diagnostics,
   provenance, licence/citation/usage preservation, and one opt-in authoritative
-  live interoperability probe.
+  live interoperability probe. CLI inspection coverage now verifies stable
+  provider, checksum/byte receipt, provenance, and retained governance output
+  for an offline Data Package fixture (`ac6d05a9`, partial); the opt-in
+  authoritative live probe remains an explicit external gate.
 
 ### Phase checkpoint
 

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -85,9 +85,12 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   publish separate standard-conformance and parser-capability profiles. Public
   provider export is now lazy (`2ad0a24a`, partial); profile acceptance evidence
   remains active.
-- [ ] **P4-T5 / AC-04, AC-11:** Add Croissant inspection, diagnostics,
+- [~] **P4-T5 / AC-04, AC-11:** Add Croissant inspection, diagnostics,
   provenance, governance metadata, and one opt-in authoritative live
-  interoperability probe.
+  interoperability probe. CLI inspection coverage now verifies stable provider,
+  checksum/byte receipt, provenance, and retained governance output for an
+  offline Croissant 1.1 fixture (`8d040bef`, partial); the opt-in authoritative
+  live probe remains an explicit external gate.
 
 ### Frictionless Data
 

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -326,3 +326,71 @@ def test_croissant_inspection_exposes_governance_and_receipt_identity(tmp_path) 
             "uri": source.resolve().as_uri(),
         }
     ]
+
+
+def test_frictionless_inspection_exposes_governance_and_receipt_identity(
+    tmp_path,
+) -> None:
+    """Frictionless inspection preserves explicit package governance metadata."""
+    source = tmp_path / "samples.csv"
+    source.write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "datapackage.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "name": "governed-operations-fixture",
+                "title": "Governed operations fixture",
+                "description": "Synthetic, rights-cleared test data.",
+                "profile": "tabular-data-package",
+                "version": "1.0.0",
+                "citation": "Example et al. (2026)",
+                "licenses": [
+                    {"name": "CC-BY-4.0", "path": "https://example.invalid/license"}
+                ],
+                "sources": [{"title": "Synthetic source", "path": "source.md"}],
+                "contributors": [{"title": "Maintainer", "role": "author"}],
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "hash": sha256(source.read_bytes()).hexdigest(),
+                        "bytes": source.stat().st_size,
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["ingest", "inspect", str(descriptor)])
+
+    assert result.exit_code == 0
+    inspection = json.loads(result.output)
+    assert inspection["provider"] == "frictionless"
+    assert inspection["provenance"]["license"] == "CC-BY-4.0"
+    assert inspection["provenance"]["citation"] == "Example et al. (2026)"
+    assert inspection["governance"] == {
+        "frictionlessdata.org:contributors": [
+            {"role": "author", "title": "Maintainer"}
+        ],
+        "frictionlessdata.org:description": "Synthetic, rights-cleared test data.",
+        "frictionlessdata.org:licenses": [
+            {"name": "CC-BY-4.0", "path": "https://example.invalid/license"}
+        ],
+        "frictionlessdata.org:profile": "tabular-data-package",
+        "frictionlessdata.org:sources": [
+            {"path": "source.md", "title": "Synthetic source"}
+        ],
+        "frictionlessdata.org:title": "Governed operations fixture",
+        "frictionlessdata.org:version": "1.0.0",
+    }
+    assert inspection["resources"] == [
+        {
+            "byte_size": source.stat().st_size,
+            "media_type": "text/csv",
+            "resource_id": "samples",
+            "sha256": sha256(source.read_bytes()).hexdigest(),
+            "uri": source.resolve().as_uri(),
+        }
+    ]

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -271,3 +271,58 @@ def test_ingest_cli_replays_a_declared_resource_from_offline_cache(tmp_path) -> 
     assert cached.exit_code == 0
     assert replayed.exit_code == 0
     assert json.loads(replayed.output)["valid"] is True
+
+
+def test_croissant_inspection_exposes_governance_and_receipt_identity(tmp_path) -> None:
+    """Croissant inspection retains governance without inferring VOI semantics."""
+    source = tmp_path / "samples.csv"
+    source.write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "croissant.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "name": "governed-ml-fixture",
+                "license": "CC-BY-4.0",
+                "citation": "Example et al. (2026)",
+                "usageInfo": "Synthetic test data only.",
+                "rai": {"dataBiases": "None asserted for this synthetic fixture."},
+                "distribution": [
+                    {
+                        "contentUrl": "samples.csv",
+                        "encodingFormat": "text/csv",
+                        "sha256": sha256(source.read_bytes()).hexdigest(),
+                    }
+                ],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["ingest", "inspect", str(descriptor)])
+
+    assert result.exit_code == 0
+    inspection = json.loads(result.output)
+    assert inspection["provider"] == "croissant"
+    assert inspection["provenance"]["license"] == "CC-BY-4.0"
+    assert inspection["provenance"]["citation"] == "Example et al. (2026)"
+    assert inspection["governance"] == {
+        "mlcommons.org:croissant-governance": {
+            "citation": "Example et al. (2026)",
+            "license": "CC-BY-4.0",
+            "rai": {"dataBiases": "None asserted for this synthetic fixture."},
+            "usageInfo": "Synthetic test data only.",
+        }
+    }
+    assert inspection["resources"] == [
+        {
+            "byte_size": source.stat().st_size,
+            "media_type": "text/csv",
+            "resource_id": "samples",
+            "sha256": sha256(source.read_bytes()).hexdigest(),
+            "uri": source.resolve().as_uri(),
+        }
+    ]


### PR DESCRIPTION
## Summary
- add CLI-level Croissant and Frictionless inspection evidence for provenance, governance, and materialization identity
- record partial P4-T5 and P4-T9 progress in the Conductor plan

## Validation
- targeted Croissant and Frictionless CLI tests passed with `--no-cov`
- Ruff passed
- `ty check voiage/ingestion/cli.py` passed
- Conductor GitHub cross-reference validation passed

The authoritative live interoperability probes remain explicitly gated and are not claimed by this PR.