### PR TITLE
test(ingestion): prove source policy preflight isolation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Harden built-in Croissant and Frictionless source preflight so unsupported
+  URI-style, DNS-like, archive, redirect-shaped, and transform declarations
+  fail before resolver/materializer callbacks, cache creation, or receipt
+  construction.
 - Add a strict local Frictionless Parquet profile: descriptors must declare
   `format: parquet`, use a `.parquet` path, declare primitive fields, and omit
   dialect settings. Parquet input is streamed through bounded Arrow batches

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -238,8 +238,10 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   unauthorized-network, secret-leakage, unsafe-transform, and resource-limit
   tests. Local policy coverage now rejects URI schemes (including `file:` and
   `data:` forms) and archive suffixes before any file, DNS, redirect, or archive
-  operation; archive extraction remains explicitly unsupported (`749083d`,
-  partial).
+  operation; Croissant/Frictionless provider regressions additionally prove
+  URI-style, DNS-like, redirect-shaped, archive, and transform declarations
+  fail before a resolver/materializer callback, cache entry, or receipt can be
+  created. Archive extraction remains explicitly unsupported (partial).
 - [~] **P7-T2 / AC-08, AC-11:** Add DNS-rebinding, redirect-policy,
   cache-poisoning, checksum-mismatch, decompression-ratio, and mutable-live-data
   tests. Partial evidence: `d3550e9c` rejects a cache-namespace symlink whose

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -102,6 +102,10 @@ policy limit is rejected before parsing. Applications can set a smaller explicit
 `SourceAccessPolicy.max_resource_bytes` limit for constrained workloads. Cache
 namespace directories are also checked before every cache operation, so a
 symlink cannot redirect a materialization outside the configured cache root.
+For Croissant and Frictionless descriptors, this source-policy preflight occurs
+before a tabular materializer is called: unsupported URI-style, DNS-like,
+archive, redirect-shaped, or transform references create neither a cache entry
+nor a materialization receipt. It is rejection evidence, not remote support.
 
 ## Verified local replay
 

--- a/tests/test_standardized_ingestion_providers.py
+++ b/tests/test_standardized_ingestion_providers.py
@@ -7,12 +7,16 @@ import json
 import subprocess
 import sys
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 from pyarrow import parquet as pq
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from voiage import ingestion
 from voiage.contracts import (
@@ -74,6 +78,93 @@ def _write_arrow_ipc(path, *, stream: bool = False, nested: bool = False) -> Non
         )
         with writer:
             writer.write_table(table)
+
+
+class _PreflightOnlyPolicy(SourceAccessPolicy):
+    """Make accidental source resolution or materialization immediately visible."""
+
+    preflight_calls: int = 0
+    resolve_calls: int = 0
+    materialize_calls: int = 0
+
+    def source_uri(self, reference: str) -> str:
+        self.preflight_calls += 1
+        return super().source_uri(reference)
+
+    def resolve(self, reference: str) -> Path:
+        self.resolve_calls += 1
+        raise AssertionError(f"unexpected resolver call for {reference!r}")
+
+    def materialize(
+        self,
+        reference: str,
+        *,
+        sha256: str | None = None,
+        byte_size: int | None = None,
+    ) -> Path:
+        self.materialize_calls += 1
+        raise AssertionError(f"unexpected materializer call for {reference!r}")
+
+
+def _unsafe_descriptor(
+    provider_id: str, reference: str, *, transform: bool
+) -> dict[str, object]:
+    """Return a minimum descriptor with one deliberately unsupported source."""
+    if provider_id == "croissant":
+        distribution: dict[str, object] = {"contentUrl": reference}
+        if transform:
+            distribution["transform"] = {"script": "not-run"}
+        return {
+            "@context": "https://mlcommons.org/croissant/1.1",
+            "distribution": [distribution],
+            "recordSet": [{"name": "samples", "field": [{"name": "id"}]}],
+        }
+    resource: dict[str, object] = {
+        "name": "samples",
+        "path": reference,
+        "schema": {"fields": [{"name": "id", "type": "integer"}]},
+    }
+    if transform:
+        resource["transform"] = {"script": "not-run"}
+    return {"resources": [resource]}
+
+
+@pytest.mark.parametrize("provider_id", ["croissant", "frictionless"])
+@pytest.mark.parametrize(
+    ("reference", "transform"),
+    [
+        ("https://example.invalid/source.csv", False),
+        ("https://example.invalid/redirect.csv", False),
+        ("//metadata.internal/source.csv", False),
+        ("source.tar.gz", False),
+        ("samples.csv", True),
+    ],
+)
+def test_built_in_providers_reject_unsafe_sources_before_callbacks_or_receipts(
+    tmp_path, provider_id: str, reference: str, transform: bool
+) -> None:
+    """Unsupported source semantics cannot reach resolver, cache, or receipt code."""
+    descriptor_path = tmp_path / f"{provider_id}.json"
+    descriptor_path.write_text(
+        json.dumps(_unsafe_descriptor(provider_id, reference, transform=transform)),
+        encoding="utf-8",
+    )
+    cache = tmp_path / "cache"
+    policy = _PreflightOnlyPolicy(tmp_path, cache_dir=cache)
+    provider = (
+        CroissantProvider() if provider_id == "croissant" else FrictionlessProvider()
+    )
+
+    with pytest.raises(IngestionError):
+        provider.ingest(descriptor_path, policy=policy)
+
+    assert policy.resolve_calls == 0
+    assert policy.materialize_calls == 0
+    provider_rejects_before_policy = transform or (
+        provider_id == "croissant" and reference.lower().endswith(".tar.gz")
+    )
+    assert policy.preflight_calls == (0 if provider_rejects_before_policy else 1)
+    assert not cache.exists()
 
 
 @pytest.mark.parametrize(

--- a/voiage/ingestion/croissant.py
+++ b/voiage/ingestion/croissant.py
@@ -103,6 +103,9 @@ class CroissantProvider:
             raise IngestionError(
                 "supported Croissant profile does not support transformations"
             )
+        # Reject a URI, archive, or traversal reference before the tabular
+        # helper can invoke a materializer supplied by an application.
+        policy.source_uri(reference)
         declared_sha256 = _sha256(distribution.get("sha256"))
         declared_byte_size = _content_size(distribution.get("contentSize"))
         try:

--- a/voiage/ingestion/frictionless.py
+++ b/voiage/ingestion/frictionless.py
@@ -130,12 +130,19 @@ class FrictionlessProvider:
             raise IngestionError("Data Package schema requires fields")
         fields = cast("list[object]", fields)
         self._validate_schema_declaration(schema, fields)
+        if resource.get("transform") not in (None, []):
+            raise IngestionError(
+                "supported Data Package profile does not support transformations"
+            )
         if "checksum" in resource:
             raise IngestionError(
                 "supported Data Package profile does not support integrity declarations"
             )
         declared_sha256 = _sha256(resource.get("hash"))
         declared_byte_size = _byte_size(resource.get("bytes"))
+        # Built-in profiles have no resolver or transport path. Validate the
+        # descriptor reference before a tabular materializer can be invoked.
+        policy.source_uri(reference)
         resource_format = resource.get("format")
         if resource_format == "parquet":
             _validate_parquet_declarations(resource)


### PR DESCRIPTION
## Summary

- preflight Croissant and Frictionless descriptor references before tabular materialization
- reject URI-style, DNS-like, redirect-shaped, archive, and transform declarations before resolver/materializer callbacks
- prove rejected inputs create neither cache entries nor receipts

## Validation

- `pytest tests/test_standardized_ingestion_providers.py tests/test_source_policy_cache.py -q` (184 passed)
- Ruff, production ty, Vale, full Conductor, cross-reference, and diff checks

No remote, redirect, archive, or transform support is added.