### PR TITLE
feat(ingestion): fixture provider SDK v1 contracts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bound the frozen ingestion-provider SDK v1 to a machine-readable consumer
+  fixture, rejected empty provider identities at registry registration, and
+  added clean optional-parser import-isolation coverage while the intentionally
+  dependency-neutral ingestion extras remain unpromoted.
 - Added pandas and Polars DataFrame-interchange consumer coverage for nullable
   categorical and timezone-aware columns, index exclusion, and conservative
   copy diagnostics based on the Arrow conversion actually returned.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -257,12 +257,18 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   phases 1–5 establish stable core contracts and conformance evidence.
 - [~] **P8-T2 / AC-12:** Add typed protocol stubs, a minimal example provider,
   reusable contract tests, capability manifests, compatibility rules, and an
-  opt-in entry-point publication checklist.
+  opt-in entry-point publication checklist. The SDK v1 now has a versioned
+  machine-readable consumer fixture, regression tests for its public protocol
+  and capability fields, and registry rejection of empty provider identities
+  (partial: a separately installed third-party provider remains future evidence).
 - [~] **P8-T3 / AC-12:** Write failing DataFrame-interchange tests covering
   pandas, Polars, dtype/null/category/timezone/index handling, copy diagnostics,
   and clean optional environments. Partial diagnostics evidence: `fdda14a`;
   producer-specific nullable/category/timezone/index consumer evidence is added
-  in this increment. Clean optional-environment evidence remains pending.
+  in this increment. Dependency-neutral `croissant`, `frictionless`, and
+  aggregate `ingestion` extras now have subprocess import-isolation regression
+  coverage while enhanced parser modules are absent (partial: actual enhanced
+  parser extras remain intentionally unpromoted).
 - [~] **P8-T4 / AC-12:** Implement the generic `__dataframe__` adapter through
   Arrow and `NormalizedInputBundle`, with no alternate preparation or numerical
   path. Partial conversion-diagnostics evidence: `fdda14a`.

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -214,9 +214,10 @@ not resolve resources, access the network, or import optional parser stacks.
 resource through the supplied `SourceAccessPolicy`.
 
 The frozen v1 SDK additionally requires `capabilities.provider_id` to equal the
-provider's `provider_id`; registration rejects mismatches. Its versioned
-compatibility and publication rules live in
-`specs/core-api/ingestion-provider-sdk-v1.md`.
+provider's non-empty `provider_id`; registration rejects mismatches and empty
+identities. Its versioned compatibility and publication rules live in
+`specs/core-api/ingestion-provider-sdk-v1.md`, with a machine-readable consumer
+fixture at `specs/core-api/fixtures/v2/ingestion-provider-sdk-v1.json`.
 
 Publish an initialized provider instance under the
 `voiage.ingestion.providers` entry-point group. The entry-point name is the
@@ -248,3 +249,14 @@ unsupported version/media-type failures, traversal and network refusal by
 import isolation. Providers must declare unsupported projection, filtering,
 streaming, and random-access features as `False`; no data transformation may
 be inferred or performed implicitly.
+
+### Optional parser environments
+
+`voiage[croissant]`, `voiage[frictionless]`, and `voiage[ingestion]` are
+currently dependency-neutral installation profiles. They deliberately do not
+install `mlcroissant` or the third-party `frictionless` package: neither stack
+has been promoted into the built-in local-only source-policy and receipt
+contract. A clean install of any profile therefore retains the same lazy,
+offline-safe import boundary as the base package. A future enhanced provider
+must add a separate named dependency, fixtures, receipt evidence, and a new
+capability profile before this statement can change.

--- a/specs/core-api/fixtures/v2/ingestion-provider-sdk-v1.json
+++ b/specs/core-api/fixtures/v2/ingestion-provider-sdk-v1.json
@@ -1,0 +1,54 @@
+{
+  "sdk_version": "1",
+  "entry_point_group": "voiage.ingestion.providers",
+  "provider_protocol": {
+    "attributes": [
+      "provider_id",
+      "capabilities"
+    ],
+    "methods": {
+      "can_handle": "(descriptor: dict[str, object]) -> bool",
+      "ingest": "(descriptor_path: Path, *, policy: SourceAccessPolicy) -> NormalizedInputBundle"
+    }
+  },
+  "capability_fields": [
+    "provider_id",
+    "format_versions",
+    "media_types",
+    "supported_transforms",
+    "supports_projection",
+    "supports_filtering",
+    "supports_streaming",
+    "supports_random_access"
+  ],
+  "optional_extra_profiles": {
+    "croissant": {
+      "dependencies": [],
+      "status": "named-reservation",
+      "reason": "The built-in local CSV profile must not delegate materialization to an unreceipted parser stack."
+    },
+    "frictionless": {
+      "dependencies": [],
+      "status": "named-reservation",
+      "reason": "The built-in local CSV profile must not delegate materialization to an unreceipted parser stack."
+    },
+    "ingestion": {
+      "dependencies": [],
+      "status": "aggregate-reservation",
+      "reason": "The aggregate extra remains dependency-neutral while both built-in profiles use the base Arrow and JSON stack."
+    }
+  },
+  "consumer_contract": {
+    "dataframe_entry_point": "voiage.ingestion.from_dataframe",
+    "normalization_boundary": "Arrow -> NormalizedInputBundle",
+    "preparation_path": "prepare_analysis_inputs",
+    "copy_outcomes": [
+      "zero_copy",
+      "not_observable"
+    ],
+    "unsupported_registry_providers": [
+      "huggingface",
+      "openml"
+    ]
+  }
+}

--- a/specs/core-api/ingestion-provider-sdk-v1.md
+++ b/specs/core-api/ingestion-provider-sdk-v1.md
@@ -32,8 +32,17 @@ identifier, error category, or normalized manifest meaning requires a new SDK
 major version.
 
 Discovery is opt-in and allow-listed. Base imports and descriptor probing never
-load third-party entry points. A provider must be tested in a clean base install
-and with only its named optional extra installed.
+load third-party entry points. The machine-readable consumer fixture is
+`specs/core-api/fixtures/v2/ingestion-provider-sdk-v1.json`; changes to its
+version, entry-point group, capability fields, or protocol surface require an
+SDK-major review. A provider must be tested in a clean base install and with
+only its named optional extra installed.
+
+The repository's `croissant`, `frictionless`, and aggregate `ingestion` extras
+are currently dependency-neutral reservations. They install the same runtime as
+the base package because the built-in local CSV profiles use only the base Arrow
+and JSON stack. This is not a claim that `mlcroissant` or `frictionless` are
+installed, nor that their remote, archive, or cache behaviours are supported.
 
 ## Consumer contract
 

--- a/tests/packaging/test_dependency_minimization.py
+++ b/tests/packaging/test_dependency_minimization.py
@@ -85,6 +85,43 @@ def test_optional_dependencies_expose_only_real_runtime_features() -> None:
     )
 
 
+def test_ingestion_optional_extras_remain_clean_import_profiles() -> None:
+    """Built-in ingestion must work when enhanced parser packages are absent."""
+    metadata = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    extras = metadata["project"]["optional-dependencies"]
+
+    assert {
+        name: extras[name] for name in ("croissant", "frictionless", "ingestion")
+    } == {
+        "croissant": [],
+        "frictionless": [],
+        "ingestion": [],
+    }
+    probe = r"""
+import importlib.abc
+import sys
+
+class BlockEnhancedParsers(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        root = fullname.partition(".")[0]
+        if root in {"mlcroissant", "frictionless"}:
+            raise ModuleNotFoundError(f"{root} intentionally absent", name=root)
+        return None
+
+sys.meta_path.insert(0, BlockEnhancedParsers())
+
+import voiage.ingestion
+from voiage.ingestion import ProviderCapabilities, ProviderRegistry
+
+assert "voiage.ingestion.croissant" not in sys.modules
+assert "voiage.ingestion.frictionless" not in sys.modules
+assert ProviderCapabilities("consumer", ("1",), ("text/csv",)).provider_id == "consumer"
+assert ProviderRegistry()._providers == ()
+"""
+    result = _run_isolated_probe(probe)
+    assert result.returncode == 0, result.stderr
+
+
 def test_base_install_imports_and_runs_numpy_without_jax() -> None:
     """Model a clean wheel environment where the JAX extra is absent."""
     probe = r"""

--- a/tests/test_ingestion_provider_sdk_contract.py
+++ b/tests/test_ingestion_provider_sdk_contract.py
@@ -1,0 +1,99 @@
+"""Versioned consumer contract tests for the provider SDK v1 surface."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from voiage.ingestion import (
+    INGESTION_PROVIDER_SDK_VERSION,
+    IngestionError,
+    ProviderCapabilities,
+    ProviderRegistry,
+)
+
+if TYPE_CHECKING:
+    from voiage.contracts import NormalizedInputBundle
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "specs/core-api/fixtures/v2/ingestion-provider-sdk-v1.json"
+
+
+def _fixture() -> dict[str, object]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_provider_sdk_v1_fixture_matches_the_public_consumer_surface() -> None:
+    """The versioned fixture prevents accidental protocol-surface drift."""
+    fixture = _fixture()
+
+    assert fixture["sdk_version"] == INGESTION_PROVIDER_SDK_VERSION
+    assert fixture["entry_point_group"] == "voiage.ingestion.providers"
+    assert fixture["provider_protocol"] == {
+        "attributes": ["provider_id", "capabilities"],
+        "methods": {
+            "can_handle": "(descriptor: dict[str, object]) -> bool",
+            "ingest": (
+                "(descriptor_path: Path, *, policy: SourceAccessPolicy) -> "
+                "NormalizedInputBundle"
+            ),
+        },
+    }
+    assert fixture["capability_fields"] == [
+        field.name for field in fields(ProviderCapabilities)
+    ]
+
+
+def test_provider_sdk_fixture_keeps_optional_profiles_dependency_neutral() -> None:
+    """Named ingestion extras cannot silently become parser-runtime dependencies."""
+    extras = _fixture()["optional_extra_profiles"]
+
+    assert extras == {
+        "croissant": {
+            "dependencies": [],
+            "status": "named-reservation",
+            "reason": (
+                "The built-in local CSV profile must not delegate materialization "
+                "to an unreceipted parser stack."
+            ),
+        },
+        "frictionless": {
+            "dependencies": [],
+            "status": "named-reservation",
+            "reason": (
+                "The built-in local CSV profile must not delegate materialization "
+                "to an unreceipted parser stack."
+            ),
+        },
+        "ingestion": {
+            "dependencies": [],
+            "status": "aggregate-reservation",
+            "reason": (
+                "The aggregate extra remains dependency-neutral while both built-in "
+                "profiles use the base Arrow and JSON stack."
+            ),
+        },
+    }
+
+
+def test_registry_rejects_an_empty_provider_identity() -> None:
+    """A consumer cannot publish an ambiguous provider capability manifest."""
+
+    class EmptyProvider:
+        provider_id = ""
+        capabilities = ProviderCapabilities(
+            provider_id="", format_versions=("1",), media_types=("text/csv",)
+        )
+
+        def can_handle(self, descriptor: dict[str, object]) -> bool:
+            return False
+
+        def ingest(self, *args: object, **kwargs: object) -> NormalizedInputBundle:
+            raise AssertionError("the registry must reject this provider first")
+
+    with pytest.raises(IngestionError, match="provider contract"):
+        ProviderRegistry((EmptyProvider(),))

--- a/voiage/ingestion/registry.py
+++ b/voiage/ingestion/registry.py
@@ -27,12 +27,14 @@ _ENTRY_POINT_GROUP = "voiage.ingestion.providers"
 def _validate_provider(provider: object) -> IngestionProvider:
     """Validate an explicitly loaded provider without importing its package."""
     capabilities = getattr(provider, "capabilities", None)
+    provider_id = getattr(provider, "provider_id", None)
     if not (
-        isinstance(getattr(provider, "provider_id", None), str)
+        isinstance(provider_id, str)
+        and bool(provider_id)
         and callable(getattr(provider, "can_handle", None))
         and callable(getattr(provider, "ingest", None))
         and isinstance(capabilities, ProviderCapabilities)
-        and capabilities.provider_id == provider.provider_id
+        and capabilities.provider_id == provider_id
     ):
         raise IngestionError(
             "entry-point provider does not satisfy the provider contract"


### PR DESCRIPTION
## Summary

- bind the frozen provider SDK v1 to a machine-readable consumer fixture and regression contracts
- reject empty provider identities during registration
- prove the named ingestion extras remain dependency-neutral and lazily importable without enhanced parser modules
- document the supported optional-environment boundary and record partial P8 evidence

## Validation

- `uv run --extra ci --extra dev pytest tests/test_ingestion_provider_sdk_contract.py tests/packaging/test_dependency_minimization.py tests/test_standardized_ingestion_provider_example.py --no-cov -q` (11 passed)
- Ruff, format, ty, Conductor validation, GitHub cross-reference validation, dependency frontier, Astro build, Vale, and diff checks passed

## Boundary

An additional offline clean-wheel `.[croissant]` probe could not complete because the local volume ran out of space during Rust compilation. This PR does not claim clean-wheel completion; the committed source-level subprocess import-isolation regression remains green.