### PR TITLE
feat(ingestion): stabilize CLI selection contracts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fixture, rejected empty provider identities at registry registration, and
   added clean optional-parser import-isolation coverage while the intentionally
   dependency-neutral ingestion extras remain unpromoted.
+- Added enforceable standardized-ingestion CLI provider assertions and explicit
+  binding-profile selection, with stable exit codes for safe source, binding,
+  and output failures. Resource projection remains unavailable where built-in
+  provider capabilities cannot enforce it.
 - Added pandas and Polars DataFrame-interchange consumer coverage for nullable
   categorical and timezone-aware columns, index exclusion, and conservative
   copy diagnostics based on the Arrow conversion actually returned.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -180,8 +180,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   that a rejected credential-bearing descriptor URI is redacted at the
   user-facing boundary, and all four ingestion commands have executable help
   contracts. Explicit non-default source-root tests now cover all materializing
-  commands and fail closed at the resource-byte limit (partial: complete Phase
-  6 acceptance reconciliation remains active).
+  commands and fail closed at the resource-byte limit. Provider/source-policy,
+  binding, and output failures now have stable differentiated exit codes while
+  Typer-owned usage errors retain exit code 2; explicit provider and binding
+  profile selection are enforced, and unsupported resource projection remains
+  absent (partial: complete Phase 6 acceptance reconciliation remains active).
 - [x] **P6-T2 / AC-07:** Add `croissant`, `frictionless`, and aggregate
   `ingestion` extras. The declared extras remain dependency-neutral because
   built-in providers require only the base Arrow/JSON stack.
@@ -202,8 +205,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
 - [~] **P6-T6 / AC-07:** Update Astro data-structure, CLI, architecture, and
   security guidance plus README, changelog, roadmap, and todo. The Astro guide,
   changelog, roadmap/todo, and README now describe the supported profile,
-  explicit safety boundary, CLI, and cross-domain examples; final docs/links
-  and phase-checkpoint evidence remains active.
+  explicit safety boundary, CLI, cross-domain examples, CLI exit taxonomy, and
+  explicit provider/binding-profile boundary; final docs/links and
+  phase-checkpoint evidence remains active.
 - [ ] **P6-T7 / AC-07:** Run automated review, CLI/docs/Vale validation, clean
   install checks, and the phase checkpoint protocol.
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -51,6 +51,22 @@ voiage ingest validate datapackage.json \
   --cache-dir .voiage-cache
 ```
 
+Use `--provider croissant` or `--provider frictionless` to assert the expected
+built-in parser at any CLI boundary. This is an assertion, not a filename or
+content-type override: the descriptor must still match exactly one registered
+provider. `calculate-from-dataset` accepts either the inline `--table` and
+repeated `--field` binding, or an explicit `--binding-profile profile.json`.
+The two binding forms cannot be combined. The built-in providers do not offer a
+`--resource` selector because their declared capabilities do not support
+projection or filtering; each supported descriptor resource is validated as a
+whole rather than silently skipping a table.
+
+CLI usage errors retain exit code 2. VOIAGE-owned failures have stable,
+machine-actionable codes: 3 for safe descriptor, provider, or source-policy
+rejection; 4 for binding-profile or semantic-binding rejection; and 5 when a
+normalized output cannot be written. Error text remains redacted and does not
+authorize remote access.
+
 `croissant.json` is recognized from its Croissant context and
 `datapackage.json` from its Data Package resource list, not from the filename.
 `validate` resolves the descriptor and every declared local resource through

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -10,6 +10,128 @@ import pytest
 from typer.testing import CliRunner
 
 from voiage.cli import app
+from voiage.ingestion import cli as ingestion_cli
+
+
+def test_ingest_cli_publishes_stable_domain_exit_codes(tmp_path) -> None:
+    """CLI syntax, source, binding, and output failures remain distinguishable."""
+    (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "datapackage.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    usage = runner.invoke(app, ["ingest", "validate", str(descriptor), "--unknown"])
+    source = runner.invoke(
+        app, ["ingest", "validate", str(descriptor), "--provider", "croissant"]
+    )
+    binding = runner.invoke(
+        app,
+        [
+            "ingest",
+            "calculate-from-dataset",
+            str(descriptor),
+            "--table",
+            "samples",
+            "--field",
+            "missing",
+        ],
+    )
+    output = runner.invoke(
+        app,
+        ["ingest", "normalize", str(descriptor), "--output", str(tmp_path)],
+    )
+
+    assert usage.exit_code == 2
+    assert source.exit_code == 3
+    assert binding.exit_code == 4
+    assert output.exit_code == 5
+
+
+def test_ingest_cli_enforces_explicit_provider_and_binding_profile(
+    tmp_path, monkeypatch
+) -> None:
+    """Explicit provider and profile inputs are asserted, never inferred."""
+    (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    descriptor = tmp_path / "datapackage.json"
+    descriptor.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.csv",
+                        "schema": {"fields": [{"name": "a"}, {"name": "b"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    profile = tmp_path / "binding-profile.json"
+    profile.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0.0",
+                "bindings": [
+                    {
+                        "role": "net_benefit",
+                        "table_id": "samples",
+                        "field_ids": ("a", "b"),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    monkeypatch.setattr(ingestion_cli, "evpi", lambda _: 0.0)
+
+    validated = runner.invoke(
+        app, ["ingest", "validate", str(descriptor), "--provider", "frictionless"]
+    )
+    calculated = runner.invoke(
+        app,
+        [
+            "ingest",
+            "calculate-from-dataset",
+            str(descriptor),
+            "--binding-profile",
+            str(profile),
+        ],
+    )
+    conflicting = runner.invoke(
+        app,
+        [
+            "ingest",
+            "calculate-from-dataset",
+            str(descriptor),
+            "--binding-profile",
+            str(profile),
+            "--table",
+            "samples",
+            "--field",
+            "a",
+        ],
+    )
+
+    assert validated.exit_code == 0, validated.output
+    assert calculated.exit_code == 0, calculated.output
+    assert json.loads(calculated.output)["binding_profile_digest"]
+    assert conflicting.exit_code == 4
+    assert "cannot be combined" in conflicting.output
 
 
 @pytest.mark.parametrize(
@@ -94,7 +216,7 @@ def test_ingest_commands_publish_stable_help_surfaces() -> None:
         assert description in result.output
 
 
-def test_ingest_inspect_and_normalize(tmp_path) -> None:
+def test_ingest_inspect_and_normalize(tmp_path, monkeypatch) -> None:
     (tmp_path / "samples.csv").write_text("a,b\n1,2\n", encoding="utf-8")
     descriptor = tmp_path / "datapackage.json"
     descriptor.write_text(
@@ -115,6 +237,7 @@ def test_ingest_inspect_and_normalize(tmp_path) -> None:
         encoding="utf-8",
     )
     runner = CliRunner()
+    monkeypatch.setattr(ingestion_cli, "evpi", lambda _: 0.0)
 
     validated = runner.invoke(app, ["ingest", "validate", str(descriptor)])
     default_inspected = runner.invoke(app, ["ingest", "inspect", str(descriptor)])
@@ -228,8 +351,8 @@ def test_inspect_does_not_materialize_declared_resource(tmp_path) -> None:
     assert inspected.exit_code == 0
     assert json.loads(inspected.output)["provider"] == "frictionless"
     assert json.loads(inspected.output)["binding_resolution"] is None
-    assert validated.exit_code == 2
-    assert normalized.exit_code == 2
+    assert validated.exit_code == 3
+    assert normalized.exit_code == 3
     assert "declared resource does not exist" in validated.output
     assert "declared resource does not exist" in normalized.output
 
@@ -241,9 +364,9 @@ def test_ingest_cli_returns_safe_error_for_unrecognized_descriptor(tmp_path) -> 
     result = CliRunner().invoke(app, ["ingest", "inspect", str(descriptor)])
     validated = CliRunner().invoke(app, ["ingest", "validate", str(descriptor)])
 
-    assert result.exit_code == 2
+    assert result.exit_code == 3
     assert "exactly one" in result.output
-    assert validated.exit_code == 2
+    assert validated.exit_code == 3
     assert "exactly one" in validated.output
 
 
@@ -267,7 +390,7 @@ def test_ingest_cli_redacts_credentials_from_rejected_resource_uris(tmp_path) ->
 
     result = CliRunner().invoke(app, ["ingest", "validate", str(descriptor)])
 
-    assert result.exit_code == 2
+    assert result.exit_code == 3
     assert "network resource access is disabled" in result.output
     assert "super-secret" not in result.output
     assert "example.invalid" not in result.output
@@ -282,7 +405,7 @@ def test_normalize_and_calculate_return_safe_errors(tmp_path) -> None:
             app,
             ["ingest", "normalize", str(descriptor), "-o", str(tmp_path / "x.arrow")],
         ).exit_code
-        == 2
+        == 3
     )
     assert (
         runner.invoke(
@@ -297,12 +420,12 @@ def test_normalize_and_calculate_return_safe_errors(tmp_path) -> None:
                 "a",
             ],
         ).exit_code
-        == 2
+        == 3
     )
 
 
 def test_materializing_ingest_commands_expose_explicit_source_policy_controls(
-    tmp_path,
+    tmp_path, monkeypatch
 ) -> None:
     """CLI callers can make materialization policy explicit and fail closed."""
     source_root = tmp_path / "declared-source-root"
@@ -325,6 +448,7 @@ def test_materializing_ingest_commands_expose_explicit_source_policy_controls(
     )
 
     runner = CliRunner()
+    monkeypatch.setattr(ingestion_cli, "evpi", lambda _: 0.0)
     source_policy = ["--source-root", str(source_root)]
     resolved = [
         runner.invoke(app, ["ingest", "validate", str(descriptor), *source_policy]),
@@ -382,7 +506,7 @@ def test_materializing_ingest_commands_expose_explicit_source_policy_controls(
 
     assert all(result.exit_code == 0 for result in resolved)
     assert json.loads(resolved[0].output)["valid"] is True
-    assert constrained.exit_code == 2
+    assert constrained.exit_code == 3
     assert "exceeds configured size limit" in constrained.output
     assert invalid_limit.exit_code == 2
     assert "Invalid value" in invalid_limit.output
@@ -418,7 +542,7 @@ def test_ingest_cli_applies_explicit_resource_size_policy(tmp_path) -> None:
         ],
     )
 
-    assert result.exit_code == 2
+    assert result.exit_code == 3
     assert "exceeds configured size limit" in result.output
 
 

--- a/voiage/ingestion/cli.py
+++ b/voiage/ingestion/cli.py
@@ -12,6 +12,7 @@ from typing import cast
 import typer
 
 from voiage.contracts.normalized_input import (
+    BindingProfile,
     DatasetManifest,
     NormalizedInputBundle,
     VOIBinding,
@@ -22,6 +23,42 @@ from voiage.ingestion.registry import default_registry
 from voiage.methods.basic import evpi
 
 app = typer.Typer(help="Validate and normalize standardized dataset descriptors.")
+
+_EXIT_INGESTION = 3
+_EXIT_BINDING = 4
+_EXIT_OUTPUT = 5
+
+
+def _assert_provider(bundle: NormalizedInputBundle, expected: str | None) -> None:
+    """Require a caller-selected provider without guessing the source format."""
+    if expected is not None and bundle.manifest.provenance.provider_id != expected:
+        raise IngestionError("descriptor does not match explicitly selected provider")
+
+
+def _binding_profile(path: Path) -> BindingProfile:
+    """Load one caller-selected binding profile without descriptor inference."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("binding profile is not valid UTF-8 JSON") from error
+    if isinstance(payload, dict) and isinstance(payload.get("bindings"), list):
+        bindings: list[object] = []
+        for candidate in payload["bindings"]:
+            if isinstance(candidate, dict):
+                binding = dict(candidate)
+                for field in (
+                    "applicable_method_families",
+                    "field_ids",
+                    "strategy_names",
+                    "transformations",
+                ):
+                    if isinstance(binding.get(field), list):
+                        binding[field] = tuple(binding[field])
+                bindings.append(binding)
+            else:
+                bindings.append(candidate)
+        payload = {**payload, "bindings": tuple(bindings)}
+    return BindingProfile.model_validate(payload)
 
 
 def _prepared_summary(bundle: NormalizedInputBundle) -> dict[str, object]:
@@ -73,10 +110,12 @@ def _bundle_summary(
     *,
     binding: VOIBinding | None = None,
     policy: SourceAccessPolicy | None = None,
+    expected_provider: str | None = None,
 ) -> dict[str, object]:
     """Return stable, non-secret metadata for a descriptor."""
     registry = default_registry()
     bundle = registry.ingest(descriptor, policy=policy)
+    _assert_provider(bundle, expected_provider)
     capabilities = registry.capabilities_for(bundle.manifest.provenance.provider_id)
     summary: dict[str, object] = {
         "capabilities": {
@@ -124,7 +163,9 @@ def _bundle_summary(
     return summary
 
 
-def _inspection_summary(descriptor: Path) -> dict[str, object]:
+def _inspection_summary(
+    descriptor: Path, *, expected_provider: str | None = None
+) -> dict[str, object]:
     """Return descriptor-only diagnostics without resolving any resources.
 
     Binding resolution, provenance receipts, and data-quality reports require
@@ -133,6 +174,8 @@ def _inspection_summary(descriptor: Path) -> dict[str, object]:
     than the metadata-only ``inspect`` command.
     """
     inspection = default_registry().inspect(descriptor)
+    if expected_provider is not None and inspection["provider_id"] != expected_provider:
+        raise IngestionError("descriptor does not match explicitly selected provider")
     capabilities = cast("dict[str, object]", inspection["capabilities"])
     return {
         "binding_resolution": None,
@@ -143,6 +186,42 @@ def _inspection_summary(descriptor: Path) -> dict[str, object]:
         "descriptor": inspection["descriptor"],
         "provider": inspection["provider_id"],
     }
+
+
+def _calculation_manifest(
+    bundle: NormalizedInputBundle,
+    *,
+    table: str | None,
+    field: list[str],
+    strategy: list[str],
+    binding_profile: Path | None,
+) -> DatasetManifest:
+    """Resolve exactly one explicit calculation binding contract."""
+    if binding_profile is not None:
+        if table is not None or field or strategy:
+            raise ValueError(
+                "--binding-profile cannot be combined with inline binding options"
+            )
+        return DatasetManifest(
+            **bundle.manifest.model_dump(
+                mode="python", exclude={"bindings", "binding_profile"}
+            ),
+            binding_profile=_binding_profile(binding_profile),
+        )
+    if table is None or not field:
+        raise ValueError(
+            "calculation requires --binding-profile or both --table and --field"
+        )
+    binding = VOIBinding(
+        role="net_benefit",
+        table_id=table,
+        field_ids=tuple(field),
+        strategy_names=tuple(strategy),
+    )
+    return DatasetManifest(
+        **bundle.manifest.model_dump(mode="python", exclude={"bindings"}),
+        bindings=(binding,),
+    )
 
 
 @app.command("validate")
@@ -166,6 +245,11 @@ def validate(
         min=1,
         help="Maximum accepted local resource size.",
     ),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Require this registered provider ID for the descriptor.",
+    ),
 ) -> None:
     """Validate a supported descriptor and its declared local resources."""
     try:
@@ -182,6 +266,7 @@ def validate(
                             cache_dir=cache_dir,
                             max_resource_bytes=max_resource_bytes,
                         ),
+                        expected_provider=provider,
                     ),
                 },
                 sort_keys=True,
@@ -189,19 +274,29 @@ def validate(
         )
     except IngestionError as error:
         typer.echo(f"Error: {error}", err=True)
-        raise typer.Exit(2) from error
+        raise typer.Exit(_EXIT_INGESTION) from error
 
 
 @app.command()
 def inspect(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Require this registered provider ID for the descriptor.",
+    ),
 ) -> None:
     """Inspect descriptor identity and provider capabilities without loading data."""
     try:
-        typer.echo(json.dumps(_inspection_summary(descriptor), sort_keys=True))
+        typer.echo(
+            json.dumps(
+                _inspection_summary(descriptor, expected_provider=provider),
+                sort_keys=True,
+            )
+        )
     except IngestionError as error:
         typer.echo(f"Error: {error}", err=True)
-        raise typer.Exit(2) from error
+        raise typer.Exit(_EXIT_INGESTION) from error
 
 
 @app.command()
@@ -223,6 +318,11 @@ def normalize(
     max_resource_bytes: int = typer.Option(
         512 * 1024 * 1024, "--max-resource-bytes", min=1
     ),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Require this registered provider ID for the descriptor.",
+    ),
 ) -> None:
     """Normalize a descriptor into a deterministic Arrow IPC file."""
     try:
@@ -234,24 +334,40 @@ def normalize(
             max_resource_bytes=max_resource_bytes,
         )
         bundle = default_registry().ingest(descriptor, policy=policy)
+        _assert_provider(bundle, provider)
         bundle.write_ipc(output)
         typer.echo(
-            json.dumps(_bundle_summary(descriptor, policy=policy), sort_keys=True)
+            json.dumps(
+                _bundle_summary(descriptor, policy=policy, expected_provider=provider),
+                sort_keys=True,
+            )
         )
     except IngestionError as error:
         typer.echo(f"Error: {error}", err=True)
-        raise typer.Exit(2) from error
+        raise typer.Exit(_EXIT_INGESTION) from error
+    except OSError as error:
+        typer.echo("Error: normalized output could not be written", err=True)
+        raise typer.Exit(_EXIT_OUTPUT) from error
 
 
 @app.command("calculate-from-dataset")
 def calculate_from_dataset(
     descriptor: Path = typer.Argument(..., exists=True, readable=True),
-    table: str = typer.Option(..., "--table", help="Explicit normalized table ID."),
+    table: str | None = typer.Option(
+        None, "--table", help="Explicit normalized table ID for an inline binding."
+    ),
     field: list[str] = typer.Option(
-        ..., "--field", help="Net-benefit field; repeat per strategy."
+        [], "--field", help="Net-benefit field; repeat per strategy."
     ),
     strategy: list[str] = typer.Option(
         [], "--strategy", help="Optional strategy name; repeat in field order."
+    ),
+    binding_profile: Path | None = typer.Option(
+        None,
+        "--binding-profile",
+        exists=True,
+        readable=True,
+        help="Explicit JSON BindingProfile; cannot be combined with inline binding flags.",
     ),
     source_root: Path | None = typer.Option(
         None,
@@ -268,6 +384,11 @@ def calculate_from_dataset(
     max_resource_bytes: int = typer.Option(
         512 * 1024 * 1024, "--max-resource-bytes", min=1
     ),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Require this registered provider ID for the descriptor.",
+    ),
 ) -> None:
     """Calculate EVPI from explicitly selected normalized net-benefit fields."""
     try:
@@ -281,15 +402,13 @@ def calculate_from_dataset(
                 max_resource_bytes=max_resource_bytes,
             ),
         )
-        binding = VOIBinding(
-            role="net_benefit",
-            table_id=table,
-            field_ids=tuple(field),
-            strategy_names=tuple(strategy),
-        )
-        manifest = DatasetManifest(
-            **bundle.manifest.model_dump(mode="python", exclude={"bindings"}),
-            bindings=(binding,),
+        _assert_provider(bundle, provider)
+        manifest = _calculation_manifest(
+            bundle,
+            table=table,
+            field=field,
+            strategy=strategy,
+            binding_profile=binding_profile,
         )
         prepared = prepare_analysis_inputs(
             NormalizedInputBundle(manifest=manifest, tables=bundle.tables)
@@ -297,12 +416,16 @@ def calculate_from_dataset(
         typer.echo(
             json.dumps(
                 {
+                    "binding_profile_digest": prepared.binding_profile_digest,
                     "evpi": evpi(prepared.net_benefits),
                     "input_digest": prepared.input_digest,
                 },
                 sort_keys=True,
             )
         )
-    except (IngestionError, ValueError) as error:
+    except IngestionError as error:
         typer.echo(f"Error: {error}", err=True)
-        raise typer.Exit(2) from error
+        raise typer.Exit(_EXIT_INGESTION) from error
+    except ValueError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(_EXIT_BINDING) from error


### PR DESCRIPTION
## Summary
- enforce explicit provider assertions for ingestion CLI commands
- accept an explicit JSON binding profile for calculation, without inferring semantics
- publish stable source, binding, and output exit codes while retaining Typer usage code 2
- document why resource projection is unavailable for the current provider capabilities

## Validation
- `TOX_WORK_DIR=/private/tmp/voiage-p6-tox CARGO_TARGET_DIR=/private/tmp/voiage-p6-cargo tox -e py312 -- tests/test_standardized_ingestion_cli.py -q` (20 passed)
- Ruff, ty, Vale, Conductor full validation, GitHub cross-reference validation, and diff check passed
- Astro build is not locally verified: the clean worktree has no independent `node_modules` and the SSD is nearly full. No cross-worktree dependency workaround was retained.