### PR TITLE
fix(ingestion): keep CLI inspection metadata-only

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -128,6 +128,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made `voiage ingest inspect` genuinely metadata-only. It now uses registry
+  inspection without resolving declared resources or VOI bindings; materialized
+  provenance, governance, receipt, and data-quality output remains available
+  from validation, normalization, and calculation.
 - Corrected the compiled conda recipe's runtime Python requirement so it
   satisfies conda-forge's non-noarch packaging contract.
 

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -88,10 +88,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   remains active.
 - [~] **P4-T5 / AC-04, AC-11:** Add Croissant inspection, diagnostics,
   provenance, governance metadata, and one opt-in authoritative live
-  interoperability probe. CLI inspection coverage now verifies stable provider,
-  checksum/byte receipt, provenance, and retained governance output for an
-  offline Croissant 1.1 fixture (`8d040bef`, partial); the opt-in authoritative
-  live probe remains an explicit external gate.
+  interoperability probe. Registry/CLI inspection now verifies stable provider
+  capabilities without resource materialization; materializing validation
+  verifies receipt, provenance, and retained governance for the offline
+  Croissant 1.1 fixture. The opt-in authoritative live probe remains an
+  explicit external gate.
 
 ### Frictionless Data
 
@@ -111,10 +112,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   acceptance evidence remains active (`2ad0a24a`, partial).
 - [~] **P4-T9 / AC-05, AC-11:** Add Frictionless inspection, diagnostics,
   provenance, licence/citation/usage preservation, and one opt-in authoritative
-  live interoperability probe. CLI inspection coverage now verifies stable
-  provider, checksum/byte receipt, provenance, and retained governance output
-  for an offline Data Package fixture (`ac6d05a9`, partial); the opt-in
-  authoritative live probe remains an explicit external gate.
+  live interoperability probe. Registry/CLI inspection now verifies stable
+  provider capabilities without resource materialization; materializing
+  validation verifies receipt, provenance, and retained governance for an
+  offline Data Package fixture. The opt-in authoritative live probe remains an
+  explicit external gate.
 
 ### Phase checkpoint
 
@@ -183,9 +185,13 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   binding, offline, and source-policy options. Every materializing command now
   accepts an explicit `--source-root` in addition to the cache, offline, and
   resource-size policy controls.
-- [x] **P6-T4 / AC-07, AC-11:** Make inspection output include data-quality,
-  provider-capability, binding-resolution, governance, and materialization
-  receipt details in stable machine-readable form.
+- [~] **P6-T4 / AC-07, AC-11:** Keep inspection and materialization evidence
+  distinct in stable machine-readable output. `ingest inspect` is now
+  descriptor-only (provider capabilities and an explicit null binding
+  resolution), so it cannot accidentally resolve resources; materializing
+  validation/normalization output carries provenance, governance, receipts,
+  and data-quality evidence. Broader receipt and live-source acceptance remains
+  active.
 - [x] **P6-T5 / AC-07:** Add Python, Croissant/ML, and
   Frictionless/operations-research examples.
 - [~] **P6-T6 / AC-07:** Update Astro data-structure, CLI, architecture, and
@@ -266,10 +272,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   evidence remains required).
 - [~] **P9-T3 / AC-13:** Add validation, inspection, data-quality, governance,
   materialization, Python API, and CLI walkthrough evidence. The canonical ML
-  Croissant and engineering Frictionless descriptors now execute the documented
-  validation/inspection path and assert provider, governance, binding-quality,
-  and materialization-receipt output; the direct DataFrame business walkthrough
-  remains covered by the executable reference example (partial).
+  Croissant and engineering Frictionless descriptors now execute a separate
+  metadata-only inspection path and materializing validation/calculation path;
+  the latter carries governance, binding-quality, and receipt evidence. The
+  direct DataFrame business walkthrough remains covered by the executable
+  reference example (partial).
 - [~] **P9-T4 / AC-13:** Assert normalized-object and numerical equivalence
   without adding domain-specific kernels or semantic inference. The reference
   runner now fails if any supported representation differs in EVPI (partial;

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -39,7 +39,8 @@ voiage ingest inspect croissant.json
 voiage ingest normalize datapackage.json --output normalized.arrow
 ```
 
-Every ingestion command accepts the same local source-policy controls. They
+The materializing commands (`validate`, `normalize`, and
+`calculate-from-dataset`) accept the same local source-policy controls. They
 never enable network access: use `--max-resource-bytes` to set a stricter
 resource cap, `--cache-dir` to select a verified materialization cache, and
 `--offline` to require replay rather than reading a source path. For example:
@@ -53,11 +54,14 @@ voiage ingest validate datapackage.json \
 `croissant.json` is recognized from its Croissant context and
 `datapackage.json` from its Data Package resource list, not from the filename.
 `validate` resolves the descriptor and every declared local resource through
-the source-access policy, then returns a stable JSON confirmation. The
-`inspect` response contains the provider, its declared capability profile, safe
-descriptor provenance, preserved governance metadata, diagnostics, table row
-counts, schema fingerprint, and content digest; neither command echoes resource
-contents or credentials.
+the source-access policy, then returns a stable JSON confirmation with
+provenance, governance metadata, diagnostics, row counts, schema fingerprint,
+and content digest. `inspect` is deliberately metadata-only: it reads only the
+JSON descriptor and reports the recognized provider, its declared capability
+profile, and `binding_resolution: null`. It does not resolve a resource,
+compute a receipt or data-quality report, or resolve a VOI binding. This means
+inspection can safely identify a descriptor even when its resource is not
+available; use a materializing command for validation or calculation.
 
 Local resources are fail-closed: paths cannot escape the configured descriptor
 root, network access is disabled by default, and a resource larger than the

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -34,30 +34,15 @@ def test_reference_descriptors_have_safe_cli_walkthroughs(
     runner = CliRunner()
 
     validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
-    inspected = runner.invoke(
-        app,
-        [
-            "ingest",
-            "inspect",
-            str(descriptor),
-            "--table",
-            "samples",
-            "--field",
-            "strategy_a",
-            "--field",
-            "strategy_b",
-        ],
-    )
+    inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
 
     assert validated.exit_code == 0
     assert json.loads(validated.output)["valid"] is True
     assert inspected.exit_code == 0
     result = json.loads(inspected.output)
     assert result["provider"] == provider
-    assert isinstance(result["governance"], dict)
-    assert result["binding_resolution"]["data_quality"]["row_count"] == 3
-    assert len(result["resources"]) == 1
-    assert len(result["resources"][0]["sha256"]) == 64
+    assert result["binding_resolution"] is None
+    assert result["capabilities"]["provider_id"] == provider
 
 
 def test_ingest_commands_publish_stable_help_surfaces() -> None:
@@ -66,7 +51,7 @@ def test_ingest_commands_publish_stable_help_surfaces() -> None:
 
     for command, description in (
         ("validate", "Validate a supported descriptor"),
-        ("inspect", "Inspect identity and optionally resolve"),
+        ("inspect", "Inspect descriptor identity and provider capabilities"),
         ("normalize", "Normalize a descriptor into a deterministic Arrow IPC"),
         (
             "calculate-from-dataset",
@@ -103,20 +88,6 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
 
     validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
     default_inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
-    inspected = runner.invoke(
-        app,
-        [
-            "ingest",
-            "inspect",
-            str(descriptor),
-            "--table",
-            "samples",
-            "--field",
-            "a",
-            "--field",
-            "b",
-        ],
-    )
     output = tmp_path / "normalized.arrow"
     normalized = runner.invoke(
         app, ["ingest", "normalize", str(descriptor), "--output", str(output)]
@@ -139,9 +110,7 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
     assert validated.exit_code == 0
     assert json.loads(validated.output)["valid"] is True
     assert default_inspected.exit_code == 0
-    assert json.loads(default_inspected.output)["binding_resolution"] is None
-    assert inspected.exit_code == 0
-    inspection = json.loads(inspected.output)
+    inspection = json.loads(default_inspected.output)
     assert inspection["provider"] == "frictionless"
     assert inspection["capabilities"] == {
         "format_versions": ["1"],
@@ -153,43 +122,21 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
         "supports_random_access": False,
         "supports_streaming": False,
     }
-    assert inspection["provenance"]["license"] == "CC-BY-4.0"
-    assert inspection["governance"] == {
-        "frictionlessdata.org:contributors": [
-            {"role": "author", "title": "Fixture maintainer"}
-        ],
-        "frictionlessdata.org:licenses": [{"name": "CC-BY-4.0"}],
+    assert inspection["binding_resolution"] is None
+    assert inspection["descriptor"] == str(descriptor)
+    assert set(inspection) == {
+        "binding_resolution",
+        "capabilities",
+        "descriptor",
+        "provider",
     }
-    resolution = inspection["binding_resolution"]
-    assert resolution["binding"]["role"] == "net_benefit"
-    assert resolution["binding"]["table_id"] == "samples"
-    assert resolution["binding"]["field_ids"] == ["a", "b"]
-    assert len(resolution["binding_profile_digest"]) == 64
-    assert len(resolution["input_digest"]) == 64
-    assert resolution["data_quality"] == {
-        **resolution["data_quality"],
-        "null_counts": {"a": 0, "b": 0},
-        "row_count": 1,
-        "selected_field_ids": ["a", "b"],
-        "table_id": "samples",
-        "unique_value_counts": {"a": 1, "b": 1},
-    }
-    assert inspection["resources"] == [
-        {
-            "byte_size": (tmp_path / "samples.csv").stat().st_size,
-            "media_type": "text/csv",
-            "resource_id": "samples",
-            "sha256": sha256((tmp_path / "samples.csv").read_bytes()).hexdigest(),
-            "uri": (tmp_path / "samples.csv").resolve().as_uri(),
-        }
-    ]
     assert normalized.exit_code == 0
     assert output.is_file()
     assert calculated.exit_code == 0
     assert "input_digest" in json.loads(calculated.output)
 
 
-def test_inspect_requires_complete_explicit_binding_options(tmp_path) -> None:
+def test_inspect_rejects_binding_options_without_loading_data(tmp_path) -> None:
     (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
     descriptor = tmp_path / "datapackage.json"
     descriptor.write_text(
@@ -217,8 +164,44 @@ def test_inspect_requires_complete_explicit_binding_options(tmp_path) -> None:
 
     assert table_only.exit_code == 2
     assert fields_only.exit_code == 2
-    assert "--table and at least one --field" in table_only.output
-    assert "--table and at least one --field" in fields_only.output
+    assert "No such option" in table_only.output
+    assert "No such option" in fields_only.output
+
+
+def test_inspect_does_not_materialize_declared_resource(tmp_path) -> None:
+    """Inspection can identify a descriptor whose local resource is absent."""
+    descriptor = tmp_path / "datapackage.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "name": "metadata-only",
+                "resources": [
+                    {
+                        "name": "missing",
+                        "path": "missing.csv",
+                        "schema": {"fields": [{"name": "a"}]},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
+    validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
+    normalized = runner.invoke(
+        app,
+        ["ingest", "normalize", str(descriptor), "--output", str(tmp_path / "x.arrow")],
+    )
+
+    assert inspected.exit_code == 0
+    assert json.loads(inspected.output)["provider"] == "frictionless"
+    assert json.loads(inspected.output)["binding_resolution"] is None
+    assert validated.exit_code == 2
+    assert normalized.exit_code == 2
+    assert "declared resource does not exist" in validated.output
+    assert "declared resource does not exist" in normalized.output
 
 
 def test_ingest_cli_returns_safe_error_for_unrecognized_descriptor(tmp_path) -> None:
@@ -288,7 +271,9 @@ def test_normalize_and_calculate_return_safe_errors(tmp_path) -> None:
     )
 
 
-def test_ingest_commands_expose_explicit_source_policy_controls(tmp_path) -> None:
+def test_materializing_ingest_commands_expose_explicit_source_policy_controls(
+    tmp_path,
+) -> None:
     """CLI callers can make materialization policy explicit and fail closed."""
     source_root = tmp_path / "declared-source-root"
     source_root.mkdir()
@@ -313,7 +298,6 @@ def test_ingest_commands_expose_explicit_source_policy_controls(tmp_path) -> Non
     source_policy = ["--source-root", str(source_root)]
     resolved = [
         runner.invoke(app, ["ingest", "validate", str(descriptor), *source_policy]),
-        runner.invoke(app, ["ingest", "inspect", str(descriptor), *source_policy]),
         runner.invoke(
             app,
             [
@@ -454,8 +438,8 @@ def test_ingest_cli_replays_a_declared_resource_from_offline_cache(tmp_path) -> 
     assert json.loads(replayed.output)["valid"] is True
 
 
-def test_croissant_inspection_exposes_governance_and_receipt_identity(tmp_path) -> None:
-    """Croissant inspection retains governance without inferring VOI semantics."""
+def test_croissant_validation_exposes_governance_and_receipt_identity(tmp_path) -> None:
+    """Materializing validation retains Croissant governance and receipts."""
     source = tmp_path / "samples.csv"
     source.write_text("a,b\n1,2\n", encoding="utf-8")
     descriptor = tmp_path / "croissant.json"
@@ -483,7 +467,7 @@ def test_croissant_inspection_exposes_governance_and_receipt_identity(tmp_path) 
         encoding="utf-8",
     )
 
-    result = CliRunner().invoke(app, ["ingest", "inspect", str(descriptor)])
+    result = CliRunner().invoke(app, ["ingest", "validate", str(descriptor)])
 
     assert result.exit_code == 0
     inspection = json.loads(result.output)
@@ -509,10 +493,10 @@ def test_croissant_inspection_exposes_governance_and_receipt_identity(tmp_path) 
     ]
 
 
-def test_frictionless_inspection_exposes_governance_and_receipt_identity(
+def test_frictionless_validation_exposes_governance_and_receipt_identity(
     tmp_path,
 ) -> None:
-    """Frictionless inspection preserves explicit package governance metadata."""
+    """Materializing validation preserves package governance metadata."""
     source = tmp_path / "samples.csv"
     source.write_text("a,b\n1,2\n", encoding="utf-8")
     descriptor = tmp_path / "datapackage.json"
@@ -544,7 +528,7 @@ def test_frictionless_inspection_exposes_governance_and_receipt_identity(
         encoding="utf-8",
     )
 
-    result = CliRunner().invoke(app, ["ingest", "inspect", str(descriptor)])
+    result = CliRunner().invoke(app, ["ingest", "validate", str(descriptor)])
 
     assert result.exit_code == 0
     inspection = json.loads(result.output)

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -140,7 +140,7 @@ def test_reference_case_cli_walkthrough_validates_inspects_and_calculates(
     options = ["--table", "samples", "--field", "strategy_a", "--field", "strategy_b"]
 
     validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
-    inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor), *options])
+    inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
     calculated = runner.invoke(
         app, ["ingest", "calculate-from-dataset", str(descriptor), *options]
     )
@@ -149,7 +149,7 @@ def test_reference_case_cli_walkthrough_validates_inspects_and_calculates(
     assert json.loads(validated.output)["valid"] is True
     inspection = json.loads(inspected.output)
     assert inspected.exit_code == 0
-    assert inspection["resources"][0]["sha256"]
-    assert inspection["binding_resolution"]["data_quality"]["row_count"] == 3
+    assert inspection["binding_resolution"] is None
+    assert inspection["provider"] in {"croissant", "frictionless"}
     assert calculated.exit_code == 0
     assert json.loads(calculated.output)["evpi"] == pytest.approx(5.0)

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path  # noqa: TC003 - public CLI annotation
+from typing import cast
 
 import typer
 
@@ -48,24 +49,6 @@ def _prepared_summary(bundle: NormalizedInputBundle) -> dict[str, object]:
         },
         "input_digest": prepared.input_digest,
     }
-
-
-def _inspection_binding(
-    table: str | None, field: list[str], strategy: list[str]
-) -> VOIBinding | None:
-    """Build an optional explicit inspection binding without semantic inference."""
-    if (table is None) != (not field):
-        raise ValueError("--table and at least one --field must be supplied together")
-    return (
-        VOIBinding(
-            role="net_benefit",
-            table_id=table,
-            field_ids=tuple(field),
-            strategy_names=tuple(strategy),
-        )
-        if table is not None
-        else None
-    )
 
 
 def _source_policy(
@@ -141,6 +124,27 @@ def _bundle_summary(
     return summary
 
 
+def _inspection_summary(descriptor: Path) -> dict[str, object]:
+    """Return descriptor-only diagnostics without resolving any resources.
+
+    Binding resolution, provenance receipts, and data-quality reports require
+    materializing resources. Those details deliberately belong to the
+    materializing validation, normalization, and calculation commands rather
+    than the metadata-only ``inspect`` command.
+    """
+    inspection = default_registry().inspect(descriptor)
+    capabilities = cast("dict[str, object]", inspection["capabilities"])
+    return {
+        "binding_resolution": None,
+        "capabilities": {
+            "provider_id": inspection["provider_id"],
+            **capabilities,
+        },
+        "descriptor": inspection["descriptor"],
+        "provider": inspection["provider_id"],
+    }
+
+
 @app.command("validate")
 def validate(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
@@ -191,51 +195,11 @@ def validate(
 @app.command()
 def inspect(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
-    table: str | None = typer.Option(
-        None, "--table", help="Optional explicit table ID for binding resolution."
-    ),
-    field: list[str] = typer.Option(
-        [], "--field", help="Net-benefit field; repeat per strategy."
-    ),
-    strategy: list[str] = typer.Option(
-        [], "--strategy", help="Optional strategy name; repeat in field order."
-    ),
-    source_root: Path | None = typer.Option(
-        None,
-        "--source-root",
-        file_okay=False,
-        exists=True,
-        readable=True,
-        help="Explicit local root allowed for declared resources.",
-    ),
-    offline: bool = typer.Option(False, "--offline", help="Require an offline replay."),
-    cache_dir: Path | None = typer.Option(
-        None, "--cache-dir", help="Verified materialization cache directory."
-    ),
-    max_resource_bytes: int = typer.Option(
-        512 * 1024 * 1024, "--max-resource-bytes", min=1
-    ),
 ) -> None:
-    """Inspect identity and optionally resolve one explicit EVPI binding."""
+    """Inspect descriptor identity and provider capabilities without loading data."""
     try:
-        binding = _inspection_binding(table, field, strategy)
-        typer.echo(
-            json.dumps(
-                _bundle_summary(
-                    descriptor,
-                    binding=binding,
-                    policy=_source_policy(
-                        descriptor,
-                        source_root=source_root,
-                        offline=offline,
-                        cache_dir=cache_dir,
-                        max_resource_bytes=max_resource_bytes,
-                    ),
-                ),
-                sort_keys=True,
-            )
-        )
-    except (IngestionError, ValueError) as error:
+        typer.echo(json.dumps(_inspection_summary(descriptor), sort_keys=True))
+    except IngestionError as error:
         typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(2) from error
 


### PR DESCRIPTION
## Summary

- Route voiage ingest inspect through metadata-only registry inspection.
- Keep materialized receipts, governance, data quality, and binding resolution on materializing commands.
- Prove absent resources can be inspected but cannot be validated or normalized.

## Validation

- Focused standardized-ingestion CLI, reference-case, and provider tests.
- ingestion-conformance tox environment.
- Ruff, ty, Vale, Astro build, Conductor full validation, and Conductor-GitHub cross-reference validation.