### PR TITLE
test(ingestion): validate DataFrame consumer diagnostics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added pandas and Polars DataFrame-interchange consumer coverage for nullable
+  categorical and timezone-aware columns, index exclusion, and conservative
+  copy diagnostics based on the Arrow conversion actually returned.
 - Added a combined Croissant context-array and governance fixture that proves
   descriptor-only inspection and materialization-receipt preservation; the
   conservative local profile now rejects unexpanded JSON-LD context objects.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -256,7 +256,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   opt-in entry-point publication checklist.
 - [~] **P8-T3 / AC-12:** Write failing DataFrame-interchange tests covering
   pandas, Polars, dtype/null/category/timezone/index handling, copy diagnostics,
-  and clean optional environments. Partial diagnostics evidence: `fdda14a`.
+  and clean optional environments. Partial diagnostics evidence: `fdda14a`;
+  producer-specific nullable/category/timezone/index consumer evidence is added
+  in this increment. Clean optional-environment evidence remains pending.
 - [~] **P8-T4 / AC-12:** Implement the generic `__dataframe__` adapter through
   Arrow and `NormalizedInputBundle`, with no alternate preparation or numerical
   path. Partial conversion-diagnostics evidence: `fdda14a`.

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -187,6 +187,10 @@ exclusion, and each Arrow field's dtype, nullability, categorical, and timezone
 decisions. A successful no-copy conversion is recorded as `zero_copy`; when
 copies are permitted, Arrow's public API does not expose the actual outcome, so
 the extension records `not_observable` rather than guessing.
+The consumer tests exercise pandas and Polars nullable categorical and
+timezone-aware columns. They assert the Arrow decisions actually returned by
+the installed producer and preserve a pandas index exclusion, but do not imply
+that every producer, dtype, or future producer version has identical behavior.
 The supported SDK contract covers explicit bindings, source-neutral provenance,
 and Arrow schema preservation; it does not promise identical behaviour for
 every DataFrame library or unsupported nested dtype.

--- a/tests/test_dataframe_interchange_sdk.py
+++ b/tests/test_dataframe_interchange_sdk.py
@@ -166,3 +166,78 @@ def test_dataframe_sdk_v1_preserves_index_exclusion_and_category_values() -> Non
         {"tier": "standard", "net_benefit": 10},
         {"tier": None, "net_benefit": None},
     ]
+
+
+def test_dataframe_sdk_reports_pandas_nullable_category_and_timezone_decisions() -> (
+    None
+):
+    """Pandas conversion records the Arrow decisions without retaining its index."""
+    pandas = pytest.importorskip("pandas")
+    index = pandas.Index(["first", "second"], name="scenario")
+    frame = pandas.DataFrame(
+        {
+            "tier": pandas.Series(["standard", None], dtype="category", index=index),
+            "cost": pandas.Series([10, None], dtype="Int64", index=index),
+            "observed_at": pandas.Series(
+                pandas.to_datetime(["2026-01-01T00:00:00Z", None]), index=index
+            ),
+        },
+        index=index,
+    )
+
+    bundle = from_dataframe(frame, dataset_id="pandas-consumer")
+    extension = bundle.manifest.model_dump(mode="json")["extensions"][
+        "voiage.dev:dataframe-interchange"
+    ]
+    decisions = {item["field_id"]: item for item in extension["field_decisions"]}
+
+    assert bundle.table("data").column_names == ["tier", "cost", "observed_at"]
+    assert bundle.table("data").to_pylist()[1] == {
+        "tier": None,
+        "cost": None,
+        "observed_at": None,
+    }
+    assert extension["copy_policy"] == "allow_copy"
+    assert extension["copy_outcome"] == "not_observable"
+    assert extension["index_policy"] == "excluded_by_dataframe_interchange_protocol"
+    assert decisions["tier"]["categorical"] is True
+    assert decisions["tier"]["nullable"] is True
+    assert decisions["cost"]["nullable"] is True
+    assert decisions["observed_at"]["timezone"] == "UTC"
+    assert decisions["observed_at"]["dtype"].startswith("timestamp[")
+
+
+def test_dataframe_sdk_reports_polars_nullable_category_and_timezone_decisions() -> (
+    None
+):
+    """Polars conversion reaches the same Arrow-backed diagnostic contract."""
+    polars = pytest.importorskip("polars")
+    frame = polars.DataFrame(
+        {
+            "tier": polars.Series(["standard", None], dtype=polars.Categorical),
+            "cost": polars.Series([10, None], dtype=polars.Int64),
+            "observed_at": polars.Series(
+                [datetime(2026, 1, 1, tzinfo=UTC), None],
+                dtype=polars.Datetime(time_zone="UTC"),
+            ),
+        }
+    )
+
+    bundle = from_dataframe(frame, dataset_id="polars-consumer")
+    extension = bundle.manifest.model_dump(mode="json")["extensions"][
+        "voiage.dev:dataframe-interchange"
+    ]
+    decisions = {item["field_id"]: item for item in extension["field_decisions"]}
+
+    assert bundle.table("data").to_pylist()[1] == {
+        "tier": None,
+        "cost": None,
+        "observed_at": None,
+    }
+    assert extension["copy_policy"] == "allow_copy"
+    assert extension["copy_outcome"] == "not_observable"
+    assert decisions["tier"]["categorical"] is True
+    assert decisions["tier"]["nullable"] is True
+    assert decisions["cost"]["nullable"] is True
+    assert decisions["observed_at"]["timezone"] == "UTC"
+    assert decisions["observed_at"]["dtype"].startswith("timestamp[")


### PR DESCRIPTION
## Summary

- add pandas and Polars consumer-contract coverage for nullable categorical and timezone-aware columns
- prove pandas index exclusion and conservative copy diagnostics from the Arrow conversion actually returned
- update the ingestion guide, changelog, and P8 Conductor evidence without claiming clean optional-environment or full Phase 8 completion

## Validation

- `uv run --extra ci --extra dev pytest tests/test_dataframe_interchange_sdk.py tests/test_standardized_ingestion_providers.py -q --no-cov` (98 passed)
- Ruff check and format, ty, full Conductor validation, cross-reference validation, and diff check
- Astro documentation build and Vale passed before rebase

Refs #467