### PR TITLE
feat(ingestion): allow explicit CLI source roots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1278,6 +1278,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unified accelerator evidence packet validation and deterministic indexing for passed GPU and blocked TPU/Metal runs, preserving CPU fallback and external-gate reasons.
 ## Unreleased
 
+- Added an explicit `--source-root` policy control to every standardized
+  ingestion CLI command, allowing descriptor and verified local resource roots
+  to be selected independently without weakening fail-closed size, cache, or
+  offline policy enforcement.
+
 - Submitted the signed v2.0.0 Rust C ABI to BinaryBuilder through Yggdrasil,
   added the Julia package licence and Aqua checks, removed runtime-only test
   dependencies and the committed library manifest, expanded Julia CI across

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -169,14 +169,17 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   diagnostic-redaction, and clean-install tests. The CLI now explicitly proves
   that a rejected credential-bearing descriptor URI is redacted at the
   user-facing boundary, and all four ingestion commands have executable help
-  contracts (partial: complete Phase 6 acceptance reconciliation remains
-  active).
+  contracts. Explicit non-default source-root tests now cover all materializing
+  commands and fail closed at the resource-byte limit (partial: complete Phase
+  6 acceptance reconciliation remains active).
 - [x] **P6-T2 / AC-07:** Add `croissant`, `frictionless`, and aggregate
   `ingestion` extras. The declared extras remain dependency-neutral because
   built-in providers require only the base Arrow/JSON stack.
 - [x] **P6-T3 / AC-07:** Implement `ingest validate`, `ingest inspect`,
   `ingest normalize`, and `calculate-from-dataset` with explicit selection,
-  binding, offline, and source-policy options.
+  binding, offline, and source-policy options. Every materializing command now
+  accepts an explicit `--source-root` in addition to the cache, offline, and
+  resource-size policy controls.
 - [x] **P6-T4 / AC-07, AC-11:** Make inspection output include data-quality,
   provider-capability, binding-resolution, governance, and materialization
   receipt details in stable machine-readable form.

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -312,12 +312,8 @@ def test_ingest_commands_expose_explicit_source_policy_controls(tmp_path) -> Non
     runner = CliRunner()
     source_policy = ["--source-root", str(source_root)]
     resolved = [
-        runner.invoke(
-            app, ["ingest", "validate", str(descriptor), *source_policy]
-        ),
-        runner.invoke(
-            app, ["ingest", "inspect", str(descriptor), *source_policy]
-        ),
+        runner.invoke(app, ["ingest", "validate", str(descriptor), *source_policy]),
+        runner.invoke(app, ["ingest", "inspect", str(descriptor), *source_policy]),
         runner.invoke(
             app,
             [

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -288,6 +288,96 @@ def test_normalize_and_calculate_return_safe_errors(tmp_path) -> None:
     )
 
 
+def test_ingest_commands_expose_explicit_source_policy_controls(tmp_path) -> None:
+    """CLI callers can make materialization policy explicit and fail closed."""
+    source_root = tmp_path / "declared-source-root"
+    source_root.mkdir()
+    (source_root / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "datapackage.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    source_policy = ["--source-root", str(source_root)]
+    resolved = [
+        runner.invoke(
+            app, ["ingest", "validate", str(descriptor), *source_policy]
+        ),
+        runner.invoke(
+            app, ["ingest", "inspect", str(descriptor), *source_policy]
+        ),
+        runner.invoke(
+            app,
+            [
+                "ingest",
+                "normalize",
+                str(descriptor),
+                "--output",
+                str(tmp_path / "normalized.arrow"),
+                *source_policy,
+            ],
+        ),
+        runner.invoke(
+            app,
+            [
+                "ingest",
+                "calculate-from-dataset",
+                str(descriptor),
+                "--table",
+                "samples",
+                "--field",
+                "a",
+                "--field",
+                "b",
+                *source_policy,
+            ],
+        ),
+    ]
+    constrained = runner.invoke(
+        app,
+        [
+            "ingest",
+            "validate",
+            str(descriptor),
+            "--source-root",
+            str(source_root),
+            "--max-resource-bytes",
+            "1",
+        ],
+    )
+    invalid_limit = runner.invoke(
+        app,
+        [
+            "ingest",
+            "validate",
+            str(descriptor),
+            "--source-root",
+            str(source_root),
+            "--max-resource-bytes",
+            "0",
+        ],
+    )
+
+    assert all(result.exit_code == 0 for result in resolved)
+    assert json.loads(resolved[0].output)["valid"] is True
+    assert constrained.exit_code == 2
+    assert "exceeds configured size limit" in constrained.output
+    assert invalid_limit.exit_code == 2
+    assert "Invalid value" in invalid_limit.output
+
+
 def test_ingest_cli_applies_explicit_resource_size_policy(tmp_path) -> None:
     """CLI policy flags constrain provider materialization without network opt-in."""
     (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -71,13 +71,14 @@ def _inspection_binding(
 def _source_policy(
     descriptor: Path,
     *,
+    source_root: Path | None,
     offline: bool,
     cache_dir: Path | None,
     max_resource_bytes: int,
 ) -> SourceAccessPolicy:
     """Build an explicit, local-only policy for one CLI invocation."""
     return SourceAccessPolicy(
-        descriptor.parent,
+        source_root or descriptor.parent,
         offline=offline,
         cache_dir=cache_dir,
         max_resource_bytes=max_resource_bytes,
@@ -143,6 +144,14 @@ def _bundle_summary(
 @app.command("validate")
 def validate(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
+    source_root: Path | None = typer.Option(
+        None,
+        "--source-root",
+        file_okay=False,
+        exists=True,
+        readable=True,
+        help="Explicit local root allowed for declared resources.",
+    ),
     offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
     cache_dir: Path | None = typer.Option(
         None, "--cache-dir", help="Verified materialization cache directory."
@@ -164,6 +173,7 @@ def validate(
                         descriptor,
                         policy=_source_policy(
                             descriptor,
+                            source_root=source_root,
                             offline=offline,
                             cache_dir=cache_dir,
                             max_resource_bytes=max_resource_bytes,
@@ -190,6 +200,14 @@ def inspect(
     strategy: list[str] = typer.Option(
         [], "--strategy", help="Optional strategy name; repeat in field order."
     ),
+    source_root: Path | None = typer.Option(
+        None,
+        "--source-root",
+        file_okay=False,
+        exists=True,
+        readable=True,
+        help="Explicit local root allowed for declared resources.",
+    ),
     offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
     cache_dir: Path | None = typer.Option(
         None, "--cache-dir", help="Verified materialization cache directory."
@@ -208,6 +226,7 @@ def inspect(
                     binding=binding,
                     policy=_source_policy(
                         descriptor,
+                        source_root=source_root,
                         offline=offline,
                         cache_dir=cache_dir,
                         max_resource_bytes=max_resource_bytes,
@@ -225,6 +244,14 @@ def inspect(
 def normalize(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
     output: Path = typer.Option(..., "--output", "-o"),
+    source_root: Path | None = typer.Option(
+        None,
+        "--source-root",
+        file_okay=False,
+        exists=True,
+        readable=True,
+        help="Explicit local root allowed for declared resources.",
+    ),
     offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
     cache_dir: Path | None = typer.Option(
         None, "--cache-dir", help="Verified materialization cache directory."
@@ -237,6 +264,7 @@ def normalize(
     try:
         policy = _source_policy(
             descriptor,
+            source_root=source_root,
             offline=offline,
             cache_dir=cache_dir,
             max_resource_bytes=max_resource_bytes,
@@ -261,6 +289,14 @@ def calculate_from_dataset(
     strategy: list[str] = typer.Option(
         [], "--strategy", help="Optional strategy name; repeat in field order."
     ),
+    source_root: Path | None = typer.Option(
+        None,
+        "--source-root",
+        file_okay=False,
+        exists=True,
+        readable=True,
+        help="Explicit local root allowed for declared resources.",
+    ),
     offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
     cache_dir: Path | None = typer.Option(
         None, "--cache-dir", help="Verified materialization cache directory."
@@ -275,6 +311,7 @@ def calculate_from_dataset(
             descriptor,
             policy=_source_policy(
                 descriptor,
+                source_root=source_root,
                 offline=offline,
                 cache_dir=cache_dir,
                 max_resource_bytes=max_resource_bytes,


### PR DESCRIPTION
## Summary
- add `--source-root` to every materializing standardized-ingestion CLI command
- preserve existing fail-closed offline, cache, and resource-size policy controls
- cover a descriptor outside its declared resource root across validate, inspect, normalize, and calculate paths
- record partial P6-T1/P6-T3 Conductor evidence; Phase 6 remains open

## Validation
- `uv run --extra ci pytest tests/test_standardized_ingestion_cli.py -q --no-cov`
- `uv run --with ruff ruff check voiage/ingestion/cli.py tests/test_standardized_ingestion_cli.py`
- `uv run --with ty ty check voiage/ingestion/cli.py`
- `python scripts/validate_conductor_github_cross_references.py .`
- `git diff --check`