### PR TITLE
docs(ingestion): document supported descriptor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ voiage --help
 See the [CLI reference](https://edithatogo.github.io/voiage/cli-reference/)
 for input schemas, output formats, logging controls, and additional commands.
 
+### Standardized dataset ingestion
+
+`voiage` can also safely normalize conservative local profiles of Croissant ML
+1.1 and Frictionless Data Package CSV descriptors before calculation. Source
+format parsers remain separate from the calculation runtime: each produces an
+Arrow-backed `NormalizedInputBundle`, and callers supply an explicit VOI
+binding. Use `voiage ingest validate`, `voiage ingest inspect`, and `voiage
+ingest normalize` for a descriptor workflow; remote URLs, archives, implicit
+column inference, and unsafe paths are rejected. See the
+[standardized-ingestion guide](https://edithatogo.github.io/voiage/standardized-dataset-ingestion/)
+for the supported-profile matrix, offline replay policy, and ML, engineering,
+and business examples.
+
 ## Capability status
 
 | Capability | Status | Scope |

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added executable CLI walkthrough evidence for the canonical Croissant ML and
   Frictionless engineering reference descriptors.
+- Linked the README to the standardized Croissant and Frictionless ingestion
+  workflow, supported-profile matrix, offline policy, and cross-domain examples.
 - Added a deterministic validator and explicit regeneration path for the
   standardized-ingestion fixture digest manifests, covering both canonical
   Croissant/Frictionless source corpora.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -166,18 +166,22 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   user-facing boundary, and all four ingestion commands have executable help
   contracts (partial: complete Phase 6 acceptance reconciliation remains
   active).
-- [ ] **P6-T2 / AC-07:** Add `croissant`, `frictionless`, and aggregate
-  `ingestion` extras.
-- [ ] **P6-T3 / AC-07:** Implement `ingest validate`, `ingest inspect`,
+- [x] **P6-T2 / AC-07:** Add `croissant`, `frictionless`, and aggregate
+  `ingestion` extras. The declared extras remain dependency-neutral because
+  built-in providers require only the base Arrow/JSON stack.
+- [x] **P6-T3 / AC-07:** Implement `ingest validate`, `ingest inspect`,
   `ingest normalize`, and `calculate-from-dataset` with explicit selection,
   binding, offline, and source-policy options.
-- [ ] **P6-T4 / AC-07, AC-11:** Make inspection output include data-quality,
+- [x] **P6-T4 / AC-07, AC-11:** Make inspection output include data-quality,
   provider-capability, binding-resolution, governance, and materialization
   receipt details in stable machine-readable form.
-- [ ] **P6-T5 / AC-07:** Add Python, Croissant/ML, and
+- [x] **P6-T5 / AC-07:** Add Python, Croissant/ML, and
   Frictionless/operations-research examples.
-- [ ] **P6-T6 / AC-07:** Update Astro data-structure, CLI, architecture, and
-  security guidance plus README, changelog, roadmap, and todo.
+- [~] **P6-T6 / AC-07:** Update Astro data-structure, CLI, architecture, and
+  security guidance plus README, changelog, roadmap, and todo. The Astro guide,
+  changelog, roadmap/todo, and README now describe the supported profile,
+  explicit safety boundary, CLI, and cross-domain examples; final docs/links
+  and phase-checkpoint evidence remains active.
 - [ ] **P6-T7 / AC-07:** Run automated review, CLI/docs/Vale validation, clean
   install checks, and the phase checkpoint protocol.
 

--- a/todo.md
+++ b/todo.md
@@ -80,6 +80,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
     *   ML and engineering reference descriptors now have executable CLI
         validation and inspection walkthroughs alongside the direct business
         DataFrame example.
+    *   The README now links the conservative Croissant/Frictionless ingestion
+        surface to its profile matrix, offline policy, and cross-domain examples.
 
 ## Completed public documentation
 


### PR DESCRIPTION
## Summary
- add a README entry point for the conservative Croissant/Frictionless descriptor workflow
- reconcile implemented Phase 6 extras, CLI, inspection, and cross-domain-example tasks with executable evidence
- retain final docs/link and phase-checkpoint work as active Conductor acceptance criteria

## Validation
- `pytest tests/test_standardized_ingestion_cli.py::test_ingest_commands_publish_stable_help_surfaces tests/test_standardized_ingestion_cli.py::test_ingest_cli_redacts_credentials_from_rejected_resource_uris -q --no-cov`
- `pnpm run check` in `docs/astro-site`
- `python scripts/validate_conductor_github_cross_references.py .`

The local disposable environment lacks `voiage._core`; `calculate-from-dataset` wheel execution remains covered by hosted checks.