### PR TITLE
fix(release): verify TestPyPI RC4 provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -679,9 +679,19 @@ jobs:
           )
           test "${#distribution_urls[@]}" -eq 4
           for distribution_url in "${distribution_urls[@]}"; do
-            uvx --from pypi-attestations pypi-attestations verify pypi --staging \
+            filename="$(basename "$distribution_url")"
+            test "$filename" != "."
+            test "$filename" != ".."
+            test -f "reviewed-dist/$filename"
+            provenance="$RUNNER_TEMP/$filename.provenance"
+            curl --fail --silent --show-error \
+              "https://test.pypi.org/integrity/voiage/${PYTHON_VERSION}/${filename}/provenance" \
+              --output "$provenance"
+            uvx --from 'pypi-attestations==0.0.30' \
+              pypi-attestations verify pypi \
+              --provenance-file "$provenance" \
               --repository "https://github.com/${GITHUB_REPOSITORY}" \
-              "$distribution_url"
+              "reviewed-dist/$filename"
           done
       - name: Install TestPyPI artifact with bounded retry
         shell: bash

--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/changelog.md
+++ b/changelog.md
@@ -105,11 +105,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Prepared the `v2.0.1-rc.3` TestPyPI candidate with explicit ecosystem version
+- Prepared the `v2.0.1-rc.4` TestPyPI candidate with explicit ecosystem version
   projections, a deterministic aggregate root for dependency-only Python SBOM
   input, and a source-bound UUIDv5 CycloneDX serial number required by GitHub
-  SBOM attestations. RC3 supersedes unpublished RC1 and RC2 staging attempts,
-  which failed closed before a draft release or registry publication.
+  SBOM attestations. RC1 and RC2 failed closed before registry publication.
+  RC3 was published to TestPyPI with exact reviewed bytes and attestations, but
+  its hosted smoke stopped at the verifier's direct staging-host constraint;
+  RC4 verifies the same PEP 740 contract through TestPyPI's Integrity API.
+  Promotion remains fail-closed for provenance retrieval, cryptographic
+  verification, exact reviewed hashes, and supported-Python installation.
 - Frictionless CSV ingestion now rejects duplicate descriptor field names and
   duplicate CSV headers through the stable ingestion error boundary.
 - Hardened stable and prerelease publishing across Python, Rust, R, and Julia:

--- a/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
@@ -67,6 +67,15 @@ releases.
 GitHub immutable releases should be enabled in hosted repository settings so
 published release assets and their tag cannot be modified.
 
+TestPyPI promotion requires exact SHA-256 equality with the privately reviewed
+release payload, GitHub build-provenance verification, cryptographic
+attestation verification, and clean-install smoke tests on every supported
+Python version. Because the attestation client's direct-URL mode accepts only
+the production distribution host, the workflow retrieves each provenance
+object from TestPyPI's Integrity API and verifies it against the corresponding
+reviewed local distribution. Integrity API, identity, digest, signature, and
+certificate errors all fail closed.
+
 ## Owner and organization gates
 
 Some controls cannot be configured from this repository alone:

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 2.0.0.9003
-Config/voiage/Release-Version: 2.0.1-rc.3
+Version: 2.0.0.9004
+Config/voiage/Release-Version: 2.0.1-rc.4
 Authors@R: person("Dylan", "Mordaunt",
     email = "voiage@users.noreply.github.com",
     role = c("aut", "cre"),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 NeedsCompilation: no
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
-SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.3 or compatible);
+SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.4 or compatible);
     Python (>= 3.12, optional, for EVPPI and EVSI through reticulate)
 Suggests:
     reticulate (>= 1.20),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 dependencies = [
  "proptest",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-ffi"
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 dependencies = [
  "proptest",
  "voiage-diagnostics",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-python"
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 dependencies = [
  "pyo3",
  "serde",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-serialization"
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-test-support"
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.1-rc.3"
+version = "2.0.1-rc.4"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/edithatogo/voiage"
 
 [workspace.dependencies]
-voiage-diagnostics = { version = "=2.0.1-rc.3", path = "crates/voiage-diagnostics" }
-voiage-domain = { version = "=2.0.1-rc.3", path = "crates/voiage-domain" }
-voiage-numerics = { version = "=2.0.1-rc.3", path = "crates/voiage-numerics" }
-voiage-serialization = { version = "=2.0.1-rc.3", path = "crates/voiage-serialization" }
+voiage-diagnostics = { version = "=2.0.1-rc.4", path = "crates/voiage-diagnostics" }
+voiage-domain = { version = "=2.0.1-rc.4", path = "crates/voiage-domain" }
+voiage-numerics = { version = "=2.0.1-rc.4", path = "crates/voiage-numerics" }
+voiage-serialization = { version = "=2.0.1-rc.4", path = "crates/voiage-serialization" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -42,7 +42,11 @@ def test_release_uses_pep740_and_exact_testpypi_promotion() -> None:
     assert "attestations: false" not in release
     assert "Verify TestPyPI distribution attestations" in release
     assert "pypi-attestations" in release
-    assert "verify pypi --staging" in release
+    assert "pypi-attestations==0.0.30" in release
+    assert "test.pypi.org/integrity/voiage/${PYTHON_VERSION}" in release
+    assert "--provenance-file" in release
+    assert '"reviewed-dist/$filename"' in release
+    assert "verify pypi --staging" not in release
     assert 'python: ["3.12", "3.13", "3.14"]' in release
     assert "Download reviewed release payload" in release
     assert "Compare TestPyPI bytes with reviewed payload" in release

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -439,6 +439,11 @@ def test_testpypi_smoke_is_bounded_and_blocks_pypi() -> None:
     assert "sleep 20" in rendered
     assert "https://test.pypi.org/simple/" in rendered
     assert "--no-deps" in rendered
+    assert "test.pypi.org/integrity/voiage/${PYTHON_VERSION}" in rendered
+    assert "pypi-attestations==0.0.30" in rendered
+    assert "--provenance-file" in rendered
+    assert "reviewed-dist/$filename" in rendered
+    assert "verify pypi --staging" not in rendered
     assert "test_wheel_black_box.py --import-mode=importlib" in rendered
 
 

--- a/todo.md
+++ b/todo.md
@@ -171,7 +171,14 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
-*   [x] Prepare the signed `v2.0.1-rc.3` TestPyPI candidate contract.
+*   [x] Preserve strict TestPyPI attestation verification through its Integrity
+    API.
+    *   Retrieve each provenance object from TestPyPI and verify it against the
+        corresponding exact reviewed distribution.
+    *   Keep Integrity API, identity, digest, signature, certificate,
+        GitHub-provenance, hash, and Python 3.12--3.14 smoke failures blocking.
+
+*   [x] Prepare the signed `v2.0.1-rc.4` TestPyPI candidate contract.
     *   Added explicit Cargo/Julia SemVer, Python PEP 440, and R numeric
         development-version projections without claiming R, Julia, or
         crates.io prerelease publication.
@@ -182,6 +189,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         the composer to root dependency-only CycloneDX Python inventories.
     *   Superseded unpublished RC2 with RC3 after adding the deterministic
         UUIDv5 serial number required by GitHub's SBOM attestation action.
+    *   Published RC3 to TestPyPI with exact reviewed bytes and attestations,
+        then superseded its hosted direct-URL verifier limitation with RC4's
+        strict TestPyPI Integrity API verification.
 
 *   [x] Normalize and archive the historical Conductor registry.
     *   Archived track:


### PR DESCRIPTION
## Summary
- verify TestPyPI PEP 740 provenance through its Integrity API against every exact reviewed distribution
- pin pypi-attestations and keep all provenance, identity, digest, signature, and certificate failures blocking
- prepare synchronized Python/Rust/R/Julia metadata for the Python-only v2.0.1-rc.4 signed candidate

## Verification
- repository harness: pass (29 workflows, zero findings)
- full tox: pass (all 15 environments, including Python 3.12-3.14, min/max dependencies, docs, type checking, contracts, and coverage)
- cargo metadata/check --locked: pass
- live RC3 PEP 740 verification through TestPyPI Integrity API: all 3 wheels and sdist OK

## Release boundary
This PR prepares a Python/TestPyPI release candidate. It does not publish R, Julia, or crates.io prereleases, and it does not publish a public GitHub or production PyPI release.