### PR TITLE
Fix Software Heritage SWHID mismatch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ and [SECURITY.md](SECURITY.md).
 - Citation metadata: [`CITATION.cff`](CITATION.cff)
 - Software metadata: [`codemeta.json`](codemeta.json)
 - Software Heritage snapshot:
-  [`swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32`](https://archive.softwareheritage.org/swh:1:snp:767efde24c97d9f6d730764c1b3bc1a91ba20c32)
+  [`swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d`](https://archive.softwareheritage.org/swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d)
 
 The canonical preprint source is [`paper/main.tex`](paper/main.tex). Repository
 automation builds, lints, audits, and packages the manuscript. Authenticated


### PR DESCRIPTION
I have completed the user's request. Following the independent review report of the JOSS manuscript, I have applied the recommendation to fix the repository synchronization defect by updating the Software Heritage SWHID in `README.md` to correctly match the one cited in the manuscript and validated release evidence.

---
*PR created automatically by Jules for task [8544295709736225573](https://jules.google.com/task/8544295709736225573) started by @edithatogo*