### PR TITLE
feat(ingestion): select explicit Croissant source pairs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add explicit, receipt-identified local Croissant record-set/distribution
+  selection for descriptors with multiple pairs. The profile rejects missing or
+  mismatched selectors and unsupported `FileObject` or `FileSet` distributions
+  without inferring a source relationship.
 - Add Croissant `contentSize` byte-integrity validation and a file-backed
   supported/rejected profile map; unsupported integrity forms now fail before
   resource materialization.

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -82,7 +82,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   materialization receipt fields while rejecting unexpanded JSON-LD context
   objects (`d814e6e1`, partial). The file-backed profile map also proves
   `contentSize` byte-integrity validation and fail-closed non-byte/alternate
-  integrity declarations (partial).
+  integrity declarations. A local multi-pair fixture now requires explicit
+  record-set and distribution selectors, proves their receipt/content identity,
+  and rejects missing, mismatched, `FileObject`, or `FileSet` selections rather
+  than inferring a relationship (partial).
 - [~] **P4-T3 / AC-04, AC-11:** Add fixtures for Croissant 1.1 conformance,
   parser-feature gaps, live datasets, citations, PROV, usage information,
   ODRL, and RAI metadata preservation. Offline governance fixture added

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -18,7 +18,7 @@ portable, auditable, and suitable for an offline calculation workflow.
 
 | Input surface | Supported profile | Explicit boundary |
 | --- | --- | --- |
-| Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one `recordSet`, one `text/csv` distribution, fields that exactly match the CSV columns, and optional `sha256`/integer-byte `contentSize` integrity declarations | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, non-CSV media types, non-SHA-256 integrity forms, and textual/structured `contentSize` values are rejected. |
+| Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one legacy `recordSet`/CSV distribution pair or explicitly selected local pairs linked by `recordSet.distribution` to distribution `@id`, fields that exactly match the selected CSV columns, and optional `sha256`/integer-byte `contentSize` integrity declarations | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, `FileObject`/`FileSet`, non-CSV media types, non-SHA-256 integrity forms, and textual/structured `contentSize` values are rejected. |
 | Frictionless Data Package | One or more explicitly schematized local CSV resources (`.csv`, comma) or TSV resources (`.tsv`, `format: tsv`, explicit tab delimiter), declared primitive types, primary/foreign keys, and boolean `required`/`unique` field constraints | Remote/live resources, archives, inferred or custom dialects, unsupported formats, transforms, undeclared or ambiguous resources, non-boolean or unsupported constraints, and schema `missingValues` declarations are rejected. |
 | Direct DataFrame interchange | pandas, Polars, or another `__dataframe__` producer that can convert through Arrow with an explicit binding | The adapter does not infer a VOI role, silently copy a disallowed frame, or create a second calculation path. |
 | Arrow IPC and Parquet | A `NormalizedInputBundle` previously written by VOIAGE | These are normalized interchange artifacts, not source-descriptor parsers. |
@@ -32,6 +32,14 @@ Authoritative live interoperability probes are deliberately opt-in and are not
 claimed by this local-profile matrix. A successful offline descriptor test is
 evidence for the documented profile only, not for every upstream feature or
 registry deployment.
+
+For a multi-pair Croissant descriptor, applications use
+`CroissantSelection(record_set="...", distribution="#...")`. Both selectors
+are mandatory and the selected record set must explicitly reference the
+selected distribution. This chooses one declared local source pair; it is not
+column projection or row filtering. CLI commands intentionally do not expose a
+generic selector, because the shared built-in provider capability profile does
+not support projection or filtering.
 
 ```bash
 voiage ingest validate datapackage.json
@@ -168,7 +176,7 @@ complete implementation of either upstream standard.
 
 | Input family | Supported profile | Consumer contract | Explicitly not supported in the built-in provider |
 | --- | --- | --- | --- |
-| Croissant ML | Croissant 1.1 descriptor, one declared local CSV distribution, one `recordSet`, explicit fields, local SHA-256 and integer-byte `contentSize` when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, multiple resources, executable metadata, implicit schema inference, unverified integrity forms, and non-byte `contentSize` values |
+| Croissant ML | Croissant 1.1 descriptor, one legacy local CSV pair or one explicitly selected and linked local record-set/distribution pair, explicit fields, local SHA-256 and integer-byte `contentSize` when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, `FileObject`/`FileSet`, executable metadata, implicit schema inference, unverified integrity forms, and non-byte `contentSize` values |
 | Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources (`.csv`, comma) or explicitly declared TSV resources (`.tsv`, `format: tsv`, `dialect: {"delimiter": "\\t"}`), with explicit field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, inferred or custom dialects, other integrity algorithms, implicit schema inference |
 | DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | `from_dataframe` preserves the Arrow schema and honours `allow_copy`; its bundle enters the same preparation path as providers and records conversion decisions. | Inferred decision semantics, unsupported nested values, and conversions that require copying when `allow_copy=False`. |
 

--- a/tests/fixtures/croissant_1_1/unsupported/fileset-distribution.json
+++ b/tests/fixtures/croissant_1_1/unsupported/fileset-distribution.json
@@ -1,0 +1,5 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "distribution": [{"@type": "FileSet", "contentUrl": "valid/data.csv"}],
+  "recordSet": [{"name": "samples", "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]}]
+}

--- a/tests/fixtures/croissant_1_1/valid/alternate.csv
+++ b/tests/fixtures/croissant_1_1/valid/alternate.csv
@@ -1,0 +1,3 @@
+strategy_c,strategy_d
+40,70
+90,30

--- a/tests/fixtures/croissant_1_1/valid/multi-pair-croissant.json
+++ b/tests/fixtures/croissant_1_1/valid/multi-pair-croissant.json
@@ -1,0 +1,20 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "name": "multi-pair-decision-samples",
+  "distribution": [
+    {"@id": "#baseline", "contentUrl": "valid/data.csv", "encodingFormat": "text/csv"},
+    {"@id": "#alternate", "contentUrl": "valid/alternate.csv", "encodingFormat": "text/csv"}
+  ],
+  "recordSet": [
+    {
+      "name": "baseline_samples",
+      "distribution": "#baseline",
+      "field": [{"name": "strategy_a"}, {"name": "strategy_b"}]
+    },
+    {
+      "name": "alternate_samples",
+      "distribution": "#alternate",
+      "field": [{"name": "strategy_c"}, {"name": "strategy_d"}]
+    }
+  ]
+}

--- a/tests/test_croissant_offline_fixtures.py
+++ b/tests/test_croissant_offline_fixtures.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from voiage.ingestion.base import IngestionError, SourceAccessPolicy
-from voiage.ingestion.croissant import CroissantProvider
+from voiage.ingestion.croissant import CroissantProvider, CroissantSelection
 from voiage.ingestion.registry import default_registry
 
 _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
@@ -27,11 +27,12 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "croissant_1_1"
         ("unsupported/content-size-text.json", "contentSize"),
         ("unsupported/key.json", "keys"),
         ("unsupported/non-csv-media-type.json", "CSV media type"),
-        ("unsupported/multiple-distributions.json", "exactly one distribution"),
-        ("unsupported/multiple-record-sets.json", "exactly one recordSet"),
+        ("unsupported/multiple-distributions.json", "recordSet selection is required"),
+        ("unsupported/multiple-record-sets.json", "recordSet selection is required"),
         ("unsupported/nested-field.json", "nested fields"),
         ("unsupported/references.json", "field references"),
         ("unsupported/field-source.json", "field sources"),
+        ("unsupported/fileset-distribution.json", "FileObject or FileSet"),
         ("unsupported/malformed-distribution.json", "distribution object"),
         ("unsupported/malformed-record-set.json", "recordSet object"),
         ("unsupported/split.json", "splits"),
@@ -147,6 +148,84 @@ def test_croissant_offline_context_array_fixture_materializes() -> None:
 
     assert bundle.manifest.dataset_id == "context-array-decision-samples"
     assert bundle.table("decision_samples").num_rows == 2
+
+
+def test_croissant_multi_pair_fixture_requires_explicit_local_selection() -> None:
+    """Multi-entry descriptors cannot silently choose a record set or file."""
+    descriptor_path = _FIXTURE_ROOT / "valid" / "multi-pair-croissant.json"
+
+    with pytest.raises(IngestionError, match="recordSet selection is required"):
+        CroissantProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(_FIXTURE_ROOT)
+        )
+
+
+@pytest.mark.parametrize(
+    ("selection", "message"),
+    [
+        (
+            CroissantSelection(record_set="missing", distribution="#baseline"),
+            "selected Croissant recordSet is not declared",
+        ),
+        (
+            CroissantSelection(record_set="baseline_samples", distribution="#missing"),
+            "selected Croissant distribution is not declared",
+        ),
+        (
+            CroissantSelection(
+                record_set="baseline_samples", distribution="#alternate"
+            ),
+            "must explicitly reference the selected distribution",
+        ),
+    ],
+)
+def test_croissant_multi_pair_fixture_rejects_invalid_selection(
+    selection: CroissantSelection, message: str
+) -> None:
+    """Missing and mismatched selectors have stable non-materializing errors."""
+    descriptor_path = _FIXTURE_ROOT / "valid" / "multi-pair-croissant.json"
+
+    with pytest.raises(IngestionError, match=message):
+        CroissantProvider().ingest(
+            descriptor_path,
+            policy=SourceAccessPolicy(_FIXTURE_ROOT),
+            selection=selection,
+        )
+
+
+def test_croissant_multi_pair_fixture_preserves_selected_receipt_identity() -> None:
+    """Explicit selections produce the selected table, receipt, and identity digest."""
+    descriptor_path = _FIXTURE_ROOT / "valid" / "multi-pair-croissant.json"
+    provider = CroissantProvider()
+    baseline = provider.ingest(
+        descriptor_path,
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+        selection=CroissantSelection(
+            record_set="baseline_samples", distribution="#baseline"
+        ),
+    )
+    alternate = provider.ingest(
+        descriptor_path,
+        policy=SourceAccessPolicy(_FIXTURE_ROOT),
+        selection=CroissantSelection(
+            record_set="alternate_samples", distribution="#alternate"
+        ),
+    )
+
+    assert baseline.manifest.resources[0].uri.endswith("/valid/data.csv")
+    assert alternate.manifest.resources[0].uri.endswith("/valid/alternate.csv")
+    assert (
+        baseline.manifest.resources[0].sha256 != alternate.manifest.resources[0].sha256
+    )
+    assert baseline.content_digest != alternate.content_digest
+    assert baseline.manifest.extensions["mlcommons.org:croissant-selection"] == {
+        "recordSet": "baseline_samples",
+        "distribution": "#baseline",
+    }
+    assert alternate.manifest.extensions["mlcommons.org:croissant-selection"] == {
+        "recordSet": "alternate_samples",
+        "distribution": "#alternate",
+    }
 
 
 def test_croissant_offline_identity_fixture_preserves_governance() -> None:

--- a/voiage/ingestion/__init__.py
+++ b/voiage/ingestion/__init__.py
@@ -14,13 +14,14 @@ from .live_probe import AuthoritativeProbeGateError, run_authoritative_probe
 from .registry import ProviderRegistry, default_registry, discover_entry_point_providers
 
 if TYPE_CHECKING:
-    from .croissant import CroissantProvider
+    from .croissant import CroissantProvider, CroissantSelection
     from .frictionless import FrictionlessProvider
 
 __all__ = [
     "INGESTION_PROVIDER_SDK_VERSION",
     "AuthoritativeProbeGateError",
     "CroissantProvider",
+    "CroissantSelection",
     "FrictionlessProvider",
     "IngestionError",
     "IngestionProvider",
@@ -40,6 +41,10 @@ def __getattr__(name: str) -> object:
         from .croissant import CroissantProvider
 
         return CroissantProvider
+    if name == "CroissantSelection":
+        from .croissant import CroissantSelection
+
+        return CroissantSelection
     if name == "FrictionlessProvider":
         from .frictionless import FrictionlessProvider
 

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import hashlib
 import json
 from pathlib import Path  # noqa: TC003 - public runtime annotation
@@ -40,9 +41,21 @@ class CroissantProvider:
         )
 
     def ingest(
-        self, descriptor_path: Path, *, policy: SourceAccessPolicy
+        self,
+        descriptor_path: Path,
+        *,
+        policy: SourceAccessPolicy,
+        selection: CroissantSelection | None = None,
     ) -> NormalizedInputBundle:
-        """Materialize the supported, unambiguous one-resource Croissant profile."""
+        """Materialize one explicitly selected local Croissant CSV pair.
+
+        Legacy one-record-set/one-distribution descriptors need no selector.
+        A descriptor with more than one local pair must instead identify both a
+        ``recordSet`` name and a distribution ``@id``.  The selected record
+        set must explicitly link to that distribution through the narrowly
+        supported local-profile ``distribution`` member; VOIAGE never guesses
+        a relationship from matching field names.
+        """
         raw = json.loads(descriptor_path.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise IngestionError("descriptor root must be a JSON object")
@@ -55,24 +68,21 @@ class CroissantProvider:
             )
         record_sets = descriptor.get("recordSet")
         distributions = descriptor.get("distribution")
-        if not isinstance(record_sets, list) or len(record_sets) != 1:
-            raise IngestionError(
-                "supported Croissant profile requires exactly one recordSet"
-            )
-        if not isinstance(distributions, list) or len(distributions) != 1:
-            raise IngestionError(
-                "supported Croissant profile requires exactly one distribution"
-            )
-        if not isinstance(record_sets[0], dict):
-            raise IngestionError(
-                "supported Croissant profile requires a recordSet object"
-            )
-        if not isinstance(distributions[0], dict):
-            raise IngestionError(
-                "supported Croissant profile requires a distribution object"
-            )
-        record_set = cast("dict[str, object]", record_sets[0])
-        distribution = cast("dict[str, object]", distributions[0])
+        if isinstance(record_sets, list):
+            for candidate in record_sets:
+                if isinstance(candidate, dict):
+                    self._reject_unsupported_record_set(
+                        cast("dict[str, object]", candidate)
+                    )
+        if isinstance(distributions, list):
+            for candidate in distributions:
+                if isinstance(candidate, dict):
+                    self._reject_unsupported_distribution(
+                        cast("dict[str, object]", candidate)
+                    )
+        record_set, distribution = _select_local_pair(
+            record_sets, distributions, selection=selection
+        )
         self._reject_unsupported_semantics(descriptor, distribution, record_set)
         table_id = record_set.get("name")
         reference = distribution.get("contentUrl")
@@ -146,7 +156,7 @@ class CroissantProvider:
                     license=_scalar_metadata(descriptor.get("license")),
                     citation=_scalar_metadata(descriptor.get("citation")),
                 ),
-                extensions=_governance_extensions(descriptor),
+                extensions=_extensions(descriptor, record_set, distribution),
             ),
             tables={table_id: table},
         )
@@ -166,6 +176,17 @@ class CroissantProvider:
             raise IngestionError(
                 "supported Croissant profile requires Croissant 1.1 conformsTo"
             )
+        CroissantProvider._reject_unsupported_distribution(distribution)
+        CroissantProvider._reject_unsupported_record_set(record_set)
+
+    @staticmethod
+    def _reject_unsupported_distribution(distribution: dict[str, object]) -> None:
+        """Reject every unsupported distribution before source access."""
+        distribution_type = distribution.get("@type")
+        if distribution_type in {"FileObject", "FileSet"}:
+            raise IngestionError(
+                "supported Croissant profile does not support FileObject or FileSet distributions"
+            )
         encoding_format = distribution.get("encodingFormat")
         if encoding_format is not None and encoding_format != "text/csv":
             raise IngestionError("supported Croissant profile requires CSV media type")
@@ -173,6 +194,10 @@ class CroissantProvider:
             raise IngestionError(
                 "supported Croissant profile does not support integrity declarations"
             )
+
+    @staticmethod
+    def _reject_unsupported_record_set(record_set: dict[str, object]) -> None:
+        """Reject record-set semantics outside the local CSV profile."""
         if any(key in record_set for key in ("key", "primaryKey")):
             raise IngestionError("supported Croissant profile does not support keys")
         if "split" in record_set:
@@ -195,6 +220,100 @@ class CroissantProvider:
                 raise IngestionError(
                     "supported Croissant profile does not support field sources"
                 )
+
+
+@dataclass(frozen=True)
+class CroissantSelection:
+    """Explicit local-profile selectors for a multi-pair Croissant descriptor.
+
+    This is an ingestion-source choice, not Arrow projection or row filtering.
+    Both identifiers are required whenever the descriptor contains multiple
+    record sets or distributions.
+    """
+
+    record_set: str | None = None
+    distribution: str | None = None
+
+
+def _select_local_pair(
+    record_sets: object,
+    distributions: object,
+    *,
+    selection: CroissantSelection | None,
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Select one proven record-set/distribution relationship without inference."""
+    if not isinstance(record_sets, list) or not record_sets:
+        raise IngestionError("supported Croissant profile requires recordSet entries")
+    if not isinstance(distributions, list) or not distributions:
+        raise IngestionError(
+            "supported Croissant profile requires distribution entries"
+        )
+    if not all(isinstance(item, dict) for item in record_sets):
+        raise IngestionError("supported Croissant profile requires recordSet objects")
+    if not all(isinstance(item, dict) for item in distributions):
+        raise IngestionError(
+            "supported Croissant profile requires distribution objects"
+        )
+
+    multi_pair = len(record_sets) > 1 or len(distributions) > 1
+    requested_record_set = selection.record_set if selection is not None else None
+    requested_distribution = selection.distribution if selection is not None else None
+    if multi_pair and requested_record_set is None:
+        raise IngestionError(
+            "Croissant recordSet selection is required for multiple local entries"
+        )
+    if multi_pair and requested_distribution is None:
+        raise IngestionError(
+            "Croissant distribution selection is required for multiple local entries"
+        )
+
+    typed_record_sets = tuple(cast("dict[str, object]", item) for item in record_sets)
+    typed_distributions = tuple(
+        cast("dict[str, object]", item) for item in distributions
+    )
+    record_set = _select_by_identifier(
+        typed_record_sets,
+        identifier=requested_record_set,
+        member="name",
+        label="recordSet",
+    )
+    distribution = _select_by_identifier(
+        typed_distributions,
+        identifier=requested_distribution,
+        member="@id",
+        label="distribution",
+    )
+    if multi_pair:
+        selected_distribution_id = distribution.get("@id")
+        if not isinstance(selected_distribution_id, str):
+            raise IngestionError(
+                "selected Croissant distribution requires a string @id"
+            )
+        if record_set.get("distribution") != selected_distribution_id:
+            raise IngestionError(
+                "selected Croissant recordSet must explicitly reference the selected distribution"
+            )
+    return record_set, distribution
+
+
+def _select_by_identifier(
+    entries: tuple[dict[str, object], ...],
+    *,
+    identifier: str | None,
+    member: str,
+    label: str,
+) -> dict[str, object]:
+    """Return a unique named entry or produce a stable selector diagnostic."""
+    if identifier is None:
+        if len(entries) == 1:
+            return entries[0]
+        raise IngestionError(f"Croissant {label} selection is required")
+    matching = tuple(entry for entry in entries if entry.get(member) == identifier)
+    if not matching:
+        raise IngestionError(f"selected Croissant {label} is not declared")
+    if len(matching) != 1:
+        raise IngestionError(f"Croissant {label} identifiers must be unique")
+    return matching[0]
 
 
 def _scalar_metadata(value: object) -> str | None:
@@ -220,7 +339,7 @@ def _content_size(value: object) -> int | None:
     """Accept the profile's non-negative integer Croissant contentSize only.
 
     The generic Croissant field is narrowed to a byte count. Unit-bearing,
-    textual, and structured values are outside this local FileObject profile,
+    textual, and structured values are outside this local CSV profile,
     so they fail before source materialization rather than being ignored.
     """
     if value is None:
@@ -295,3 +414,20 @@ def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:
         if any(key in descriptor for key in keys)
         else {}
     )
+
+
+def _extensions(
+    descriptor: dict[str, object],
+    record_set: dict[str, object],
+    distribution: dict[str, object],
+) -> dict[str, object]:
+    """Retain governance and the explicit source-pair identity separately."""
+    extensions = _governance_extensions(descriptor)
+    record_set_id = record_set.get("name")
+    distribution_id = distribution.get("@id")
+    if isinstance(record_set_id, str) and isinstance(distribution_id, str):
+        extensions["mlcommons.org:croissant-selection"] = {
+            "distribution": distribution_id,
+            "recordSet": record_set_id,
+        }
+    return extensions


### PR DESCRIPTION
## Summary

- add explicit local Croissant record-set/distribution pair selection
- require a declared pair relationship, with stable missing/mismatch diagnostics
- retain FileObject/FileSet, archive, transform, and remote rejection

## Validation

- `pytest tests/test_croissant_offline_fixtures.py tests/test_standardized_ingestion_providers.py -q --no-cov` (139 passed)
- Ruff, ty, Vale, full Conductor validation, GitHub cross-reference validation, and `git diff --check`

This is a partial P4 evidence increment; authoritative live-provider and clean-extra gates remain active.