### PR TITLE
feat(ingestion): support strict Frictionless Parquet resources

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a strict local Frictionless Parquet profile: descriptors must declare
+  `format: parquet`, use a `.parquet` path, declare primitive fields, and omit
+  dialect settings. Parquet input is streamed through bounded Arrow batches
+  and carries the same verified receipt and source-policy limits as CSV/TSV.
 - Add explicit, receipt-identified local Croissant record-set/distribution
   selection for descriptors with multiple pairs. The profile rejects missing or
   mismatched selectors and unsupported `FileObject` or `FileSet` distributions

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -121,8 +121,11 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   explicit `.json`/`format: json` UTF-8 arrays of scalar object rows with a
   declared primitive field schema, verified receipt, and bounded-row policy;
   JSON Lines, envelopes, JSON paths, nested values, parser declarations, and
-  remote/archive resources reject (`dc7d0fff`, partial). Remaining acceptance
-  evidence is tracked below.
+  remote/archive resources reject (`dc7d0fff`, partial). The strict local
+  Parquet profile accepts only `.parquet` resources explicitly declared as
+  `format: parquet` without a dialect, streams bounded PyArrow batches,
+  preserves verified receipts, and validates the same declared primitive fields
+  and keys (partial). Remaining acceptance evidence is tracked below.
 - [~] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
   documented supported profile. Public provider export is now lazy; profile
   acceptance evidence remains active (`2ad0a24a`, partial).

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -1,6 +1,6 @@
 ---
 title: Standardized dataset ingestion
-description: Bring Croissant ML and strict Frictionless CSV, TSV, or JSON Table inputs into VOIAGE safely.
+description: Bring Croissant ML and strict Frictionless CSV, TSV, JSON Table, or Parquet inputs into VOIAGE safely.
 ---
 
 VOIAGE separates source parsing from calculation. A provider reads a descriptor
@@ -19,9 +19,9 @@ portable, auditable, and suitable for an offline calculation workflow.
 | Input surface | Supported profile | Explicit boundary |
 | --- | --- | --- |
 | Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one legacy `recordSet`/CSV distribution pair or explicitly selected local pairs linked by `recordSet.distribution` to distribution `@id`, fields that exactly match the selected CSV columns, and optional `sha256`/integer-byte `contentSize` integrity declarations | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, `FileObject`/`FileSet`, non-CSV media types, non-SHA-256 integrity forms, and textual/structured `contentSize` values are rejected. |
-| Frictionless Data Package | One or more explicitly schematized local CSV resources (`.csv`, comma), TSV resources (`.tsv`, `format: tsv`, explicit tab delimiter), or JSON Table resources (`.json`, `format: json`, UTF-8 array of object rows), declared primitive types, primary/foreign keys, and boolean `required`/`unique` field constraints | Remote/live resources, archives, inferred or custom dialects, JSON Lines/envelopes/paths/nested rows, unsupported formats, transforms, undeclared or ambiguous resources, non-boolean or unsupported constraints, and schema `missingValues` declarations are rejected. |
+| Frictionless Data Package | One or more explicitly schematized local CSV resources (`.csv`, comma), TSV resources (`.tsv`, `format: tsv`, explicit tab delimiter), JSON Table resources (`.json`, `format: json`, UTF-8 array of object rows), or Parquet resources (`.parquet`, `format: parquet`, no dialect), declared primitive types, primary/foreign keys, and boolean `required`/`unique` field constraints | Remote/live resources, archives, inferred or custom dialects, JSON Lines/envelopes/paths/nested rows, unsupported formats, transforms, undeclared or ambiguous resources, non-boolean or unsupported constraints, and schema `missingValues` declarations are rejected. |
 | Direct DataFrame interchange | pandas, Polars, or another `__dataframe__` producer that can convert through Arrow with an explicit binding | The adapter does not infer a VOI role, silently copy a disallowed frame, or create a second calculation path. |
-| Arrow IPC and Parquet | A `NormalizedInputBundle` previously written by VOIAGE | These are normalized interchange artifacts, not source-descriptor parsers. |
+| Arrow IPC | A `NormalizedInputBundle` previously written by VOIAGE | This is a normalized interchange artifact, not a source-descriptor parser. |
 
 The built-in providers use only the base Arrow/JSON runtime. The named
 `croissant`, `frictionless`, and `ingestion` extras are stable installation
@@ -177,7 +177,7 @@ complete implementation of either upstream standard.
 | Input family | Supported profile | Consumer contract | Explicitly not supported in the built-in provider |
 | --- | --- | --- | --- |
 | Croissant ML | Croissant 1.1 descriptor, one legacy local CSV pair or one explicitly selected and linked local record-set/distribution pair, explicit fields, local SHA-256 and integer-byte `contentSize` when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, `FileObject`/`FileSet`, executable metadata, implicit schema inference, unverified integrity forms, and non-byte `contentSize` values |
-| Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources (`.csv`, comma), explicitly declared TSV resources (`.tsv`, `format: tsv`, `dialect: {"delimiter": "\\t"}`), or JSON Table resources (`.json`, `format: json`, UTF-8 JSON array of object rows), with explicit field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, inferred or custom dialects, JSON Lines/envelopes/JSON paths/nested rows, other integrity algorithms, implicit schema inference |
+| Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources (`.csv`, comma), explicitly declared TSV resources (`.tsv`, `format: tsv`, `dialect: {"delimiter": "\\t"}`), JSON Table resources (`.json`, `format: json`, UTF-8 JSON array of object rows), or local Parquet resources (`.parquet`, `format: parquet`, no dialect), with explicit primitive field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, inferred or custom dialects, JSON Lines/envelopes/JSON paths/nested rows, other integrity algorithms, implicit schema inference, Arrow IPC source resources |
 | DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | `from_dataframe` preserves the Arrow schema and honours `allow_copy`; its bundle enters the same preparation path as providers and records conversion decisions. | Inferred decision semantics, unsupported nested values, and conversions that require copying when `allow_copy=False`. |
 
 All providers default to local-only access. Inputs that fall outside these
@@ -185,11 +185,12 @@ profiles fail with a stable `IngestionError`; they are not partially loaded or
 silently transformed. Compatibility will expand only with new fixtures,
 source-policy evidence, and a documented provider capability change.
 
-The file-backed Frictionless corpus includes a valid receipted CSV package,
+The Frictionless corpus includes a valid receipted CSV package and
+runtime-generated local Parquet packages,
 offline replay, metadata-only inspection of an absent declared resource, and
 fail-closed descriptor, field-identity, and dialect cases. It is evidence for
 this local profile only; it does not establish support for a remote catalogue,
-archive, Parquet/Arrow source resource, or the complete upstream specification.
+archive, Arrow IPC source resource, or the complete upstream specification.
 
 ## Authoritative interoperability probes
 

--- a/tests/test_frictionless_offline_fixtures.py
+++ b/tests/test_frictionless_offline_fixtures.py
@@ -25,7 +25,7 @@ _FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "frictionless_v1"
             "unsupported/non-comma-dialect.json",
             "CSV resources require a .csv path and comma delimiter",
         ),
-        ("unsupported/non-csv-format.json", "requires CSV or TSV format"),
+        ("unsupported/non-csv-format.json", "Parquet resources require a .parquet"),
         ("unsupported/integrity-declaration.json", "hash must be a SHA-256"),
         ("unsupported/unsupported-type.json", "unsupported Data Package field type"),
         (

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -307,6 +307,7 @@ def test_ingest_inspect_and_normalize(tmp_path, monkeypatch) -> None:
             "text/csv",
             "text/tab-separated-values",
             "application/json",
+            "application/vnd.apache.parquet",
         ],
         "provider_id": "frictionless",
         "supported_transforms": [],

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pandas as pd
 import polars as pl
 import pyarrow as pa
+from pyarrow import parquet as pq
 import pytest
 
 from voiage import ingestion
@@ -380,6 +381,114 @@ def test_frictionless_provider_ingests_explicit_local_json_table(tmp_path) -> No
     ]
     assert bundle.manifest.resources[0].media_type == "application/json"
     assert bundle.manifest.resources[0].sha256 == digest_file(source)
+
+
+def test_frictionless_provider_ingests_strict_local_parquet_resource(tmp_path) -> None:
+    """The Parquet profile keeps Arrow schema and immutable receipt identity."""
+    source = tmp_path / "samples.parquet"
+    table = pa.table({"id": pa.array([1, 2]), "value": pa.array([1.5, 2.5])})
+    pq.write_table(table, source)
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": source.name,
+                        "format": "parquet",
+                        "hash": digest_file(source),
+                        "bytes": source.stat().st_size,
+                        "schema": {
+                            "primaryKey": "id",
+                            "fields": [
+                                {"name": "id", "type": "integer"},
+                                {"name": "value", "type": "number"},
+                            ],
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = FrictionlessProvider().ingest(
+        descriptor_path, policy=SourceAccessPolicy(tmp_path)
+    )
+
+    assert bundle.table("samples").equals(table)
+    receipt = bundle.manifest.resources[0]
+    assert receipt.media_type == "application/vnd.apache.parquet"
+    assert receipt.sha256 == digest_file(source)
+    assert receipt.byte_size == source.stat().st_size
+
+
+def test_frictionless_parquet_profile_enforces_resource_row_limit(tmp_path) -> None:
+    """Parquet row groups cannot bypass the shared materialization policy."""
+    source = tmp_path / "samples.parquet"
+    pq.write_table(pa.table({"id": [1, 2, 3]}), source, row_group_size=3)
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": source.name,
+                        "format": "parquet",
+                        "schema": {"fields": [{"name": "id", "type": "integer"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match="row limit"):
+        FrictionlessProvider().ingest(
+            descriptor_path,
+            policy=SourceAccessPolicy(tmp_path, max_resource_rows=2),
+        )
+
+
+@pytest.mark.parametrize(
+    ("path", "dialect", "message"),
+    [
+        (
+            "samples.parquet",
+            {"delimiter": ","},
+            "Parquet resources do not support dialect declarations",
+        ),
+        ("samples.csv", None, "Parquet resources require a .parquet path"),
+    ],
+)
+def test_frictionless_provider_rejects_ambiguous_parquet_declarations(
+    tmp_path, path, dialect, message
+) -> None:
+    """Parquet support must not infer a dialect or filename semantics."""
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": path,
+                        "format": "parquet",
+                        "dialect": dialect,
+                        "schema": {"fields": [{"name": "id"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
 
 
 @pytest.mark.parametrize(
@@ -933,7 +1042,12 @@ def test_provider_capabilities_declare_conservative_supported_profiles(
     expected_media_types = (
         ("text/csv",)
         if provider.provider_id == "croissant"
-        else ("text/csv", "text/tab-separated-values", "application/json")
+        else (
+            "text/csv",
+            "text/tab-separated-values",
+            "application/json",
+            "application/vnd.apache.parquet",
+        )
     )
     assert capabilities.media_types == expected_media_types
     assert capabilities.supports_projection is False

--- a/voiage/ingestion/_tabular.py
+++ b/voiage/ingestion/_tabular.py
@@ -8,6 +8,7 @@ from pathlib import Path  # noqa: TC003 - public runtime annotation
 
 import pyarrow as pa
 from pyarrow import csv
+from pyarrow import parquet as pq
 
 from voiage.contracts.normalized_input import ResourceManifest
 from voiage.ingestion.base import IngestionError, SourceAccessPolicy
@@ -108,6 +109,34 @@ def read_json_table(
         raise IngestionError(
             "declared JSON Table resource cannot be converted to Arrow"
         ) from error
+
+
+def read_parquet(
+    reference: str,
+    policy: SourceAccessPolicy,
+    *,
+    sha256: str | None = None,
+    byte_size: int | None = None,
+) -> pa.Table:
+    """Read one declared local Parquet resource through bounded Arrow batches."""
+    if not reference.casefold().endswith(".parquet"):
+        raise IngestionError(
+            "declared resource must use the supported .parquet filename suffix"
+        )
+    path = policy.materialize(reference, sha256=sha256, byte_size=byte_size)
+    try:
+        source = pq.ParquetFile(path)
+        batches: list[pa.RecordBatch] = []
+        total_rows = 0
+        for batch in source.iter_batches(batch_size=policy.max_batch_rows):
+            total_rows += batch.num_rows
+            policy.validate_tabular_batch(
+                batch_rows=batch.num_rows, total_rows=total_rows
+            )
+            batches.append(batch)
+        return pa.Table.from_batches(batches, schema=source.schema_arrow)
+    except pa.ArrowException as error:
+        raise IngestionError("declared Parquet resource cannot be parsed") from error
 
 
 def materialization_receipt(

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -24,6 +24,7 @@ from voiage.ingestion._tabular import (
     materialization_receipt,
     read_csv,
     read_json_table,
+    read_parquet,
 )
 from voiage.ingestion.base import (
     IngestionError,
@@ -39,7 +40,12 @@ class FrictionlessProvider:
     capabilities = ProviderCapabilities(
         provider_id=provider_id,
         format_versions=("1",),
-        media_types=("text/csv", "text/tab-separated-values", "application/json"),
+        media_types=(
+            "text/csv",
+            "text/tab-separated-values",
+            "application/json",
+            "application/vnd.apache.parquet",
+        ),
     )
 
     def can_handle(self, descriptor: dict[str, object]) -> bool:
@@ -129,7 +135,16 @@ class FrictionlessProvider:
         declared_sha256 = _sha256(resource.get("hash"))
         declared_byte_size = _byte_size(resource.get("bytes"))
         resource_format = resource.get("format")
-        if resource_format == "json":
+        if resource_format == "parquet":
+            _validate_parquet_declarations(resource)
+            table = read_parquet(
+                reference,
+                policy,
+                sha256=declared_sha256,
+                byte_size=declared_byte_size,
+            )
+            media_type = "application/vnd.apache.parquet"
+        elif resource_format == "json":
             _validate_json_table_declarations(resource)
             _validate_json_table_field_schema(fields)
             table = read_json_table(
@@ -478,6 +493,15 @@ def _validate_json_table_declarations(resource: dict[str, object]) -> None:
     }.intersection(resource)
     if unsupported:
         raise IngestionError("JSON Table resources do not support parser declarations")
+
+
+def _validate_parquet_declarations(resource: dict[str, object]) -> None:
+    """Reject declaration features outside the strict local Parquet profile."""
+    reference = resource.get("path")
+    if not isinstance(reference, str) or not reference.casefold().endswith(".parquet"):
+        raise IngestionError("Parquet resources require a .parquet path")
+    if "dialect" in resource:
+        raise IngestionError("Parquet resources do not support dialect declarations")
 
 
 def _validate_json_table_field_schema(fields: list[object]) -> None:


### PR DESCRIPTION
## Summary
- add explicit local Frictionless `.parquet` + `format: parquet` support
- stream Parquet through bounded Arrow batches with existing source-policy limits
- preserve strict declared-field/key validation and verified receipts

## Validation
- `uv run --extra dev --extra ci pytest tests/test_standardized_ingestion_providers.py tests/test_frictionless_offline_fixtures.py tests/test_standardized_ingestion_conformance.py tests/test_standardized_ingestion_cli.py tests/test_ingestion_provider_sdk_contract.py -q --no-cov`
- Ruff, ty, Vale, Conductor, cross-reference, and diff checks

The profile remains local-only and deliberately excludes remote/archive/Arrow IPC source resources.