### PR TITLE
test(ingestion): exercise reference-case CLI walkthroughs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added executable CLI walkthrough evidence for the canonical Croissant ML and
+  Frictionless engineering reference descriptors.
 - Added a deterministic validator and explicit regeneration path for the
   standardized-ingestion fixture digest manifests, covering both canonical
   Croissant/Frictionless source corpora.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -243,7 +243,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [~] **P9-T2 / AC-13:** Represent every case as Croissant, Frictionless, and
   direct inputs using the same binding profile and pinned artifact digests.
 - [~] **P9-T3 / AC-13:** Add validation, inspection, data-quality, governance,
-  materialization, Python API, and CLI walkthrough evidence.
+  materialization, Python API, and CLI walkthrough evidence. The canonical ML
+  Croissant and engineering Frictionless descriptors now execute the documented
+  validation/inspection path and assert provider, governance, binding-quality,
+  and materialization-receipt output; the direct DataFrame business walkthrough
+  remains covered by the executable reference example (partial).
 - [~] **P9-T4 / AC-13:** Assert normalized-object and numerical equivalence
   without adding domain-specific kernels or semantic inference.
 - [~] **P9-T5 / AC-13:** Publish the support matrix and run fixture

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -4,10 +4,60 @@ from __future__ import annotations
 
 from hashlib import sha256
 import json
+from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from voiage.cli import app
+
+
+@pytest.mark.parametrize(
+    ("descriptor_name", "provider"),
+    [
+        (
+            "canonical-decision.croissant.json",
+            "croissant",
+        ),
+        (
+            "canonical-decision.datapackage.json",
+            "frictionless",
+        ),
+    ],
+)
+def test_reference_descriptors_have_safe_cli_walkthroughs(
+    descriptor_name: str, provider: str
+) -> None:
+    """ML and engineering fixtures expose the documented CLI evidence path."""
+    fixture_root = Path(__file__).parent / "fixtures" / "standardized_ingestion"
+    descriptor = fixture_root / descriptor_name
+    runner = CliRunner()
+
+    validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
+    inspected = runner.invoke(
+        app,
+        [
+            "ingest",
+            "inspect",
+            str(descriptor),
+            "--table",
+            "samples",
+            "--field",
+            "strategy_a",
+            "--field",
+            "strategy_b",
+        ],
+    )
+
+    assert validated.exit_code == 0
+    assert json.loads(validated.output)["valid"] is True
+    assert inspected.exit_code == 0
+    result = json.loads(inspected.output)
+    assert result["provider"] == provider
+    assert isinstance(result["governance"], dict)
+    assert result["binding_resolution"]["data_quality"]["row_count"] == 3
+    assert len(result["resources"]) == 1
+    assert len(result["resources"][0]["sha256"]) == 64
 
 
 def test_ingest_commands_publish_stable_help_surfaces() -> None:

--- a/todo.md
+++ b/todo.md
@@ -77,6 +77,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         xarray compute-facing views without introducing a second runtime path.
     *   CLI validation now has a credential-redaction regression contract for
         rejected descriptor resource URIs.
+    *   ML and engineering reference descriptors now have executable CLI
+        validation and inspection walkthroughs alongside the direct business
+        DataFrame example.
 
 ## Completed public documentation
 


### PR DESCRIPTION
## Summary
- run the canonical ML Croissant and engineering Frictionless reference descriptors through documented CLI validation and inspection
- assert provider identity, stable governance output, binding data quality, and materialization receipt digest output
- record partial Phase 9 walkthrough evidence while retaining the full release/checkpoint gates

## Validation
- `pytest tests/test_standardized_ingestion_cli.py::test_reference_descriptors_have_safe_cli_walkthroughs -q --no-cov`
- `ruff check tests/test_standardized_ingestion_cli.py`
- `python scripts/validate_conductor_github_cross_references.py .`