### PR TITLE
test(ingestion): validate deterministic fixture manifests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a deterministic validator and explicit regeneration path for the
+  standardized-ingestion fixture digest manifests, covering both canonical
+  Croissant/Frictionless source corpora.
 - Expanded the offline Croissant 1.1 fixture corpus with fail-closed coverage
   for integrity declarations, non-CSV media types, and field sources.
 - Reject malformed Croissant distribution and record-set entries through the

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -128,11 +128,18 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [ ] **P5-T1 / AC-06:** Define the canonical decision fixture and failing
   parity assertions across Croissant, Frictionless, Arrow IPC, Parquet, and
   direct NumPy/xarray representations.
-- [ ] **P5-T2 / AC-06:** Add the deterministic fixture manifest with pinned
-  descriptor, resource, schema, and content digests.
-- [ ] **P5-T3 / AC-06:** Implement deterministic fixture generation and the
+- [~] **P5-T2 / AC-06:** Add the deterministic fixture manifest with pinned
+  descriptor, resource, schema, and content digests. Both checked-in fixture
+  corpora are now verified through one deterministic digest-manifest validator
+  (`scripts/validate_standardized_ingestion_fixtures.py`, partial: descriptor
+  and resource digests are pinned; schema and content semantics remain covered
+  by conformance tests).
+- [~] **P5-T3 / AC-06:** Implement deterministic fixture generation and the
   schema, provenance, ordering, meaningful-change, and numerical-equivalence
-  conformance matrix.
+  conformance matrix. The fixture validator now fails closed on stale artifact
+  digests and supports explicit deterministic ``--write`` regeneration; the
+  existing cross-format/property/reference-case tests provide partial semantic
+  matrix evidence. Full parser-differential coverage remains active.
 - [~] **P5-T4 / AC-06, AC-10, AC-11:** Assert binding-profile, data-quality,
   governance-metadata, and materialization-receipt parity without requiring
   source formats to share irrelevant descriptive metadata. Canonical Croissant

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -163,8 +163,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [~] **P6-T1 / AC-07:** Write failing Python API, CLI help, exit-code,
   diagnostic-redaction, and clean-install tests. The CLI now explicitly proves
   that a rejected credential-bearing descriptor URI is redacted at the
-  user-facing boundary (partial: complete Phase 6 acceptance reconciliation
-  remains active).
+  user-facing boundary, and all four ingestion commands have executable help
+  contracts (partial: complete Phase 6 acceptance reconciliation remains
+  active).
 - [ ] **P6-T2 / AC-07:** Add `croissant`, `frictionless`, and aggregate
   `ingestion` extras.
 - [ ] **P6-T3 / AC-07:** Implement `ingest validate`, `ingest inspect`,

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -125,9 +125,12 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 
 ## Phase 5 — Prove cross-format conformance (#331)
 
-- [ ] **P5-T1 / AC-06:** Define the canonical decision fixture and failing
+- [~] **P5-T1 / AC-06:** Define the canonical decision fixture and failing
   parity assertions across Croissant, Frictionless, Arrow IPC, Parquet, and
-  direct NumPy/xarray representations.
+  direct NumPy/xarray representations. The canonical corpus now asserts the
+  same explicit preparation result across all listed source representations,
+  including equal xarray and NumPy runtime views (partial: parser-differential
+  acceptance remains active under P5-T5).
 - [~] **P5-T2 / AC-06:** Add the deterministic fixture manifest with pinned
   descriptor, resource, schema, and content digests. Both checked-in fixture
   corpora are now verified through one deterministic digest-manifest validator

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -160,8 +160,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 
 ## Phase 6 — Ship the user-facing product surface (#332)
 
-- [ ] **P6-T1 / AC-07:** Write failing Python API, CLI help, exit-code,
-  diagnostic-redaction, and clean-install tests.
+- [~] **P6-T1 / AC-07:** Write failing Python API, CLI help, exit-code,
+  diagnostic-redaction, and clean-install tests. The CLI now explicitly proves
+  that a rejected credential-bearing descriptor URI is redacted at the
+  user-facing boundary (partial: complete Phase 6 acceptance reconciliation
+  remains active).
 - [ ] **P6-T2 / AC-07:** Add `croissant`, `frictionless`, and aggregate
   `ingestion` extras.
 - [ ] **P6-T3 / AC-07:** Implement `ingest validate`, `ingest inspect`,

--- a/scripts/validate_standardized_ingestion_fixtures.py
+++ b/scripts/validate_standardized_ingestion_fixtures.py
@@ -1,0 +1,98 @@
+"""Validate or deterministically refresh standardized-ingestion fixtures.
+
+The source descriptors and CSV resources are deliberately kept as small,
+human-reviewable fixture corpora.  Their companion manifests pin every source
+artifact, so an intentional fixture update must be explicit: run this script
+with ``--write`` and review the resulting digest change.
+"""
+
+from __future__ import annotations
+
+import argparse
+from hashlib import sha256
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_FIXTURE_ROOT = (
+    Path(__file__).parents[1] / "tests" / "fixtures" / "standardized_ingestion"
+)
+
+
+def _source_files(manifest_path: Path) -> dict[str, str]:
+    """Return deterministic SHA-256 digests for one fixture's source files."""
+    stem = manifest_path.name.removesuffix(".manifest.json")
+    return {
+        path.name: sha256(path.read_bytes()).hexdigest()
+        for path in sorted(manifest_path.parent.glob(f"{stem}.*"))
+        if path != manifest_path
+    }
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    """Read and minimally validate a fixture manifest before comparing it."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"{path}: fixture manifest must be a JSON object")
+    if payload.get("schema_version") != "1.0.0":
+        raise ValueError(f"{path}: unsupported fixture schema_version")
+    if not isinstance(payload.get("dataset_id"), str) or not payload["dataset_id"]:
+        raise ValueError(f"{path}: fixture manifest requires a dataset_id")
+    return payload
+
+
+def validate_fixture_manifest(path: Path, *, write: bool = False) -> bool:
+    """Validate one manifest, or refresh only its generated ``files`` mapping.
+
+    Returns ``True`` when the checked-in manifest already matches the source
+    artifacts.  ``--write`` is deliberately limited to the digest mapping:
+    dataset and binding semantics always remain review-owned metadata.
+    """
+    payload = _read_manifest(path)
+    expected = _source_files(path)
+    if payload.get("files") == expected:
+        return True
+    if write:
+        payload["files"] = expected
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return False
+    return False
+
+
+def fixture_manifests(root: Path) -> tuple[Path, ...]:
+    """Find fixture manifests in stable order and reject an empty corpus."""
+    manifests = tuple(sorted(root.glob("*.manifest.json")))
+    if not manifests:
+        raise ValueError(f"{root}: no standardized-ingestion fixture manifests")
+    return manifests
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run deterministic digest validation for the complete fixture corpus."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="refresh only stale generated digest mappings",
+    )
+    args = parser.parse_args(argv)
+    stale = [
+        path
+        for path in fixture_manifests(args.root)
+        if not validate_fixture_manifest(path, write=args.write)
+    ]
+    if stale and not args.write:
+        for path in stale:
+            print(f"stale fixture manifest: {path}")
+        return 1
+    if stale:
+        for path in stale:
+            print(f"refreshed fixture manifest: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -165,6 +165,32 @@ def test_ingest_cli_returns_safe_error_for_unrecognized_descriptor(tmp_path) -> 
     assert "exactly one" in validated.output
 
 
+def test_ingest_cli_redacts_credentials_from_rejected_resource_uris(tmp_path) -> None:
+    """User-facing diagnostics must not disclose credentials in a descriptor."""
+    descriptor = tmp_path / "croissant.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "distribution": [
+                    {"contentUrl": "ssh://user:super-secret@example.invalid/data.csv"}
+                ],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["ingest", "validate", str(descriptor)])
+
+    assert result.exit_code == 2
+    assert "network resource access is disabled" in result.output
+    assert "super-secret" not in result.output
+    assert "example.invalid" not in result.output
+
+
 def test_normalize_and_calculate_return_safe_errors(tmp_path) -> None:
     descriptor = tmp_path / "unknown.json"
     descriptor.write_text("{}", encoding="utf-8")

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -10,6 +10,25 @@ from typer.testing import CliRunner
 from voiage.cli import app
 
 
+def test_ingest_commands_publish_stable_help_surfaces() -> None:
+    """All documented ingestion commands remain discoverable through the CLI."""
+    runner = CliRunner()
+
+    for command, description in (
+        ("validate", "Validate a supported descriptor"),
+        ("inspect", "Inspect identity and optionally resolve"),
+        ("normalize", "Normalize a descriptor into a deterministic Arrow IPC"),
+        (
+            "calculate-from-dataset",
+            "Calculate EVPI from explicitly selected normalized net-benefit fields",
+        ),
+    ):
+        result = runner.invoke(app, ["ingest", command, "--help"])
+
+        assert result.exit_code == 0
+        assert description in result.output
+
+
 def test_ingest_inspect_and_normalize(tmp_path) -> None:
     (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
     descriptor = tmp_path / "datapackage.json"

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -14,6 +14,7 @@ import numpy as np
 import polars as pl
 import pyarrow as pa
 import pytest
+import xarray as xr
 
 from voiage.contracts import (
     DatasetManifest,
@@ -135,6 +136,40 @@ def test_canonical_decision_fixture_has_cross_format_evpi_parity(tmp_path) -> No
     assert {bundle.schema_fingerprint for bundle in bundles} == {
         direct.schema_fingerprint
     }
+
+
+def test_cross_format_preparation_has_identical_numpy_and_xarray_views() -> None:
+    """Normalized preparation owns both existing compute-facing representations."""
+    policy = SourceAccessPolicy(_FIXTURE_ROOT)
+    bundles = (
+        _direct_bundle(
+            pa.table(
+                {
+                    "strategy_a": np.asarray([10.0, 30.0, 20.0]),
+                    "strategy_b": np.asarray([20.0, 10.0, 25.0]),
+                }
+            )
+        ),
+        _bound(
+            default_registry().ingest(
+                _FIXTURE_ROOT / "canonical-decision.croissant.json", policy=policy
+            )
+        ),
+        _bound(
+            default_registry().ingest(
+                _FIXTURE_ROOT / "canonical-decision.datapackage.json", policy=policy
+            )
+        ),
+    )
+    prepared = tuple(prepare_analysis_inputs(bundle) for bundle in bundles)
+    expected = prepared[0].net_benefits.values
+
+    assert isinstance(expected, xr.DataArray)
+    assert expected.dims == ("n_samples", "n_strategies")
+    assert expected.strategy.values.tolist() == ["A", "B"]
+    for item in prepared:
+        assert item.net_benefits.values.equals(expected)
+        assert np.array_equal(item.net_benefits.numpy_values, expected.values)
 
 
 def test_canonical_source_formats_preserve_binding_quality_and_receipt_parity() -> None:

--- a/tests/test_standardized_ingestion_fixture_validator.py
+++ b/tests/test_standardized_ingestion_fixture_validator.py
@@ -1,0 +1,35 @@
+"""Tests for deterministic standardized-ingestion fixture digest manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+from scripts import validate_standardized_ingestion_fixtures as validator
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "standardized_ingestion"
+
+
+def test_checked_in_fixture_corpus_has_current_digests() -> None:
+    """Both canonical source-format corpora are pinned by their manifests."""
+    manifests = validator.fixture_manifests(FIXTURE_ROOT)
+
+    assert [path.name for path in manifests] == [
+        "canonical-decision.manifest.json",
+        "cost-outcome-decision.manifest.json",
+    ]
+    assert validator.main([str(FIXTURE_ROOT)]) == 0
+
+
+def test_fixture_validator_detects_and_deterministically_refreshes_changes(
+    tmp_path: Path,
+) -> None:
+    """Digest refreshes are reproducible and require an explicit write command."""
+    root = tmp_path / "fixtures"
+    shutil.copytree(FIXTURE_ROOT, root)
+    resource = root / "canonical-decision.csv"
+    resource.write_text(resource.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    assert validator.main([str(root)]) == 1
+    assert validator.main([str(root), "--write"]) == 0
+    assert validator.main([str(root)]) == 0

--- a/todo.md
+++ b/todo.md
@@ -70,6 +70,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         boundary, optional CSV profiles, and provenance propagation. The
         unchecked acceptance criteria in the Conductor track remain active;
         issues #325--#333 and #467--#468 must not be closed or archived yet.
+    *   The deterministic fixture-manifest validator now pins both checked-in
+        source corpora; semantic and parser-differential conformance remains
+        active under Phase 5.
 
 ## Completed public documentation
 

--- a/todo.md
+++ b/todo.md
@@ -75,6 +75,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
         active under Phase 5.
     *   Canonical cross-format preparation now asserts identical NumPy and
         xarray compute-facing views without introducing a second runtime path.
+    *   CLI validation now has a credential-redaction regression contract for
+        rejected descriptor resource URIs.
 
 ## Completed public documentation
 

--- a/todo.md
+++ b/todo.md
@@ -73,6 +73,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
     *   The deterministic fixture-manifest validator now pins both checked-in
         source corpora; semantic and parser-differential conformance remains
         active under Phase 5.
+    *   Canonical cross-format preparation now asserts identical NumPy and
+        xarray compute-facing views without introducing a second runtime path.
 
 ## Completed public documentation
 


### PR DESCRIPTION
## Summary
- validate both standardized-ingestion fixture manifest digest maps
- make digest refresh explicit and deterministic with `--write`
- assert direct NumPy, Croissant, and Frictionless inputs produce identical canonical xarray and NumPy runtime views
- add CLI regression contracts for help surfaces and credential redaction
- record partial Phase 5 and Phase 6 Conductor evidence without closing remaining acceptance work

## Validation
- `pytest tests/test_standardized_ingestion_cli.py::test_ingest_commands_publish_stable_help_surfaces tests/test_standardized_ingestion_cli.py::test_ingest_cli_redacts_credentials_from_rejected_resource_uris tests/test_standardized_ingestion_fixture_validator.py tests/test_standardized_ingestion_conformance.py::test_cross_format_preparation_has_identical_numpy_and_xarray_views -q --no-cov`
- `ruff check tests/test_standardized_ingestion_cli.py tests/test_standardized_ingestion_conformance.py tests/test_standardized_ingestion_fixture_validator.py scripts/validate_standardized_ingestion_fixtures.py`
- `python scripts/validate_standardized_ingestion_fixtures.py`
- `python scripts/validate_conductor_github_cross_references.py .`

Native EVPI equivalence is intentionally left to the hosted wheel matrix because this disposable local environment lacks `voiage._core`.