### PR TITLE
test(ingestion): expand cross-domain reference cases

### DIFF
--- a/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
+++ b/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
@@ -3,16 +3,17 @@ title: Standardized Ingestion Reference Cases
 description: Deterministic ML, engineering, and business EVPI examples using one explicit VOI binding.
 ---
 
-These three synthetic, rights-cleared reference cases use the same pinned
-decision samples and the same explicit net-benefit binding. They demonstrate
-format interoperability, not domain-specific modelling: no field names,
-strategies, units, or transformations are inferred.
+These deterministic, in-repository synthetic examples demonstrate format
+interoperability, not domain-specific modelling: no field names, strategies,
+units, or transformations are inferred. They contain no third-party source
+data and make no claim about external data rights, live provider availability,
+or a real-world decision recommendation.
 
-| Community | Descriptor or input | Decision interpretation |
-| --- | --- | --- |
-| Machine learning | Croissant 1.1 | Compare model-selection net benefits across posterior samples. |
-| Engineering and operations | Frictionless Data Package | Compare design alternatives across simulated operating scenarios. |
-| Business | Arrow DataFrame-interchange SDK | Compare investment strategies across decision scenarios. |
+| Community | Croissant | Frictionless | Direct normalized input | Explicit method |
+| --- | --- | --- | --- | --- |
+| Machine learning | `canonical-decision.croissant.json` | `canonical-decision.datapackage.json` | Explicit Arrow table and binding | EVPI on model-selection net benefits. |
+| Engineering and operations | `cost-outcome-decision.croissant.json` | `cost-outcome-decision.datapackage.json` | Explicit Arrow table and bindings | EVPI on cost/outcome net benefits at a declared WTP. |
+| Business | `canonical-decision.croissant.json` | `canonical-decision.datapackage.json` | Explicit Arrow table and binding | EVPI on investment-strategy net benefits. |
 
 The fixture records two strategies, `strategy_a` and `strategy_b`, and binds
 them explicitly as `A` and `B`:
@@ -32,22 +33,27 @@ Run the complete reproducible walkthrough from a source checkout:
 uv run python examples/standardized_ingestion/reference_cases.py
 ```
 
-The output contains identical EVPI values for `ml`, `engineering`, and
-`business`. The business case deliberately enters through
-`from_dataframe(..., allow_copy=False)`, using Arrow's standard DataFrame
-interchange protocol with an explicit zero-copy requirement. The runner fails
-if any format reaches a different value, making the example an executable
-cross-format regression check as well as a tutorial. Its machine-readable
-output also records the identical normalized Arrow schemas, the matching
-Croissant/Frictionless resource digests, and the content-addressed direct
-DataFrame provenance digest.
+The output is a machine-readable case catalogue. Every community has
+`croissant`, `frictionless`, and `direct` results; the optional `dataframe`
+result is an additional SDK-consumer check. The runner fails if a required
+surface reaches a different EVPI, a provider receipt differs from the pinned
+CSV digest, or the Arrow schema changes. The `dataframe` result exercises
+`from_dataframe(..., allow_copy=False)` with the explicit zero-copy requirement;
+it does not replace the direct normalized input.
 
 To inspect the descriptor-backed forms before calculating, run:
 
 ```bash
 voiage ingest validate tests/fixtures/standardized_ingestion/canonical-decision.croissant.json
 voiage ingest inspect tests/fixtures/standardized_ingestion/canonical-decision.datapackage.json
+voiage ingest validate tests/fixtures/standardized_ingestion/cost-outcome-decision.croissant.json
+voiage ingest inspect tests/fixtures/standardized_ingestion/cost-outcome-decision.datapackage.json
 ```
+
+`inspect` is deliberately metadata-only; it does not materialize a resource.
+`validate` materializes the declared local CSV and reports its receipt, pinned
+digest, retained governance metadata, and data-quality evidence. Binding
+resolution remains explicit in Python rather than inferred from the descriptor.
 
 ## Cost/outcome derivation case
 
@@ -67,6 +73,9 @@ assert run_cost_outcome_reference_cases()["ml"] == 20.0 / 3.0
 
 The pinned sources, digests, binding details, and willingness-to-pay value are
 recorded in `cost-outcome-decision.manifest.json` beside the fixture files.
+The scripts deliberately report a fixture as deterministic synthetic data,
+rather than presenting a substitute for a rights clearance or live provider
+receipt.
 
 The input descriptors and their SHA-256 digests live in
 [`tests/fixtures/standardized_ingestion/`](https://github.com/edithatogo/voiage/tree/main/tests/fixtures/standardized_ingestion).

--- a/examples/standardized_ingestion/reference_cases.py
+++ b/examples/standardized_ingestion/reference_cases.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 import pyarrow as pa
 
@@ -21,6 +22,16 @@ from voiage.methods.basic import evpi
 
 _ROOT = Path(__file__).parents[2]
 _FIXTURES = _ROOT / "tests" / "fixtures" / "standardized_ingestion"
+
+
+def _artifact(stem: str) -> dict[str, Any]:
+    """Load the review-owned identity for one deterministic synthetic fixture."""
+    payload = json.loads(
+        (_FIXTURES / f"{stem}.manifest.json").read_text(encoding="utf-8")
+    )
+    if not isinstance(payload, dict):  # pragma: no cover - static JSON fixture
+        raise TypeError("reference fixture manifest must be a JSON object")
+    return payload
 
 
 def _binding() -> VOIBinding:
@@ -73,7 +84,9 @@ def _direct() -> NormalizedInputBundle:
             provenance=SourceProvenance(
                 provider_id="direct-reference-case",
                 source_uri="urn:voiage:reference-case:direct",
-                descriptor_digest="f" * 64,
+                descriptor_digest=_artifact("canonical-decision")["normalized"][
+                    "resource_sha256"
+                ],
             ),
             bindings=(_binding(),),
         ),
@@ -144,7 +157,9 @@ def _direct_cost_outcome() -> NormalizedInputBundle:
             provenance=SourceProvenance(
                 provider_id="direct-reference-case",
                 source_uri="urn:voiage:reference-case:direct-cost-outcome",
-                descriptor_digest="e" * 64,
+                descriptor_digest=_artifact("cost-outcome-decision")["normalized"][
+                    "resource_sha256"
+                ],
             ),
             bindings=_cost_outcome_bindings(),
         ),
@@ -251,5 +266,75 @@ def run_cost_outcome_reference_cases() -> dict[str, dict[str, float]]:
     return _repeat_for_domains(values)
 
 
+def run_cross_format_reference_cases() -> dict[str, dict[str, object]]:
+    """Return reproducible P9 evidence for every community and input surface.
+
+    The ML and business scenarios intentionally share the small explicit
+    net-benefit fixture; the engineering scenario uses explicit cost/outcome
+    bindings.  All forms are local, deterministic repository fixtures.  Their
+    accompanying records make no claim about a live registry, external source
+    rights, or inferred domain semantics.
+    """
+    net_benefit = cast("dict[str, Any]", run_reference_cases())
+    cost_outcome = run_cost_outcome_reference_cases()
+
+    def case(
+        *,
+        artifact_stem: str,
+        method: str,
+        surfaces: dict[str, float],
+    ) -> dict[str, object]:
+        artifact = _artifact(artifact_stem)
+        receipts = cast("dict[str, list[str]]", net_benefit["resource_digests"])
+        if artifact_stem == "cost-outcome-decision":
+            policy = SourceAccessPolicy(_FIXTURES)
+            receipts = {
+                surface: [resource.sha256 for resource in bundle.manifest.resources]
+                for surface, bundle in _cost_outcome_surfaces(
+                    policy, _cost_outcome_bindings()
+                ).items()
+            }
+        provider_receipts = {
+            surface: values[0]
+            for surface, values in receipts.items()
+            if surface in {"croissant", "frictionless"}
+        }
+        resource_sha256 = artifact["normalized"]["resource_sha256"]
+        if set(provider_receipts.values()) != {resource_sha256}:
+            raise RuntimeError("reference-case receipts must match pinned artifacts")
+        required = {
+            surface: surfaces[surface]
+            for surface in ("croissant", "direct", "frictionless")
+        }
+        if len(set(required.values())) != 1:
+            raise RuntimeError("reference-case surfaces must have identical EVPI")
+        return {
+            "artifact": artifact,
+            "expected_evpi": next(iter(required.values())),
+            "governance": artifact["governance"],
+            "method": method,
+            "receipt_sha256": resource_sha256,
+            "surfaces": surfaces,
+        }
+
+    return {
+        "ml": case(
+            artifact_stem="canonical-decision",
+            method="EVPI on explicit model-selection net benefits",
+            surfaces=cast("dict[str, float]", net_benefit["evpi"]["ml"]),
+        ),
+        "engineering": case(
+            artifact_stem="cost-outcome-decision",
+            method="EVPI on explicit cost/outcome net benefits at WTP 20,000",
+            surfaces=cost_outcome["engineering"],
+        ),
+        "business": case(
+            artifact_stem="canonical-decision",
+            method="EVPI on explicit investment-strategy net benefits",
+            surfaces=cast("dict[str, float]", net_benefit["evpi"]["business"]),
+        ),
+    }
+
+
 if __name__ == "__main__":
-    print(json.dumps(run_reference_cases(), sort_keys=True))
+    print(json.dumps(run_cross_format_reference_cases(), sort_keys=True))

--- a/tests/fixtures/standardized_ingestion/canonical-decision.manifest.json
+++ b/tests/fixtures/standardized_ingestion/canonical-decision.manifest.json
@@ -17,6 +17,11 @@
     "canonical-decision.csv": "f56d1b3708adff6ea76db79abb77f897bae4fbb2d96f112a13814eb21f6d5ab9",
     "canonical-decision.datapackage.json": "4252c19f66d9dac69e071fb55f1c66bdd9f568a7ad2d0695f578757e20de45c0"
   },
+  "governance": {
+    "rights_status": "in-repository deterministic fixture; no external claim",
+    "synthetic": true,
+    "third_party_data": false
+  },
   "normalized": {
     "content_digest": "b01aa0dc619cb785aecd153d76b26198044d6c61d54dfd3599332d6db2e91161",
     "resource_sha256": "f56d1b3708adff6ea76db79abb77f897bae4fbb2d96f112a13814eb21f6d5ab9",

--- a/tests/fixtures/standardized_ingestion/cost-outcome-decision.manifest.json
+++ b/tests/fixtures/standardized_ingestion/cost-outcome-decision.manifest.json
@@ -33,6 +33,11 @@
     "cost-outcome-decision.csv": "691decee94d6ad294372da2ab4690a018b9bbfd37ce083f9b68a41dacf8dcb18",
     "cost-outcome-decision.datapackage.json": "7012194bea0f0e030b383972be17ece7e51d0a91f2a4c6dd272307da143cd86b"
   },
+  "governance": {
+    "rights_status": "in-repository deterministic fixture; no external claim",
+    "synthetic": true,
+    "third_party_data": false
+  },
   "normalized": {
     "content_digest": "792402668c639eb5c43dd7caddf1efcea19c44d7f0c22116537e5b2782dffdf9",
     "resource_sha256": "691decee94d6ad294372da2ab4690a018b9bbfd37ce083f9b68a41dacf8dcb18",

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -45,6 +45,36 @@ def test_reference_descriptors_have_safe_cli_walkthroughs(
     assert result["capabilities"]["provider_id"] == provider
 
 
+@pytest.mark.parametrize(
+    ("descriptor_name", "provider"),
+    [
+        ("canonical-decision.croissant.json", "croissant"),
+        ("canonical-decision.datapackage.json", "frictionless"),
+        ("cost-outcome-decision.croissant.json", "croissant"),
+        ("cost-outcome-decision.datapackage.json", "frictionless"),
+    ],
+)
+def test_cross_domain_reference_descriptors_validate_and_inspect(
+    descriptor_name: str, provider: str
+) -> None:
+    """P9 fixture descriptors retain one local, non-materializing CLI route."""
+    fixture_root = Path(__file__).parent / "fixtures" / "standardized_ingestion"
+    descriptor = fixture_root / descriptor_name
+    runner = CliRunner()
+
+    validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
+    inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
+
+    assert validated.exit_code == 0
+    validation = json.loads(validated.output)
+    assert validation["valid"] is True
+    assert validation["resources"][0]["sha256"]
+    assert inspected.exit_code == 0
+    inspection = json.loads(inspected.output)
+    assert inspection["provider"] == provider
+    assert inspection["binding_resolution"] is None
+
+
 def test_ingest_commands_publish_stable_help_surfaces() -> None:
     """All documented ingestion commands remain discoverable through the CLI."""
     runner = CliRunner()

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -74,6 +74,33 @@ def test_cost_outcome_reference_cases_are_equivalent_across_input_surfaces() -> 
         }
         for domain in ("ml", "engineering", "business")
     }
+
+
+def test_each_domain_reference_case_has_all_supported_input_surfaces() -> None:
+    """Each documented community can reproduce its case through every surface."""
+    path = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "standardized_ingestion"
+        / "reference_cases.py"
+    )
+    spec = importlib.util.spec_from_file_location("reference_cases", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    cases = module.run_cross_format_reference_cases()
+
+    assert set(cases) == {"ml", "engineering", "business"}
+    for case in cases.values():
+        for surface in ("croissant", "direct", "frictionless"):
+            assert case["surfaces"][surface] == pytest.approx(case["expected_evpi"])
+        assert (
+            case["receipt_sha256"] == case["artifact"]["normalized"]["resource_sha256"]
+        )
+        assert case["governance"]["synthetic"] is True
+        assert case["governance"]["third_party_data"] is False
     assert (
         module._business_cost_outcome_dataframe().manifest.provenance.provider_id
         == ("dataframe-interchange")


### PR DESCRIPTION
## Summary\n- run ML, engineering/operations, and business cases through Croissant, Frictionless, and direct normalized input surfaces\n- preserve pinned fixture digest and provider receipt evidence with truthful deterministic-synthetic governance metadata\n- add descriptor validate/metadata-only inspect walkthrough coverage and a support/method matrix\n\n## Validation\n- .......................................                                  [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97
  /private/tmp/voiage-p9-per-format-examples/.venv/lib/python3.14/site-packages/xarray/core/dtypes.py:97: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
    NAT_TYPES = {np.datetime64("NaT").dtype, np.timedelta64("NaT").dtype}

tests/test_standardized_ingestion_conformance.py: 31 warnings
  /private/tmp/voiage-p9-per-format-examples/.venv/lib/python3.14/site-packages/pyarrow/interchange/from_dataframe.py:88: DeprecationWarning: Support for the dataframe interchange protocol is deprecated since version 1.40.0
    return _from_dataframe(df.__dataframe__(allow_copy=allow_copy),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html (39 passed)\n- Ruff, ty, fixture validator, full Conductor validation, cross-reference validation, Vale, Astro build\n\nP9 remains in progress: this PR closes a bounded repository-evidence slice only; it does not claim external rights clearance or live-provider support.