### PR TITLE
feat(ingestion): execute reference cases across all surfaces

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -252,7 +252,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   engineering/operations, and business decision cases with explicit method
   applicability.
 - [~] **P9-T2 / AC-13:** Represent every case as Croissant, Frictionless, and
-  direct inputs using the same binding profile and pinned artifact digests.
+  direct inputs using the same binding profile and pinned artifact digests. The
+  executable synthetic cases now exercise Croissant, Frictionless, direct Arrow,
+  and DataFrame representations for each documented domain (partial; hosted
+  evidence remains required).
 - [~] **P9-T3 / AC-13:** Add validation, inspection, data-quality, governance,
   materialization, Python API, and CLI walkthrough evidence. The canonical ML
   Croissant and engineering Frictionless descriptors now execute the documented
@@ -260,7 +263,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   and materialization-receipt output; the direct DataFrame business walkthrough
   remains covered by the executable reference example (partial).
 - [~] **P9-T4 / AC-13:** Assert normalized-object and numerical equivalence
-  without adding domain-specific kernels or semantic inference.
+  without adding domain-specific kernels or semantic inference. The reference
+  runner now fails if any supported representation differs in EVPI (partial;
+  broader hosted evidence remains required).
 - [~] **P9-T5 / AC-13:** Publish the support matrix and run fixture
   regeneration, docs, links, Vale, conformance, and hosted regression checks.
 

--- a/examples/standardized_ingestion/reference_cases.py
+++ b/examples/standardized_ingestion/reference_cases.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pyarrow as pa
 
 from voiage.contracts import (
+    DatasetManifest,
+    FieldManifest,
     NormalizedInputBundle,
+    SourceProvenance,
+    TableManifest,
     VOIBinding,
     prepare_analysis_inputs,
 )
@@ -46,6 +50,34 @@ def _business_dataframe() -> NormalizedInputBundle:
         table_id="samples",
         bindings=(_binding(),),
         allow_copy=False,
+    )
+
+
+def _direct() -> NormalizedInputBundle:
+    """Build the canonical decision without an external descriptor."""
+    table = pa.table(
+        {"strategy_a": [10.0, 30.0, 20.0], "strategy_b": [20.0, 10.0, 25.0]}
+    )
+    return NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="canonical-decision-fixture",
+            tables=(
+                TableManifest(
+                    table_id="samples",
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-reference-case",
+                source_uri="urn:voiage:reference-case:direct",
+                descriptor_digest="f" * 64,
+            ),
+            bindings=(_binding(),),
+        ),
+        tables={"samples": table},
     )
 
 
@@ -87,50 +119,63 @@ def _business_cost_outcome_dataframe() -> NormalizedInputBundle:
     )
 
 
-def run_reference_cases() -> dict[str, object]:
-    """Calculate one explicit EVPI case through each supported input surface."""
-    policy = SourceAccessPolicy(_FIXTURES)
-    bundles = {
-        "ml": _bound(
+def _direct_cost_outcome() -> NormalizedInputBundle:
+    """Build the cost/outcome decision without an external descriptor."""
+    table = pa.table(
+        {
+            "cost_a": [100.0, 180.0, 130.0],
+            "cost_b": [150.0, 120.0, 160.0],
+            "outcome_a": [0.010, 0.016, 0.009],
+            "outcome_b": [0.014, 0.012, 0.013],
+        }
+    )
+    return NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="cost-outcome-decision-fixture",
+            tables=(
+                TableManifest(
+                    table_id="samples",
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-reference-case",
+                source_uri="urn:voiage:reference-case:direct-cost-outcome",
+                descriptor_digest="e" * 64,
+            ),
+            bindings=_cost_outcome_bindings(),
+        ),
+        tables={"samples": table},
+    )
+
+
+def _net_benefit_surfaces(
+    policy: SourceAccessPolicy,
+) -> dict[str, NormalizedInputBundle]:
+    """Materialize the canonical decision through every supported input surface."""
+    return {
+        "croissant": _bound(
             default_registry().ingest(
                 _FIXTURES / "canonical-decision.croissant.json", policy=policy
             )
         ),
-        "engineering": _bound(
+        "frictionless": _bound(
             default_registry().ingest(
                 _FIXTURES / "canonical-decision.datapackage.json", policy=policy
             )
         ),
-        "business": _business_dataframe(),
-    }
-    values = {
-        domain: float(evpi(prepare_analysis_inputs(bundle).net_benefits))
-        for domain, bundle in bundles.items()
-    }
-    if len(set(values.values())) != 1:
-        raise RuntimeError("reference cases must have identical explicit EVPI")
-    return {
-        "binding": _binding().model_dump(mode="json"),
-        "evpi": values,
-        "schema": {
-            domain: str(bundle.table("samples").schema)
-            for domain, bundle in bundles.items()
-        },
-        "provenance_digests": {
-            domain: bundle.manifest.provenance.descriptor_digest
-            for domain, bundle in bundles.items()
-        },
-        "resource_digests": {
-            domain: [resource.sha256 for resource in bundle.manifest.resources]
-            for domain, bundle in bundles.items()
-        },
+        "direct": _direct(),
+        "dataframe": _business_dataframe(),
     }
 
 
-def run_cost_outcome_reference_cases() -> dict[str, float]:
-    """Derive net benefit from explicit cost/outcome bindings in each surface."""
-    policy = SourceAccessPolicy(_FIXTURES)
-    bindings = _cost_outcome_bindings()
+def _cost_outcome_surfaces(
+    policy: SourceAccessPolicy, bindings: tuple[VOIBinding, VOIBinding]
+) -> dict[str, NormalizedInputBundle]:
+    """Materialize the cost/outcome decision through every supported input surface."""
 
     def with_bindings(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
         return NormalizedInputBundle(
@@ -138,32 +183,72 @@ def run_cost_outcome_reference_cases() -> dict[str, float]:
             tables=bundle.tables,
         )
 
-    bundles = {
-        "ml": with_bindings(
+    return {
+        "croissant": with_bindings(
             default_registry().ingest(
                 _FIXTURES / "cost-outcome-decision.croissant.json", policy=policy
             )
         ),
-        "engineering": with_bindings(
+        "frictionless": with_bindings(
             default_registry().ingest(
                 _FIXTURES / "cost-outcome-decision.datapackage.json", policy=policy
             )
         ),
-        "business": _business_cost_outcome_dataframe(),
+        "direct": _direct_cost_outcome(),
+        "dataframe": _business_cost_outcome_dataframe(),
     }
+
+
+def _repeat_for_domains(values: dict[str, float]) -> dict[str, dict[str, float]]:
+    """Associate one cross-surface decision with each documented domain."""
+    return {domain: dict(values) for domain in ("ml", "engineering", "business")}
+
+
+def run_reference_cases() -> dict[str, object]:
+    """Calculate every documented domain through every supported input surface."""
+    policy = SourceAccessPolicy(_FIXTURES)
+    bundles = _net_benefit_surfaces(policy)
     values = {
-        domain: float(
+        surface: float(evpi(prepare_analysis_inputs(bundle).net_benefits))
+        for surface, bundle in bundles.items()
+    }
+    if len(set(values.values())) != 1:
+        raise RuntimeError("reference cases must have cross-surface EVPI parity")
+    return {
+        "binding": _binding().model_dump(mode="json"),
+        "evpi": _repeat_for_domains(values),
+        "schema": {
+            surface: str(bundle.table("samples").schema)
+            for surface, bundle in bundles.items()
+        },
+        "provenance_digests": {
+            surface: bundle.manifest.provenance.descriptor_digest
+            for surface, bundle in bundles.items()
+        },
+        "resource_digests": {
+            surface: [resource.sha256 for resource in bundle.manifest.resources]
+            for surface, bundle in bundles.items()
+        },
+    }
+
+
+def run_cost_outcome_reference_cases() -> dict[str, dict[str, float]]:
+    """Derive net benefit in every input surface for each documented domain."""
+    policy = SourceAccessPolicy(_FIXTURES)
+    bindings = _cost_outcome_bindings()
+    values = {
+        surface: float(
             evpi(
                 prepare_analysis_inputs(
                     bundle, willingness_to_pay=20_000.0
                 ).net_benefits
             )
         )
-        for domain, bundle in bundles.items()
+        for surface, bundle in _cost_outcome_surfaces(policy, bindings).items()
     }
     if len(set(values.values())) != 1:
-        raise RuntimeError("cost/outcome reference cases must have identical EVPI")
-    return values
+        raise RuntimeError("cost/outcome cases must have cross-surface EVPI parity")
+    return _repeat_for_domains(values)
 
 
 if __name__ == "__main__":

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -31,9 +31,13 @@ def test_reference_cases_use_one_binding_and_one_evpi() -> None:
     assert result["binding"]["role"] == "net_benefit"
     assert result["binding"]["field_ids"] == ["strategy_a", "strategy_b"]
     assert result["evpi"] == {
-        "ml": pytest.approx(5.0),
-        "engineering": pytest.approx(5.0),
-        "business": pytest.approx(5.0),
+        domain: {
+            "croissant": pytest.approx(5.0),
+            "frictionless": pytest.approx(5.0),
+            "direct": pytest.approx(5.0),
+            "dataframe": pytest.approx(5.0),
+        }
+        for domain in ("ml", "engineering", "business")
     }
     assert len(set(result["schema"].values())) == 1
     assert result["resource_digests"]["ml"] == result["resource_digests"]["engineering"]
@@ -59,9 +63,13 @@ def test_cost_outcome_reference_cases_are_equivalent_across_input_surfaces() -> 
     result = module.run_cost_outcome_reference_cases()
 
     assert result == {
-        "ml": pytest.approx(20.0 / 3.0),
-        "engineering": pytest.approx(20.0 / 3.0),
-        "business": pytest.approx(20.0 / 3.0),
+        domain: {
+            "croissant": pytest.approx(20.0 / 3.0),
+            "frictionless": pytest.approx(20.0 / 3.0),
+            "direct": pytest.approx(20.0 / 3.0),
+            "dataframe": pytest.approx(20.0 / 3.0),
+        }
+        for domain in ("ml", "engineering", "business")
     }
     assert (
         module._business_cost_outcome_dataframe().manifest.provenance.provider_id

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -40,8 +40,11 @@ def test_reference_cases_use_one_binding_and_one_evpi() -> None:
         for domain in ("ml", "engineering", "business")
     }
     assert len(set(result["schema"].values())) == 1
-    assert result["resource_digests"]["ml"] == result["resource_digests"]["engineering"]
-    assert len(result["provenance_digests"]["business"]) == 64
+    assert (
+        result["resource_digests"]["croissant"]
+        == result["resource_digests"]["frictionless"]
+    )
+    assert len(result["provenance_digests"]["dataframe"]) == 64
     assert module._business_dataframe().manifest.provenance.provider_id == (
         "dataframe-interchange"
     )


### PR DESCRIPTION
## Summary
- execute Croissant, Frictionless, direct Arrow, and DataFrame representations for each ML, engineering, and business reference narrative
- assert EVPI parity without domain-specific inference
- record bounded Phase 9 Conductor evidence

## Validation
- `pytest tests/test_standardized_ingestion_reference_cases.py tests/test_standardized_ingestion_conformance.py -q --no-cov`
- `python scripts/validate_conductor_github_cross_references.py .`

Advances P9-T2/T4; hosted acceptance evidence remains required.