### PR TITLE
chore(release): prepare v2.0.1-rc.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
     outputs:
       tag_sha: ${{ steps.tag.outputs.tag_sha }}
       is_prerelease: ${{ steps.tag.outputs.is_prerelease }}
+      python_version: ${{ steps.version.outputs.python_version }}
     steps:
       - name: Check out repository for tag resolution
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -112,7 +113,17 @@ jobs:
       - name: Install locked validation tooling
         run: uv sync --locked --extra ci
       - name: Fail closed on release version
-        run: uv run --no-sync python -m voiage.versioning --release-tag "$RELEASE_TAG"
+        id: version
+        shell: bash
+        run: |
+          uv run --no-sync python -m voiage.versioning --release-tag "$RELEASE_TAG"
+          python_version="$(
+            uv run --no-sync python -m voiage.versioning \
+              --release-tag "$RELEASE_TAG" \
+              --print-python-version
+          )"
+          test -n "$python_version"
+          echo "python_version=$python_version" >> "$GITHUB_OUTPUT"
 
   wheels:
     name: Native wheel (${{ matrix.platform }})
@@ -364,6 +375,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       TAG_SHA: ${{ needs.resolve-tag.outputs.tag_sha }}
+      PYTHON_VERSION: ${{ needs.resolve-tag.outputs.python_version }}
       EXPECTED_NATIVE_ARCHITECTURES: linux-x86_64,macos-arm64,windows-x86_64
     steps:
       - name: Check out immutable release commit
@@ -386,10 +398,8 @@ jobs:
           merge-multiple: true
       - name: Validate complete extensible artifact set
         run: |
-          release_version="${RELEASE_TAG#v}"
-          export RELEASE_VERSION="$release_version"
-          python -c "import os; from pathlib import Path; version=os.environ['RELEASE_VERSION']; abi=os.environ['VOIAGE_PYTHON_ABI']; expected=set(os.environ['EXPECTED_NATIVE_ARCHITECTURES'].split(',')); wheels=list(Path('dist').glob('*.whl')); manifests=list(Path('dist').glob('wheel-manifest-*.txt')); actual={m.stem.removeprefix('wheel-manifest-') for m in manifests}; assert actual==expected, f'expected native architectures {expected}, found {actual}'; assert len(wheels)==len(manifests)>0, f'expected one wheel per architecture manifest: {wheels=} {manifests=}'; declared={m.read_text(encoding='utf-8').strip() for m in manifests}; assert declared=={w.name for w in wheels}; assert all(f'voiage-{version}-{abi}-' in w.name for w in wheels)"
-          python -c "import os; from pathlib import Path; version=os.environ['RELEASE_VERSION']; sdists=list(Path('dist').glob('*.tar.gz')); assert len(sdists)==1, f'expected exactly one source distribution, found {sdists}'; assert sdists[0].name==f'voiage-{version}.tar.gz'"
+          python -c "import os; from pathlib import Path; version=os.environ['PYTHON_VERSION']; abi=os.environ['VOIAGE_PYTHON_ABI']; expected=set(os.environ['EXPECTED_NATIVE_ARCHITECTURES'].split(',')); wheels=list(Path('dist').glob('*.whl')); manifests=list(Path('dist').glob('wheel-manifest-*.txt')); actual={m.stem.removeprefix('wheel-manifest-') for m in manifests}; assert actual==expected, f'expected native architectures {expected}, found {actual}'; assert len(wheels)==len(manifests)>0, f'expected one wheel per architecture manifest: {wheels=} {manifests=}'; declared={m.read_text(encoding='utf-8').strip() for m in manifests}; assert declared=={w.name for w in wheels}; assert all(f'voiage-{version}-{abi}-' in w.name for w in wheels)"
+          python -c "import os; from pathlib import Path; version=os.environ['PYTHON_VERSION']; sdists=list(Path('dist').glob('*.tar.gz')); assert len(sdists)==1, f'expected exactly one source distribution, found {sdists}'; assert sdists[0].name==f'voiage-{version}.tar.gz'"
       - name: Attest release artifacts
         id: provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
@@ -399,8 +409,8 @@ jobs:
         shell: bash
         run: |
           test -s "$PROVENANCE_BUNDLE"
-          cp "$PROVENANCE_BUNDLE" "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl"
-          test -s "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl"
+          cp "$PROVENANCE_BUNDLE" "dist/voiage-${PYTHON_VERSION}.intoto.jsonl"
+          test -s "dist/voiage-${PYTHON_VERSION}.intoto.jsonl"
         env:
           PROVENANCE_BUNDLE: ${{ steps.provenance.outputs.bundle-path }}
       - name: Bind polyglot SBOM to release subjects
@@ -595,6 +605,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       TAG_SHA: ${{ needs.resolve-tag.outputs.tag_sha }}
+      PYTHON_VERSION: ${{ needs.resolve-tag.outputs.python_version }}
     steps:
       - name: Check out immutable release commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -621,7 +632,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          release_version="${RELEASE_TAG#v}"
           expected_manifest="$RUNNER_TEMP/reviewed-testpypi-manifest"
           remote_manifest="$RUNNER_TEMP/remote-testpypi-manifest"
           release_json="$RUNNER_TEMP/testpypi-release.json"
@@ -633,7 +643,7 @@ jobs:
           done | LC_ALL=C sort > "$expected_manifest"
           for attempt in 1 2 3 4 5 6; do
             if curl --fail --silent --show-error \
-              "https://test.pypi.org/pypi/voiage/${release_version}/json" \
+              "https://test.pypi.org/pypi/voiage/${PYTHON_VERSION}/json" \
               > "$release_json"; then
               jq -r '.urls[] | "\(.digests.sha256)  \(.filename)"' \
                 "$release_json" | LC_ALL=C sort > "$remote_manifest"
@@ -651,7 +661,7 @@ jobs:
           mkdir testpypi-dist
           python -m pip download --no-deps --only-binary=:all: \
             --index-url https://test.pypi.org/simple/ \
-            --dest testpypi-dist "voiage==$release_version"
+            --dest testpypi-dist "voiage==$PYTHON_VERSION"
           reviewed="$(find reviewed-dist -maxdepth 1 -name '*manylinux*x86_64.whl' -print -quit)"
           downloaded="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
           test -n "$reviewed"
@@ -662,10 +672,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          release_version="${RELEASE_TAG#v}"
           mapfile -t distribution_urls < <(
             curl --fail --silent --show-error \
-              "https://test.pypi.org/pypi/voiage/${release_version}/json" |
+              "https://test.pypi.org/pypi/voiage/${PYTHON_VERSION}/json" |
               jq --exit-status --raw-output '.urls[].url'
           )
           test "${#distribution_urls[@]}" -eq 4
@@ -677,12 +686,11 @@ jobs:
       - name: Install TestPyPI artifact with bounded retry
         shell: bash
         run: |
-          release_version="${RELEASE_TAG#v}"
           uv export --locked --extra ci --no-dev --no-emit-project --output-file locked-requirements.txt
           uv venv --python "${{ matrix.python }}" .testpypi-venv
           uv pip install --python .testpypi-venv -r locked-requirements.txt
           for attempt in 1 2 3 4 5 6; do
-            if uv pip install --python .testpypi-venv --no-deps --refresh-package voiage --index-url https://test.pypi.org/simple/ "voiage==$release_version"; then
+            if uv pip install --python .testpypi-venv --no-deps --refresh-package voiage --index-url https://test.pypi.org/simple/ "voiage==$PYTHON_VERSION"; then
               break
             fi
             if [[ "$attempt" == "6" ]]; then

--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
-version = "2.0.0"
+version = "2.0.1-rc.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/changelog.md
+++ b/changelog.md
@@ -91,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Prepared the `v2.0.1-rc.1` TestPyPI candidate with explicit ecosystem version
+  projections: canonical Cargo/Julia SemVer, normalized Python PEP 440, and an
+  honest numeric R development version bound to the canonical release identity.
 - Hardened stable and prerelease publishing across Python, Rust, R, and Julia:
   TestPyPI now verifies the complete reviewed distribution set and every
   attestation; prereleases cannot reach production PyPI or become the latest

--- a/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
@@ -62,6 +62,14 @@ The version numbers in package manifests must align with the latest released
 Python tag. Tag prefixes and registry targets remain ecosystem-specific; only
 the version value is shared.
 
+For a Python release candidate, Cargo and Julia retain the canonical SemVer
+identity (for example, `2.0.1-rc.1`) while Python uses its normalized PEP 440
+distribution identity (`2.0.1rc1`). R cannot represent an alphanumeric
+prerelease in `DESCRIPTION`, so it uses a numeric development version below the
+target stable release and records the canonical identity in
+`Config/voiage/Release-Version`. Such a candidate is Python/TestPyPI-only: it
+does not create `r-v*`, `julia-v*`, or `rust-v*` publication tags.
+
 ## Validation
 
 The repo-local validator checks the canonical version against binding manifests:

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 2.0.0
+Version: 2.0.0.9001
+Config/voiage/Release-Version: 2.0.1-rc.1
 Authors@R: person("Dylan", "Mordaunt",
     email = "voiage@users.noreply.github.com",
     role = c("aut", "cre"),
@@ -18,7 +19,7 @@ Encoding: UTF-8
 NeedsCompilation: no
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
-SystemRequirements: voiage-ffi shared library (version 2.0.0 or compatible);
+SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.1 or compatible);
     Python (>= 3.12, optional, for EVPPI and EVSI through reticulate)
 Suggests:
     reticulate (>= 1.20),

--- a/r-package/voiageR/tests/testthat/test-release-workflow.R
+++ b/r-package/voiageR/tests/testthat/test-release-workflow.R
@@ -22,8 +22,10 @@ test_that("the R release workflow is tied to r-v tags and source artifacts", {
   expect_true(any(grepl("R CMD build", workflow_text, fixed = TRUE)))
   expect_true(any(grepl("tools/build-manual.R", workflow_text, fixed = TRUE)))
   expect_true(any(grepl("r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6", workflow_text, fixed = TRUE)))
+  expect_true(any(grepl("permissions: {}", workflow_text, fixed = TRUE)))
   expect_true(any(grepl("contents: read", workflow_text, fixed = TRUE)))
-  expect_false(any(grepl("contents: write", workflow_text, fixed = TRUE)))
+  expect_true(any(grepl("contents: write", workflow_text, fixed = TRUE)))
+  expect_true(any(grepl("gh release create", workflow_text, fixed = TRUE)))
   expect_false(any(grepl("rust-v*", workflow_text, fixed = TRUE)))
 })
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 dependencies = [
  "proptest",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-ffi"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 dependencies = [
  "proptest",
  "voiage-diagnostics",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-python"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 dependencies = [
  "pyo3",
  "serde",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-serialization"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-test-support"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1-rc.1"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/edithatogo/voiage"
 
 [workspace.dependencies]
-voiage-diagnostics = { version = "=2.0.0", path = "crates/voiage-diagnostics" }
-voiage-domain = { version = "=2.0.0", path = "crates/voiage-domain" }
-voiage-numerics = { version = "=2.0.0", path = "crates/voiage-numerics" }
-voiage-serialization = { version = "=2.0.0", path = "crates/voiage-serialization" }
+voiage-diagnostics = { version = "=2.0.1-rc.1", path = "crates/voiage-diagnostics" }
+voiage-domain = { version = "=2.0.1-rc.1", path = "crates/voiage-domain" }
+voiage-numerics = { version = "=2.0.1-rc.1", path = "crates/voiage-numerics" }
+voiage-serialization = { version = "=2.0.1-rc.1", path = "crates/voiage-serialization" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/scripts/compose_polyglot_sbom.py
+++ b/scripts/compose_polyglot_sbom.py
@@ -308,6 +308,12 @@ def _r_inventory(
             "voiage:inventory:source": "r-package/voiageR/DESCRIPTION",
         },
     )
+    release_identity = fields.get("Config/voiage/Release-Version")
+    if release_identity:
+        _set_properties(
+            root,
+            {"voiage:release:canonical-version": release_identity.strip()},
+        )
 
     components = [root]
     direct_refs: list[str] = []
@@ -559,12 +565,46 @@ def compose_sbom(
             )
             == "true"
         ]
-        first_party_components.extend((r_components[0], julia_components[0]))
+        first_party_components.append(julia_components[0])
         mismatches = [
             f"{component['name']}={component.get('version', '<missing>')}"
             for component in first_party_components
             if component.get("version") != source_version
         ]
+        r_component = r_components[0]
+        r_version = r_component.get("version")
+        r_properties = _property_map(r_component.get("properties"))
+        if r_version != source_version:
+            expected_r_identity = r_properties.get(
+                "voiage:release:canonical-version"
+            )
+            rc_match = re.fullmatch(
+                r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+                r"-rc\.(?P<rc>\d+)",
+                source_version,
+            )
+            r_parts = (
+                tuple(int(part) for part in r_version.split("."))
+                if isinstance(r_version, str)
+                and re.fullmatch(r"\d+(?:\.\d+)+", r_version)
+                else ()
+            )
+            target_parts = (
+                tuple(
+                    int(rc_match.group(part))
+                    for part in ("major", "minor", "patch")
+                )
+                if rc_match is not None
+                else ()
+            )
+            if (
+                rc_match is None
+                or expected_r_identity != source_version
+                or len(r_parts) < 4
+                or r_parts[:3] >= target_parts
+                or r_parts[-1] != 9000 + int(rc_match.group("rc"))
+            ):
+                mismatches.append(f"{r_component['name']}={r_version or '<missing>'}")
         if mismatches:
             raise SbomError(
                 "release binding versions do not match source version "

--- a/tests/packaging/test_wheel_black_box.py
+++ b/tests/packaging/test_wheel_black_box.py
@@ -82,7 +82,7 @@ def test_installed_native_provenance_matches_built_artifact() -> None:
     if os.environ.get("WHEEL_VENV") is None:
         return
     info = native.runtime_info()
-    assert info["core_version"] == version("voiage")
+    assert str(info["core_version"]).replace("-rc.", "rc") == version("voiage")
     assert info["source_revision"] == os.environ["EXPECTED_SOURCE_REVISION"]
     assert info["source_tree_git_oid"] == os.environ["EXPECTED_SOURCE_TREE_GIT_OID"]
     assert info["source_dirty"] is False

--- a/tests/test_compose_polyglot_sbom.py
+++ b/tests/test_compose_polyglot_sbom.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tomllib
@@ -375,6 +376,121 @@ def test_release_composition_rejects_binding_version_drift(
             cargo_workspace=cargo_workspace,
             r_description=r_description,
             julia_project=julia_project,
+        )
+
+
+def test_release_composition_accepts_explicit_retained_r_prerelease_identity(
+    python_sbom: Path,
+    cargo_workspace: Path,
+    r_description: Path,
+    julia_project: Path,
+) -> None:
+    for path in (
+        cargo_workspace / "Cargo.toml",
+        cargo_workspace / "Cargo.lock",
+        julia_project,
+    ):
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("1.2.3", "1.2.3-rc.1"),
+            encoding="utf-8",
+        )
+    r_description.write_text(
+        r_description.read_text(encoding="utf-8").replace(
+            "Version: 1.2.3",
+            "Version: 1.2.2.9001\nConfig/voiage/Release-Version: 1.2.3-rc.1",
+        ),
+        encoding="utf-8",
+    )
+
+    document = compose_sbom(
+        python_sbom=python_sbom,
+        cargo_workspace=cargo_workspace,
+        r_description=r_description,
+        julia_project=julia_project,
+        source_version="1.2.3-rc.1",
+        source_commit=SOURCE_COMMIT,
+        source_tag="v1.2.3-rc.1",
+    )
+
+    r_component = next(
+        component
+        for component in document["components"]
+        if _properties(component).get("voiage:ecosystem") == "r"
+        and component["name"] == "voiageR"
+    )
+    assert r_component["version"] == "1.2.2.9001"
+    assert _properties(r_component)["voiage:release:canonical-version"] == "1.2.3-rc.1"
+
+
+def test_release_composition_rejects_unbound_r_prerelease_version(
+    python_sbom: Path,
+    cargo_workspace: Path,
+    r_description: Path,
+    julia_project: Path,
+) -> None:
+    for path in (
+        cargo_workspace / "Cargo.toml",
+        cargo_workspace / "Cargo.lock",
+        julia_project,
+    ):
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("1.2.3", "1.2.3-rc.1"),
+            encoding="utf-8",
+        )
+    r_description.write_text(
+        r_description.read_text(encoding="utf-8").replace(
+            "Version: 1.2.3",
+            "Version: 1.2.2.9001",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SbomError, match="voiageR=1.2.2.9001"):
+        compose_sbom(
+            python_sbom=python_sbom,
+            cargo_workspace=cargo_workspace,
+            r_description=r_description,
+            julia_project=julia_project,
+            source_version="1.2.3-rc.1",
+            source_commit=SOURCE_COMMIT,
+            source_tag="v1.2.3-rc.1",
+        )
+
+
+@pytest.mark.parametrize("r_version", ["1.2.3.9001", "1.2.2.9002"])
+def test_release_composition_rejects_invalid_r_prerelease_projection(
+    python_sbom: Path,
+    cargo_workspace: Path,
+    r_description: Path,
+    julia_project: Path,
+    r_version: str,
+) -> None:
+    for path in (
+        cargo_workspace / "Cargo.toml",
+        cargo_workspace / "Cargo.lock",
+        julia_project,
+    ):
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("1.2.3", "1.2.3-rc.1"),
+            encoding="utf-8",
+        )
+    r_description.write_text(
+        r_description.read_text(encoding="utf-8").replace(
+            "Version: 1.2.3",
+            f"Version: {r_version}\nConfig/voiage/Release-Version: 1.2.3-rc.1",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SbomError, match=rf"voiageR={re.escape(r_version)}"):
+        compose_sbom(
+            python_sbom=python_sbom,
+            cargo_workspace=cargo_workspace,
+            r_description=r_description,
+            julia_project=julia_project,
+            source_version="1.2.3-rc.1",
+            source_commit=SOURCE_COMMIT,
+            source_tag="v1.2.3-rc.1",
         )
 
 

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -86,7 +86,7 @@ def test_python_release_workflow_builds_and_publishes_aggregated_artifacts() -> 
     )
     assert "id: provenance" in release_workflow
     assert "${{ steps.provenance.outputs.bundle-path }}" in release_workflow
-    assert "dist/voiage-${RELEASE_TAG#v}.intoto.jsonl" in release_workflow
+    assert "dist/voiage-${PYTHON_VERSION}.intoto.jsonl" in release_workflow
     assert "dist/*.intoto.jsonl" in release_workflow
     assert (
         "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"
@@ -182,6 +182,28 @@ def test_python_release_publish_job_is_exact_tag_and_least_privilege() -> None:
     assert "needs: [resolve-tag, test-pypi-smoke]" in release_workflow
     assert "needs: [resolve-tag, pypi]" in release_workflow
     assert "is_prerelease: ${{ steps.tag.outputs.is_prerelease }}" in release_workflow
+    assert (
+        "python_version: ${{ steps.version.outputs.python_version }}"
+        in release_workflow
+    )
+    assert (
+        "python -m voiage.versioning \\\n"
+        '              --release-tag "$RELEASE_TAG" \\\n'
+        "              --print-python-version" in release_workflow
+    )
+    assert (
+        release_workflow.count(
+            "PYTHON_VERSION: ${{ needs.resolve-tag.outputs.python_version }}"
+        )
+        == 2
+    )
+    assert "${RELEASE_TAG#v}.intoto.jsonl" not in release_workflow
+    assert '"dist/voiage-${PYTHON_VERSION}.intoto.jsonl"' in release_workflow
+    assert 'release_version="${RELEASE_TAG#v}"' not in release_workflow
+    assert (
+        '"https://test.pypi.org/pypi/voiage/${PYTHON_VERSION}/json"' in release_workflow
+    )
+    assert '"voiage==$PYTHON_VERSION"' in release_workflow
     assert (
         release_workflow.count("if: needs.resolve-tag.outputs.is_prerelease != 'true'")
         == 2

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -16,7 +16,13 @@ def test_version_sync_launcher_prefers_repository_package() -> None:
     assert path_setup < package_import
 
 
-def _write_versioned_repo(root: Path, version: str) -> None:
+def _write_versioned_repo(
+    root: Path,
+    version: str,
+    *,
+    r_version: str | None = None,
+    r_release_version: str | None = None,
+) -> None:
     (root / "pyproject.toml").write_text(
         """
 [project]
@@ -37,10 +43,10 @@ dynamic = ["version"]
         encoding="utf-8",
     )
     (root / "r-package/voiageR").mkdir(parents=True)
-    (root / "r-package/voiageR/DESCRIPTION").write_text(
-        "Package: voiageR\nVersion: " + version + "\n",
-        encoding="utf-8",
-    )
+    description = f"Package: voiageR\nVersion: {r_version or version}\n"
+    if r_release_version is not None:
+        description += f"Config/voiage/Release-Version: {r_release_version}\n"
+    (root / "r-package/voiageR/DESCRIPTION").write_text(description, encoding="utf-8")
 
 
 def test_validate_version_sync_accepts_matching_manifests(tmp_path: Path) -> None:
@@ -51,6 +57,100 @@ def test_validate_version_sync_accepts_matching_manifests(tmp_path: Path) -> Non
     assert canonical == "0.2.0"
     assert mismatches == []
     assert versioning.main(["--repo-root", str(tmp_path)]) == 0
+
+
+def test_release_candidate_projects_ecosystem_versions(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_versioned_repo(
+        tmp_path,
+        "2.0.1-rc.1",
+        r_version="2.0.0.9001",
+        r_release_version="2.0.1-rc.1",
+    )
+
+    identity = versioning.release_identity("2.0.1-rc.1")
+    canonical, mismatches = versioning.validate_version_sync(tmp_path)
+
+    assert identity == versioning.ReleaseIdentity(
+        canonical="2.0.1-rc.1",
+        python="2.0.1rc1",
+        cargo="2.0.1-rc.1",
+        julia="2.0.1-rc.1",
+        is_prerelease=True,
+    )
+    assert canonical == "2.0.1-rc.1"
+    assert mismatches == []
+    assert (
+        versioning.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--release-tag",
+                "v2.0.1-rc.1",
+                "--print-python-version",
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out == "2.0.1rc1\n"
+
+
+def test_stable_release_identity_remains_exact() -> None:
+    assert versioning.release_identity("2.0.1") == versioning.ReleaseIdentity(
+        canonical="2.0.1",
+        python="2.0.1",
+        cargo="2.0.1",
+        julia="2.0.1",
+        is_prerelease=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "2.0.1-alpha.1",
+        "2.0.1-beta.1",
+        "2.0.1-rc",
+        "2.0.1-rc.01",
+        "02.0.1",
+        "2.0",
+    ],
+)
+def test_release_identity_rejects_unsupported_versions(version: str) -> None:
+    with pytest.raises(versioning.VersionSyncError, match="unsupported canonical"):
+        versioning.release_identity(version)
+
+
+def test_release_candidate_requires_explicit_r_identity(tmp_path: Path) -> None:
+    _write_versioned_repo(
+        tmp_path,
+        "2.0.1-rc.1",
+        r_version="2.0.0.9001",
+    )
+
+    with pytest.raises(versioning.VersionSyncError, match="R release identity"):
+        versioning.validate_version_sync(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "r_version",
+    ["2.0.1-rc.1", "2.0.1.9001", "2.0.0.9002"],
+)
+def test_release_candidate_rejects_invalid_r_projection(
+    tmp_path: Path,
+    r_version: str,
+) -> None:
+    _write_versioned_repo(
+        tmp_path,
+        "2.0.1-rc.1",
+        r_version=r_version,
+        r_release_version="2.0.1-rc.1",
+    )
+
+    with pytest.raises(versioning.VersionSyncError, match="R package version"):
+        versioning.validate_version_sync(tmp_path)
 
 
 def test_validate_version_sync_reports_manifest_drift(

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -107,6 +107,13 @@ def test_stable_release_identity_remains_exact() -> None:
     )
 
 
+def test_stable_release_rejects_r_version_drift(tmp_path: Path) -> None:
+    _write_versioned_repo(tmp_path, "2.0.1", r_version="2.0.0")
+
+    with pytest.raises(versioning.VersionSyncError, match="R"):
+        versioning.validate_version_sync(tmp_path)
+
+
 @pytest.mark.parametrize(
     "version",
     [

--- a/todo.md
+++ b/todo.md
@@ -169,6 +169,14 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Prepare the signed `v2.0.1-rc.1` TestPyPI candidate contract.
+    *   Added explicit Cargo/Julia SemVer, Python PEP 440, and R numeric
+        development-version projections without claiming R, Julia, or
+        crates.io prerelease publication.
+    *   Bound release filenames, TestPyPI queries, attestations, and smoke
+        installs to the normalized Python identity while preserving the
+        canonical signed tag and mixed-language SBOM identity.
+
 *   [x] Normalize and archive the historical Conductor registry.
     *   Archived track:
         `conductor/archive/conductor-registry-normalization_20260727/`.

--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -166,9 +166,7 @@ def _read_description_release_version(path: Path) -> str | None:
     for line in path.read_text(encoding="utf-8").splitlines():
         match = _DESCRIPTION_RELEASE_VERSION_RE.match(line.strip())
         if match:
-            version = match.group("version").strip()
-            if version:
-                return version
+            return match.group("version").strip()
     return None
 
 

--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -19,6 +19,16 @@ from defusedxml import ElementTree
 
 REPO_ROOT = Path.cwd()
 _DESCRIPTION_VERSION_RE = re.compile(r"^Version:\s*(?P<version>\S+)\s*$")
+_DESCRIPTION_RELEASE_VERSION_RE = re.compile(
+    r"^Config/voiage/Release-Version:\s*(?P<version>\S+)\s*$"
+)
+_CANONICAL_VERSION_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\."
+    r"(?P<minor>0|[1-9]\d*)\."
+    r"(?P<patch>0|[1-9]\d*)"
+    r"(?:-rc\.(?P<rc>0|[1-9]\d*))?$"
+)
+_R_VERSION_RE = re.compile(r"^(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){1,}$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,6 +48,17 @@ class VersionMismatch:
     path: Path
     expected: str
     found: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseIdentity:
+    """Canonical release identity and its ecosystem-specific projections."""
+
+    canonical: str
+    python: str
+    cargo: str
+    julia: str
+    is_prerelease: bool
 
 
 class VersionSyncError(RuntimeError):
@@ -140,6 +161,85 @@ def _read_description_version(path: Path) -> str:
     raise VersionSyncError(f"{path}: missing Version field")
 
 
+def _read_description_release_version(path: Path) -> str | None:
+    """Read the optional canonical release identity from an R DESCRIPTION."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = _DESCRIPTION_RELEASE_VERSION_RE.match(line.strip())
+        if match:
+            version = match.group("version").strip()
+            if version:
+                return version
+    return None
+
+
+def release_identity(version: str) -> ReleaseIdentity:
+    """Validate a canonical version and project it into package ecosystems.
+
+    Stable versions are identical in Cargo, Julia, and Python. Release
+    candidates retain their SemVer spelling in Cargo and Julia while Python
+    uses its normalized PEP 440 spelling. Other prerelease labels are rejected
+    so release automation cannot silently invent ecosystem-specific mappings.
+    """
+    match = _CANONICAL_VERSION_RE.fullmatch(version)
+    if match is None:
+        raise VersionSyncError(
+            f"unsupported canonical version {version!r}; expected MAJOR.MINOR.PATCH"
+            " or MAJOR.MINOR.PATCH-rc.N"
+        )
+    rc = match.group("rc")
+    python_version = version if rc is None else version.split("-rc.", 1)[0] + f"rc{rc}"
+    return ReleaseIdentity(
+        canonical=version,
+        python=python_version,
+        cargo=version,
+        julia=version,
+        is_prerelease=rc is not None,
+    )
+
+
+def _read_r_release_identity(path: Path) -> str:
+    """Read the canonical identity represented by an R DESCRIPTION."""
+    return _read_description_release_version(path) or _read_description_version(path)
+
+
+def _r_version_mismatch(
+    path: Path,
+    identity: ReleaseIdentity,
+) -> VersionMismatch | None:
+    """Validate the native R version that represents a canonical identity."""
+    r_version = _read_description_version(path)
+    if not identity.is_prerelease:
+        if r_version == identity.canonical:
+            return None
+        return VersionMismatch("R", path, identity.canonical, r_version)
+
+    if _R_VERSION_RE.fullmatch(r_version) is None:
+        return VersionMismatch(
+            "R package version",
+            path,
+            "a numeric R development version",
+            r_version,
+        )
+
+    canonical_match = _CANONICAL_VERSION_RE.fullmatch(identity.canonical)
+    assert canonical_match is not None  # validated by release_identity
+    rc_number = int(canonical_match.group("rc") or "0")
+    r_parts = tuple(int(part) for part in r_version.split("."))
+    target_parts = tuple(
+        int(canonical_match.group(part)) for part in ("major", "minor", "patch")
+    )
+    expected_suffix = 9000 + rc_number
+    if r_parts[:3] >= target_parts or r_parts[-1] != expected_suffix:
+        return VersionMismatch(
+            "R package version",
+            path,
+            f"a numeric version below {'.'.join(map(str, target_parts))} "
+            f"ending in .{expected_suffix}",
+            r_version,
+        )
+    return None
+
+
 VERSION_TARGETS: tuple[VersionTarget, ...] = (
     VersionTarget(
         "Python Rust adapter",
@@ -148,7 +248,9 @@ VERSION_TARGETS: tuple[VersionTarget, ...] = (
     ),
     VersionTarget("Julia", Path("bindings/julia/Project.toml"), _read_toml_version),
     VersionTarget(
-        "R", Path("r-package/voiageR/DESCRIPTION"), _read_description_version
+        "R release identity",
+        Path("r-package/voiageR/DESCRIPTION"),
+        _read_r_release_identity,
     ),
 )
 
@@ -156,6 +258,7 @@ VERSION_TARGETS: tuple[VersionTarget, ...] = (
 def validate_release_tag(tag: str, repo_root: Path = REPO_ROOT) -> str:
     """Fail closed unless ``tag`` exactly matches the Cargo workspace version."""
     canonical = _read_canonical_version(repo_root / "pyproject.toml")
+    release_identity(canonical)
     expected = f"v{canonical}"
     if tag != expected:
         raise VersionSyncError(
@@ -169,6 +272,7 @@ def collect_version_mismatches(
 ) -> tuple[str, list[VersionMismatch]]:
     """Collect manifest version mismatches against the canonical repo version."""
     canonical = _read_canonical_version(repo_root / "pyproject.toml")
+    identity = release_identity(canonical)
     mismatches: list[VersionMismatch] = []
     for target in VERSION_TARGETS:
         manifest_path = repo_root / target.path
@@ -184,6 +288,12 @@ def collect_version_mismatches(
                     found=found,
                 )
             )
+    r_path = repo_root / "r-package/voiageR/DESCRIPTION"
+    r_mismatch = _r_version_mismatch(r_path, identity)
+    if r_mismatch is not None and not any(
+        mismatch.path == r_path for mismatch in mismatches
+    ):
+        mismatches.append(r_mismatch)
     return canonical, mismatches
 
 
@@ -229,6 +339,11 @@ def main(argv: list[str] | None = None) -> int:
         "--release-tag",
         help="Require an exact v<workspace-version> release tag.",
     )
+    parser.add_argument(
+        "--print-python-version",
+        action="store_true",
+        help="Print only the normalized Python package version.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -239,20 +354,26 @@ def main(argv: list[str] | None = None) -> int:
         print(str(exc), file=sys.stderr)
         return 1
 
-    print(
-        f"validated version synchronization against {args.repo_root / 'pyproject.toml'} @ {canonical}"
-    )
+    if args.print_python_version:
+        print(release_identity(canonical).python)
+    else:
+        print(
+            f"validated version synchronization against "
+            f"{args.repo_root / 'pyproject.toml'} @ {canonical}"
+        )
     return 0
 
 
 __all__ = [
     "REPO_ROOT",
+    "ReleaseIdentity",
     "VersionMismatch",
     "VersionSyncError",
     "VersionTarget",
     "collect_version_mismatches",
     "format_version_mismatches",
     "main",
+    "release_identity",
     "validate_release_tag",
     "validate_version_sync",
 ]


### PR DESCRIPTION
## Summary

- prepare canonical `v2.0.1-rc.1` manifests across Cargo and Julia
- project the candidate to Python PEP 440 `2.0.1rc1` and R development version `2.0.0.9001`
- bind TestPyPI artifact names, queries, attestations, and smoke installs to the normalized Python version
- retain the canonical signed-tag identity in the polyglot SBOM while fail-closing on invalid R projections

## Release boundary

This is a Python/TestPyPI-only release candidate. It does not publish to production PyPI, crates.io, R, or Julia registries and does not create a public/latest GitHub release. A signed tag will be created only after this PR is merged and the exact merged commit is green; tag staging will create a private draft for explicit hash review before TestPyPI publication.

## Validation

- `actionlint .github/workflows/release.yml`
- focused release/version/SBOM tests: 65 passed
- real maturin sdist and wheel names: `voiage-2.0.1rc1`
- full tox matrix: vale, JOSS, harness, typecheck, docs, frontier, version sync, Python 3.13/3.14, min/max dependencies, and 90% coverage passed
- rerun corrected lanes: lint passed; Python 3.12 passed (2,447 tests, 16 expected skips)