### PR TITLE
feat(ingestion): record DataFrame conversion diagnostics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distinct Croissant 1.10 context.
 - Added executable CLI walkthrough evidence for the canonical Croissant ML and
   Frictionless engineering reference descriptors.
-- Linked the README to the standardized Croissant and Frictionless ingestion
-  workflow, supported-profile matrix, offline policy, and cross-domain examples.
+- Added auditable DataFrame-interchange conversion diagnostics for copy policy,
+  index exclusion, and Arrow dtype/nullability/categorical/timezone decisions;
+  copy-permitted conversions explicitly retain an unobservable outcome rather
+  than claiming a copy result that Arrow cannot report.
 - Added a deterministic validator and explicit regeneration path for the
   standardized-ingestion fixture digest manifests, covering both canonical
   Croissant/Frictionless source corpora.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -234,10 +234,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   opt-in entry-point publication checklist.
 - [~] **P8-T3 / AC-12:** Write failing DataFrame-interchange tests covering
   pandas, Polars, dtype/null/category/timezone/index handling, copy diagnostics,
-  and clean optional environments.
+  and clean optional environments. Partial diagnostics evidence: `fdda14a`.
 - [~] **P8-T4 / AC-12:** Implement the generic `__dataframe__` adapter through
   Arrow and `NormalizedInputBundle`, with no alternate preparation or numerical
-  path.
+  path. Partial conversion-diagnostics evidence: `fdda14a`.
 - [~] **P8-T5 / AC-12:** Assess Hugging Face and OpenML Croissant support and
   create registry-specific providers only for documented, tested gaps.
 - [~] **P8-T6 / AC-12:** Run SDK consumer tests, conformance, numerical

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -141,7 +141,7 @@ complete implementation of either upstream standard.
 | --- | --- | --- | --- |
 | Croissant ML | Croissant 1.1 descriptor, one declared local CSV distribution, one `recordSet`, explicit fields, local SHA-256 when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, multiple resources, executable metadata, implicit schema inference |
 | Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources with explicit field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, other integrity algorithms, implicit schema inference |
-| DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | `from_dataframe` preserves the Arrow schema and honours `allow_copy`; its bundle enters the same preparation path as providers. | Inferred decision semantics, unsupported nested values, and conversions that require copying when `allow_copy=False`. |
+| DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | `from_dataframe` preserves the Arrow schema and honours `allow_copy`; its bundle enters the same preparation path as providers and records conversion decisions. | Inferred decision semantics, unsupported nested values, and conversions that require copying when `allow_copy=False`. |
 
 All providers default to local-only access. Inputs that fall outside these
 profiles fail with a stable `IngestionError`; they are not partially loaded or
@@ -172,6 +172,11 @@ The adapter deliberately keeps the exchange boundary visible. Use
 `from_dataframe(frame, dataset_id="business", allow_copy=False)` when the
 caller requires Arrow to reject a conversion that would copy the source data;
 the resulting bundle always follows the same normalized preparation path.
+Its `voiage.dev:dataframe-interchange` extension records copy policy, index
+exclusion, and each Arrow field's dtype, nullability, categorical, and timezone
+decisions. A successful no-copy conversion is recorded as `zero_copy`; when
+copies are permitted, Arrow's public API does not expose the actual outcome, so
+the extension records `not_observable` rather than guessing.
 The supported SDK contract covers explicit bindings, source-neutral provenance,
 and Arrow schema preservation; it does not promise identical behaviour for
 every DataFrame library or unsupported nested dtype.

--- a/specs/core-api/ingestion-provider-sdk-v1.md
+++ b/specs/core-api/ingestion-provider-sdk-v1.md
@@ -45,6 +45,14 @@ Nullable values, categories, and timezone-aware values are supported when Arrow
 can materialize them. Nested values and conversions requiring a disallowed copy
 fail with a stable `ValueError`; no alternate calculation path is used.
 
+The resulting manifest records source-neutral conversion diagnostics and a
+`voiage.dev:dataframe-interchange` extension. They state the requested copy
+policy, index exclusion, and per-field Arrow dtype, nullability, categorical,
+and timezone decisions. A successful `allow_copy=False` conversion is recorded
+as zero-copy. When copying is permitted, Arrow's public interchange API does
+not reveal whether a copy actually occurred, so the outcome is recorded as
+`not_observable` rather than guessed.
+
 ## Publication checklist
 
 1. Declare an entry point that returns an initialized provider instance.

--- a/tests/test_dataframe_interchange_sdk.py
+++ b/tests/test_dataframe_interchange_sdk.py
@@ -61,6 +61,60 @@ def test_dataframe_sdk_forwards_copy_policy_and_preserves_nullable_schema() -> N
     assert bundle.manifest.tables[0].fields[2].dtype == "timestamp[s, tz=UTC]"
 
 
+def test_dataframe_sdk_records_copy_and_schema_conversion_diagnostics() -> None:
+    """Consumers can audit the non-semantic interchange decisions made."""
+    table = pa.table(
+        {
+            "tier": pa.array(["standard", None]).dictionary_encode(),
+            "observed_at": pa.array(
+                [datetime(2026, 1, 1, tzinfo=UTC), None],
+                type=pa.timestamp("s", tz="UTC"),
+            ),
+        }
+    )
+
+    bundle = from_dataframe(table, dataset_id="auditable-sdk", allow_copy=False)
+    extension = bundle.manifest.model_dump(mode="json")["extensions"][
+        "voiage.dev:dataframe-interchange"
+    ]
+
+    assert extension == {
+        "adapter_version": "1",
+        "copy_outcome": "zero_copy",
+        "copy_policy": "disallow_copy",
+        "field_decisions": [
+            {
+                "categorical": True,
+                "dtype": "dictionary<values=string, indices=int32, ordered=0>",
+                "field_id": "tier",
+                "nullable": True,
+                "timezone": None,
+            },
+            {
+                "categorical": False,
+                "dtype": "timestamp[s, tz=UTC]",
+                "field_id": "observed_at",
+                "nullable": True,
+                "timezone": "UTC",
+            },
+        ],
+        "index_policy": "excluded_by_dataframe_interchange_protocol",
+    }
+    assert bundle.manifest.diagnostics[0].code == "dataframe_interchange.copy.zero_copy"
+
+
+def test_dataframe_sdk_does_not_claim_an_unobservable_copy_outcome() -> None:
+    """Arrow's public interchange API does not report copies when allowed."""
+    bundle = from_dataframe(pa.table({"value": [1]}), dataset_id="auditable-sdk")
+    extension = bundle.manifest.model_dump(mode="json")["extensions"][
+        "voiage.dev:dataframe-interchange"
+    ]
+
+    assert extension["copy_policy"] == "allow_copy"
+    assert extension["copy_outcome"] == "not_observable"
+    assert bundle.manifest.diagnostics[0].code == "dataframe_interchange.copy.unknown"
+
+
 def test_dataframe_sdk_bundle_uses_the_standard_preparation_contract() -> None:
     """DataFrame callers receive the same explicit-binding VOI input as providers."""
     bundle = from_dataframe(

--- a/voiage/ingestion/dataframe.py
+++ b/voiage/ingestion/dataframe.py
@@ -10,11 +10,15 @@ from pyarrow.interchange import from_dataframe as arrow_from_dataframe
 from voiage.contracts.normalized_input import (
     DatasetManifest,
     FieldManifest,
+    IngestionDiagnostic,
     NormalizedInputBundle,
     SourceProvenance,
     TableManifest,
     VOIBinding,
 )
+
+_DIAGNOSTIC_EXTENSION = "voiage.dev:dataframe-interchange"
+_ADAPTER_VERSION = "1"
 
 
 def from_dataframe(
@@ -38,6 +42,7 @@ def from_dataframe(
             "with the requested copy policy"
         ) from error
     descriptor_digest = _table_digest(table, dataset_id=dataset_id, table_id=table_id)
+    conversion_details = _conversion_details(table, allow_copy=allow_copy)
     return NormalizedInputBundle(
         manifest=DatasetManifest(
             dataset_id=dataset_id,
@@ -56,6 +61,24 @@ def from_dataframe(
                 descriptor_digest=descriptor_digest,
             ),
             bindings=bindings,
+            diagnostics=(
+                IngestionDiagnostic(
+                    code=(
+                        "dataframe_interchange.copy.zero_copy"
+                        if not allow_copy
+                        else "dataframe_interchange.copy.unknown"
+                    ),
+                    severity="info",
+                    message=(
+                        "DataFrame interchange conversion was required to be zero-copy."
+                        if not allow_copy
+                        else "DataFrame interchange conversion permitted copies; "
+                        "the Arrow public API does not expose the exact copy outcome."
+                    ),
+                    table_id=table_id,
+                ),
+            ),
+            extensions={_DIAGNOSTIC_EXTENSION: conversion_details},
         ),
         tables={table_id: table},
     )
@@ -74,3 +97,30 @@ def _table_digest(table: pa.Table, *, dataset_id: str, table_id: str) -> str:
     hasher.update(b"\0")
     hasher.update(sink.getvalue().to_pybytes())
     return hasher.hexdigest()
+
+
+def _conversion_details(table: pa.Table, *, allow_copy: bool) -> dict[str, object]:
+    """Return stable, non-semantic diagnostics for an interchange conversion.
+
+    Arrow's public DataFrame-interchange interface can guarantee that a
+    successful ``allow_copy=False`` conversion did not permit copying.  It
+    deliberately does not expose whether a conversion with copying allowed
+    actually copied, so that state is recorded as ``not_observable`` rather
+    than guessed.
+    """
+    return {
+        "adapter_version": _ADAPTER_VERSION,
+        "copy_policy": "disallow_copy" if not allow_copy else "allow_copy",
+        "copy_outcome": "zero_copy" if not allow_copy else "not_observable",
+        "index_policy": "excluded_by_dataframe_interchange_protocol",
+        "field_decisions": [
+            {
+                "field_id": field.name,
+                "dtype": str(field.type),
+                "nullable": field.nullable,
+                "categorical": pa.types.is_dictionary(field.type),
+                "timezone": getattr(field.type, "tz", None),
+            }
+            for field in table.schema
+        ],
+    }


### PR DESCRIPTION
## Summary
- record stable, source-neutral DataFrame interchange conversion diagnostics
- distinguish guaranteed zero-copy conversions from Arrow copy outcomes that are not observable
- document the SDK diagnostic contract and record partial Phase 8 evidence

## Local validation
- `PYTHONPATH=. /tmp/voiage-phase4-coverage.Wsb9CC/bin/python -m pytest tests/test_dataframe_interchange_sdk.py tests/test_standardized_ingestion_providers.py -q --no-cov`
- `ruff check` and `ruff format --check`
- `ty check voiage/ingestion/dataframe.py`
- `pnpm run check` in `docs/astro-site`
- `python scripts/validate_conductor_github_cross_references.py .`

Phase 8 remains in progress pending the broader SDK consumer, clean-install, full-tox, security, and hosted-check evidence.