### PR TITLE
fix(ingestion): reject hard-linked cache entries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accepted the standard JSON-LD context-array form for the supported Croissant
   1.1 offline profile and added an adversarial fixture that rejects the
   distinct Croissant 1.10 context.
+- Reject hard-linked standardized-ingestion cache entries so a verified object
+  cannot share a writable inode with an untrusted alternate path.
 - Added executable CLI walkthrough evidence for the canonical Croissant ML and
   Frictionless engineering reference descriptors.
 - Linked the README to the standardized Croissant and Frictionless ingestion

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -205,8 +205,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   cache-poisoning, checksum-mismatch, decompression-ratio, and mutable-live-data
   tests. Partial evidence: `d3550e9c` rejects a cache-namespace symlink whose
   resolved directory escapes the configured cache root before it can redirect a
-  verified materialization; the remote/archive and mutable-live-source cases
-  remain active.
+  verified materialization; hard-linked cache entries are also rejected so a
+  verified object cannot share a writable inode with an alternate path
+  (partial). The remote/archive and mutable-live-source cases remain active.
 - [~] **P7-T3 / AC-08, AC-11:** Complete source-policy enforcement,
   content-addressed verified caching, immutable materialization receipts,
   offline replay, and streaming or bounded-batch behavior.

--- a/tests/test_source_policy_cache.py
+++ b/tests/test_source_policy_cache.py
@@ -225,6 +225,29 @@ def test_materialize_rejects_a_symlinked_cache_entry(tmp_path) -> None:
         policy.materialize("source.csv", sha256=digest)
 
 
+def test_materialize_rejects_a_hard_linked_cache_entry(tmp_path) -> None:
+    """A cache object must not share a writable inode with another path."""
+    source = tmp_path / "source.csv"
+    payload = b"value\n1\n"
+    source.write_bytes(payload)
+    digest = _digest(payload)
+    cache = tmp_path / "cache"
+    policy = SourceAccessPolicy(tmp_path, cache_dir=cache)
+    cached = policy.materialize("source.csv", sha256=digest)
+    replacement = tmp_path / "replacement.csv"
+    cached.unlink()
+    replacement.write_bytes(payload)
+    cached.hardlink_to(replacement)
+
+    with pytest.raises(IngestionError, match="cached materialization checksum"):
+        policy.materialize("source.csv", sha256=digest)
+    source.unlink()
+    with pytest.raises(IngestionError, match="verified offline materialization"):
+        SourceAccessPolicy(tmp_path, cache_dir=cache, offline=True).materialize(
+            "source.csv", sha256=digest
+        )
+
+
 def test_materialize_rejects_a_cache_namespace_symlink_that_escapes_cache_root(
     tmp_path,
 ) -> None:

--- a/todo.md
+++ b/todo.md
@@ -82,6 +82,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
         DataFrame example.
     *   The README now links the conservative Croissant/Frictionless ingestion
         surface to its profile matrix, offline policy, and cross-domain examples.
+    *   Verified offline-cache entries now reject symlinks and hard links so a
+        cache object cannot be redirected or mutated through another path.
 
 ## Completed public documentation
 

--- a/voiage/ingestion/base.py
+++ b/voiage/ingestion/base.py
@@ -92,7 +92,7 @@ class SourceAccessPolicy:
                     "offline replay requires an expected SHA-256 digest"
                 )
             cached = self._cache_path(expected)
-            if cached is None or not cached.is_file() or cached.is_symlink():
+            if not self._is_safe_cached_file(cached):
                 raise IngestionError("no verified offline materialization is available")
             if self._digest(cached) != expected:
                 raise IngestionError("cached materialization checksum does not match")
@@ -113,11 +113,7 @@ class SourceAccessPolicy:
         assert cached is not None
         cached.parent.mkdir(parents=True, exist_ok=True)
         if cached.exists():
-            if (
-                not cached.is_file()
-                or cached.is_symlink()
-                or self._digest(cached) != actual
-            ):
+            if not self._is_safe_cached_file(cached) or self._digest(cached) != actual:
                 raise IngestionError("cached materialization checksum does not match")
             return cached
         shutil.copyfile(source, cached)
@@ -151,6 +147,13 @@ class SourceAccessPolicy:
         if candidate != self.root and self.root not in candidate.parents:
             raise IngestionError("resource path escapes the configured source root")
         return candidate
+
+    @staticmethod
+    def _is_safe_cached_file(candidate: Path | None) -> bool:
+        """Return whether a cache object has no alternate writable path."""
+        if candidate is None or not candidate.is_file() or candidate.is_symlink():
+            return False
+        return candidate.stat().st_nlink == 1
 
     @staticmethod
     def _validate_digest(digest: str) -> str:


### PR DESCRIPTION
## Summary
- reject hard-linked objects from content-addressed ingestion caches
- cover cache-hit and offline-replay poisoning paths
- record Phase 7 P7-T2 partial security evidence

## Validation
- `.venv/bin/python -m pytest tests/test_source_policy_cache.py -q --no-cov`
- `uvx ruff check voiage/ingestion/base.py tests/test_source_policy_cache.py`
- `.venv/bin/python scripts/validate_conductor_github_cross_references.py .`
- `git diff --check`

The strict cache invariant prevents a verified cache entry from sharing a writable inode with an arbitrary alternate path.