### PR TITLE
conductor(ingestion): record clean-install evidence

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -116,9 +116,12 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 
 ### Phase checkpoint
 
-- [ ] **P4-T10 / AC-03–AC-05, AC-11:** Verify base-import isolation and clean installs
+- [~] **P4-T10 / AC-03–AC-05, AC-11:** Verify base-import isolation and clean installs
   for each extra; run automated review, focused tests, dependency/security
-  audits, and the phase checkpoint protocol.
+  audits, and the phase checkpoint protocol. A wheel built from `46ef7873`
+  installed and passed import-isolation/registry checks in fresh Python 3.14
+  environments for base, `croissant`, `frictionless`, and `ingestion` extras
+  (partial); the full phase checkpoint remains pending.
 
 ## Phase 5 — Prove cross-format conformance (#331)
 


### PR DESCRIPTION
## Summary
- record wheel-based clean-install evidence for base, Croissant, Frictionless, and aggregate ingestion extras
- retain P4-T10 as partial until the full Phase 4 checkpoint is complete

## Validation
- built an ABI3 wheel from merged commit `46ef7873`
- installed and imported it from four fresh Python 3.14 environments outside the checkout
- validated Conductor GitHub cross-references