### PR TITLE
docs(ingestion): publish supported profile matrix

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -183,7 +183,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [~] **P7-T6 / AC-08:** Run typing, Ruff, coverage, mutation targets,
   dependency audits, repository harness, full `tox`, and all hosted checks.
 - [~] **P7-T7 / AC-08:** Publish supported-standard compatibility and
-  deprecation policy without claiming unsupported upstream coverage.
+  deprecation policy without claiming unsupported upstream coverage. The Astro
+  support matrix now distinguishes conservative supported Croissant,
+  Frictionless, DataFrame, and normalized Arrow profiles from rejected
+  remote/archive/transform and authoritative-live paths (`1dc545a7`, partial).
 - [~] **P7-T8 / AC-08:** Run automated review, resolve high-confidence
   findings, and complete the final implementation checkpoint.
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -14,6 +14,25 @@ and explicit table schemas. Remote URLs, archive extraction, implicit
 column inference, and path traversal are rejected. This makes an input
 portable, auditable, and suitable for an offline calculation workflow.
 
+## Support matrix
+
+| Input surface | Supported profile | Explicit boundary |
+| --- | --- | --- |
+| Croissant ML | Croissant 1.1, one `recordSet`, one `text/csv` distribution, and fields that exactly match the CSV columns | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, and non-CSV media types are rejected. |
+| Frictionless Data Package | One or more explicitly schematized comma-delimited CSV resources, declared primitive types, keys, and supported foreign keys | Remote/live resources, archives, custom dialects, unsupported formats, transforms, and undeclared or ambiguous resources are rejected. |
+| Direct DataFrame interchange | pandas, Polars, or another `__dataframe__` producer that can convert through Arrow with an explicit binding | The adapter does not infer a VOI role, silently copy a disallowed frame, or create a second calculation path. |
+| Arrow IPC and Parquet | A `NormalizedInputBundle` previously written by VOIAGE | These are normalized interchange artifacts, not source-descriptor parsers. |
+
+The built-in providers use only the base Arrow/JSON runtime. The named
+`croissant`, `frictionless`, and `ingestion` extras are stable installation
+surfaces for optional future validators; installing any of them does not add a
+new calculation engine or cause a provider to be imported eagerly.
+
+Authoritative live interoperability probes are deliberately opt-in and are not
+claimed by this local-profile matrix. A successful offline descriptor test is
+evidence for the documented profile only, not for every upstream feature or
+registry deployment.
+
 ```bash
 voiage ingest validate datapackage.json
 voiage ingest inspect croissant.json


### PR DESCRIPTION
## Summary
- publish the supported Croissant, Frictionless, DataFrame, and normalized Arrow profile matrix
- make rejected remote, archive, transform, and authoritative-live paths explicit
- record partial P7-T7 evidence in the Conductor plan

## Validation
- `pnpm run check` passed with zero diagnostics
- Conductor GitHub cross-reference validation passed