### PR TITLE
fix(release): retry TestPyPI Simple propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -659,9 +659,18 @@ jobs:
             sleep 20
           done
           mkdir testpypi-dist
-          python -m pip download --no-deps --only-binary=:all: \
-            --index-url https://test.pypi.org/simple/ \
-            --dest testpypi-dist "voiage==$PYTHON_VERSION"
+          for attempt in 1 2 3 4 5 6; do
+            if python -m pip download --no-deps --only-binary=:all: \
+              --index-url https://test.pypi.org/simple/ \
+              --dest testpypi-dist "voiage==$PYTHON_VERSION"; then
+              break
+            fi
+            if [[ "$attempt" == "6" ]]; then
+              echo "TestPyPI Simple API did not expose the reviewed release" >&2
+              exit 1
+            fi
+            sleep 20
+          done
           reviewed="$(find reviewed-dist -maxdepth 1 -name '*manylinux*x86_64.whl' -print -quit)"
           downloaded="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
           test -n "$reviewed"

--- a/changelog.md
+++ b/changelog.md
@@ -108,6 +108,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added a bounded retry around the TestPyPI Simple API download so propagation
+  lag after the JSON API exposes a reviewed release does not create a false
+  negative in the supported-Python smoke matrix.
 - Prepared the `v2.0.1-rc.4` TestPyPI candidate with explicit ecosystem version
   projections, a deterministic aggregate root for dependency-only Python SBOM
   input, and a source-bound UUIDv5 CycloneDX serial number required by GitHub

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -435,9 +435,10 @@ def test_testpypi_smoke_is_bounded_and_blocks_pypi() -> None:
         "resolve-tag",
         "test-pypi-smoke",
     ]
-    assert "for attempt in 1 2 3 4 5 6" in rendered
+    assert rendered.count("for attempt in 1 2 3 4 5 6") >= 3
     assert "sleep 20" in rendered
     assert "https://test.pypi.org/simple/" in rendered
+    assert "TestPyPI Simple API did not expose the reviewed release" in rendered
     assert "--no-deps" in rendered
     assert "test.pypi.org/integrity/voiage/${PYTHON_VERSION}" in rendered
     assert "pypi-attestations==0.0.30" in rendered

--- a/todo.md
+++ b/todo.md
@@ -171,6 +171,12 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Bound TestPyPI JSON-to-Simple API propagation lag.
+    *   Retry the exact reviewed wheel download for the same bounded six
+        attempts used by the TestPyPI JSON and installation gates.
+    *   Preserve failure after the propagation window and all exact-hash,
+        provenance, and black-box smoke requirements.
+
 *   [x] Preserve strict TestPyPI attestation verification through its Integrity
     API.
     *   Retrieve each provenance object from TestPyPI and verify it against the


### PR DESCRIPTION
## Summary
- retry the TestPyPI Simple API wheel download across the existing bounded propagation window
- preserve the exact reviewed hash, PEP 740 provenance, and black-box installation gates
- document the JSON-to-Simple propagation behavior observed during the successful RC4 run

## Verification
- repository harness: pass (29 workflows, zero findings)
- focused release workflow contracts: 29 passed
- full tox: every environment and test command passed, including Python 3.12-3.14, min/max dependencies, docs, type checking, contracts, and coverage

## Evidence
RC4 run 30629613417 succeeded after the Simple API propagated: all three Python smoke jobs verified exact bytes and attestations, installed, and passed black-box tests.