### PR TITLE
test(ingestion): assert cross-format receipt parity

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -133,9 +133,12 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [ ] **P5-T3 / AC-06:** Implement deterministic fixture generation and the
   schema, provenance, ordering, meaningful-change, and numerical-equivalence
   conformance matrix.
-- [ ] **P5-T4 / AC-06, AC-10, AC-11:** Assert binding-profile, data-quality,
+- [~] **P5-T4 / AC-06, AC-10, AC-11:** Assert binding-profile, data-quality,
   governance-metadata, and materialization-receipt parity without requiring
-  source formats to share irrelevant descriptive metadata.
+  source formats to share irrelevant descriptive metadata. Canonical Croissant
+  and Frictionless fixtures now assert explicit binding, binding-profile,
+  data-quality, and receipt parity while leaving format-specific descriptive
+  provenance independent (`e9a22f0c`, partial).
 - [ ] **P5-T5 / AC-06:** Add malformed/adversarial cases, property-based mapping
   tests, parser-differential checks, and fresh-process PyArrow/Polars checks.
 - [ ] **P5-T6 / AC-06:** Add the conformance matrix to tox and hosted CI; run

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -159,7 +159,9 @@ def test_canonical_source_formats_preserve_binding_quality_and_receipt_parity() 
         frictionless_prepared.binding_profile_digest
     )
     assert croissant_prepared.quality_report == frictionless_prepared.quality_report
-    assert [receipt.model_dump(mode="json") for receipt in croissant.manifest.resources] == [
+    assert [
+        receipt.model_dump(mode="json") for receipt in croissant.manifest.resources
+    ] == [
         receipt.model_dump(mode="json") for receipt in frictionless.manifest.resources
     ]
 

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -135,6 +135,35 @@ def test_canonical_decision_fixture_has_cross_format_evpi_parity(tmp_path) -> No
     }
 
 
+def test_canonical_source_formats_preserve_binding_quality_and_receipt_parity() -> None:
+    """Provider metadata may differ, but decision inputs and receipts must agree."""
+    policy = SourceAccessPolicy(_FIXTURE_ROOT)
+    croissant = _bound(
+        default_registry().ingest(
+            _FIXTURE_ROOT / "canonical-decision.croissant.json", policy=policy
+        )
+    )
+    frictionless = _bound(
+        default_registry().ingest(
+            _FIXTURE_ROOT / "canonical-decision.datapackage.json", policy=policy
+        )
+    )
+
+    croissant_prepared = prepare_analysis_inputs(croissant)
+    frictionless_prepared = prepare_analysis_inputs(frictionless)
+
+    assert croissant_prepared.binding.model_dump(mode="json") == (
+        frictionless_prepared.binding.model_dump(mode="json")
+    )
+    assert croissant_prepared.binding_profile_digest == (
+        frictionless_prepared.binding_profile_digest
+    )
+    assert croissant_prepared.quality_report == frictionless_prepared.quality_report
+    assert [receipt.model_dump(mode="json") for receipt in croissant.manifest.resources] == [
+        receipt.model_dump(mode="json") for receipt in frictionless.manifest.resources
+    ]
+
+
 @settings(max_examples=30, deadline=None)
 @given(
     rows=st.lists(


### PR DESCRIPTION
## Summary
- assert canonical Croissant/Frictionless binding, data-quality, and materialization-receipt parity
- retain format-specific descriptive provenance as intentionally independent
- record partial P5-T4 evidence in the Conductor plan

## Validation
- targeted conformance test passed with `--no-cov`
- Ruff passed
- Conductor GitHub cross-reference validation passed