### PR TITLE
ci(ingestion): add standardized conformance lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,33 @@ jobs:
         name: codecov-umbrella
         fail_ci_if_error: false
 
+  ingestion-conformance:
+    name: Standardized Ingestion Conformance
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        persist-credentials: false
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+      with:
+        version: "0.11.29"
+        enable-cache: true
+        cache-suffix: ${{ github.job }}
+        cache-dependency-glob: "uv.lock"
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      with:
+        python-version: "3.14"
+
+    - name: Run tox conformance matrix
+      run: uv run --with tox tox -e ingestion-conformance
+      env:
+        CI: true
+
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -156,8 +156,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   converts their Arrow tables through Polars before asserting identical schema
   and rows (`b16b52df`, partial); adversarial and parser-differential coverage
   remains active.
-- [ ] **P5-T6 / AC-06:** Add the conformance matrix to tox and hosted CI; run
-  automated review, validation, and the phase checkpoint protocol.
+- [~] **P5-T6 / AC-06:** Add the conformance matrix to tox and hosted CI; run
+  automated review, validation, and the phase checkpoint protocol. The explicit
+  `ingestion-conformance` tox environment and named hosted job now run the
+  canonical cross-format, fixture-digest, and reference-case matrix (partial:
+  hosted result and phase checkpoint remain active).
 
 ## Phase 6 — Ship the user-facing product surface (#332)
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ env_list =
     harness
     typecheck
     docs
+    ingestion-conformance
     frontier-contract
     version-sync
     py312
@@ -94,6 +95,13 @@ commands =
     pnpm install --frozen-lockfile
     pnpm run check
     pnpm run build
+
+[testenv:ingestion-conformance]
+description = Run the canonical standardized-ingestion conformance matrix
+deps =
+    .[ci]
+commands =
+    pytest tests/test_standardized_ingestion_conformance.py tests/test_standardized_ingestion_fixture_validator.py tests/test_standardized_ingestion_reference_cases.py --no-cov -q
 
 [testenv:frontier-contract]
 commands =


### PR DESCRIPTION
## Summary
- add a named packaged-wheel tox environment for standardized ingestion conformance
- execute that environment in the protected CI workflow
- record Phase 5 Conductor and changelog evidence

## Local validation
- `uv run --with tox tox -e ingestion-conformance` (12 passed)
- `python scripts/validate_conductor_github_cross_references.py .`

Closes no issue; advances Conductor `standardized-dataset-ingestion_20260723` P5-T6 without claiming the remaining hosted acceptance evidence.