### PR TITLE
feat(ingestion): validate Croissant content size

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add Croissant `contentSize` byte-integrity validation and a file-backed
+  supported/rejected profile map; unsupported integrity forms now fail before
+  resource materialization.
 - Add fail-closed parsed-row limits for built-in Croissant and Frictionless
   delimited resources, including a `voiage ingest --max-resource-rows` policy
   option on materializing commands.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -80,7 +80,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   adversarial coverage: `5a3a7b04`. A combined context-array/governance fixture
   now proves descriptor-only inspection, retained non-semantic governance, and
   materialization receipt fields while rejecting unexpanded JSON-LD context
-  objects (`d814e6e1`, partial).
+  objects (`d814e6e1`, partial). The file-backed profile map also proves
+  `contentSize` byte-integrity validation and fail-closed non-byte/alternate
+  integrity declarations (partial).
 - [~] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
   parser-feature gaps, live datasets, citations, PROV, usage information,
   ODRL, and RAI metadata preservation. Offline governance fixture added

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -18,7 +18,7 @@ portable, auditable, and suitable for an offline calculation workflow.
 
 | Input surface | Supported profile | Explicit boundary |
 | --- | --- | --- |
-| Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one `recordSet`, one `text/csv` distribution, and fields that exactly match the CSV columns | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, and non-CSV media types are rejected. |
+| Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one `recordSet`, one `text/csv` distribution, fields that exactly match the CSV columns, and optional `sha256`/integer-byte `contentSize` integrity declarations | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, non-CSV media types, non-SHA-256 integrity forms, and textual/structured `contentSize` values are rejected. |
 | Frictionless Data Package | One or more explicitly schematized local CSV resources (`.csv`, comma) or TSV resources (`.tsv`, `format: tsv`, explicit tab delimiter), declared primitive types, primary/foreign keys, and boolean `required`/`unique` field constraints | Remote/live resources, archives, inferred or custom dialects, unsupported formats, transforms, undeclared or ambiguous resources, non-boolean or unsupported constraints, and schema `missingValues` declarations are rejected. |
 | Direct DataFrame interchange | pandas, Polars, or another `__dataframe__` producer that can convert through Arrow with an explicit binding | The adapter does not infer a VOI role, silently copy a disallowed frame, or create a second calculation path. |
 | Arrow IPC and Parquet | A `NormalizedInputBundle` previously written by VOIAGE | These are normalized interchange artifacts, not source-descriptor parsers. |
@@ -104,8 +104,9 @@ policy can replay only that verified digest; it never falls back to a changed or
 missing source file and never performs a network refresh.
 
 The built-in providers use this path directly. A Croissant distribution may
-declare `sha256`; a Frictionless CSV resource may declare a 64-character
-SHA-256 `hash` and non-negative `bytes`. With those declarations, ingesting
+declare a 64-character `sha256` and a non-negative integer `contentSize` byte
+count; a Frictionless CSV resource may declare a 64-character SHA-256 `hash`
+and non-negative `bytes`. With those declarations, ingesting
 once with `cache_dir` creates the verified cache entry, and a later
 `voiage ingest ... --offline --cache-dir .voiage-cache` replays it even when
 the original local CSV is no longer present. Other hash algorithms and
@@ -167,7 +168,7 @@ complete implementation of either upstream standard.
 
 | Input family | Supported profile | Consumer contract | Explicitly not supported in the built-in provider |
 | --- | --- | --- | --- |
-| Croissant ML | Croissant 1.1 descriptor, one declared local CSV distribution, one `recordSet`, explicit fields, local SHA-256 when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, multiple resources, executable metadata, implicit schema inference |
+| Croissant ML | Croissant 1.1 descriptor, one declared local CSV distribution, one `recordSet`, explicit fields, local SHA-256 and integer-byte `contentSize` when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, multiple resources, executable metadata, implicit schema inference, unverified integrity forms, and non-byte `contentSize` values |
 | Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources (`.csv`, comma) or explicitly declared TSV resources (`.tsv`, `format: tsv`, `dialect: {"delimiter": "\\t"}`), with explicit field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, inferred or custom dialects, other integrity algorithms, implicit schema inference |
 | DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | `from_dataframe` preserves the Arrow schema and honours `allow_copy`; its bundle enters the same preparation path as providers and records conversion decisions. | Inferred decision semantics, unsupported nested values, and conversions that require copying when `allow_copy=False`. |
 

--- a/tests/fixtures/croissant_1_1/profile-map.json
+++ b/tests/fixtures/croissant_1_1/profile-map.json
@@ -1,0 +1,17 @@
+{
+  "profile": "VOIAGE built-in Croissant 1.1 local CSV profile",
+  "supported": [
+    {"feature": "FileObject.contentUrl with text/csv", "fixture": "valid/croissant.json"},
+    {"feature": "FileObject.sha256 local digest", "fixture": "valid/croissant.json"},
+    {"feature": "FileObject.contentSize non-negative byte count", "fixture": "valid/content-size-croissant.json"},
+    {"feature": "RecordSet explicit scalar fields", "fixture": "valid/croissant.json"}
+  ],
+  "rejected": [
+    {"feature": "JSON-LD context object expansion", "fixture": "unsupported/context-object.json", "message": "string JSON-LD context entries"},
+    {"feature": "FileObject contentChecksum/checksum integrity forms", "fixture": "unsupported/integrity-declaration.json", "message": "integrity declarations"},
+    {"feature": "FileObject textual contentSize", "fixture": "unsupported/content-size-text.json", "message": "contentSize"},
+    {"feature": "FileObject contentSize mismatch", "fixture": "unsupported/content-size-mismatch.json", "message": "byte size does not match"},
+    {"feature": "RecordSet split/key/reference/nested semantics", "fixture": "unsupported/split.json", "message": "splits"},
+    {"feature": "transforms and archive resources", "fixture": "unsupported/transform.json", "message": "transformations"}
+  ]
+}

--- a/tests/fixtures/croissant_1_1/unsupported/content-size-mismatch.json
+++ b/tests/fixtures/croissant_1_1/unsupported/content-size-mismatch.json
@@ -1,0 +1,5 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "distribution": [{"contentUrl": "valid/data.csv", "contentSize": 42}],
+  "recordSet": [{"name": "samples", "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]}]
+}

--- a/tests/fixtures/croissant_1_1/unsupported/content-size-text.json
+++ b/tests/fixtures/croissant_1_1/unsupported/content-size-text.json
@@ -1,0 +1,5 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "distribution": [{"contentUrl": "valid/data.csv", "contentSize": "43 bytes"}],
+  "recordSet": [{"name": "samples", "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]}]
+}

--- a/tests/fixtures/croissant_1_1/valid/content-size-croissant.json
+++ b/tests/fixtures/croissant_1_1/valid/content-size-croissant.json
@@ -1,0 +1,14 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
+  "name": "content-size-decision-samples",
+  "distribution": [{
+    "contentUrl": "valid/data.csv",
+    "contentSize": 43,
+    "encodingFormat": "text/csv"
+  }],
+  "recordSet": [{
+    "name": "decision_samples",
+    "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+  }]
+}

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,8 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
         ("unsupported/checksum-mismatch.json", "SHA-256"),
         ("unsupported/context-object.json", "string JSON-LD context entries"),
         ("unsupported/integrity-declaration.json", "integrity declarations"),
+        ("unsupported/content-size-mismatch.json", "byte size does not match"),
+        ("unsupported/content-size-text.json", "contentSize"),
         ("unsupported/key.json", "keys"),
         ("unsupported/non-csv-media-type.json", "CSV media type"),
         ("unsupported/multiple-distributions.json", "exactly one distribution"),
@@ -71,6 +74,34 @@ def test_croissant_offline_valid_profile_fixture_materializes() -> None:
     assert receipt.uri == resource_path.resolve().as_uri()
     assert receipt.sha256 == hashlib.sha256(resource_path.read_bytes()).hexdigest()
     assert receipt.byte_size == resource_path.stat().st_size
+
+
+def test_croissant_content_size_is_verified_and_retained_in_receipt() -> None:
+    """The accepted Croissant contentSize is an actual byte-integrity check."""
+    bundle = CroissantProvider().ingest(
+        _FIXTURE_ROOT / "valid" / "content-size-croissant.json",
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+    )
+
+    assert bundle.manifest.resources[0].byte_size == 43
+
+
+def test_croissant_profile_map_exercises_every_documented_boundary() -> None:
+    """Fixtures make support and rejection explicit, never best-effort."""
+    profile = json.loads((_FIXTURE_ROOT / "profile-map.json").read_text())
+
+    for entry in profile["supported"]:
+        bundle = CroissantProvider().ingest(
+            _FIXTURE_ROOT / entry["fixture"],
+            policy=SourceAccessPolicy(_FIXTURE_ROOT),
+        )
+        assert bundle.manifest.provenance.provider_id == "croissant"
+    for entry in profile["rejected"]:
+        with pytest.raises(IngestionError, match=entry["message"]):
+            CroissantProvider().ingest(
+                _FIXTURE_ROOT / entry["fixture"],
+                policy=SourceAccessPolicy(_FIXTURE_ROOT),
+            )
 
 
 def test_croissant_preserves_declared_field_data_type_as_descriptive_metadata(

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -93,11 +93,15 @@ class CroissantProvider:
             raise IngestionError(
                 "supported Croissant profile does not support transformations"
             )
-        declared_sha256 = distribution.get("sha256")
-        if declared_sha256 is not None and not isinstance(declared_sha256, str):
-            raise IngestionError("declared Croissant SHA-256 must be a string")
+        declared_sha256 = _sha256(distribution.get("sha256"))
+        declared_byte_size = _content_size(distribution.get("contentSize"))
         try:
-            table = read_csv(reference, policy, sha256=declared_sha256)
+            table = read_csv(
+                reference,
+                policy,
+                sha256=declared_sha256,
+                byte_size=declared_byte_size,
+            )
         except IngestionError as error:
             if declared_sha256 is not None and "checksum" in str(error):
                 raise IngestionError(
@@ -128,7 +132,11 @@ class CroissantProvider:
                 tables=(TableManifest(table_id=table_id, fields=manifest_fields),),
                 resources=(
                     materialization_receipt(
-                        reference, table_id, policy, sha256=declared_sha256
+                        reference,
+                        table_id,
+                        policy,
+                        sha256=declared_sha256,
+                        byte_size=declared_byte_size,
                     ),
                 ),
                 provenance=SourceProvenance(
@@ -192,6 +200,36 @@ class CroissantProvider:
 def _scalar_metadata(value: object) -> str | None:
     """Expose scalar metadata in provenance without coercing structured values."""
     return value if isinstance(value, str) else None
+
+
+def _sha256(value: object) -> str | None:
+    """Accept only an explicit SHA-256 FileObject declaration."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise IngestionError("Croissant sha256 must be a SHA-256 string")
+    candidate = value.lower()
+    if len(candidate) != 64 or any(
+        char not in "0123456789abcdef" for char in candidate
+    ):
+        raise IngestionError("Croissant sha256 must be a SHA-256 string")
+    return candidate
+
+
+def _content_size(value: object) -> int | None:
+    """Accept the profile's non-negative integer Croissant contentSize only.
+
+    The generic Croissant field is narrowed to a byte count. Unit-bearing,
+    textual, and structured values are outside this local FileObject profile,
+    so they fail before source materialization rather than being ignored.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise IngestionError(
+            "supported Croissant profile requires contentSize to be a non-negative integer"
+        )
+    return value
 
 
 def _declared_data_type(field: dict[str, object]) -> str | None:


### PR DESCRIPTION
## Summary
- validate a declared non-negative integer Croissant `contentSize` through the existing local SourceAccessPolicy materialization and receipt path
- add a file-backed supported/rejected Croissant profile map and integrity fixtures
- document the narrow profile boundary and record truthful partial P4-T2 evidence

## Validation
- `uv run --extra ci --extra dev pytest tests/test_croissant_offline_fixtures.py tests/test_standardized_ingestion_providers.py -q` (132 passed)
- Ruff check and format
- `ty check voiage/ingestion/croissant.py`
- full Conductor and GitHub cross-reference validation
- `git diff --check`

`tox -e vale` did not complete after dependency installation in the isolated environment; this PR makes no Vale-success claim.

No remote/archive/transform/ML-parser support is added.