### PR TITLE
test(ingestion): add cross-provider mapping properties

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -155,8 +155,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   tests, parser-differential checks, and fresh-process PyArrow/Polars checks.
   A fresh-process IPC/Parquet round-trip now reads normalized bundles and
   converts their Arrow tables through Polars before asserting identical schema
-  and rows (`b16b52df`, partial); adversarial and parser-differential coverage
-  remains active.
+  and rows (`b16b52df`). Generated Croissant/Frictionless CSV mappings now
+  assert identical rows and explicit binding preparation, while malformed
+  parser nodes and mismatched declared resource digests fail through the
+  stable error taxonomy (partial: broader parser-differential coverage remains
+  active; `0c6a2e7a`).
 - [~] **P5-T6 / AC-06:** Add the conformance matrix to tox and hosted CI; run
   automated review, validation, and the phase checkpoint protocol. The explicit
   `ingestion-conformance` tox environment and named hosted job now run the

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -309,7 +309,7 @@ def test_dataframe_and_direct_input_preserve_explicit_binding_under_column_order
     )
 )
 def test_provider_mapping_property_preserves_rows_and_explicit_binding(
-    rows: list[tuple[int, int]]
+    rows: list[tuple[int, int]],
 ) -> None:
     """Both descriptor formats preserve generated CSV rows without inference."""
     with TemporaryDirectory() as directory:
@@ -371,9 +371,10 @@ def test_provider_mapping_property_preserves_rows_and_explicit_binding(
         )
         expected = [[strategy_a, strategy_b] for strategy_a, strategy_b in rows]
 
-        assert croissant.table("samples").to_pylist() == frictionless.table(
-            "samples"
-        ).to_pylist()
+        assert (
+            croissant.table("samples").to_pylist()
+            == frictionless.table("samples").to_pylist()
+        )
         for bundle in (croissant, frictionless):
             prepared = prepare_analysis_inputs(bundle)
             assert prepared.net_benefits.numpy_values.tolist() == expected

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+from tempfile import TemporaryDirectory
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -294,3 +295,86 @@ def test_dataframe_and_direct_input_preserve_explicit_binding_under_column_order
     assert evpi(direct_prepared.net_benefits.numpy_values) == pytest.approx(
         evpi(dataframe_prepared.net_benefits.numpy_values)
     )
+
+
+@settings(max_examples=20, deadline=None)
+@given(
+    rows=st.lists(
+        st.tuples(
+            st.integers(min_value=-10_000, max_value=10_000),
+            st.integers(min_value=-10_000, max_value=10_000),
+        ),
+        min_size=1,
+        max_size=8,
+    )
+)
+def test_provider_mapping_property_preserves_rows_and_explicit_binding(
+    rows: list[tuple[int, int]]
+) -> None:
+    """Both descriptor formats preserve generated CSV rows without inference."""
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        csv_path = root / "samples.csv"
+        csv_path.write_text(
+            "strategy_a,strategy_b\n"
+            + "".join(
+                f"{strategy_a},{strategy_b}\n" for strategy_a, strategy_b in rows
+            ),
+            encoding="utf-8",
+        )
+        croissant_path = root / "croissant.json"
+        croissant_path.write_text(
+            json.dumps(
+                {
+                    "@context": "https://mlcommons.org/croissant/1.1",
+                    "name": "property-decision-fixture",
+                    "distribution": [{"contentUrl": csv_path.name}],
+                    "recordSet": [
+                        {
+                            "name": "samples",
+                            "field": [
+                                {"name": "strategy_a"},
+                                {"name": "strategy_b"},
+                            ],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        frictionless_path = root / "datapackage.json"
+        frictionless_path.write_text(
+            json.dumps(
+                {
+                    "name": "property-decision-fixture",
+                    "resources": [
+                        {
+                            "name": "samples",
+                            "path": csv_path.name,
+                            "schema": {
+                                "fields": [
+                                    {"name": "strategy_a", "type": "integer"},
+                                    {"name": "strategy_b", "type": "integer"},
+                                ]
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        policy = SourceAccessPolicy(root)
+        croissant = _bound(default_registry().ingest(croissant_path, policy=policy))
+        frictionless = _bound(
+            default_registry().ingest(frictionless_path, policy=policy)
+        )
+        expected = [[strategy_a, strategy_b] for strategy_a, strategy_b in rows]
+
+        assert croissant.table("samples").to_pylist() == frictionless.table(
+            "samples"
+        ).to_pylist()
+        for bundle in (croissant, frictionless):
+            prepared = prepare_analysis_inputs(bundle)
+            assert prepared.net_benefits.numpy_values.tolist() == expected
+            assert prepared.net_benefits.strategy_names == ["A", "B"]

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -713,6 +713,77 @@ def test_providers_reject_ambiguous_or_incomplete_descriptors(
         provider.ingest(path, policy=SourceAccessPolicy(tmp_path))
 
 
+@pytest.mark.parametrize(
+    ("key", "value", "message"),
+    [
+        ("recordSet", ["not-an-object"], "recordSet object"),
+        ("distribution", ["not-an-object"], "distribution object"),
+    ],
+)
+def test_croissant_provider_rejects_non_object_parser_nodes_with_stable_error(
+    tmp_path, key: str, value: list[str], message: str
+) -> None:
+    """Adversarial JSON nodes cannot escape as parser implementation errors."""
+    _write_csv(tmp_path)
+    descriptor = {
+        "@context": "https://mlcommons.org/croissant/1.1",
+        "name": "malformed-croissant-node",
+        "recordSet": [{"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}],
+        "distribution": [{"contentUrl": "samples.csv"}],
+    }
+    descriptor[key] = value
+    descriptor_path = tmp_path / "croissant.json"
+    descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+
+    with pytest.raises(IngestionError, match=message):
+        default_registry().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
+def test_builtin_providers_do_not_silently_ignore_integrity_declarations(
+    tmp_path,
+) -> None:
+    """A profile without a verifier must reject, rather than ignore, a digest claim."""
+    _write_csv(tmp_path)
+    croissant_path = tmp_path / "croissant.json"
+    croissant_path.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "distribution": [
+                    {"contentUrl": "samples.csv", "sha256": "0" * 64}
+                ],
+                "recordSet": [
+                    {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    frictionless_path = tmp_path / "datapackage.json"
+    frictionless_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "hash": "0" * 64,
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    for path, message in (
+        (croissant_path, "declared Croissant SHA-256"),
+        (frictionless_path, "checksum"),
+    ):
+        with pytest.raises(IngestionError, match=message):
+            default_registry().ingest(path, policy=SourceAccessPolicy(tmp_path))
+
+
 def test_registry_rejects_invalid_and_ambiguous_descriptors(tmp_path) -> None:
     invalid = tmp_path / "invalid.json"
     invalid.write_text("[1]", encoding="utf-8")

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -749,9 +749,7 @@ def test_builtin_providers_do_not_silently_ignore_integrity_declarations(
         json.dumps(
             {
                 "@context": "https://mlcommons.org/croissant/1.1",
-                "distribution": [
-                    {"contentUrl": "samples.csv", "sha256": "0" * 64}
-                ],
+                "distribution": [{"contentUrl": "samples.csv", "sha256": "0" * 64}],
                 "recordSet": [
                     {"name": "samples", "field": [{"name": "a"}, {"name": "b"}]}
                 ],


### PR DESCRIPTION
## Summary

- add generated Croissant/Frictionless CSV mapping parity through the normalized preparation boundary
- add adversarial stable-error coverage for malformed Croissant parser nodes
- assert mismatched integrity declarations fail rather than being ignored
- record partial P5-T5 Conductor evidence; parser-differential coverage remains active

## Validation

- `.venv/bin/python -m pytest -q --no-cov tests/test_standardized_ingestion_conformance.py tests/test_standardized_ingestion_providers.py`
- `uv run --with ruff ruff check tests/test_standardized_ingestion_conformance.py tests/test_standardized_ingestion_providers.py`
- `python scripts/validate_conductor_github_cross_references.py .`