### PR TITLE
test(ingestion): harden Croissant context corpus

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a combined Croissant context-array and governance fixture that proves
+  descriptor-only inspection and materialization-receipt preservation; the
+  conservative local profile now rejects unexpanded JSON-LD context objects.
 - Accepted the standard JSON-LD context-array form for the supported Croissant
   1.1 offline profile and added an adversarial fixture that rejects the
   distinct Croissant 1.10 context.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -77,7 +77,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   missing source-provenance and JOSS contract files in this clean worktree.
   Non-object descriptor-root handling is covered by the shared provider guard
   (`333ee68f`, `d745d2d6`, `1e4e6bd7`). JSON-LD context-array and exact-version
-  adversarial coverage: `5a3a7b04` (partial).
+  adversarial coverage: `5a3a7b04`. A combined context-array/governance fixture
+  now proves descriptor-only inspection, retained non-semantic governance, and
+  materialization receipt fields while rejecting unexpanded JSON-LD context
+  objects (`d814e6e1`, partial).
 - [~] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
   parser-feature gaps, live datasets, citations, PROV, usage information,
   ODRL, and RAI metadata preservation. Offline governance fixture added

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -18,7 +18,7 @@ portable, auditable, and suitable for an offline calculation workflow.
 
 | Input surface | Supported profile | Explicit boundary |
 | --- | --- | --- |
-| Croissant ML | Croissant 1.1, one `recordSet`, one `text/csv` distribution, and fields that exactly match the CSV columns | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, and non-CSV media types are rejected. |
+| Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one `recordSet`, one `text/csv` distribution, and fields that exactly match the CSV columns | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, and non-CSV media types are rejected. |
 | Frictionless Data Package | One or more explicitly schematized comma-delimited CSV resources, declared primitive types, keys, and supported foreign keys | Remote/live resources, archives, custom dialects, unsupported formats, transforms, and undeclared or ambiguous resources are rejected. |
 | Direct DataFrame interchange | pandas, Polars, or another `__dataframe__` producer that can convert through Arrow with an explicit binding | The adapter does not infer a VOI role, silently copy a disallowed frame, or create a second calculation path. |
 | Arrow IPC and Parquet | A `NormalizedInputBundle` previously written by VOIAGE | These are normalized interchange artifacts, not source-descriptor parsers. |

--- a/tests/fixtures/croissant_1_1/unsupported/context-object.json
+++ b/tests/fixtures/croissant_1_1/unsupported/context-object.json
@@ -1,0 +1,12 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "https://mlcommons.org/croissant/1.1",
+    {"@vocab": "https://example.invalid/unexpanded/"}
+  ],
+  "distribution": [{"contentUrl": "valid/data.csv", "encodingFormat": "text/csv"}],
+  "recordSet": [{
+    "name": "decision_samples",
+    "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+  }]
+}

--- a/tests/fixtures/croissant_1_1/valid/context-array-governed-croissant.json
+++ b/tests/fixtures/croissant_1_1/valid/context-array-governed-croissant.json
@@ -1,0 +1,22 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "https://mlcommons.org/croissant/1.1"
+  ],
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
+  "@id": "https://example.invalid/croissant/context-array",
+  "name": "context-array-governed-decision-samples",
+  "license": "CC-BY-4.0",
+  "citation": "Example et al. (2026)",
+  "creator": [{"name": "Fixture maintainer"}],
+  "usageInfo": "Synthetic offline fixture only.",
+  "provenance": {"wasGeneratedBy": "simulation"},
+  "distribution": [{
+    "contentUrl": "valid/data.csv",
+    "encodingFormat": "text/csv"
+  }],
+  "recordSet": [{
+    "name": "decision_samples",
+    "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+  }]
+}

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
 
 from voiage.ingestion.base import IngestionError, SourceAccessPolicy
 from voiage.ingestion.croissant import CroissantProvider
+from voiage.ingestion.registry import default_registry
 
 _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
 
@@ -18,6 +20,7 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
         ("unsupported/non-object-root.json", "descriptor root must be a JSON object"),
         ("unsupported/archive.json", "archives"),
         ("unsupported/checksum-mismatch.json", "SHA-256"),
+        ("unsupported/context-object.json", "string JSON-LD context entries"),
         ("unsupported/integrity-declaration.json", "integrity declarations"),
         ("unsupported/key.json", "keys"),
         ("unsupported/non-csv-media-type.json", "CSV media type"),
@@ -62,6 +65,12 @@ def test_croissant_offline_valid_profile_fixture_materializes() -> None:
         {"strategy_a": 100.0, "strategy_b": 80.0},
         {"strategy_a": 60.0, "strategy_b": 90.0},
     ]
+    receipt = bundle.manifest.resources[0]
+    resource_path = _FIXTURE_ROOT / "valid" / "data.csv"
+    assert receipt.resource_id == "decision_samples"
+    assert receipt.uri == resource_path.resolve().as_uri()
+    assert receipt.sha256 == hashlib.sha256(resource_path.read_bytes()).hexdigest()
+    assert receipt.byte_size == resource_path.stat().st_size
 
 
 def test_croissant_preserves_declared_field_data_type_as_descriptive_metadata(
@@ -136,3 +145,33 @@ def test_croissant_offline_governance_fixture_preserves_metadata() -> None:
     assert dict(governance["odrl"]) == {"permission": "use"}
     assert dict(governance["provenance"]) == {"wasGeneratedBy": "simulation"}
     assert dict(governance["rai"]) == {"risk": "low"}
+
+
+def test_croissant_context_array_governance_fixture_is_metadata_only() -> None:
+    """One fixture proves context arrays coexist with retained governance metadata."""
+    descriptor_path = _FIXTURE_ROOT / "valid" / "context-array-governed-croissant.json"
+    bundle = CroissantProvider().ingest(
+        descriptor_path,
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert bundle.manifest.dataset_id == "context-array-governed-decision-samples"
+    assert bundle.manifest.provenance.citation == "Example et al. (2026)"
+    governance = bundle.manifest.extensions["mlcommons.org:croissant-governance"]
+    assert governance["@id"] == "https://example.invalid/croissant/context-array"
+    assert tuple(dict(creator) for creator in governance["creator"]) == (
+        {"name": "Fixture maintainer"},
+    )
+    assert governance["usageInfo"] == "Synthetic offline fixture only."
+    assert dict(governance["provenance"]) == {"wasGeneratedBy": "simulation"}
+
+
+def test_croissant_fixture_inspection_is_descriptor_only() -> None:
+    """Inspection identifies the profile without creating receipts or governance output."""
+    descriptor_path = _FIXTURE_ROOT / "valid" / "context-array-governed-croissant.json"
+
+    inspection = default_registry().inspect(descriptor_path)
+
+    assert inspection["provider_id"] == "croissant"
+    assert inspection["capabilities"]["format_versions"] == ("1.1",)
+    assert set(inspection) == {"descriptor", "provider_id", "capabilities"}

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -49,6 +49,10 @@ class CroissantProvider:
         descriptor = cast("dict[str, object]", raw)
         if not _has_croissant_1_1_context(descriptor.get("@context")):
             raise IngestionError("supported Croissant profile requires version 1.1")
+        if not _has_only_string_context_entries(descriptor.get("@context")):
+            raise IngestionError(
+                "supported Croissant profile requires string JSON-LD context entries"
+            )
         record_sets = descriptor.get("recordSet")
         distributions = descriptor.get("distribution")
         if not isinstance(record_sets, list) or len(record_sets) != 1:
@@ -217,6 +221,13 @@ def _has_croissant_1_1_context(value: object) -> bool:
             "https://mlcommons.org/croissant/1.1",
         }
         for context in _context_entries(value)
+    )
+
+
+def _has_only_string_context_entries(value: object) -> bool:
+    """Keep the offline profile free of unexpanded JSON-LD context objects."""
+    return isinstance(value, str) or (
+        isinstance(value, list) and all(isinstance(entry, str) for entry in value)
     )
 
 


### PR DESCRIPTION
## Summary
- reject JSON-LD context objects outside the local Croissant profile
- add valid context-array/governance and adversarial fixtures
- assert descriptor-only inspection and materialization receipt boundaries
- record partial P4 evidence without claiming live, remote, archive, or transform support

## Validation
- `uv run pytest tests/test_croissant_offline_fixtures.py tests/test_standardized_ingestion_providers.py -q` (117 passed)
- Ruff check/format; ty; Conductor full/cross-reference validation; diff check

Closes no issue: this is an incremental, still-partial P4 evidence slice.