### PR TITLE
fix(release): prepare v2.0.1-rc.2 SBOM root

### DIFF
--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/changelog.md
+++ b/changelog.md
@@ -93,9 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Prepared the `v2.0.1-rc.1` TestPyPI candidate with explicit ecosystem version
-  projections: canonical Cargo/Julia SemVer, normalized Python PEP 440, and an
-  honest numeric R development version bound to the canonical release identity.
+- Prepared the `v2.0.1-rc.2` TestPyPI candidate with explicit ecosystem version
+  projections and a deterministic aggregate root for dependency-only Python
+  SBOM input. RC2 supersedes the unpublished RC1 staging attempt, which failed
+  closed before a draft release or registry publication.
 - Hardened stable and prerelease publishing across Python, Rust, R, and Julia:
   TestPyPI now verifies the complete reviewed distribution set and every
   attestation; prereleases cannot reach production PyPI or become the latest

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 2.0.0.9001
-Config/voiage/Release-Version: 2.0.1-rc.1
+Version: 2.0.0.9002
+Config/voiage/Release-Version: 2.0.1-rc.2
 Authors@R: person("Dylan", "Mordaunt",
     email = "voiage@users.noreply.github.com",
     role = c("aut", "cre"),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 NeedsCompilation: no
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
-SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.1 or compatible);
+SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.2 or compatible);
     Python (>= 3.12, optional, for EVPPI and EVSI through reticulate)
 Suggests:
     reticulate (>= 1.20),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 dependencies = [
  "proptest",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-ffi"
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 dependencies = [
  "proptest",
  "voiage-diagnostics",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-python"
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 dependencies = [
  "pyo3",
  "serde",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-serialization"
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-test-support"
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.1-rc.1"
+version = "2.0.1-rc.2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/edithatogo/voiage"
 
 [workspace.dependencies]
-voiage-diagnostics = { version = "=2.0.1-rc.1", path = "crates/voiage-diagnostics" }
-voiage-domain = { version = "=2.0.1-rc.1", path = "crates/voiage-domain" }
-voiage-numerics = { version = "=2.0.1-rc.1", path = "crates/voiage-numerics" }
-voiage-serialization = { version = "=2.0.1-rc.1", path = "crates/voiage-serialization" }
+voiage-diagnostics = { version = "=2.0.1-rc.2", path = "crates/voiage-diagnostics" }
+voiage-domain = { version = "=2.0.1-rc.2", path = "crates/voiage-domain" }
+voiage-numerics = { version = "=2.0.1-rc.2", path = "crates/voiage-numerics" }
+voiage-serialization = { version = "=2.0.1-rc.2", path = "crates/voiage-serialization" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/scripts/compose_polyglot_sbom.py
+++ b/scripts/compose_polyglot_sbom.py
@@ -495,8 +495,15 @@ def compose_sbom(
     if not isinstance(metadata, dict):
         raise SbomError("Python input is missing metadata")
     root = metadata.get("component")
-    if not isinstance(root, dict):
-        raise SbomError("Python input is missing metadata.component")
+    synthesized_python_root = not isinstance(root, dict)
+    if synthesized_python_root:
+        root = {
+            "bom-ref": f"voiage-release:{source_version}",
+            "name": "voiage",
+            "type": "application",
+            "version": source_version,
+        }
+        metadata["component"] = root
     root_ref = _component_ref(root, context="metadata")
     root["version"] = source_version
     _set_properties(
@@ -532,6 +539,17 @@ def compose_sbom(
                 "voiage:inventory:resolution": "resolved-installed",
             },
         )
+    if synthesized_python_root:
+        python_component_refs = {
+            _component_ref(component, context="Python inventory")
+            for component in python_components
+        }
+        python_dependencies = [
+            dependency
+            for dependency in python_dependencies
+            if isinstance(dependency, dict)
+            and dependency.get("ref") in python_component_refs
+        ]
 
     cargo_components, cargo_dependencies, workspace_refs = _cargo_inventory(
         cargo_workspace
@@ -575,9 +593,7 @@ def compose_sbom(
         r_version = r_component.get("version")
         r_properties = _property_map(r_component.get("properties"))
         if r_version != source_version:
-            expected_r_identity = r_properties.get(
-                "voiage:release:canonical-version"
-            )
+            expected_r_identity = r_properties.get("voiage:release:canonical-version")
             rc_match = re.fullmatch(
                 r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
                 r"-rc\.(?P<rc>\d+)",
@@ -590,10 +606,7 @@ def compose_sbom(
                 else ()
             )
             target_parts = (
-                tuple(
-                    int(rc_match.group(part))
-                    for part in ("major", "minor", "patch")
-                )
+                tuple(int(rc_match.group(part)) for part in ("major", "minor", "patch"))
                 if rc_match is not None
                 else ()
             )
@@ -626,7 +639,15 @@ def compose_sbom(
             raise SbomError(f"duplicate component bom-ref: {reference}")
         component_by_ref[reference] = component
 
-    root_direct = [*workspace_refs, r_root, julia_root]
+    python_root_refs = (
+        [
+            _component_ref(component, context="Python inventory")
+            for component in python_components
+        ]
+        if synthesized_python_root
+        else []
+    )
+    root_direct = [*python_root_refs, *workspace_refs, r_root, julia_root]
     root_dependency = _dependency_entry(root_ref, root_direct)
     document["components"] = [
         component_by_ref[reference] for reference in sorted(component_by_ref)

--- a/tests/test_compose_polyglot_sbom.py
+++ b/tests/test_compose_polyglot_sbom.py
@@ -279,6 +279,47 @@ def test_composes_all_ecosystems_with_explicit_resolution_scope(
     assert "pkg:cran/voiageR@1.2.3" in graph["root-component"]
 
 
+def test_composition_synthesizes_root_for_dependency_only_python_inventory(
+    tmp_path: Path,
+    python_sbom: Path,
+    cargo_workspace: Path,
+    r_description: Path,
+    julia_project: Path,
+) -> None:
+    dependency_only = json.loads(python_sbom.read_text(encoding="utf-8"))
+    del dependency_only["metadata"]["component"]
+    dependency_only_path = _write_json(
+        tmp_path / "python-requirements.cdx.json",
+        dependency_only,
+    )
+
+    document = _compose(
+        python_sbom=dependency_only_path,
+        cargo_workspace=cargo_workspace,
+        r_description=r_description,
+        julia_project=julia_project,
+    )
+
+    root = document["metadata"]["component"]
+    assert root == {
+        "bom-ref": "voiage-release:1.2.3",
+        "name": "voiage",
+        "properties": [
+            {"name": "voiage:ecosystem", "value": "python"},
+            {"name": "voiage:inventory:resolution", "value": "resolved-installed"},
+            {"name": "voiage:sbom:aggregate-root", "value": "true"},
+        ],
+        "type": "application",
+        "version": "1.2.3",
+    }
+    root_dependency = next(
+        dependency
+        for dependency in document["dependencies"]
+        if dependency["ref"] == "voiage-release:1.2.3"
+    )
+    assert "pkg:pypi/numpy@2.3.1" in root_dependency["dependsOn"]
+
+
 def test_composition_is_byte_for_byte_deterministic(
     tmp_path: Path,
     python_sbom: Path,

--- a/todo.md
+++ b/todo.md
@@ -169,13 +169,15 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
-*   [x] Prepare the signed `v2.0.1-rc.1` TestPyPI candidate contract.
+*   [x] Prepare the signed `v2.0.1-rc.2` TestPyPI candidate contract.
     *   Added explicit Cargo/Julia SemVer, Python PEP 440, and R numeric
         development-version projections without claiming R, Julia, or
         crates.io prerelease publication.
     *   Bound release filenames, TestPyPI queries, attestations, and smoke
         installs to the normalized Python identity while preserving the
         canonical signed tag and mixed-language SBOM identity.
+    *   Superseded the unpublished RC1 staging attempt with RC2 after teaching
+        the composer to root dependency-only CycloneDX Python inventories.
 
 *   [x] Normalize and archive the historical Conductor registry.
     *   Archived track:


### PR DESCRIPTION
## Summary

- synthesize a deterministic aggregate root when `cyclonedx-py requirements` supplies a dependency-only Python BOM
- attach every resolved Python component to that root while retaining canonical mixed-language release identity
- bump the unpublished candidate to canonical `v2.0.1-rc.2`, Python `2.0.1rc2`, and R `2.0.0.9002`

## Incident boundary

The signed RC1 staging run failed closed before creating a GitHub draft or publishing to any registry because its generated Python BOM lacked `metadata.component`. RC1 remains immutable and unpublished. RC2 supersedes it; production PyPI, crates.io, R, Julia, and public/latest GitHub release paths remain out of scope.

## Validation

- 47 focused SBOM, version, and release-workflow tests passed
- exact `cyclonedx-bom==7.3.0` requirements output reproduced the missing-root shape and composed successfully into a 112-component validated SBOM
- version synchronization emits `2.0.1rc2`; Cargo, Julia, and R projections validated
- Ruff, actionlint, and diff checks passed