### PR TITLE
feat(ingestion): support local Frictionless Arrow IPC files

### DIFF
--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -125,7 +125,12 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   Parquet profile accepts only `.parquet` resources explicitly declared as
   `format: parquet` without a dialect, streams bounded PyArrow batches,
   preserves verified receipts, and validates the same declared primitive fields
-  and keys (partial). Remaining acceptance evidence is tracked below.
+  and keys (partial). The local Arrow IPC
+  file increment accepts exact `.arrow`/`format: arrow` and Feather
+  `.feather`/`format: feather` pairs through bounded Arrow file batches and
+  verified receipts; streams, Flight, dataset directories, parser
+  declarations, and remote/archive sources reject (partial). Remaining
+  acceptance evidence is tracked below.
 - [~] **P4-T8 / AC-05:** Implement the lazy optional Frictionless provider and
   documented supported profile. Public provider export is now lazy; profile
   acceptance evidence remains active (`2ad0a24a`, partial).

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -19,7 +19,7 @@ portable, auditable, and suitable for an offline calculation workflow.
 | Input surface | Supported profile | Explicit boundary |
 | --- | --- | --- |
 | Croissant ML | Croissant 1.1 with string-only JSON-LD context entries, one legacy `recordSet`/CSV distribution pair or explicitly selected local pairs linked by `recordSet.distribution` to distribution `@id`, fields that exactly match the selected CSV columns, and optional `sha256`/integer-byte `contentSize` integrity declarations | Remote/live catalogs, archives, transforms, splits, keys, nested fields, field references, JSON-LD context objects, `FileObject`/`FileSet`, non-CSV media types, non-SHA-256 integrity forms, and textual/structured `contentSize` values are rejected. |
-| Frictionless Data Package | One or more explicitly schematized local CSV resources (`.csv`, comma), TSV resources (`.tsv`, `format: tsv`, explicit tab delimiter), JSON Table resources (`.json`, `format: json`, UTF-8 array of object rows), or Parquet resources (`.parquet`, `format: parquet`, no dialect), declared primitive types, primary/foreign keys, and boolean `required`/`unique` field constraints | Remote/live resources, archives, inferred or custom dialects, JSON Lines/envelopes/paths/nested rows, unsupported formats, transforms, undeclared or ambiguous resources, non-boolean or unsupported constraints, and schema `missingValues` declarations are rejected. |
+| Frictionless Data Package | One or more explicitly schematized local CSV resources (`.csv`, comma), TSV resources (`.tsv`, `format: tsv`, explicit tab delimiter), JSON Table resources (`.json`, `format: json`, UTF-8 array of object rows), Parquet resources (`.parquet`, `format: parquet`, no dialect), or Arrow IPC file resources (`.arrow`, `format: arrow`; `.feather`, `format: feather`), with declared primitive types, primary/foreign keys, and boolean `required`/`unique` field constraints | Remote/live resources, archives, inferred or custom dialects, JSON Lines/envelopes/paths/nested rows, Arrow streams, Flight endpoints, dataset directories, unsupported formats, transforms, undeclared or ambiguous resources, non-boolean or unsupported constraints, and schema `missingValues` declarations are rejected. |
 | Direct DataFrame interchange | pandas, Polars, or another `__dataframe__` producer that can convert through Arrow with an explicit binding | The adapter does not infer a VOI role, silently copy a disallowed frame, or create a second calculation path. |
 | Arrow IPC | A `NormalizedInputBundle` previously written by VOIAGE | This is a normalized interchange artifact, not a source-descriptor parser. |
 
@@ -177,7 +177,7 @@ complete implementation of either upstream standard.
 | Input family | Supported profile | Consumer contract | Explicitly not supported in the built-in provider |
 | --- | --- | --- | --- |
 | Croissant ML | Croissant 1.1 descriptor, one legacy local CSV pair or one explicitly selected and linked local record-set/distribution pair, explicit fields, local SHA-256 and integer-byte `contentSize` when declared | Produces one Arrow-backed bundle; callers add explicit bindings before preparation. | Remote downloads, archives, transformations, `FileObject`/`FileSet`, executable metadata, implicit schema inference, unverified integrity forms, and non-byte `contentSize` values |
-| Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources (`.csv`, comma), explicitly declared TSV resources (`.tsv`, `format: tsv`, `dialect: {"delimiter": "\\t"}`), JSON Table resources (`.json`, `format: json`, UTF-8 JSON array of object rows), or local Parquet resources (`.parquet`, `format: parquet`, no dialect), with explicit primitive field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, inferred or custom dialects, JSON Lines/envelopes/JSON paths/nested rows, other integrity algorithms, implicit schema inference, Arrow IPC source resources |
+| Frictionless Data Package | Data Package v1-style descriptor, one or more local CSV resources (`.csv`, comma), explicitly declared TSV resources (`.tsv`, `format: tsv`, `dialect: {"delimiter": "\\t"}`), JSON Table resources (`.json`, `format: json`, UTF-8 JSON array of object rows), local Parquet resources (`.parquet`, `format: parquet`, no dialect), or Arrow IPC file resources (`.arrow`, `format: arrow`; `.feather`, `format: feather`), with explicit primitive field schemas, primary keys, and intra-package foreign keys; optional SHA-256 `hash` and `bytes` verification | Produces Arrow-backed tables and preserved key references; callers add explicit bindings before preparation. | Remote URLs, archives, transformations, inferred or custom dialects, JSON Lines/envelopes/JSON paths/nested rows, Arrow streams, Flight endpoints, dataset directories, other integrity algorithms, implicit schema inference |
 | DataFrame interchange | A producer accepted by Arrow's `__dataframe__` interchange conversion, with explicit VOI bindings supplied by the caller | `from_dataframe` preserves the Arrow schema and honours `allow_copy`; its bundle enters the same preparation path as providers and records conversion decisions. | Inferred decision semantics, unsupported nested values, and conversions that require copying when `allow_copy=False`. |
 
 All providers default to local-only access. Inputs that fall outside these
@@ -185,12 +185,15 @@ profiles fail with a stable `IngestionError`; they are not partially loaded or
 silently transformed. Compatibility will expand only with new fixtures,
 source-policy evidence, and a documented provider capability change.
 
-The Frictionless corpus includes a valid receipted CSV package and
-runtime-generated local Parquet packages,
-offline replay, metadata-only inspection of an absent declared resource, and
-fail-closed descriptor, field-identity, and dialect cases. It is evidence for
-this local profile only; it does not establish support for a remote catalogue,
-archive, Arrow IPC source resource, or the complete upstream specification.
+The file-backed Frictionless corpus includes valid receipted CSV, TSV, JSON
+Table, runtime-generated local Parquet, and Arrow IPC file packages, offline
+replay, metadata-only inspection of an absent declared resource, and fail-closed
+descriptor, field-identity, and dialect cases. The Arrow profile accepts only
+explicit local IPC file containers (`.arrow` or Feather v2 `.feather`) and
+checks each retained record batch against the source policy before table
+construction. It is evidence for this local profile only; it does not establish
+support for a remote catalogue, archive, Arrow streams/Flight/dataset
+directories, or the complete upstream specification.
 
 ## Authoritative interoperability probes
 

--- a/tests/test_standardized_ingestion_cli.py
+++ b/tests/test_standardized_ingestion_cli.py
@@ -308,6 +308,7 @@ def test_ingest_inspect_and_normalize(tmp_path, monkeypatch) -> None:
             "text/tab-separated-values",
             "application/json",
             "application/vnd.apache.parquet",
+            "application/vnd.apache.arrow.file",
         ],
         "provider_id": "frictionless",
         "supported_transforms": [],

--- a/tests/test_standardized_ingestion_conformance.py
+++ b/tests/test_standardized_ingestion_conformance.py
@@ -233,7 +233,12 @@ def test_provider_rejects_declared_field_order_that_differs_from_csv_order(
     descriptor_path = tmp_path / descriptor_name
     descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
 
-    with pytest.raises(IngestionError, match="exactly declare the CSV columns"):
+    expected = (
+        "exactly declare the CSV columns"
+        if descriptor_name.endswith(".croissant.json")
+        else "exactly declare resource columns"
+    )
+    with pytest.raises(IngestionError, match=expected):
         default_registry().ingest(descriptor_path, policy=SourceAccessPolicy(tmp_path))
 
 

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -36,6 +36,7 @@ from voiage.ingestion import (
 )
 from voiage.ingestion._tabular import (
     digest_file,
+    read_arrow_ipc,
     read_csv,
     read_json_table,
     read_parquet,
@@ -52,6 +53,27 @@ from voiage.ingestion.registry import ProviderRegistry
 
 def _write_csv(tmp_path) -> None:
     (tmp_path / "samples.csv").write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+
+
+def _write_arrow_ipc(path, *, stream: bool = False, nested: bool = False) -> None:
+    """Write a deterministic local Arrow file or deliberately unsupported stream."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "value": pa.array([1.5, 2.5], type=pa.float64()),
+            "label": pa.array(["one", "two"], type=pa.string()),
+        }
+        if not nested
+        else {"id": pa.array([[1], [2]])}
+    )
+    with pa.OSFile(str(path), "wb") as sink:
+        writer = (
+            pa.ipc.new_stream(sink, table.schema)
+            if stream
+            else pa.ipc.new_file(sink, table.schema)
+        )
+        with writer:
+            writer.write_table(table)
 
 
 @pytest.mark.parametrize(
@@ -506,6 +528,261 @@ def test_frictionless_provider_rejects_ambiguous_parquet_declarations(
                         "format": "parquet",
                         "dialect": dialect,
                         "schema": {"fields": [{"name": "id"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
+@pytest.mark.parametrize(
+    ("filename", "resource_format"),
+    [("samples.arrow", "arrow"), ("samples.feather", "feather")],
+)
+def test_frictionless_provider_ingests_explicit_local_arrow_ipc_file(
+    tmp_path, filename: str, resource_format: str
+) -> None:
+    """The local profile accepts only an explicit Arrow IPC file container."""
+    source = tmp_path / filename
+    _write_arrow_ipc(source)
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "name": "arrow-operations-fixture",
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": filename,
+                        "format": resource_format,
+                        "hash": digest_file(source),
+                        "bytes": source.stat().st_size,
+                        "schema": {
+                            "primaryKey": "id",
+                            "fields": [
+                                {
+                                    "name": "id",
+                                    "type": "integer",
+                                    "constraints": {
+                                        "required": True,
+                                        "unique": True,
+                                    },
+                                },
+                                {"name": "value", "type": "number"},
+                                {"name": "label", "type": "string"},
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = FrictionlessProvider().ingest(
+        descriptor_path, policy=SourceAccessPolicy(tmp_path)
+    )
+
+    assert bundle.table("samples").to_pylist() == [
+        {"id": 1, "value": 1.5, "label": "one"},
+        {"id": 2, "value": 2.5, "label": "two"},
+    ]
+    assert bundle.manifest.tables[0].primary_key == ("id",)
+    assert (
+        bundle.manifest.resources[0].media_type == "application/vnd.apache.arrow.file"
+    )
+    assert bundle.manifest.resources[0].sha256 == digest_file(source)
+
+
+def test_frictionless_arrow_ipc_profile_enforces_batch_row_policy(tmp_path) -> None:
+    """An Arrow file batch is rejected before a complete table is retained."""
+    source = tmp_path / "samples.arrow"
+    _write_arrow_ipc(source)
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": source.name,
+                        "format": "arrow",
+                        "schema": {
+                            "fields": [
+                                {"name": "id", "type": "integer"},
+                                {"name": "value", "type": "number"},
+                                {"name": "label", "type": "string"},
+                            ]
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match="batch row limit"):
+        FrictionlessProvider().ingest(
+            descriptor_path,
+            policy=SourceAccessPolicy(tmp_path, max_resource_rows=2, max_batch_rows=1),
+        )
+
+
+def test_arrow_ipc_reader_rejects_invalid_suffix_and_parse_conversion_errors(
+    tmp_path, monkeypatch
+) -> None:
+    """Every low-level Arrow file failure stays inside the ingestion boundary."""
+    policy = SourceAccessPolicy(tmp_path)
+
+    with pytest.raises(IngestionError, match="support only Arrow IPC file suffixes"):
+        read_arrow_ipc("samples.arrow", policy, suffix=".ipc")
+    with pytest.raises(IngestionError, match="supported .feather suffix"):
+        read_arrow_ipc("samples.arrow", policy, suffix=".feather")
+
+    (tmp_path / "invalid.arrow").write_bytes(b"not-an-arrow-file")
+    with pytest.raises(IngestionError, match="cannot be parsed as an Arrow file"):
+        read_arrow_ipc("invalid.arrow", policy, suffix=".arrow")
+
+    source = tmp_path / "samples.arrow"
+    _write_arrow_ipc(source)
+
+    def fail_from_batches(*_: object, **__: object) -> object:
+        raise pa.ArrowInvalid("synthetic Arrow table construction failure")
+
+    monkeypatch.setattr(
+        _tabular.pa, "Table", SimpleNamespace(from_batches=fail_from_batches)
+    )
+    with pytest.raises(IngestionError, match="cannot be parsed as an Arrow file"):
+        read_arrow_ipc("samples.arrow", policy, suffix=".arrow")
+
+
+@pytest.mark.parametrize(
+    ("resource", "message"),
+    [
+        (
+            {"path": "samples.feather", "format": "arrow"},
+            "matching .arrow/.feather path and format",
+        ),
+        (
+            {"path": "samples.arrow", "format": "feather"},
+            "matching .arrow/.feather path and format",
+        ),
+        (
+            {"path": "samples.arrow", "format": "arrow", "dialect": {}},
+            "do not support parser declarations",
+        ),
+        (
+            {"path": "samples.arrow", "format": "arrow", "compression": "zstd"},
+            "do not support parser declarations",
+        ),
+        (
+            {"path": "https://example.invalid/samples.arrow", "format": "arrow"},
+            "network resource access is disabled",
+        ),
+    ],
+)
+def test_frictionless_arrow_ipc_declaration_errors_fail_closed(
+    tmp_path, resource, message
+) -> None:
+    """Profile/transport declarations fail without inferring an Arrow source."""
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        **resource,
+                        "schema": {"fields": [{"name": "id", "type": "integer"}]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
+@pytest.mark.parametrize(
+    ("schema", "message"),
+    [
+        ({"fields": []}, "Arrow IPC schema requires at least one field"),
+        ({"fields": [{"type": "integer"}]}, "Arrow IPC fields require string names"),
+        (
+            {"fields": [{"name": "id", "format": "ignored"}]},
+            "Arrow IPC fields contain unsupported declarations",
+        ),
+    ],
+)
+def test_frictionless_arrow_ipc_field_declarations_fail_before_resource_reads(
+    tmp_path, schema, message
+) -> None:
+    """Unsupported Arrow field semantics are rejected before materialization."""
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": "missing.arrow",
+                        "format": "arrow",
+                        "schema": schema,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(IngestionError, match=message):
+        FrictionlessProvider().ingest(
+            descriptor_path, policy=SourceAccessPolicy(tmp_path)
+        )
+
+
+@pytest.mark.parametrize(
+    ("stream", "nested", "message"),
+    [
+        (True, False, "cannot be parsed as an Arrow file"),
+        (False, True, "field type does not match"),
+    ],
+)
+def test_frictionless_arrow_ipc_rejects_streams_and_schema_mismatches(
+    tmp_path, stream: bool, nested: bool, message: str
+) -> None:
+    """IPC streams and Arrow types outside the declared primitive schema fail."""
+    source = tmp_path / "samples.arrow"
+    _write_arrow_ipc(source, stream=stream, nested=nested)
+    fields = (
+        [{"name": "id", "type": "string"}]
+        if nested
+        else [
+            {"name": "id", "type": "integer"},
+            {"name": "value", "type": "number"},
+            {"name": "label", "type": "string"},
+        ]
+    )
+    descriptor_path = tmp_path / "datapackage.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "name": "samples",
+                        "path": source.name,
+                        "format": "arrow",
+                        "schema": {"fields": fields},
                     }
                 ]
             }
@@ -1075,6 +1352,7 @@ def test_provider_capabilities_declare_conservative_supported_profiles(
             "text/tab-separated-values",
             "application/json",
             "application/vnd.apache.parquet",
+            "application/vnd.apache.arrow.file",
         )
     )
     assert capabilities.media_types == expected_media_types

--- a/voiage/ingestion/_tabular.py
+++ b/voiage/ingestion/_tabular.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path  # noqa: TC003 - public runtime annotation
 
 import pyarrow as pa
-from pyarrow import csv
+from pyarrow import csv, ipc
 from pyarrow import parquet as pq
 
 from voiage.contracts.normalized_input import ResourceManifest
@@ -137,6 +137,47 @@ def read_parquet(
         return pa.Table.from_batches(batches, schema=source.schema_arrow)
     except pa.ArrowException as error:
         raise IngestionError("declared Parquet resource cannot be parsed") from error
+
+
+def read_arrow_ipc(
+    reference: str,
+    policy: SourceAccessPolicy,
+    *,
+    sha256: str | None = None,
+    byte_size: int | None = None,
+    suffix: str,
+) -> pa.Table:
+    """Read one local Arrow IPC file using bounded record batches.
+
+    The built-in Frictionless profile accepts only Arrow *file* containers.
+    It deliberately does not accept Arrow IPC streams, Flight endpoints,
+    dataset directories, or any transport inferred from a descriptor. Feather
+    v2 uses this same Arrow IPC file container and is distinguished only by its
+    explicit descriptor format and filename suffix.
+    """
+    if suffix not in {".arrow", ".feather"}:
+        raise IngestionError("built-in providers support only Arrow IPC file suffixes")
+    if not reference.casefold().endswith(suffix):
+        raise IngestionError(
+            f"declared Arrow IPC resource must use the supported {suffix} suffix"
+        )
+    path = policy.materialize(reference, sha256=sha256, byte_size=byte_size)
+    try:
+        reader = ipc.open_file(path)
+        batches: list[pa.RecordBatch] = []
+        total_rows = 0
+        for index in range(reader.num_record_batches):
+            batch = reader.get_batch(index)
+            total_rows += batch.num_rows
+            policy.validate_tabular_batch(
+                batch_rows=batch.num_rows, total_rows=total_rows
+            )
+            batches.append(batch)
+        return pa.Table.from_batches(batches, schema=reader.schema)
+    except pa.ArrowException as error:
+        raise IngestionError(
+            "declared Arrow IPC resource cannot be parsed as an Arrow file"
+        ) from error
 
 
 def materialization_receipt(

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -22,6 +22,7 @@ from voiage.contracts.normalized_input import (
 )
 from voiage.ingestion._tabular import (
     materialization_receipt,
+    read_arrow_ipc,
     read_csv,
     read_json_table,
     read_parquet,
@@ -45,6 +46,7 @@ class FrictionlessProvider:
             "text/tab-separated-values",
             "application/json",
             "application/vnd.apache.parquet",
+            "application/vnd.apache.arrow.file",
         ),
     )
 
@@ -154,6 +156,17 @@ class FrictionlessProvider:
                 byte_size=declared_byte_size,
             )
             media_type = "application/json"
+        elif resource_format in {"arrow", "feather"}:
+            suffix = _validate_arrow_ipc_declarations(resource)
+            _validate_arrow_ipc_field_schema(fields)
+            table = read_arrow_ipc(
+                reference,
+                policy,
+                sha256=declared_sha256,
+                byte_size=declared_byte_size,
+                suffix=suffix,
+            )
+            media_type = "application/vnd.apache.arrow.file"
         else:
             delimiter, suffix, media_type = _delimited_text_profile(
                 reference,
@@ -182,7 +195,7 @@ class FrictionlessProvider:
             table.column_names
         ):
             raise IngestionError(
-                "Data Package fields must exactly declare the CSV columns"
+                "Data Package fields must exactly declare resource columns"
             )
         return (
             table_id,
@@ -516,6 +529,53 @@ def _validate_json_table_field_schema(fields: list[object]) -> None:
             raise IngestionError("JSON Table fields require string names")
         if set(raw_field).difference(allowed):
             raise IngestionError("JSON Table fields contain unsupported declarations")
+
+
+def _validate_arrow_ipc_declarations(resource: dict[str, object]) -> str:
+    """Return the explicit Arrow IPC suffix or reject unpreservable semantics.
+
+    Arrow IPC and Feather v2 are file containers, not a general Arrow transport
+    selector. Requiring both an exact format and filename suffix avoids
+    sniffing a stream or treating an arbitrary binary payload as a table.
+    """
+    reference, resource_format = resource.get("path"), resource.get("format")
+    profiles = {"arrow": ".arrow", "feather": ".feather"}
+    suffix = profiles.get(resource_format) if isinstance(resource_format, str) else None
+    if (
+        not isinstance(reference, str)
+        or suffix is None
+        or not reference.casefold().endswith(suffix)
+    ):
+        raise IngestionError(
+            "Arrow IPC resources require matching .arrow/.feather path and format"
+        )
+    unsupported = {
+        "compression",
+        "data",
+        "dialect",
+        "encoding",
+        "jsonPath",
+        "mediatype",
+        "pathType",
+        "transform",
+    }.intersection(resource)
+    if unsupported:
+        raise IngestionError("Arrow IPC resources do not support parser declarations")
+    return suffix
+
+
+def _validate_arrow_ipc_field_schema(fields: list[object]) -> None:
+    """Require only the primitive field declarations this profile enforces."""
+    if not fields:
+        raise IngestionError("Arrow IPC schema requires at least one field")
+    allowed = {"constraints", "description", "name", "title", "type"}
+    for raw_field in fields:
+        if not isinstance(raw_field, dict) or not isinstance(
+            raw_field.get("name"), str
+        ):
+            raise IngestionError("Arrow IPC fields require string names")
+        if set(raw_field).difference(allowed):
+            raise IngestionError("Arrow IPC fields contain unsupported declarations")
 
 
 def _governance_extensions(descriptor: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- add strict local Frictionless Arrow IPC file and Feather v2 profiles
- enforce source-policy batch bounds, integrity receipts, declared primitive schemas, and keys
- reject streams, Flight, dataset directories, remote/archive paths, and parser declarations

## Validation

- `pytest tests/test_standardized_ingestion_providers.py -q` (128 passed)
- Ruff format/check, production `ty check`
- full Conductor and GitHub cross-reference validation

The profile is deliberately local-file-only; it does not claim Arrow stream, Flight, dataset-directory, remote, archive, or transformation support.