### PR TITLE
test(ingestion): pin normalized fixture identities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a deterministic validator and explicit regeneration path for the
   standardized-ingestion fixture digest manifests, covering both canonical
   Croissant/Frictionless source corpora.
+- Pinned each standardized-ingestion fixture corpus to a format-neutral
+  normalized schema and content identity, and added conformance checks for
+  declaration-order rejection and receipt-digest sensitivity.
 - Expanded the offline Croissant 1.1 fixture corpus with fail-closed coverage
   for integrity declarations, non-CSV media types, and field sources.
 - Reject malformed Croissant distribution and record-set entries through the

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -138,15 +138,17 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [~] **P5-T2 / AC-06:** Add the deterministic fixture manifest with pinned
   descriptor, resource, schema, and content digests. Both checked-in fixture
   corpora are now verified through one deterministic digest-manifest validator
-  (`scripts/validate_standardized_ingestion_fixtures.py`, partial: descriptor
-  and resource digests are pinned; schema and content semantics remain covered
-  by conformance tests).
+  (`scripts/validate_standardized_ingestion_fixtures.py`). It pins descriptor,
+  resource, format-neutral schema, and direct normalized-content digests
+  (partial: the corpus remains intentionally small).
 - [~] **P5-T3 / AC-06:** Implement deterministic fixture generation and the
   schema, provenance, ordering, meaningful-change, and numerical-equivalence
   conformance matrix. The fixture validator now fails closed on stale artifact
-  digests and supports explicit deterministic ``--write`` regeneration; the
-  existing cross-format/property/reference-case tests provide partial semantic
-  matrix evidence. Full parser-differential coverage remains active.
+  and normalized-identity digests and supports explicit deterministic
+  ``--write`` regeneration. Provider declarations that disagree with CSV order
+  fail rather than reorder data, and changed resource bytes change receipts and
+  normalized content (partial: full parser-differential coverage remains
+  active).
 - [~] **P5-T4 / AC-06, AC-10, AC-11:** Assert binding-profile, data-quality,
   governance-metadata, and materialization-receipt parity without requiring
   source formats to share irrelevant descriptive metadata. Canonical Croissant

--- a/scripts/validate_standardized_ingestion_fixtures.py
+++ b/scripts/validate_standardized_ingestion_fixtures.py
@@ -2,8 +2,9 @@
 
 The source descriptors and CSV resources are deliberately kept as small,
 human-reviewable fixture corpora.  Their companion manifests pin every source
-artifact, so an intentional fixture update must be explicit: run this script
-with ``--write`` and review the resulting digest change.
+artifact and the format-neutral normalized identity, so an intentional fixture
+update must be explicit: run this script with ``--write`` and review the
+resulting digest change.
 """
 
 from __future__ import annotations
@@ -13,6 +14,17 @@ from hashlib import sha256
 import json
 from pathlib import Path
 from typing import Any
+
+import pyarrow.csv as pacsv
+
+from voiage.contracts import (
+    DatasetManifest,
+    FieldManifest,
+    NormalizedInputBundle,
+    SourceProvenance,
+    TableManifest,
+    VOIBinding,
+)
 
 DEFAULT_FIXTURE_ROOT = (
     Path(__file__).parents[1] / "tests" / "fixtures" / "standardized_ingestion"
@@ -41,19 +53,81 @@ def _read_manifest(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _bindings(payload: dict[str, Any]) -> tuple[VOIBinding, ...]:
+    """Load the singular and plural binding forms used by the fixture corpus."""
+    plural = payload.get("bindings")
+    if plural is None:
+        raw_bindings = [payload.get("binding")]
+    elif isinstance(plural, list):
+        raw_bindings = plural
+    else:
+        raise TypeError("fixture bindings must be a list")
+    return tuple(
+        VOIBinding.model_validate_json(json.dumps(binding)) for binding in raw_bindings
+    )
+
+
+def normalized_identity(path: Path) -> dict[str, str]:
+    """Return the reproducible direct normalized identity for one CSV fixture.
+
+    The identity is format-neutral.  It deliberately excludes source-specific
+    descriptor URIs and governance metadata, which optional providers preserve
+    separately and which cannot be meaningfully identical across formats.
+    """
+    payload = _read_manifest(path)
+    stem = path.name.removesuffix(".manifest.json")
+    resource_path = path.parent / f"{stem}.csv"
+    table = pacsv.read_csv(resource_path)
+    resource_sha256 = sha256(resource_path.read_bytes()).hexdigest()
+    bindings = _bindings(payload)
+    table_id = bindings[0].table_id
+    bundle = NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id=payload["dataset_id"],
+            tables=(
+                TableManifest(
+                    table_id=table_id,
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-fixture",
+                source_uri=f"urn:voiage:fixture:{payload['dataset_id']}",
+                descriptor_digest=resource_sha256,
+            ),
+            bindings=bindings,
+        ),
+        tables={table_id: table},
+    )
+    return {
+        "content_digest": bundle.content_digest,
+        "resource_sha256": resource_sha256,
+        "schema_fingerprint": bundle.schema_fingerprint,
+    }
+
+
 def validate_fixture_manifest(path: Path, *, write: bool = False) -> bool:
-    """Validate one manifest, or refresh only its generated ``files`` mapping.
+    """Validate one manifest, or refresh its generated digest mappings.
 
     Returns ``True`` when the checked-in manifest already matches the source
-    artifacts.  ``--write`` is deliberately limited to the digest mapping:
+    artifacts and normalized identity.  ``--write`` is deliberately limited
+    to derived digest mappings:
     dataset and binding semantics always remain review-owned metadata.
     """
     payload = _read_manifest(path)
-    expected = _source_files(path)
-    if payload.get("files") == expected:
+    expected_files = _source_files(path)
+    expected_normalized = normalized_identity(path)
+    if (
+        payload.get("files") == expected_files
+        and payload.get("normalized") == expected_normalized
+    ):
         return True
     if write:
-        payload["files"] = expected
+        payload["files"] = expected_files
+        payload["normalized"] = expected_normalized
         path.write_text(
             json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )

--- a/tests/fixtures/standardized_ingestion/canonical-decision.manifest.json
+++ b/tests/fixtures/standardized_ingestion/canonical-decision.manifest.json
@@ -17,5 +17,10 @@
     "canonical-decision.csv": "f56d1b3708adff6ea76db79abb77f897bae4fbb2d96f112a13814eb21f6d5ab9",
     "canonical-decision.datapackage.json": "4252c19f66d9dac69e071fb55f1c66bdd9f568a7ad2d0695f578757e20de45c0"
   },
+  "normalized": {
+    "content_digest": "b01aa0dc619cb785aecd153d76b26198044d6c61d54dfd3599332d6db2e91161",
+    "resource_sha256": "f56d1b3708adff6ea76db79abb77f897bae4fbb2d96f112a13814eb21f6d5ab9",
+    "schema_fingerprint": "1ef18b22a0cbe24532c60b97633a8b1dcf9d62c5f2c4a45b4fd56d3ce598e59c"
+  },
   "schema_version": "1.0.0"
 }

--- a/tests/fixtures/standardized_ingestion/cost-outcome-decision.manifest.json
+++ b/tests/fixtures/standardized_ingestion/cost-outcome-decision.manifest.json
@@ -1,13 +1,42 @@
 {
   "bindings": [
-    {"field_ids": ["cost_a", "cost_b"], "role": "cost", "strategy_names": ["A", "B"], "table_id": "samples", "unit": "currency"},
-    {"field_ids": ["outcome_a", "outcome_b"], "role": "outcome", "strategy_names": ["A", "B"], "table_id": "samples", "unit": "outcome"}
+    {
+      "field_ids": [
+        "cost_a",
+        "cost_b"
+      ],
+      "role": "cost",
+      "strategy_names": [
+        "A",
+        "B"
+      ],
+      "table_id": "samples",
+      "unit": "currency"
+    },
+    {
+      "field_ids": [
+        "outcome_a",
+        "outcome_b"
+      ],
+      "role": "outcome",
+      "strategy_names": [
+        "A",
+        "B"
+      ],
+      "table_id": "samples",
+      "unit": "outcome"
+    }
   ],
   "dataset_id": "cost-outcome-decision-fixture",
   "files": {
     "cost-outcome-decision.croissant.json": "0f6870628fc5d8b306c922751282880c4d803a3f92ff52dbff8339ad0174eab5",
     "cost-outcome-decision.csv": "691decee94d6ad294372da2ab4690a018b9bbfd37ce083f9b68a41dacf8dcb18",
     "cost-outcome-decision.datapackage.json": "7012194bea0f0e030b383972be17ece7e51d0a91f2a4c6dd272307da143cd86b"
+  },
+  "normalized": {
+    "content_digest": "792402668c639eb5c43dd7caddf1efcea19c44d7f0c22116537e5b2782dffdf9",
+    "resource_sha256": "691decee94d6ad294372da2ab4690a018b9bbfd37ce083f9b68a41dacf8dcb18",
+    "schema_fingerprint": "8575a783ff42051ed80724381a39eebced785e90470d54a3605bed63274be024"
   },
   "schema_version": "1.0.0",
   "willingness_to_pay": 20000.0

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -17,6 +17,7 @@ import pyarrow as pa
 import pytest
 import xarray as xr
 
+from scripts import validate_standardized_ingestion_fixtures as fixture_validator
 from voiage.contracts import (
     DatasetManifest,
     FieldManifest,
@@ -27,6 +28,7 @@ from voiage.contracts import (
     prepare_analysis_inputs,
 )
 from voiage.ingestion import SourceAccessPolicy, default_registry, from_dataframe
+from voiage.ingestion.base import IngestionError
 from voiage.methods.basic import evpi
 
 _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "standardized_ingestion"
@@ -92,6 +94,9 @@ def test_canonical_decision_fixture_manifest_pins_source_artifacts() -> None:
         for path in _FIXTURE_ROOT.glob("canonical-decision.*")
         if path.name != "canonical-decision.manifest.json"
     } == manifest["files"]
+    assert manifest["normalized"] == fixture_validator.normalized_identity(
+        _FIXTURE_ROOT / "canonical-decision.manifest.json"
+    )
 
 
 def test_canonical_decision_fixture_has_cross_format_evpi_parity(tmp_path) -> None:
@@ -202,6 +207,57 @@ def test_canonical_source_formats_preserve_binding_quality_and_receipt_parity() 
     ] == [
         receipt.model_dump(mode="json") for receipt in frictionless.manifest.resources
     ]
+
+
+@pytest.mark.parametrize(
+    ("descriptor_name", "field_path"),
+    [
+        ("canonical-decision.croissant.json", ("recordSet", 0, "field")),
+        ("canonical-decision.datapackage.json", ("resources", 0, "schema", "fields")),
+    ],
+)
+def test_provider_rejects_declared_field_order_that_differs_from_csv_order(
+    tmp_path: Path, descriptor_name: str, field_path: tuple[object, ...]
+) -> None:
+    """Descriptor order is an identity check, not an opportunity to reorder data."""
+    (tmp_path / "canonical-decision.csv").write_bytes(
+        (_FIXTURE_ROOT / "canonical-decision.csv").read_bytes()
+    )
+    descriptor = json.loads(
+        (_FIXTURE_ROOT / descriptor_name).read_text(encoding="utf-8")
+    )
+    target = descriptor
+    for part in field_path:
+        target = target[part]
+    target.reverse()
+    descriptor_path = tmp_path / descriptor_name
+    descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+
+    with pytest.raises(IngestionError, match="exactly declare the CSV columns"):
+        default_registry().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "descriptor_name",
+    ["canonical-decision.croissant.json", "canonical-decision.datapackage.json"],
+)
+def test_provider_receipts_are_content_digest_sensitive(
+    tmp_path: Path, descriptor_name: str
+) -> None:
+    """A changed local resource cannot retain a stale materialization receipt."""
+    for path in _FIXTURE_ROOT.glob("canonical-decision.*"):
+        if path.name != "canonical-decision.manifest.json":
+            (tmp_path / path.name).write_bytes(path.read_bytes())
+    descriptor_path = tmp_path / descriptor_name
+    policy = SourceAccessPolicy(tmp_path)
+    original = default_registry().ingest(descriptor_path, policy=policy)
+    (tmp_path / "canonical-decision.csv").write_text(
+        "strategy_a,strategy_b\n11,20\n30,10\n20,25\n", encoding="utf-8"
+    )
+    changed = default_registry().ingest(descriptor_path, policy=policy)
+
+    assert original.manifest.resources[0].sha256 != changed.manifest.resources[0].sha256
+    assert original.content_digest != changed.content_digest
 
 
 def test_arrow_round_trips_are_equivalent_in_a_fresh_python_process(tmp_path) -> None:

--- a/tests/test_standardized_ingestion_fixture_validator.py
+++ b/tests/test_standardized_ingestion_fixture_validator.py
@@ -33,3 +33,24 @@ def test_fixture_validator_detects_and_deterministically_refreshes_changes(
     assert validator.main([str(root)]) == 1
     assert validator.main([str(root), "--write"]) == 0
     assert validator.main([str(root)]) == 0
+
+
+def test_fixture_normalized_identity_is_pinned_and_content_sensitive(
+    tmp_path: Path,
+) -> None:
+    """Fixture manifests bind direct normalized content, not just descriptor bytes."""
+    root = tmp_path / "fixtures"
+    shutil.copytree(FIXTURE_ROOT, root)
+    manifest = root / "canonical-decision.manifest.json"
+    original = validator.normalized_identity(manifest)
+
+    (root / "canonical-decision.csv").write_text(
+        "strategy_a,strategy_b\n11.0,20.0\n30.0,10.0\n20.0,25.0\n",
+        encoding="utf-8",
+    )
+    changed = validator.normalized_identity(manifest)
+
+    assert changed["schema_fingerprint"] == original["schema_fingerprint"]
+    assert changed["resource_sha256"] != original["resource_sha256"]
+    assert changed["content_digest"] != original["content_digest"]
+    assert validator.main([str(root)]) == 1


### PR DESCRIPTION
## Summary
- pin source-artifact plus format-neutral normalized schema/content identities for the canonical Croissant and Frictionless fixture corpora
- prove declaration-order rejection and content-sensitive materialization receipts across both conservative providers
- record only partial P5 conformance evidence; no remote or unsupported provider profile is enabled

## Validation
- `tox -e ingestion-conformance`
- focused conformance, fixture-validator, and reference-case pytest (20 passed)
- Ruff, ty, Vale, deterministic fixture validation, full Conductor validation, and GitHub cross-reference validation

Refs #331