### PR TITLE
test(ingestion): cover Croissant sha256 validation

### DIFF
--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -1626,6 +1626,27 @@ def test_croissant_provider_validates_declared_local_sha256(
         )
 
 
+@pytest.mark.parametrize("checksum", [42, "not-a-sha256"])
+def test_croissant_provider_rejects_malformed_declared_sha256_before_reading(
+    tmp_path, checksum: object
+) -> None:
+    """Malformed Croissant integrity declarations fail before materialization."""
+    descriptor_path = tmp_path / "croissant.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "@context": "https://mlcommons.org/croissant/1.1",
+                "distribution": [{"contentUrl": "not-read.csv", "sha256": checksum}],
+                "recordSet": [{"name": "samples", "field": [{"name": "a"}]}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match="sha256 must be a SHA-256 string"):
+        CroissantProvider().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
+
+
 def test_croissant_provider_preserves_non_checksum_ingestion_error(tmp_path) -> None:
     """Only checksum failures are translated into Croissant integrity diagnostics."""
     descriptor_path = tmp_path / "croissant.json"


### PR DESCRIPTION
## Summary
Adds the two regression cases required by #703 hosted changed-code coverage: non-string and malformed-string Croissant `sha256` declarations now prove a stable `IngestionError` occurs before source materialization.

## Validation
- 134 focused Croissant/provider tests pass without coverage instrumentation
- Ruff check/format
- `ty check voiage/ingestion/croissant.py`
- full Conductor and GitHub cross-reference validation
- `git diff --check`

Local pytest-cov/coverage instrumentation fails before collection in isolated Python 3.14 and 3.13 due to NumPy native extension duplicate-load (`cannot load module more than once per process`). The new cases directly execute both previously missed branches; hosted changed-code coverage remains the authoritative policy gate.