### PR TITLE
feat(ingestion): support Croissant context arrays

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Accepted the standard JSON-LD context-array form for the supported Croissant
+  1.1 offline profile and added an adversarial fixture that rejects the
+  distinct Croissant 1.10 context.
 - Added executable CLI walkthrough evidence for the canonical Croissant ML and
   Frictionless engineering reference descriptors.
 - Linked the README to the standardized Croissant and Frictionless ingestion

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -76,7 +76,8 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   and provider validation pass; full tox remains blocked by the pre-existing
   missing source-provenance and JOSS contract files in this clean worktree.
   Non-object descriptor-root handling is covered by the shared provider guard
-  (`333ee68f`, `d745d2d6`, `1e4e6bd7`, partial).
+  (`333ee68f`, `d745d2d6`, `1e4e6bd7`). JSON-LD context-array and exact-version
+  adversarial coverage: `5a3a7b04` (partial).
 - [~] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
   parser-feature gaps, live datasets, citations, PROV, usage information,
   ODRL, and RAI metadata preservation. Offline governance fixture added

--- a/tests/fixtures/croissant_1_1/unsupported/version-1-10.json
+++ b/tests/fixtures/croissant_1_1/unsupported/version-1-10.json
@@ -1,0 +1,10 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.10",
+  "distribution": [{"contentUrl": "../valid/data.csv", "encodingFormat": "text/csv"}],
+  "recordSet": [
+    {
+      "name": "decision_samples",
+      "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+    }
+  ]
+}

--- a/tests/fixtures/croissant_1_1/valid/context-array-croissant.json
+++ b/tests/fixtures/croissant_1_1/valid/context-array-croissant.json
@@ -1,0 +1,23 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "https://mlcommons.org/croissant/1.1"
+  ],
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
+  "name": "context-array-decision-samples",
+  "distribution": [
+    {
+      "contentUrl": "valid/data.csv",
+      "encodingFormat": "text/csv"
+    }
+  ],
+  "recordSet": [
+    {
+      "name": "decision_samples",
+      "field": [
+        {"name": "strategy_a"},
+        {"name": "strategy_b"}
+      ]
+    }
+  ]
+}

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -31,6 +31,7 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
         ("unsupported/split.json", "splits"),
         ("unsupported/transform.json", "transformations"),
         ("unsupported/version-1-0.json", "version 1.1"),
+        ("unsupported/version-1-10.json", "version 1.1"),
         ("unsupported/wrong-columns.json", "exactly declare"),
     ],
 )
@@ -90,6 +91,22 @@ def test_croissant_rejects_a_non_scalar_declared_field_data_type(tmp_path) -> No
 
     with pytest.raises(IngestionError, match="dataType must be a string"):
         CroissantProvider().ingest(descriptor, policy=SourceAccessPolicy(tmp_path))
+
+
+def test_croissant_offline_context_array_fixture_materializes() -> None:
+    """A Croissant 1.1 context can coexist with other JSON-LD contexts."""
+    descriptor_path = _FIXTURE_ROOT / "valid" / "context-array-croissant.json"
+
+    assert CroissantProvider().can_handle(
+        {"@context": ["https://schema.org/", "https://mlcommons.org/croissant/1.1"]}
+    )
+    bundle = CroissantProvider().ingest(
+        descriptor_path,
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert bundle.manifest.dataset_id == "context-array-decision-samples"
+    assert bundle.table("decision_samples").num_rows == 2
 
 
 def test_croissant_offline_identity_fixture_preserves_governance() -> None:

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -34,8 +34,10 @@ class CroissantProvider:
 
     def can_handle(self, descriptor: dict[str, object]) -> bool:
         """Recognize the Croissant context rather than a filename convention."""
-        context = descriptor.get("@context")
-        return isinstance(context, str) and "mlcommons.org/croissant" in context
+        return any(
+            "mlcommons.org/croissant" in context
+            for context in _context_entries(descriptor.get("@context"))
+        )
 
     def ingest(
         self, descriptor_path: Path, *, policy: SourceAccessPolicy
@@ -45,8 +47,7 @@ class CroissantProvider:
         if not isinstance(raw, dict):
             raise IngestionError("descriptor root must be a JSON object")
         descriptor = cast("dict[str, object]", raw)
-        context = descriptor.get("@context")
-        if not (isinstance(context, str) and "mlcommons.org/croissant/1.1" in context):
+        if not _has_croissant_1_1_context(descriptor.get("@context")):
             raise IngestionError("supported Croissant profile requires version 1.1")
         record_sets = descriptor.get("recordSet")
         distributions = descriptor.get("distribution")
@@ -195,6 +196,28 @@ def _declared_data_type(field: dict[str, object]) -> str | None:
     if value is None or isinstance(value, str):
         return value
     raise IngestionError("Croissant field dataType must be a string")
+
+
+def _context_entries(value: object) -> tuple[str, ...]:
+    """Return string entries from a JSON-LD context without coercion."""
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list):
+        return tuple(entry for entry in value if isinstance(entry, str))
+    return ()
+
+
+def _has_croissant_1_1_context(value: object) -> bool:
+    """Recognize the exact supported context among JSON-LD context entries."""
+    return any(
+        context.rstrip("/")
+        in {
+            "mlcommons.org/croissant/1.1",
+            "http://mlcommons.org/croissant/1.1",
+            "https://mlcommons.org/croissant/1.1",
+        }
+        for context in _context_entries(value)
+    )
 
 
 def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
## Summary\n- accept the supported Croissant 1.1 context when it appears in a JSON-LD context array\n- reject the distinct Croissant 1.10 context rather than accepting a version prefix\n- add file-backed offline conformance and adversarial fixtures\n- record the incremental P4-T2 evidence in the Conductor plan\n\n## Validation\n- ........................................................................ [ 69%]
...............................                                          [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
  /private/tmp/voiage-p4-croissant-governance/.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
    NAT_TYPES = {np.datetime64("NaT").dtype, np.timedelta64("NaT").dtype}

tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_adapter_does_not_require_a_specific_frame_library
tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_preserves_supported_nullable_and_temporal_values
tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_reports_a_disallowed_copy
tests/test_standardized_ingestion_providers.py::test_dataframe_interchange_rejects_unsupported_nested_values_with_stable_error
tests/test_standardized_ingestion_providers.py::test_registry_supports_a_fake_provider_with_injected_source_policy
  /private/tmp/voiage-p4-croissant-governance/.venv/lib/python3.14/site-packages/pyarrow/interchange/from_dataframe.py:88: DeprecationWarning: Support for the dataframe interchange protocol is deprecated since version 1.40.0
    return _from_dataframe(df.__dataframe__(allow_copy=allow_copy),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html (103 passed)\n- All checks passed!\n- \n\nThe full phase remains partial: this commits a bounded offline-conformance increment only; it does not claim the authoritative live probe or Phase 4 checkpoint.