### PR TITLE
fix(release): prepare v2.0.1-rc.3 attestable SBOM

### DIFF
--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/changelog.md
+++ b/changelog.md
@@ -91,10 +91,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Prepared the `v2.0.1-rc.2` TestPyPI candidate with explicit ecosystem version
-  projections and a deterministic aggregate root for dependency-only Python
-  SBOM input. RC2 supersedes the unpublished RC1 staging attempt, which failed
-  closed before a draft release or registry publication.
+- Prepared the `v2.0.1-rc.3` TestPyPI candidate with explicit ecosystem version
+  projections, a deterministic aggregate root for dependency-only Python SBOM
+  input, and a source-bound UUIDv5 CycloneDX serial number required by GitHub
+  SBOM attestations. RC3 supersedes unpublished RC1 and RC2 staging attempts,
+  which failed closed before a draft release or registry publication.
 - Frictionless CSV ingestion now rejects duplicate descriptor field names and
   duplicate CSV headers through the stable ingestion error boundary.
 - Hardened stable and prerelease publishing across Python, Rust, R, and Julia:

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 2.0.0.9002
-Config/voiage/Release-Version: 2.0.1-rc.2
+Version: 2.0.0.9003
+Config/voiage/Release-Version: 2.0.1-rc.3
 Authors@R: person("Dylan", "Mordaunt",
     email = "voiage@users.noreply.github.com",
     role = c("aut", "cre"),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 NeedsCompilation: no
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
-SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.2 or compatible);
+SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.3 or compatible);
     Python (>= 3.12, optional, for EVPPI and EVSI through reticulate)
 Suggests:
     reticulate (>= 1.20),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 dependencies = [
  "proptest",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-ffi"
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 dependencies = [
  "proptest",
  "voiage-diagnostics",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-python"
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 dependencies = [
  "pyo3",
  "serde",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-serialization"
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-test-support"
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.1-rc.2"
+version = "2.0.1-rc.3"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/edithatogo/voiage"
 
 [workspace.dependencies]
-voiage-diagnostics = { version = "=2.0.1-rc.2", path = "crates/voiage-diagnostics" }
-voiage-domain = { version = "=2.0.1-rc.2", path = "crates/voiage-domain" }
-voiage-numerics = { version = "=2.0.1-rc.2", path = "crates/voiage-numerics" }
-voiage-serialization = { version = "=2.0.1-rc.2", path = "crates/voiage-serialization" }
+voiage-diagnostics = { version = "=2.0.1-rc.3", path = "crates/voiage-diagnostics" }
+voiage-domain = { version = "=2.0.1-rc.3", path = "crates/voiage-domain" }
+voiage-numerics = { version = "=2.0.1-rc.3", path = "crates/voiage-numerics" }
+voiage-serialization = { version = "=2.0.1-rc.3", path = "crates/voiage-serialization" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/scripts/compose_polyglot_sbom.py
+++ b/scripts/compose_polyglot_sbom.py
@@ -13,6 +13,7 @@ import sys
 import tomllib
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
+import uuid
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -32,6 +33,15 @@ HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 R_DEPENDENCY = re.compile(r"^([A-Za-z][A-Za-z0-9.]*)\s*(?:\(([^)]+)\))?$")
 
 JsonObject = dict[str, Any]
+
+
+def _release_serial_number(source_tag: str, source_commit: str) -> str:
+    """Return a deterministic CycloneDX UUID URN for one immutable source."""
+    identity = (
+        "https://github.com/edithatogo/voiage/releases/tag/"
+        f"{source_tag}@{source_commit}"
+    )
+    return f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_URL, identity)}"
 
 
 class SbomError(ValueError):
@@ -665,7 +675,7 @@ def compose_sbom(
     document["bomFormat"] = "CycloneDX"
     document["specVersion"] = SPEC_VERSION
     document["version"] = 1
-    document.pop("serialNumber", None)
+    document["serialNumber"] = _release_serial_number(source_tag, source_commit)
     validate_sbom(
         document,
         expected_commit=source_commit,
@@ -692,6 +702,24 @@ def validate_sbom(
         errors.append(f"specVersion must be {SPEC_VERSION}")
     if document.get("version") != 1:
         errors.append("BOM version must be 1")
+    serial_number = document.get("serialNumber")
+    try:
+        parsed_serial = uuid.UUID(str(serial_number).removeprefix("urn:uuid:"))
+    except ValueError:
+        errors.append("serialNumber must be a UUID URN")
+    else:
+        if not isinstance(serial_number, str) or not serial_number.startswith(
+            "urn:uuid:"
+        ):
+            errors.append("serialNumber must be a UUID URN")
+        if parsed_serial.version != 5:
+            errors.append("serialNumber must use deterministic UUIDv5")
+    if (
+        expected_commit is not None
+        and expected_tag is not None
+        and serial_number != _release_serial_number(expected_tag, expected_commit)
+    ):
+        errors.append("serialNumber does not match the source identity")
 
     metadata = document.get("metadata")
     if not isinstance(metadata, dict):

--- a/tests/test_compose_polyglot_sbom.py
+++ b/tests/test_compose_polyglot_sbom.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tomllib
 from typing import Any
+import uuid
 
 import pytest
 
@@ -376,6 +377,49 @@ def test_composition_is_byte_for_byte_deterministic(
         text=True,
     )
     assert "validated" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("serial_number", "message"),
+    [
+        ("not-a-uuid", "serialNumber must be a UUID URN"),
+        (
+            str(uuid.uuid5(uuid.NAMESPACE_URL, "missing-urn-prefix")),
+            "serialNumber must be a UUID URN",
+        ),
+        (
+            "urn:uuid:123e4567-e89b-42d3-a456-426614174000",
+            "serialNumber must use deterministic UUIDv5",
+        ),
+        (
+            f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_URL, 'wrong-source')}",
+            "serialNumber does not match the source identity",
+        ),
+    ],
+)
+def test_validator_rejects_invalid_or_unbound_serial_number(
+    python_sbom: Path,
+    cargo_workspace: Path,
+    r_description: Path,
+    julia_project: Path,
+    serial_number: str,
+    message: str,
+) -> None:
+    document = _compose(
+        python_sbom=python_sbom,
+        cargo_workspace=cargo_workspace,
+        r_description=r_description,
+        julia_project=julia_project,
+    )
+    document["serialNumber"] = serial_number
+
+    with pytest.raises(SbomError, match=message):
+        validate_sbom(
+            document,
+            expected_commit=SOURCE_COMMIT,
+            expected_tag="v1.2.3",
+            expected_version="1.2.3",
+        )
 
 
 def test_validator_rejects_dangling_dependency_reference(

--- a/todo.md
+++ b/todo.md
@@ -169,7 +169,7 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
-*   [x] Prepare the signed `v2.0.1-rc.2` TestPyPI candidate contract.
+*   [x] Prepare the signed `v2.0.1-rc.3` TestPyPI candidate contract.
     *   Added explicit Cargo/Julia SemVer, Python PEP 440, and R numeric
         development-version projections without claiming R, Julia, or
         crates.io prerelease publication.
@@ -178,6 +178,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
         canonical signed tag and mixed-language SBOM identity.
     *   Superseded the unpublished RC1 staging attempt with RC2 after teaching
         the composer to root dependency-only CycloneDX Python inventories.
+    *   Superseded unpublished RC2 with RC3 after adding the deterministic
+        UUIDv5 serial number required by GitHub's SBOM attestation action.
 
 *   [x] Normalize and archive the historical Conductor registry.
     *   Archived track:


### PR DESCRIPTION
## Summary

- emit a deterministic source-bound UUIDv5 CycloneDX `serialNumber`
- validate UUID URN shape, UUIDv5 determinism, and exact source tag/commit binding
- bump the unpublished candidate to canonical `v2.0.1-rc.3`, Python `2.0.1rc3`, and R `2.0.0.9003`

## Incident boundary

RC2 composed its dependency-only Python inventory successfully, then failed closed because the exact pinned `actions/attest-sbom` predicate recognizes CycloneDX only when `bomFormat`, `specVersion`, and `serialNumber` are present. No draft or registry publication occurred. RC3 supersedes unpublished RC1 and RC2 without rewriting either signed tag.

## Validation

- inspected exact pinned `actions/attest-sbom@4651f806...` predicate source
- 51 focused SBOM, version, and release-workflow tests passed
- composed the exact dependency-only Python input into a validated 112-component SBOM
- verified the generated document satisfies the pinned action detection fields and carries a deterministic UUID URN
- version synchronization emits `2.0.1rc3`; Cargo, Julia, and R projections validated
- Ruff and diff checks passed