### PR TITLE
ci: harden polyglot release promotion

### DIFF
--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -12,28 +12,44 @@ permissions: {}
 jobs:
   verify-base-release:
     name: Verify shared immutable release manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
+      - name: Checkout exact retained-binding tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - name: Download shared release identity
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           version="${GITHUB_REF_NAME#*-v}"
+          source_commit="$(git rev-parse HEAD)"
           gh release download "v${version}" --repo "$GITHUB_REPOSITORY" \
             --pattern release-manifest.json --pattern polyglot.sbom.cdx.json
-          jq -e --arg version "$version" \
+          jq -e --arg source_commit "$source_commit" \
             '.schema_version == "1.0.0" and
-             any(.artifacts[]; .name | contains($version))' \
+             .source_commit == $source_commit and
+             (.artifacts | type == "array" and length > 0)' \
             release-manifest.json
+          jq -e \
+            --arg version "$version" \
+            --arg source_commit "$source_commit" \
+            --arg source_tag "v${version}" \
+            '.metadata.component.version == $version and
+             any(.metadata.properties[];
+                 .name == "voiage:source:commit" and .value == $source_commit) and
+             any(.metadata.properties[];
+                 .name == "voiage:source:tag" and .value == $source_tag)' \
+            polyglot.sbom.cdx.json
 
   julia:
     name: Release Julia package
     needs: verify-base-release
     if: startsWith(github.ref_name, 'julia-v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     defaults:
@@ -44,13 +60,21 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: "1.85"
       - name: Build the Rust C ABI used by Julia
         working-directory: rust
         run: cargo build --release --locked --package voiage-ffi
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
         with:
           version: "1.11"
-      - run: echo "Project.toml version is $(grep '^version' Project.toml)"
+      - name: Verify Project.toml version matches release tag
+        shell: bash
+        run: |
+          expected="${GITHUB_REF_NAME#julia-v}"
+          actual="$(sed -n 's/^version = "\(.*\)"/\1/p' Project.toml)"
+          test -n "$actual"
+          test "$actual" = "$expected"
       - run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'
         env:
           VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/rust/target/release/libvoiage_ffi.so
@@ -59,9 +83,9 @@ jobs:
     name: Release R package
     needs: verify-base-release
     if: startsWith(github.ref_name, 'r-v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
     defaults:
       run:
         working-directory: r-package/voiageR
@@ -70,6 +94,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: "1.85"
       - name: Build the Rust C ABI used by R
         working-directory: rust
         run: cargo build --release --locked --package voiage-ffi
@@ -91,3 +117,21 @@ jobs:
       - run: Rscript -e 'rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")'
         env:
           VOIAGE_FFI_LIBRARY: ${{ github.workspace }}/rust/target/release/libvoiage_ffi.so
+      - name: Publish immutable R source and manual release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          package_version="${GITHUB_REF_NAME#r-v}"
+          source_archive="$(find . -maxdepth 1 -name "voiageR_${package_version}.tar.gz" -print -quit)"
+          manual="$(find . -maxdepth 1 -name 'voiageR-manual.pdf' -print -quit)"
+          test -f "$source_archive"
+          test -f "$manual"
+          gh release create "$GITHUB_REF_NAME" \
+            "$source_archive" "$manual" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "voiageR ${package_version}" \
+            --generate-notes \
+            --latest=false

--- a/.github/workflows/polyglot-assurance.yml
+++ b/.github/workflows/polyglot-assurance.yml
@@ -1,6 +1,7 @@
 name: Polyglot Assurance Frontier
 
 on:
+  merge_group:
   pull_request:
     paths:
       - ".github/workflows/polyglot-assurance.yml"
@@ -75,11 +76,10 @@ jobs:
           python-version: "3.14"
       - name: Generate resolved Python dependency inventory
         run: |
-          uv export --frozen --no-dev --no-emit-project --format requirements-txt \
-            --output-file .polyglot-requirements.txt
-          uvx --from cyclonedx-bom==7.3.0 cyclonedx-py requirements \
-            .polyglot-requirements.txt --output-reproducible --of JSON \
-            -o python.sbom.cdx.json
+          uv sync --frozen --no-dev
+          uvx --from cyclonedx-bom==7.3.0 cyclonedx-py environment .venv \
+            --pyproject pyproject.toml --mc-type library \
+            --output-reproducible --of JSON -o python.sbom.cdx.json
       - name: Compose mixed-language dependency inventory
         run: >-
           python scripts/compose_polyglot_sbom.py compose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     outputs:
       tag_sha: ${{ steps.tag.outputs.tag_sha }}
+      is_prerelease: ${{ steps.tag.outputs.is_prerelease }}
     steps:
       - name: Check out repository for tag resolution
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -90,6 +91,11 @@ jobs:
           jq -e '.verification.verified == true' tag-verification.json >/dev/null
           test "$(jq -r '.tagger.email' tag-verification.json)" = "$APPROVED_TAGGER_EMAIL"
           echo "tag_sha=$tag_sha" >> "$GITHUB_OUTPUT"
+          if [[ "${RELEASE_TAG#v}" == *-* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
         with:
@@ -614,7 +620,34 @@ jobs:
       - name: Compare TestPyPI bytes with reviewed payload
         shell: bash
         run: |
+          set -euo pipefail
           release_version="${RELEASE_TAG#v}"
+          expected_manifest="$RUNNER_TEMP/reviewed-testpypi-manifest"
+          remote_manifest="$RUNNER_TEMP/remote-testpypi-manifest"
+          release_json="$RUNNER_TEMP/testpypi-release.json"
+          for distribution in reviewed-dist/*; do
+            test -f "$distribution"
+            printf '%s  %s\n' \
+              "$(sha256sum "$distribution" | cut -d ' ' -f1)" \
+              "$(basename "$distribution")"
+          done | LC_ALL=C sort > "$expected_manifest"
+          for attempt in 1 2 3 4 5 6; do
+            if curl --fail --silent --show-error \
+              "https://test.pypi.org/pypi/voiage/${release_version}/json" \
+              > "$release_json"; then
+              jq -r '.urls[] | "\(.digests.sha256)  \(.filename)"' \
+                "$release_json" | LC_ALL=C sort > "$remote_manifest"
+              if cmp --silent "$expected_manifest" "$remote_manifest"; then
+                break
+              fi
+            fi
+            if [[ "$attempt" == "6" ]]; then
+              echo "TestPyPI distribution set does not match the reviewed payload" >&2
+              diff --unified "$expected_manifest" "$remote_manifest" || true
+              exit 1
+            fi
+            sleep 20
+          done
           mkdir testpypi-dist
           python -m pip download --no-deps --only-binary=:all: \
             --index-url https://test.pypi.org/simple/ \
@@ -628,19 +661,19 @@ jobs:
       - name: Verify TestPyPI distribution attestations
         shell: bash
         run: |
-          distribution="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
+          set -euo pipefail
           release_version="${RELEASE_TAG#v}"
-          filename="$(basename "$distribution")"
-          distribution_url="$(
+          mapfile -t distribution_urls < <(
             curl --fail --silent --show-error \
               "https://test.pypi.org/pypi/voiage/${release_version}/json" |
-              jq --raw-output --arg filename "$filename" \
-                '.urls[] | select(.filename == $filename) | .url'
-          )"
-          test -n "$distribution_url"
-          uvx --from pypi-attestations pypi-attestations verify pypi --staging \
-            --repository "https://github.com/${GITHUB_REPOSITORY}" \
-            "$distribution_url"
+              jq --exit-status --raw-output '.urls[].url'
+          )
+          test "${#distribution_urls[@]}" -eq 4
+          for distribution_url in "${distribution_urls[@]}"; do
+            uvx --from pypi-attestations pypi-attestations verify pypi --staging \
+              --repository "https://github.com/${GITHUB_REPOSITORY}" \
+              "$distribution_url"
+          done
       - name: Install TestPyPI artifact with bounded retry
         shell: bash
         run: |
@@ -670,6 +703,7 @@ jobs:
   pypi:
     name: Publish to PyPI
     needs: [resolve-tag, test-pypi-smoke]
+    if: needs.resolve-tag.outputs.is_prerelease != 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment: pypi
@@ -708,6 +742,7 @@ jobs:
   github-release:
     name: Publish verified GitHub Release
     needs: [resolve-tag, pypi]
+    if: needs.resolve-tag.outputs.is_prerelease != 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/rust-crates-release.yml
+++ b/.github/workflows/rust-crates-release.yml
@@ -5,49 +5,145 @@ on:
     tags:
       - "rust-v*"
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing signed Rust release tag to publish"
+        required: true
+        type: string
 
 permissions: {}
+
+concurrency:
+  group: crates-io-${{ inputs.release_tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   publish:
     name: Publish Rust core crates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: crates-io
     permissions:
       contents: read
       id-token: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:
-      - name: Checkout
+      - name: Check out repository for tag resolution
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
+          fetch-depth: 1
           persist-credentials: false
-      - name: Install Rust
+      - name: Resolve signed immutable Rust release identity
+        shell: bash
+        env:
+          APPROVED_TAGGER_EMAIL: ${{ vars.RELEASE_TAGGER_EMAIL }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^rust-v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
+          release_version="${RELEASE_TAG#rust-v}"
+          remote_oid="$(
+            git ls-remote --exit-code --refs origin "refs/tags/$RELEASE_TAG" |
+              cut -f1
+          )"
+          test -n "$remote_oid"
+          git fetch --force --no-tags origin \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          test "$(git rev-parse "refs/tags/$RELEASE_TAG")" = "$remote_oid"
+          test "$(git cat-file -t "refs/tags/$RELEASE_TAG")" = tag
+          tag_sha="$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")"
+          test -n "$APPROVED_TAGGER_EMAIL"
+          gh api "repos/${GITHUB_REPOSITORY}/git/tags/$remote_oid" \
+            > rust-tag-verification.json
+          jq -e '.verification.verified == true' \
+            rust-tag-verification.json >/dev/null
+          test "$(
+            jq -r '.tagger.email' rust-tag-verification.json
+          )" = "$APPROVED_TAGGER_EMAIL"
+          git checkout --detach "$tag_sha"
+          test "$(git rev-parse HEAD)" = "$tag_sha"
+          test -z "$(git status --short)"
+
+          gh release download "v${release_version}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern release-manifest.json
+          jq -e --arg source_commit "$tag_sha" \
+            '.schema_version == "1.0.0" and
+             .source_commit == $source_commit' \
+            release-manifest.json >/dev/null
+
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          echo "RELEASE_COMMIT=$tag_sha" >> "$GITHUB_ENV"
+      - name: Install Rust 1.85
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
         with:
-          toolchain: stable
+          toolchain: "1.85"
+      - name: Verify all public crate versions match the release tag
+        working-directory: rust
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo metadata --format-version 1 --no-deps > metadata.json
+          mapfile -t public_crates < <(
+            jq -r '
+              .packages[]
+              | select(.publish == null or .publish != [])
+              | [.name, .version]
+              | @tsv
+            ' metadata.json | LC_ALL=C sort
+          )
+          expected=(
+            $'voiage-diagnostics\t'"$RELEASE_VERSION"
+            $'voiage-domain\t'"$RELEASE_VERSION"
+            $'voiage-numerics\t'"$RELEASE_VERSION"
+            $'voiage-serialization\t'"$RELEASE_VERSION"
+          )
+          test "${#public_crates[@]}" -eq "${#expected[@]}"
+          for index in "${!expected[@]}"; do
+            test "${public_crates[$index]}" = "${expected[$index]}"
+          done
       - name: Validate workspace packaging
         working-directory: rust
-        run: cargo package --workspace --locked --allow-dirty --no-verify
+        run: |
+          # Verification happens during `cargo publish` after each internal
+          # dependency is visible in the registry. Before the first publish,
+          # dependent packages cannot yet resolve this new exact version.
+          cargo package --locked --no-verify --package voiage-domain
+          cargo package --locked --no-verify --package voiage-diagnostics
+          cargo package --locked --no-verify --package voiage-numerics
+          cargo package --locked --no-verify --package voiage-serialization
       - name: Obtain short-lived crates.io credential
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
-      - name: Publish domain contracts
+      - name: Publish dependency-ordered crates with bounded visibility waits
         working-directory: rust
-        run: cargo publish --locked --package voiage-domain
+        shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-      - name: Publish diagnostics
-        working-directory: rust
-        run: cargo publish --locked --package voiage-diagnostics
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-      - name: Publish numerical kernels
-        working-directory: rust
-        run: cargo publish --locked --package voiage-numerics
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-      - name: Publish serialization
-        working-directory: rust
-        run: cargo publish --locked --package voiage-serialization
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          wait_for_crate() {
+            local crate="$1"
+            for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+              if cargo info "${crate}@${RELEASE_VERSION}" >/dev/null 2>&1; then
+                return 0
+              fi
+              if [[ "$attempt" == "12" ]]; then
+                echo "::error::${crate}@${RELEASE_VERSION} did not become visible"
+                return 1
+              fi
+              sleep 10
+            done
+          }
+
+          cargo publish --locked --package voiage-domain
+          wait_for_crate voiage-domain
+
+          cargo publish --locked --package voiage-diagnostics
+          wait_for_crate voiage-diagnostics
+
+          cargo publish --locked --package voiage-numerics
+          cargo publish --locked --package voiage-serialization
+          wait_for_crate voiage-numerics
+          wait_for_crate voiage-serialization

--- a/changelog.md
+++ b/changelog.md
@@ -83,6 +83,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Hardened stable and prerelease publishing across Python, Rust, R, and Julia:
+  TestPyPI now verifies the complete reviewed distribution set and every
+  attestation; prereleases cannot reach production PyPI or become the latest
+  GitHub release; Rust publication is bound to a signed tag and shared manifest;
+  and retained bindings validate exact shared source and version identity.
+- Expanded Renovate to cover declared R and Julia compatibility minima, added
+  merge-queue coverage to polyglot assurance, and repaired push-time dependency
+  inventory generation so its CycloneDX input always has a root component.
 - Recorded the authenticated SciCrunch submission, no-match duplicate check,
   account declarations, confirmation page, and pending external RRID curation.
 - Expanded the compiled conda-forge recipe from a Python 3.12-only build to

--- a/docs/astro-site/src/content/docs/developer-guide/polyglot-tooling.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/polyglot-tooling.mdx
@@ -25,7 +25,9 @@ Those tools are not forced onto non-Python bindings. The equivalent gates per ec
 Each binding follows the release conventions of its own ecosystem:
 
 - **Python**: `v*` tags, PyPI/TestPyPI publication, conda-forge via feedstock
-- **Rust**: `rust-v*` tags, GitHub Releases for the internal workspace; no crates.io package is currently claimed
+- **Rust**: signed `rust-v*` tags, four public core crates through crates.io
+  Trusted Publishing, with FFI/PyO3/test-support crates retained as private
+  workspace packages
 - **Julia**: `julia-v*` tags with TagBot sync and General registry
 - **R**: `r-v*` tags, GitHub Releases with CRAN/r-universe handled externally
 

--- a/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
@@ -53,7 +53,9 @@ The repository keeps ecosystem-specific tag and registry conventions:
 
 - Python publishes from `v*` tags
 - Julia publishes from `julia-v*` tags
-- Rust workspace artifacts are released from `rust-v*` tags; no crates.io package is currently claimed
+- Four binding-independent Rust core crates publish to crates.io from signed
+  `rust-v*` tags through Trusted Publishing; FFI, PyO3, and test-support crates
+  remain private
 - R publishes from `r-v*` tags
 
 The version numbers in package manifests must align with the latest released

--- a/docs/release/binding-submission-checklist.md
+++ b/docs/release/binding-submission-checklist.md
@@ -32,7 +32,7 @@ maintainer approval is inferred from an in-repo workflow or release tag.
 | Python | Automated PyPI/TestPyPI publish, tag-driven release, conda-forge update PR | conda-forge feedstock merge | No |
 | R | GitHub Release source archives | CRAN and r-universe | No |
 | Julia | Yggdrasil JLL build, Registrator, and subpackage TagBot sync | BinaryBuilder and Julia General bot/maintainer acceptance | No |
-| Rust | Publishable core crates plus GitHub Release workspace artifacts | crates.io review/indexing and trusted publishing credentials | Yes, repository-ready |
+| Rust | Signed-tag publication of four core crates plus shared GitHub Release evidence | crates.io indexing and configured Trusted Publishers | Yes, repository-ready |
 | Spack | Manual recipe preparation for Spack repository | Spack maintainer review and PR merge | No |
 | EasyBuild | Manual easyconfig preparation for EasyBuild repository | EasyBuild maintainer review and PR merge | No |
 | HPSF | Manual curation submission | External curation review / listing policy | No |
@@ -84,7 +84,12 @@ Software Heritage archival is complete for the v1.0.0 origin request: request
 
 - [x] `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc`, and `cargo package` gates exist in CI.
 - [x] The binding-independent Rust core crates are publishable on crates.io; FFI, PyO3, and test-support crates remain private.
-- [x] The tag-driven crates.io workflow publishes core crates in dependency order using `CARGO_REGISTRY_TOKEN`.
+- [x] The tag-driven crates.io workflow resolves an exact signed annotated
+  `rust-v*` tag, binds it to the shared `v*` release manifest, verifies all
+  public crate versions, and publishes the dependency layers with bounded
+  registry-visibility waits.
+- [x] Publication obtains a short-lived crates.io Trusted Publishing credential
+  through GitHub OIDC; no long-lived crates.io token is stored in the workflow.
 - [x] GitHub Release source archives are attached to the release.
 - [x] The Rust crate remains the canonical execution core and contract owner.
 
@@ -93,7 +98,9 @@ Software Heritage archival is complete for the v1.0.0 origin request: request
 If the question is "are all language versions submitted to their corresponding
 registries today?", the repo can only answer this partially:
 
-- The in-repo publishing workflows are in place for Python and the binding-independent Rust core; crates.io publication still requires the maintainer token and registry-side acceptance.
+- The in-repo publishing workflows are in place for Python and the
+  binding-independent Rust core; crates.io publication requires the configured
+  environment-bound Trusted Publishers and subsequent registry visibility.
 - Julia's JLL recipe is submitted; BinaryBuilder acceptance must precede the
   source-package Registrator submission. Conda-forge, CRAN, and r-universe
   still require external registry-side action or approval.
@@ -177,7 +184,8 @@ states:
 - HPSF and E4S remain external/manual curation targets because this repository
   cannot confirm inclusion from a package API alone.
 
-So the current live state is: Python is confirmed on PyPI; Rust is an internal
-workspace artifact; R, Julia, conda-forge, r-universe, Spack, and EasyBuild are
-not confirmed in their external registries; HPSF and E4S remain manual curation
-targets. The retired Go, TypeScript, and .NET channels are not v1.0 targets.
+So the recorded live state is: Python is confirmed on PyPI; the four
+binding-independent Rust core crates are the crates.io publication set while
+the adapter and test crates remain internal; R, Julia, conda-forge, r-universe,
+Spack, and EasyBuild are not confirmed in their external registries; HPSF and
+E4S remain manual curation targets. The retired Go, TypeScript, and .NET channels are not v1.0 targets.

--- a/renovate.json
+++ b/renovate.json
@@ -14,11 +14,42 @@
   ],
   "enabledManagers": [
     "cargo",
+    "custom.regex",
     "github-actions",
     "npm",
     "pep621",
     "pip_requirements",
     "pip_setup"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update CRAN minimum versions in the R DESCRIPTION",
+      "managerFilePatterns": ["/^r-package/voiageR/DESCRIPTION$/"],
+      "matchStrings": [
+        "(?<depName>reticulate) \\(>= (?<currentValue>[^)]+)\\)",
+        "(?<depName>knitr) \\(>= (?<currentValue>[^)]+)\\)",
+        "(?<depName>rmarkdown) \\(>= (?<currentValue>[^)]+)\\)",
+        "(?<depName>testthat) \\(>= (?<currentValue>[^)]+)\\)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "{{#if (equals depName 'reticulate')}}rstudio/reticulate{{else}}{{#if (equals depName 'knitr')}}yihui/knitr{{else}}{{#if (equals depName 'rmarkdown')}}rstudio/rmarkdown{{else}}r-lib/testthat{{/if}}{{/if}}{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "semver-coerced"
+    },
+    {
+      "customType": "regex",
+      "description": "Update non-stdlib Julia compatibility bounds",
+      "managerFilePatterns": ["/^bindings/julia/Project.toml$/"],
+      "matchStrings": [
+        "(?:^|\\n)(?<depName>Aqua) = \"(?<currentValue>[^\"]+)\"",
+        "(?:^|\\n)(?<depName>JSON) = \"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "{{#if (equals depName 'Aqua')}}JuliaTesting/Aqua.jl{{else}}JuliaIO/JSON.jl{{/if}}",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "versioningTemplate": "semver-coerced"
+    }
   ],
   "schedule": ["every weekend"],
   "minimumReleaseAge": "14 days",
@@ -39,6 +70,12 @@
       "automerge": true,
       "automergeType": "branch",
       "groupName": "github actions"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "rangeStrategy": "bump",
+      "automerge": false,
+      "labels": ["dependencies", "polyglot"]
     },
     {
       "matchPackageNames": ["python"],

--- a/roadmap.md
+++ b/roadmap.md
@@ -275,7 +275,7 @@ evidence and is not reopened by this queue.
 1.  **Automated Publishing Pipeline:**
     *   **Status: `✅ Done`**
     *   TestPyPI → PyPI publishing on `v*` tags, plus conda-forge feedstock recipe updates with the external feedstock merge remaining outside this repository.
-    *   Retained release workflows validate Rust workspace, Python, R, and Julia artifacts and attach GitHub release artifacts. The Rust workspace is intentionally internal (`publish = false`); no crates.io package, npm package, NuGet package, Go binding, TypeScript binding, .NET binding, or WASM surface is claimed. Registry-side indexing or approval remains external for conda-forge, CRAN/r-universe, and Julia General.
+    *   Retained release workflows validate Rust workspace, Python, R, and Julia artifacts and attach GitHub release artifacts. Four binding-independent Rust core crates publish through crates.io Trusted Publishing; the FFI, PyO3, and test-support crates remain `publish = false`. No npm package, NuGet package, Go binding, TypeScript binding, .NET binding, or WASM surface is claimed. Registry-side indexing or approval remains external for conda-forge, CRAN/r-universe, and Julia General.
     *   Repository versioning is now tag-derived for Python through
         `setuptools-scm`; external binding manifests stay synchronized to the
         latest released tag, and the version-sync validator is enforced in CI
@@ -351,7 +351,10 @@ evidence and is not reopened by this queue.
           Registrator publishes the `bindings/julia` subpackage to General and
           subpackage-aware TagBot creates collision-free releases. BinaryBuilder
           and General acceptance remain external.
-        - Rust: GitHub Releases for the internal `publish = false` workspace; a future crates.io facade would require a separate contract.
+        - Rust: four binding-independent core crates publish to crates.io from
+          signed `rust-v*` tags through short-lived Trusted Publishing
+          credentials; FFI, PyO3, and test-support crates remain private and
+          release through the shared GitHub artifact set.
     *   CI/CD must be language-specific and release-aware for every binding:
         - Build, lint/format, type/static checks, unit tests, docs checks, and shared conformance fixtures.
         - Package dry-run validation on pull requests.

--- a/tests/test_julia_release_workflow.py
+++ b/tests/test_julia_release_workflow.py
@@ -11,7 +11,9 @@ def test_julia_release_workflow_and_checklist_align() -> None:
     ).read_text()
 
     assert "julia-v*" in workflow_text
-    assert "Project.toml version" in workflow_text
+    assert "Verify Project.toml version matches release tag" in workflow_text
+    assert 'expected="${GITHUB_REF_NAME#julia-v}"' in workflow_text
+    assert 'test "$actual" = "$expected"' in workflow_text
     assert "Pkg.test()" in workflow_text
     assert 'gh release create "${GITHUB_REF_NAME}"' not in workflow_text
     assert "permissions:\n      contents: read" in workflow_text

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -31,6 +31,7 @@ def test_required_pr_workflows_support_merge_queue() -> None:
         "codeql.yml",
         "dependency-review.yml",
         "operational-assurance.yml",
+        "polyglot-assurance.yml",
     ):
         assert "merge_group:" in _text(name), name
 
@@ -104,7 +105,12 @@ def test_binding_releases_consume_the_shared_release_identity() -> None:
     workflow = _text("bindings-release.yml")
     assert "Verify shared immutable release manifest" in workflow
     assert "release-manifest.json" in workflow
+    assert ".source_commit == $source_commit" in workflow
+    assert ".metadata.component.version == $version" in workflow
+    assert 'toolchain: "1.85"' in workflow
+    assert "ubuntu-24.04" in workflow
     assert workflow.count("needs: verify-base-release") == 2
+    assert "Publish immutable R source and manual release" in workflow
 
 
 def test_shared_numerical_corpus_crosses_every_runtime_boundary() -> None:
@@ -141,6 +147,16 @@ def test_renovate_is_the_only_update_pr_producer() -> None:
     assert {"cargo", "github-actions", "npm", "pep621"} <= set(
         renovate["enabledManagers"]
     )
+    assert "custom.regex" in renovate["enabledManagers"]
+    custom_managers = renovate["customManagers"]
+    assert any(
+        "r-package/voiageR/DESCRIPTION" in manager["managerFilePatterns"][0]
+        for manager in custom_managers
+    )
+    assert any(
+        "bindings/julia/Project.toml" in manager["managerFilePatterns"][0]
+        for manager in custom_managers
+    )
     assert renovate["minimumReleaseAge"] == "14 days"
 
 
@@ -156,6 +172,14 @@ def test_dependency_graph_and_immutable_release_contracts_are_explicit() -> None
     assert "contents: write" in assurance
     assert "immutable release" in release.lower()
     assert "immutable releases" in quality.lower()
+
+
+def test_push_dependency_inventory_has_a_root_component() -> None:
+    """The push-only SBOM composition path must produce metadata.component."""
+    assurance = _text("polyglot-assurance.yml")
+    assert "cyclonedx-py environment .venv" in assurance
+    assert "--pyproject pyproject.toml --mc-type library" in assurance
+    assert "compose_polyglot_sbom.py compose" in assurance
 
 
 def test_ci_has_one_required_local_authority() -> None:

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -181,6 +181,11 @@ def test_python_release_publish_job_is_exact_tag_and_least_privilege() -> None:
     assert "needs: [resolve-tag, test-pypi]" in release_workflow
     assert "needs: [resolve-tag, test-pypi-smoke]" in release_workflow
     assert "needs: [resolve-tag, pypi]" in release_workflow
+    assert "is_prerelease: ${{ steps.tag.outputs.is_prerelease }}" in release_workflow
+    assert (
+        release_workflow.count("if: needs.resolve-tag.outputs.is_prerelease != 'true'")
+        == 2
+    )
 
 
 def test_python_release_keeps_staging_separate_from_publication() -> None:
@@ -230,6 +235,19 @@ def test_python_release_keeps_staging_separate_from_publication() -> None:
     assert 'gh release edit "$RELEASE_TAG" --draft=false' in release_workflow
     assert "git cat-file -t" in release_workflow
     assert ".verification.verified == true" in release_workflow
+
+
+def test_testpypi_requires_the_complete_reviewed_distribution_set() -> None:
+    release_workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert "reviewed-testpypi-manifest" in release_workflow
+    assert "remote-testpypi-manifest" in release_workflow
+    assert (
+        "jq -r '.urls[] | \"\\(.digests.sha256)  \\(.filename)\"'" in release_workflow
+    )
+    assert 'cmp --silent "$expected_manifest" "$remote_manifest"' in release_workflow
+    assert 'test "${#distribution_urls[@]}" -eq 4' in release_workflow
+    assert 'for distribution_url in "${distribution_urls[@]}"; do' in release_workflow
 
 
 def test_release_wheels_are_installed_and_exercised_before_upload() -> None:

--- a/tests/test_r_release_workflow.py
+++ b/tests/test_r_release_workflow.py
@@ -28,8 +28,11 @@ def test_r_release_workflow_and_checklist_align() -> None:
         "r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6"
         in ci_workflow_text
     )
-    assert "contents: read" in workflow_text
-    assert "contents: write" not in workflow_text
+    assert "Publish immutable R source and manual release" in workflow_text
+    assert 'gh release create "$GITHUB_REF_NAME"' in workflow_text
+    assert '"voiageR_${package_version}.tar.gz"' in workflow_text
+    assert "--latest=false" in workflow_text
+    assert "contents: write" in workflow_text
     assert "rust-v*" not in workflow_text
 
     assert (

--- a/tests/test_rust_release_workflow.py
+++ b/tests/test_rust_release_workflow.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import yaml
+
 
 def test_rust_release_workflow_and_checklist_align() -> None:
     root = Path.cwd()
@@ -14,20 +16,54 @@ def test_rust_release_workflow_and_checklist_align() -> None:
     ).read_text()
 
     assert '"rust-v*"' not in workflow_text
-    assert "contents: write" not in workflow_text
+    assert "contents: write" not in crates_workflow_text
     assert '"julia-v*"' in workflow_text
     assert '"r-v*"' in workflow_text
     assert '"rust-v*"' in crates_workflow_text
+    assert "release_tag:" in crates_workflow_text
+    assert "runs-on: ubuntu-24.04" in crates_workflow_text
+    assert 'toolchain: "1.85"' in crates_workflow_text
+    assert (
+        '[[ "$RELEASE_TAG" =~ ^rust-v[0-9]+\\.[0-9]+\\.[0-9]+' in crates_workflow_text
+    )
+    assert 'git cat-file -t "refs/tags/$RELEASE_TAG"' in crates_workflow_text
+    assert ".verification.verified == true" in crates_workflow_text
+    assert "vars.RELEASE_TAGGER_EMAIL" in crates_workflow_text
+    assert 'gh release download "v${release_version}"' in crates_workflow_text
+    assert ".source_commit == $source_commit" in crates_workflow_text
+    assert "Verify all public crate versions match the release tag" in (
+        crates_workflow_text
+    )
     assert "cargo publish --locked --package voiage-domain" in crates_workflow_text
     assert "cargo publish --locked --package voiage-diagnostics" in crates_workflow_text
     assert "cargo publish --locked --package voiage-numerics" in crates_workflow_text
     assert (
         "cargo publish --locked --package voiage-serialization" in crates_workflow_text
     )
+    assert "wait_for_crate voiage-domain" in crates_workflow_text
+    assert "wait_for_crate voiage-diagnostics" in crates_workflow_text
+    assert "wait_for_crate voiage-numerics" in crates_workflow_text
+    assert "wait_for_crate voiage-serialization" in crates_workflow_text
     assert "CARGO_REGISTRY_TOKEN" in crates_workflow_text
+    assert "secrets.CARGO_REGISTRY_TOKEN" not in crates_workflow_text
+    assert "rust-lang/crates-io-auth-action@" in crates_workflow_text
 
     assert (
         "The Rust crate remains the canonical execution core and contract owner."
         in checklist_text
     )
     assert "core crates are publishable on crates.io" in checklist_text
+    assert "short-lived crates.io Trusted Publishing credential" in checklist_text
+
+
+def test_rust_release_workflow_has_least_privilege_oidc_permissions() -> None:
+    workflow = yaml.safe_load(
+        Path(".github/workflows/rust-crates-release.yml").read_text()
+    )
+    assert workflow["permissions"] == {}
+    publish = workflow["jobs"]["publish"]
+    assert publish["environment"] == "crates-io"
+    assert publish["permissions"] == {
+        "contents": "read",
+        "id-token": "write",
+    }


### PR DESCRIPTION
## Summary
- fail closed Python prereleases and verify the complete TestPyPI distribution and attestation set
- bind Rust, R, and Julia releases to exact shared source/version identity; add crates.io propagation gates and immutable R assets
- extend Renovate to R/Julia, make Polyglot Assurance merge-queue safe, and repair push-time SBOM generation

## Verification
- full `tox` matrix: passed (Python 3.12/3.13/3.14, min/max dependencies, 91.79% coverage)
- `actionlint`: passed
- repository harness: 0 findings across 29 workflows
- push-only CycloneDX composition reproduced locally with 154 components

No independent approval is requested; the repository uses maintainer self-review plus protected automated checks.