### PR TITLE
feat(ingestion): support strict Frictionless TSV resources

### DIFF
--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -1,6 +1,6 @@
 ---
 title: Standardized dataset ingestion
-description: Bring Croissant ML and Frictionless Data Package CSV inputs into VOIAGE safely.
+description: Bring Croissant ML and strict Frictionless CSV or TSV inputs into VOIAGE safely.
 ---
 
 VOIAGE separates source parsing from calculation. A provider reads a descriptor
@@ -19,7 +19,7 @@ portable, auditable, and suitable for an offline calculation workflow.
 | Input surface | Supported profile | Explicit boundary |
 | --- | --- | --- |
 | Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one `recordSet`, one `text/csv` distribution, and fields that exactly match the CSV columns | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, and non-CSV media types are rejected. |
-| Frictionless Data Package | One or more explicitly schematized comma-delimited CSV resources, declared primitive types, keys, and supported foreign keys | Remote/live resources, archives, custom dialects, unsupported formats, transforms, and undeclared or ambiguous resources are rejected. |
+| Frictionless Data Package | One or more explicitly schematized local CSV resources (`.csv`, comma) or TSV resources (`.tsv`, `format: tsv`, explicit tab delimiter), declared primitive types, keys, and supported foreign keys | Remote/live resources, archives, inferred or custom dialects, unsupported formats, transforms, and undeclared or ambiguous resources are rejected. |
 | Direct DataFrame interchange | pandas, Polars, or another `__dataframe__` producer that can convert through Arrow with an explicit binding | The adapter does not infer a VOI role, silently copy a disallowed frame, or create a second calculation path. |
 | Arrow IPC and Parquet | A `NormalizedInputBundle` previously written by VOIAGE | These are normalized interchange artifacts, not source-descriptor parsers. |
 
@@ -163,7 +163,7 @@ complete implementation of either upstream standard.
 | Input family | Supported profile | Consumer contract | Explicitly not supported in the built-in provider |
 | --- | --- | --- | --- |
 | Croissant ML | Croissant 1.1 descriptor, one declared local CSV distribution, one `recordSet`, explicit fields, local SHA-256 when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, multiple resources, executable metadata, implicit schema inference |
-| Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources with explicit field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, other integrity algorithms, implicit schema inference |
+| Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources (`.csv`, comma) or explicitly declared TSV resources (`.tsv`, `format: tsv`, `dialect: {"delimiter": "\\t"}`), with explicit field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, inferred or custom dialects, other integrity algorithms, implicit schema inference |
 | DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | `from_dataframe` preserves the Arrow schema and honours `allow_copy`; its bundle enters the same preparation path as providers and records conversion decisions. | Inferred decision semantics, unsupported nested values, and conversions that require copying when `allow_copy=False`. |
 
 All providers default to local-only access. Inputs that fall outside these

--- a/tests/fixtures/frictionless_v1/unsupported/tsv-wrong-dialect.json
+++ b/tests/fixtures/frictionless_v1/unsupported/tsv-wrong-dialect.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "name": "operations_tsv",
+      "path": "valid/data.tsv",
+      "format": "tsv",
+      "dialect": {"delimiter": ","},
+      "schema": {
+        "fields": [
+          {"name": "scenario_id"},
+          {"name": "net_benefit"}
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/frictionless_v1/valid/data.tsv
+++ b/tests/fixtures/frictionless_v1/valid/data.tsv
@@ -1,0 +1,3 @@
+scenario_id	net_benefit
+1	100.0
+2	80.0

--- a/tests/fixtures/frictionless_v1/valid/tsv-datapackage.json
+++ b/tests/fixtures/frictionless_v1/valid/tsv-datapackage.json
@@ -1,0 +1,19 @@
+{
+  "name": "operations-tsv-fixture",
+  "profile": "tabular-data-package",
+  "resources": [
+    {
+      "name": "operations_tsv",
+      "path": "valid/data.tsv",
+      "format": "tsv",
+      "dialect": {"delimiter": "\t"},
+      "schema": {
+        "primaryKey": "scenario_id",
+        "fields": [
+          {"name": "scenario_id", "type": "integer"},
+          {"name": "net_benefit", "type": "number"}
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_frictionless_offline_fixtures.py
+++ b/tests/test_frictionless_offline_fixtures.py
@@ -21,8 +21,11 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "frictionless_v1"
     [
         ("unsupported/malformed-resource.json", "resources must be objects"),
         ("unsupported/non-object-root.json", "descriptor root must be a JSON object"),
-        ("unsupported/non-comma-dialect.json", "only CSV comma dialect"),
-        ("unsupported/non-csv-format.json", "requires CSV format"),
+        (
+            "unsupported/non-comma-dialect.json",
+            "CSV resources require a .csv path and comma delimiter",
+        ),
+        ("unsupported/non-csv-format.json", "requires CSV or TSV format"),
         ("unsupported/integrity-declaration.json", "hash must be a SHA-256"),
         ("unsupported/unsupported-type.json", "unsupported Data Package field type"),
         ("unsupported/required-null.json", "required field contains null"),
@@ -32,7 +35,14 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "frictionless_v1"
             "unsupported/duplicate-schema-fields.json",
             "ambiguous duplicate field names",
         ),
-        ("unsupported/unsupported-dialect-property.json", "only CSV comma dialect"),
+        (
+            "unsupported/unsupported-dialect-property.json",
+            "CSV resources require a .csv path and comma delimiter",
+        ),
+        (
+            "unsupported/tsv-wrong-dialect.json",
+            "TSV resources require an explicit tab delimiter",
+        ),
     ],
 )
 def test_frictionless_offline_unsupported_profile_fixtures_fail_closed(
@@ -61,6 +71,20 @@ def test_frictionless_offline_valid_profile_fixture_materializes() -> None:
     assert bundle.manifest.extensions["frictionlessdata.org:profile"] == (
         "tabular-data-package"
     )
+
+
+def test_frictionless_offline_tsv_profile_fixture_materializes() -> None:
+    """The fixture corpus records the exact supported tab-separated profile."""
+    bundle = FrictionlessProvider().ingest(
+        _FIXTURE_ROOT / "valid" / "tsv-datapackage.json",
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert bundle.table("operations_tsv").to_pylist() == [
+        {"scenario_id": 1, "net_benefit": 100.0},
+        {"scenario_id": 2, "net_benefit": 80.0},
+    ]
+    assert bundle.manifest.resources[0].media_type == "text/tab-separated-values"
 
 
 def test_frictionless_offline_receipted_fixture_preserves_declared_receipt() -> None:

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -267,7 +267,7 @@ def test_ingest_inspect_and_normalize(tmp_path, monkeypatch) -> None:
     assert inspection["provider"] == "frictionless"
     assert inspection["capabilities"] == {
         "format_versions": ["1"],
-        "media_types": ["text/csv"],
+        "media_types": ["text/csv", "text/tab-separated-values"],
         "provider_id": "frictionless",
         "supported_transforms": [],
         "supports_filtering": False,

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -242,6 +242,107 @@ def test_frictionless_provider_validates_declared_types_constraints_and_primary_
     assert bundle.table("samples").column_names == ["id", "value"]
 
 
+def test_frictionless_provider_ingests_explicit_tab_separated_resource(
+    tmp_path,
+) -> None:
+    """The strict local profile accepts an explicitly declared TSV dialect."""
+    source = tmp_path / "samples.tsv"
+    source.write_text("id\tvalue\n1\t1.5\n2\t2.5\n", encoding="utf-8")
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "name": "tabular-operations-fixture",
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "samples.tsv",
+                        "format": "tsv",
+                        "dialect": {"delimiter": "\t"},
+                        "schema": {
+                            "primaryKey": "id",
+                            "fields": [
+                                {"name": "id", "type": "integer"},
+                                {"name": "value", "type": "number"},
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = FrictionlessProvider().ingest(
+        descriptor_path, policy=SourceAccessPolicy(tmp_path)
+    )
+
+    assert bundle.table("samples").to_pylist() == [
+        {"id": 1, "value": 1.5},
+        {"id": 2, "value": 2.5},
+    ]
+    assert bundle.manifest.resources[0].media_type == "text/tab-separated-values"
+    assert bundle.manifest.resources[0].sha256 == digest_file(source)
+
+
+@pytest.mark.parametrize(
+    ("path", "resource_format", "dialect", "message"),
+    [
+        (
+            "samples.tsv",
+            "tsv",
+            {"delimiter": ","},
+            "TSV resources require an explicit tab delimiter",
+        ),
+        (
+            "samples.tsv",
+            "csv",
+            {"delimiter": "\t"},
+            "CSV resources require a .csv path and comma delimiter",
+        ),
+        (
+            "samples.csv",
+            "tsv",
+            {"delimiter": "\t"},
+            "TSV resources require a .tsv path",
+        ),
+        (
+            "samples.tsv",
+            "tsv",
+            {"delimiter": "\t", "quoteChar": '"'},
+            "strict CSV/TSV dialects accept only delimiter",
+        ),
+    ],
+)
+def test_frictionless_provider_rejects_ambiguous_or_unsupported_tsv_dialects(
+    tmp_path, path, resource_format, dialect, message
+) -> None:
+    """A TSV descriptor must make its local parsing semantics unambiguous."""
+    (tmp_path / path).write_text("id\tvalue\n1\t2\n", encoding="utf-8")
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": path,
+                        "format": resource_format,
+                        "dialect": dialect,
+                        "schema": {"fields": [{"name": "id"}, {"name": "value"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
 def test_frictionless_provider_preserves_package_governance_metadata(tmp_path) -> None:
     (tmp_path / "samples.csv").write_text("id,value\n1,1.5\n", encoding="utf-8")
     descriptor_path = tmp_path / "datapackage.json"
@@ -383,7 +484,7 @@ def test_frictionless_provider_rejects_unsupported_or_invalid_schema_claims(
                 "dialect": {"delimiter": ";"},
                 "schema": {"fields": [{"name": "id"}]},
             },
-            "only CSV comma dialect",
+            "CSV resources require a .csv path and comma delimiter",
         ),
         (
             "id\n1\n",
@@ -536,7 +637,12 @@ def test_provider_capabilities_declare_conservative_supported_profiles(
 
     assert capabilities.provider_id == provider.provider_id
     assert version in capabilities.format_versions
-    assert capabilities.media_types == ("text/csv",)
+    expected_media_types = (
+        ("text/csv",)
+        if provider.provider_id == "croissant"
+        else ("text/csv", "text/tab-separated-values")
+    )
+    assert capabilities.media_types == expected_media_types
     assert capabilities.supports_projection is False
     assert capabilities.supports_filtering is False
     assert capabilities.supports_streaming is False

--- a/voiage/ingestion/_tabular.py
+++ b/voiage/ingestion/_tabular.py
@@ -23,15 +23,32 @@ def read_csv(
     *,
     sha256: str | None = None,
     byte_size: int | None = None,
+    delimiter: str = ",",
+    suffix: str = ".csv",
 ) -> pa.Table:
-    """Read a declared CSV file after policy enforcement."""
-    if not reference.lower().endswith(".csv"):
-        raise IngestionError("built-in providers currently support CSV resources only")
+    """Read one declared local delimited-text resource after policy enforcement.
+
+    Built-in providers select the delimiter and filename suffix from their
+    documented profile.  This helper intentionally does not infer either from
+    source bytes or a filename.
+    """
+    if delimiter not in {",", "\t"}:
+        raise IngestionError("built-in providers support only comma or tab delimiters")
+    if suffix not in {".csv", ".tsv"}:
+        raise IngestionError("built-in providers support only CSV or TSV suffixes")
+    if not reference.lower().endswith(suffix):
+        raise IngestionError(
+            f"declared resource must use the supported {suffix} filename suffix"
+        )
     path = policy.materialize(reference, sha256=sha256, byte_size=byte_size)
     try:
-        return csv.read_csv(path)
+        if delimiter == ",":
+            return csv.read_csv(path)
+        return csv.read_csv(path, parse_options=csv.ParseOptions(delimiter=delimiter))
     except pa.ArrowException as error:
-        raise IngestionError("declared CSV resource cannot be parsed") from error
+        raise IngestionError(
+            "declared delimited-text resource cannot be parsed"
+        ) from error
 
 
 def materialization_receipt(
@@ -41,6 +58,7 @@ def materialization_receipt(
     *,
     sha256: str | None = None,
     byte_size: int | None = None,
+    media_type: str = "text/csv",
 ) -> ResourceManifest:
     """Return immutable local-resource identity after policy resolution."""
     path = policy.materialize(reference, sha256=sha256, byte_size=byte_size)
@@ -48,6 +66,6 @@ def materialization_receipt(
         resource_id=resource_id,
         uri=policy.source_uri(reference),
         sha256=digest_file(path),
-        media_type="text/csv",
+        media_type=media_type,
         byte_size=path.stat().st_size,
     )

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -35,7 +35,7 @@ class FrictionlessProvider:
     capabilities = ProviderCapabilities(
         provider_id=provider_id,
         format_versions=("1",),
-        media_types=("text/csv",),
+        media_types=("text/csv", "text/tab-separated-values"),
     )
 
     def can_handle(self, descriptor: dict[str, object]) -> bool:
@@ -117,25 +117,24 @@ class FrictionlessProvider:
         if not isinstance(fields, list):
             raise IngestionError("Data Package schema requires fields")
         fields = cast("list[object]", fields)
-        resource_format = resource.get("format")
-        if resource_format not in (None, "csv"):
-            raise IngestionError("supported Data Package profile requires CSV format")
         if "checksum" in resource:
             raise IngestionError(
                 "supported Data Package profile does not support integrity declarations"
             )
         declared_sha256 = _sha256(resource.get("hash"))
         declared_byte_size = _byte_size(resource.get("bytes"))
-        dialect = resource.get("dialect")
-        if dialect not in (None, {"delimiter": ","}):
-            raise IngestionError(
-                "supported Data Package profile accepts only CSV comma dialect"
-            )
+        delimiter, suffix, media_type = _delimited_text_profile(
+            reference,
+            resource.get("format"),
+            resource.get("dialect"),
+        )
         table = read_csv(
             reference,
             policy,
             sha256=declared_sha256,
             byte_size=declared_byte_size,
+            delimiter=delimiter,
+            suffix=suffix,
         )
         self._validate_schema(table, fields)
         primary_key = self._primary_key(schema)
@@ -165,6 +164,7 @@ class FrictionlessProvider:
                 policy,
                 sha256=declared_sha256,
                 byte_size=declared_byte_size,
+                media_type=media_type,
             ),
             self._foreign_keys(schema, table_id),
         )
@@ -283,7 +283,8 @@ class FrictionlessProvider:
         for item in fields:
             if not isinstance(item, dict) or not isinstance(item.get("name"), str):
                 raise IngestionError("Data Package fields require string names")
-            declared_names.append(cast("str", item["name"]))
+            field = cast("dict[str, object]", item)
+            declared_names.append(cast("str", field["name"]))
         if len(declared_names) != len(set(declared_names)):
             raise IngestionError(
                 "Data Package schema has ambiguous duplicate field names"
@@ -378,6 +379,39 @@ def _byte_size(value: object) -> int | None:
             "Data Package resource bytes must be a non-negative integer"
         )
     return value
+
+
+def _delimited_text_profile(
+    reference: str, resource_format: object, dialect: object
+) -> tuple[str, str, str]:
+    """Return one explicit local CSV or TSV profile without sniffing dialects.
+
+    The Data Package profile deliberately supports only exact descriptor/file
+    pairs.  In particular, a tab-separated resource must declare both its TSV
+    format and tab delimiter, avoiding an accidental comma parse of a `.tsv`
+    file or a hidden dialect feature that Arrow would interpret differently.
+    """
+    normalized_path = reference.casefold()
+    if resource_format in (None, "csv"):
+        if not normalized_path.endswith(".csv") or dialect not in (
+            None,
+            {"delimiter": ","},
+        ):
+            raise IngestionError(
+                "CSV resources require a .csv path and comma delimiter"
+            )
+        return ",", ".csv", "text/csv"
+    if resource_format != "tsv":
+        raise IngestionError(
+            "supported Data Package profile requires CSV or TSV format"
+        )
+    if not normalized_path.endswith(".tsv"):
+        raise IngestionError("TSV resources require a .tsv path")
+    if isinstance(dialect, dict) and set(dialect) != {"delimiter"}:
+        raise IngestionError("strict CSV/TSV dialects accept only delimiter")
+    if dialect != {"delimiter": "\t"}:
+        raise IngestionError("TSV resources require an explicit tab delimiter")
+    return "\t", ".tsv", "text/tab-separated-values"
 
 
 def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- Adds one strict local TSV profile: a .tsv path, format: tsv, and an exact tab delimiter.
- Retains fail-closed CSV/TSV filename and dialect validation; no remote, archive, transform, JSON, Parquet, Arrow, or inferred-dialect support.
- Adds file-backed valid and adversarial Frictionless fixtures, receipt media-type coverage, and documentation/support-matrix updates.

## Validation

- Focused ingestion/provider/CLI suite: 139 passed.
- Ruff check and format, ty check.
- Conductor full validation and GitHub cross-reference validation.

## Boundary

This is incremental P4 evidence only. It does not claim complete Frictionless conformance or close the active standardized-dataset-ingestion track. The attempted dependency-frontier upgrade could not complete because the PortableSSD had 109 MiB free and Polars extraction returned ENOSPC; the generated uv.lock change was reverted.