### PR TITLE
docs(ingestion): bound cross-domain method evidence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@
   prepared inputs, EVPI, schema fingerprints, and materialization receipts are
   checked against direct normalized input; malformed JSON/Parquet resources and
   Arrow streams remain rejected.
+- Add a declared long net-benefit fixture with Croissant, Frictionless, and
+  direct Arrow normalization and EVPI equivalence evidence; preserve explicit
+  sample, strategy, and value bindings rather than inferring long-table roles.
 - Add a deterministic cross-domain method-applicability matrix and CEAF
   equivalence evidence for the engineering cost/outcome reference fixture;
   explicitly bound the ML and business fixtures to the methods and data shapes

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@
   prepared inputs, EVPI, schema fingerprints, and materialization receipts are
   checked against direct normalized input; malformed JSON/Parquet resources and
   Arrow streams remain rejected.
+- Add a deterministic cross-domain method-applicability matrix and CEAF
+  equivalence evidence for the engineering cost/outcome reference fixture;
+  explicitly bound the ML and business fixtures to the methods and data shapes
+  they actually provide.
 - Add a strict local Frictionless Parquet profile: descriptors must declare
   `format: parquet`, use a `.parquet` path, declare primitive fields, and omit
   dialect settings. Parquet input is streamed through bounded Arrow batches

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -341,10 +341,17 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   reference example (partial).
 - [~] **P9-T4 / AC-13:** Assert normalized-object and numerical equivalence
   without adding domain-specific kernels or semantic inference. The reference
-  runner now fails if any supported representation differs in EVPI (partial;
-  broader hosted evidence remains required).
+  runner now fails if any supported representation differs in EVPI. The
+  engineering cost/outcome fixture additionally proves normalized net-benefit
+  and CEAF equivalence across Croissant, Frictionless, direct Arrow, and
+  DataFrame inputs at declared WTP values; EVSI, EVPPI, ENBS, long-form, and
+  perspective-split claims remain explicitly out of scope for these fixtures
+  (partial; broader hosted evidence remains required).
 - [~] **P9-T5 / AC-13:** Publish the support matrix and run fixture
   regeneration, docs, links, Vale, conformance, and hosted regression checks.
+  The public reference-case page now records the per-community method and
+  shape applicability boundary so the examples make no unsupported method
+  claims (partial; hosted evidence remains required).
 
 ## Follow-on recommendation incorporation (2026-07-24)
 

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -344,7 +344,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   runner now fails if any supported representation differs in EVPI. The
   engineering cost/outcome fixture additionally proves normalized net-benefit
   and CEAF equivalence across Croissant, Frictionless, direct Arrow, and
-  DataFrame inputs at declared WTP values; EVSI, EVPPI, ENBS, long-form, and
+  DataFrame inputs at declared WTP values. A separate explicitly bound long
+  net-benefit fixture now proves equivalent Croissant, Frictionless, and direct
+  Arrow normalization without semantic inference; EVSI, EVPPI, ENBS, and
   perspective-split claims remain explicitly out of scope for these fixtures
   (partial; broader hosted evidence remains required).
 - [~] **P9-T5 / AC-13:** Publish the support matrix and run fixture

--- a/docs/astro-site/src/content/docs/examples/index.mdx
+++ b/docs/astro-site/src/content/docs/examples/index.mdx
@@ -28,7 +28,7 @@ This index groups the runnable notebook tutorials and supporting long-form examp
 ## Cross-Domain Tutorials
 
 - [Expected-utility information pricing](/examples/expected-utility-information/) — accessible synthetic EUI, CEI, BPI, SPI, PPI, and VoC walkthrough
-- [Standardized Ingestion Reference Cases](/examples/standardized-ingestion-reference-cases/) — identical explicit EVPI across Croissant, Frictionless, and the DataFrame-interchange SDK
+- [Standardized Ingestion Reference Cases](/examples/standardized-ingestion-reference-cases/) — identical explicit EVPI across Croissant, Frictionless, and the DataFrame-interchange SDK, plus bounded engineering CEAF equivalence
 - [Financial VOI](https://github.com/edithatogo/voiage/blob/main/examples/financial_voi.ipynb)
 - [Environmental VOI](https://github.com/edithatogo/voiage/blob/main/examples/environmental_voi.ipynb)
 - [Engineering VOI](https://github.com/edithatogo/voiage/blob/main/examples/engineering_voi.ipynb)

--- a/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
+++ b/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
@@ -77,6 +77,26 @@ The scripts deliberately report a fixture as deterministic synthetic data,
 rather than presenting a substitute for a rights clearance or live provider
 receipt.
 
+## Long-layout equivalence
+
+`long-decision` records the same deterministic two-strategy samples as the
+canonical wide fixture, but declares a sample identifier, strategy label, and
+one net-benefit value per row. Its long binding explicitly names all three
+fields and fixes the strategy order; no column or label is inferred. The
+Croissant, Frictionless, and direct Arrow representations must each normalize
+to the same `ValueArray` as the wide fixture before EVPI is calculated.
+
+```python
+from examples.standardized_ingestion.reference_cases import run_long_reference_cases
+
+long_case = run_long_reference_cases()
+normalized = long_case["normalized_net_benefit"]
+assert normalized["croissant"] == normalized["frictionless"] == normalized["direct"]
+```
+
+This evidence covers declared long net-benefit rows only. It does not turn an
+arbitrary long table into a cost/outcome or perspective-specific dataset.
+
 ### CEAF equivalence
 
 The engineering fixture also supplies paired cost and outcome PSA rows for the
@@ -104,9 +124,9 @@ DataFrame surface is checked before the example returns.
 
 | Community | EVPI | CEAF | EVPPI / EVSI / ENBS | Shape coverage |
 | --- | --- | --- | --- | --- |
-| Machine learning | Evaluated on explicit wide net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide only; no long, cost/outcome, or perspective-split fixture. |
-| Engineering and operations | Evaluated at WTP 20,000. | Evaluated on paired cost/outcome PSA rows at WTP 10,000, 20,000, and 30,000. | Not applicable: no conditional or study-design inputs. | Cost/outcome wide rows; no long or perspective-split fixture. |
-| Business | Evaluated on explicit wide net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide only; no long, cost/outcome, or perspective-split fixture. |
+| Machine learning | Evaluated on explicit wide and declared long net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide and declared long net-benefit rows; no perspective-split fixture. |
+| Engineering and operations | Evaluated at WTP 20,000. | Evaluated on paired cost/outcome PSA rows at WTP 10,000, 20,000, and 30,000. | Not applicable: no conditional or study-design inputs. | Cost/outcome wide rows and declared long net-benefit rows; no perspective-split fixture. |
+| Business | Evaluated on explicit wide and declared long net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide and declared long net-benefit rows; no perspective-split fixture. |
 
 This matrix is a fixture-support boundary, not a statement that the omitted
 methods or shapes are unsupported by `voiage` generally. It prevents these

--- a/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
+++ b/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
@@ -1,6 +1,6 @@
 ---
 title: Standardized Ingestion Reference Cases
-description: Deterministic ML, engineering, and business EVPI examples using one explicit VOI binding.
+description: Deterministic ML, engineering, and business examples with bounded EVPI and CEAF evidence.
 ---
 
 These deterministic, in-repository synthetic examples demonstrate format
@@ -12,7 +12,7 @@ or a real-world decision recommendation.
 | Community | Croissant | Frictionless | Direct normalized input | Explicit method |
 | --- | --- | --- | --- | --- |
 | Machine learning | `canonical-decision.croissant.json` | `canonical-decision.datapackage.json` | Explicit Arrow table and binding | EVPI on model-selection net benefits. |
-| Engineering and operations | `cost-outcome-decision.croissant.json` | `cost-outcome-decision.datapackage.json` | Explicit Arrow table and bindings | EVPI on cost/outcome net benefits at a declared WTP. |
+| Engineering and operations | `cost-outcome-decision.croissant.json` | `cost-outcome-decision.datapackage.json` | Explicit Arrow table and bindings | EVPI at a declared WTP; CEAF over paired cost/outcome PSA rows at declared thresholds. |
 | Business | `canonical-decision.croissant.json` | `canonical-decision.datapackage.json` | Explicit Arrow table and binding | EVPI on investment-strategy net benefits. |
 
 The fixture records two strategies, `strategy_a` and `strategy_b`, and binds
@@ -76,6 +76,42 @@ recorded in `cost-outcome-decision.manifest.json` beside the fixture files.
 The scripts deliberately report a fixture as deterministic synthetic data,
 rather than presenting a substitute for a rights clearance or live provider
 receipt.
+
+### CEAF equivalence
+
+The engineering fixture also supplies paired cost and outcome PSA rows for the
+same two strategies. It can therefore be converted to net benefit at the fixed
+WTP thresholds 10,000, 20,000, and 30,000 and passed to the existing CEAF
+method. This is intentionally narrower than an EVSI, EVPPI, or ENBS claim:
+those methods need conditional-model or study-design inputs that these fixtures
+do not supply.
+
+```python
+from examples.standardized_ingestion.reference_cases import (
+    run_cost_outcome_ceaf_reference_cases,
+)
+
+ceaf = run_cost_outcome_ceaf_reference_cases()
+assert ceaf["croissant"] == ceaf["frictionless"] == ceaf["direct"]
+assert ceaf["croissant"]["optimal_strategy_names"] == ("B", "B", "B")
+```
+
+The returned records also include the normalized net-benefit samples at WTP
+20,000. Equality across Croissant, Frictionless, direct Arrow, and the optional
+DataFrame surface is checked before the example returns.
+
+## Method applicability matrix
+
+| Community | EVPI | CEAF | EVPPI / EVSI / ENBS | Shape coverage |
+| --- | --- | --- | --- | --- |
+| Machine learning | Evaluated on explicit wide net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide only; no long, cost/outcome, or perspective-split fixture. |
+| Engineering and operations | Evaluated at WTP 20,000. | Evaluated on paired cost/outcome PSA rows at WTP 10,000, 20,000, and 30,000. | Not applicable: no conditional or study-design inputs. | Cost/outcome wide rows; no long or perspective-split fixture. |
+| Business | Evaluated on explicit wide net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide only; no long, cost/outcome, or perspective-split fixture. |
+
+This matrix is a fixture-support boundary, not a statement that the omitted
+methods or shapes are unsupported by `voiage` generally. It prevents these
+small deterministic examples from being presented as evidence for inputs they
+do not contain.
 
 The input descriptors and their SHA-256 digests live in
 [`tests/fixtures/standardized_ingestion/`](https://github.com/edithatogo/voiage/tree/main/tests/fixtures/standardized_ingestion).

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -247,7 +247,12 @@ every DataFrame library or unsupported nested dtype.
 
 Each example must declare its binding rather than relying on a domain-specific
 calculation path, so their resulting net-benefit matrices are directly
-comparable with the existing VOI APIs.
+comparable with the existing VOI APIs. The [reference-case method
+matrix](/examples/standardized-ingestion-reference-cases/#method-applicability-matrix)
+records the narrower evidence boundary: CEAF is demonstrated only for the
+paired engineering cost/outcome fixture, while the ML and business fixtures
+demonstrate EVPI only. It does not infer long-form or perspective-split inputs,
+or use these examples as evidence for EVPPI, EVSI, or ENBS.
 
 ## Third-party providers
 

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -251,8 +251,10 @@ comparable with the existing VOI APIs. The [reference-case method
 matrix](/examples/standardized-ingestion-reference-cases/#method-applicability-matrix)
 records the narrower evidence boundary: CEAF is demonstrated only for the
 paired engineering cost/outcome fixture, while the ML and business fixtures
-demonstrate EVPI only. It does not infer long-form or perspective-split inputs,
-or use these examples as evidence for EVPPI, EVSI, or ENBS.
+demonstrate EVPI only. A separate fixture covers explicitly declared long-form
+net-benefit rows, but the providers do not infer a long layout or
+perspective-split inputs, or use these examples as evidence for EVPPI, EVSI,
+or ENBS.
 
 ## Third-party providers
 

--- a/examples/standardized_ingestion/reference_cases.py
+++ b/examples/standardized_ingestion/reference_cases.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
+import numpy as np
 import pyarrow as pa
 
 from voiage.contracts import (
@@ -19,6 +20,8 @@ from voiage.contracts import (
 )
 from voiage.ingestion import SourceAccessPolicy, default_registry, from_dataframe
 from voiage.methods.basic import evpi
+from voiage.methods.ceaf import calculate_ceaf
+from voiage.schema import ValueArray
 
 _ROOT = Path(__file__).parents[2]
 _FIXTURES = _ROOT / "tests" / "fixtures" / "standardized_ingestion"
@@ -264,6 +267,93 @@ def run_cost_outcome_reference_cases() -> dict[str, dict[str, float]]:
     if len(set(values.values())) != 1:
         raise RuntimeError("cost/outcome cases must have cross-surface EVPI parity")
     return _repeat_for_domains(values)
+
+
+def run_cost_outcome_ceaf_reference_cases() -> dict[str, dict[str, object]]:
+    """Calculate CEAF only where the deterministic fixture supplies its inputs.
+
+    The engineering cost/outcome rows provide paired PSA samples for two
+    strategies.  Reconstructing net benefit at declared WTP thresholds creates
+    the required samples-by-strategies-by-thresholds surface without inventing
+    a conditional model, sample-information study, or perspective split.
+    """
+    thresholds = np.asarray([10_000.0, 20_000.0, 30_000.0])
+    policy = SourceAccessPolicy(_FIXTURES)
+    results: dict[str, dict[str, object]] = {}
+    for surface, bundle in _cost_outcome_surfaces(
+        policy, _cost_outcome_bindings()
+    ).items():
+        table = bundle.table("samples")
+        costs = np.column_stack(
+            [table[name].to_numpy() for name in ("cost_a", "cost_b")]
+        )
+        outcomes = np.column_stack(
+            [table[name].to_numpy() for name in ("outcome_a", "outcome_b")]
+        )
+        net_benefits = (
+            outcomes[:, :, None] * thresholds[None, None, :] - costs[:, :, None]
+        )
+        result = calculate_ceaf(
+            ValueArray.from_numpy_perspectives(
+                net_benefits,
+                strategy_names=["A", "B"],
+                perspective_names=[str(int(value)) for value in thresholds],
+            ),
+            thresholds,
+        )
+        results[surface] = {
+            "optimal_strategy_names": tuple(result.optimal_strategy_names),
+            "acceptability_probabilities": tuple(
+                float(value) for value in result.acceptability_probabilities
+            ),
+            "expected_net_benefit": tuple(
+                float(value) for value in result.expected_net_benefit
+            ),
+            "normalized_net_benefit_at_20000": tuple(
+                tuple(float(value) for value in row)
+                for row in prepare_analysis_inputs(
+                    bundle, willingness_to_pay=20_000.0
+                ).net_benefits.numpy_values
+            ),
+        }
+    if len({repr(value) for value in results.values()}) != 1:
+        raise RuntimeError("cost/outcome CEAF must have cross-surface parity")
+    return results
+
+
+def method_applicability_matrix() -> dict[str, dict[str, str]]:
+    """State only methods supported by the current deterministic fixtures."""
+    unavailable = (
+        "not applicable: fixture lacks the required conditional or study-design inputs"
+    )
+    return {
+        "ml": {
+            "EVPI": "evaluated: explicit wide net-benefit samples",
+            "CEAF": "not applicable: fixture lacks cost/outcome WTP thresholds",
+            "EVPPI/EVSI/ENBS": unavailable,
+            "wide/long/cost-outcome/perspective": (
+                "wide only; no long, cost/outcome, or perspective split fixture"
+            ),
+        },
+        "engineering": {
+            "EVPI": "evaluated: explicit cost/outcome net benefits at WTP 20,000",
+            "CEAF": (
+                "evaluated: paired cost/outcome PSA rows at WTP 10,000/20,000/30,000"
+            ),
+            "EVPPI/EVSI/ENBS": unavailable,
+            "wide/long/cost-outcome/perspective": (
+                "cost/outcome wide rows; no long or perspective split fixture"
+            ),
+        },
+        "business": {
+            "EVPI": "evaluated: explicit wide net-benefit samples",
+            "CEAF": "not applicable: fixture lacks cost/outcome WTP thresholds",
+            "EVPPI/EVSI/ENBS": unavailable,
+            "wide/long/cost-outcome/perspective": (
+                "wide only; no long, cost/outcome, or perspective split fixture"
+            ),
+        },
+    }
 
 
 def run_cross_format_reference_cases() -> dict[str, dict[str, object]]:

--- a/examples/standardized_ingestion/reference_cases.py
+++ b/examples/standardized_ingestion/reference_cases.py
@@ -46,10 +46,58 @@ def _binding() -> VOIBinding:
     )
 
 
+def _long_binding() -> VOIBinding:
+    """Bind the deterministic long-form fixture without inferring its columns."""
+    return VOIBinding(
+        role="net_benefit",
+        table_id="samples",
+        field_ids=("net_benefit",),
+        strategy_names=("A", "B"),
+        layout="long",
+        sample_id_field_id="sample_id",
+        strategy_field_id="strategy",
+        value_field_id="net_benefit",
+    )
+
+
 def _bound(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
     return NormalizedInputBundle(
         manifest=bundle.manifest.model_copy(update={"bindings": (_binding(),)}),
         tables=bundle.tables,
+    )
+
+
+def _direct_long() -> NormalizedInputBundle:
+    """Build the long-form decision table without an external descriptor."""
+    table = pa.table(
+        {
+            "sample_id": [1, 1, 2, 2, 3, 3],
+            "strategy": ["A", "B", "A", "B", "A", "B"],
+            "net_benefit": [10.0, 20.0, 30.0, 10.0, 20.0, 25.0],
+        }
+    )
+    return NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="long-decision-fixture",
+            tables=(
+                TableManifest(
+                    table_id="samples",
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-reference-case",
+                source_uri="urn:voiage:reference-case:direct-long",
+                descriptor_digest=_artifact("long-decision")["normalized"][
+                    "resource_sha256"
+                ],
+            ),
+            bindings=(_long_binding(),),
+        ),
+        tables={"samples": table},
     )
 
 
@@ -190,6 +238,34 @@ def _net_benefit_surfaces(
     }
 
 
+def _long_net_benefit_surfaces(
+    policy: SourceAccessPolicy,
+) -> dict[str, NormalizedInputBundle]:
+    """Materialize the same net-benefit decision through explicit long rows."""
+
+    def with_binding(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
+        return NormalizedInputBundle(
+            manifest=bundle.manifest.model_copy(
+                update={"bindings": (_long_binding(),)}
+            ),
+            tables=bundle.tables,
+        )
+
+    return {
+        "croissant": with_binding(
+            default_registry().ingest(
+                _FIXTURES / "long-decision.croissant.json", policy=policy
+            )
+        ),
+        "frictionless": with_binding(
+            default_registry().ingest(
+                _FIXTURES / "long-decision.datapackage.json", policy=policy
+            )
+        ),
+        "direct": _direct_long(),
+    }
+
+
 def _cost_outcome_surfaces(
     policy: SourceAccessPolicy, bindings: tuple[VOIBinding, VOIBinding]
 ) -> dict[str, NormalizedInputBundle]:
@@ -267,6 +343,39 @@ def run_cost_outcome_reference_cases() -> dict[str, dict[str, float]]:
     if len(set(values.values())) != 1:
         raise RuntimeError("cost/outcome cases must have cross-surface EVPI parity")
     return _repeat_for_domains(values)
+
+
+def run_long_reference_cases() -> dict[str, object]:
+    """Prove that declared long rows normalize to the canonical wide decision."""
+    policy = SourceAccessPolicy(_FIXTURES)
+    wide = _net_benefit_surfaces(policy)
+    long = _long_net_benefit_surfaces(policy)
+    wide_values = {
+        surface: tuple(
+            tuple(float(value) for value in row)
+            for row in prepare_analysis_inputs(bundle).net_benefits.numpy_values
+        )
+        for surface, bundle in wide.items()
+        if surface != "dataframe"
+    }
+    long_values = {
+        surface: tuple(
+            tuple(float(value) for value in row)
+            for row in prepare_analysis_inputs(bundle).net_benefits.numpy_values
+        )
+        for surface, bundle in long.items()
+    }
+    if len(set(long_values.values())) != 1 or set(wide_values.values()) != set(
+        long_values.values()
+    ):
+        raise RuntimeError("long and wide reference cases must normalize identically")
+    values = {
+        surface: float(evpi(prepare_analysis_inputs(bundle).net_benefits))
+        for surface, bundle in long.items()
+    }
+    if len(set(values.values())) != 1:
+        raise RuntimeError("long reference cases must have cross-surface EVPI parity")
+    return {"normalized_net_benefit": long_values, "evpi": values}
 
 
 def run_cost_outcome_ceaf_reference_cases() -> dict[str, dict[str, object]]:

--- a/tests/fixtures/standardized_ingestion/long-decision.croissant.json
+++ b/tests/fixtures/standardized_ingestion/long-decision.croissant.json
@@ -1,0 +1,19 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "distribution": [
+    {
+      "contentUrl": "long-decision.csv"
+    }
+  ],
+  "name": "long-decision-fixture",
+  "recordSet": [
+    {
+      "field": [
+        {"name": "sample_id"},
+        {"name": "strategy"},
+        {"name": "net_benefit"}
+      ],
+      "name": "samples"
+    }
+  ]
+}

--- a/tests/fixtures/standardized_ingestion/long-decision.csv
+++ b/tests/fixtures/standardized_ingestion/long-decision.csv
@@ -1,0 +1,7 @@
+sample_id,strategy,net_benefit
+1,A,10.0
+1,B,20.0
+2,A,30.0
+2,B,10.0
+3,A,20.0
+3,B,25.0

--- a/tests/fixtures/standardized_ingestion/long-decision.datapackage.json
+++ b/tests/fixtures/standardized_ingestion/long-decision.datapackage.json
@@ -1,0 +1,16 @@
+{
+  "name": "long-decision-fixture",
+  "resources": [
+    {
+      "name": "samples",
+      "path": "long-decision.csv",
+      "schema": {
+        "fields": [
+          {"name": "sample_id", "type": "integer"},
+          {"name": "strategy", "type": "string"},
+          {"name": "net_benefit", "type": "number"}
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/standardized_ingestion/long-decision.manifest.json
+++ b/tests/fixtures/standardized_ingestion/long-decision.manifest.json
@@ -1,0 +1,34 @@
+{
+  "binding": {
+    "field_ids": [
+      "net_benefit"
+    ],
+    "layout": "long",
+    "role": "net_benefit",
+    "sample_id_field_id": "sample_id",
+    "strategy_field_id": "strategy",
+    "strategy_names": [
+      "A",
+      "B"
+    ],
+    "table_id": "samples",
+    "value_field_id": "net_benefit"
+  },
+  "dataset_id": "long-decision-fixture",
+  "files": {
+    "long-decision.croissant.json": "eb3488789d950c1683defabe07eb9d68c5089ca2bce92f0d9a79f62546c86e09",
+    "long-decision.csv": "747a807344c26e9c36db56b2bfcb1d7291ddeb9b48710c3f1c460d5fc09d0527",
+    "long-decision.datapackage.json": "e1302f35f345c38d7c76c4515c663e0fd86ceeef5d1fb4e780b065503383d4f6"
+  },
+  "governance": {
+    "rights_status": "in-repository deterministic fixture; no external claim",
+    "synthetic": true,
+    "third_party_data": false
+  },
+  "normalized": {
+    "content_digest": "1eb9988c2795fbd12d993c2abcabf62f6b0f7bd61fe0ae06bb6aac82073e2d9f",
+    "resource_sha256": "747a807344c26e9c36db56b2bfcb1d7291ddeb9b48710c3f1c460d5fc09d0527",
+    "schema_fingerprint": "7936e848fb91f0689018ec83b1a58647f7ed797415596e1b7ce469b25115fc32"
+  },
+  "schema_version": "1.0.0"
+}

--- a/tests/test_standardized_ingestion_fixture_validator.py
+++ b/tests/test_standardized_ingestion_fixture_validator.py
@@ -17,6 +17,7 @@ def test_checked_in_fixture_corpus_has_current_digests() -> None:
     assert [path.name for path in manifests] == [
         "canonical-decision.manifest.json",
         "cost-outcome-decision.manifest.json",
+        "long-decision.manifest.json",
     ]
     assert validator.main([str(FIXTURE_ROOT)]) == 0
 

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -76,6 +76,36 @@ def test_cost_outcome_reference_cases_are_equivalent_across_input_surfaces() -> 
     }
 
 
+def test_long_reference_cases_normalize_identically_to_wide_inputs() -> None:
+    """Long rows use the same prepared ValueArray as the explicit wide case."""
+    path = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "standardized_ingestion"
+        / "reference_cases.py"
+    )
+    spec = importlib.util.spec_from_file_location("reference_cases", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = module.run_long_reference_cases()
+
+    assert set(result["normalized_net_benefit"]) == {
+        "croissant",
+        "frictionless",
+        "direct",
+    }
+    assert (
+        len({repr(value) for value in result["normalized_net_benefit"].values()}) == 1
+    )
+    assert result["evpi"] == {
+        surface: pytest.approx(5.0)
+        for surface in ("croissant", "frictionless", "direct")
+    }
+
+
 def test_cost_outcome_ceaf_is_equivalent_across_input_surfaces() -> None:
     """CEAF is evidence only for the paired engineering cost/outcome fixture."""
     path = (

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -76,6 +76,55 @@ def test_cost_outcome_reference_cases_are_equivalent_across_input_surfaces() -> 
     }
 
 
+def test_cost_outcome_ceaf_is_equivalent_across_input_surfaces() -> None:
+    """CEAF is evidence only for the paired engineering cost/outcome fixture."""
+    path = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "standardized_ingestion"
+        / "reference_cases.py"
+    )
+    spec = importlib.util.spec_from_file_location("reference_cases", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = module.run_cost_outcome_ceaf_reference_cases()
+
+    assert set(result) == {"croissant", "frictionless", "direct", "dataframe"}
+    assert len({repr(value) for value in result.values()}) == 1
+    assert result["croissant"]["optimal_strategy_names"] == ("B", "B", "B")
+    assert result["croissant"]["acceptability_probabilities"] == pytest.approx(
+        (2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0)
+    )
+
+
+def test_method_applicability_matrix_does_not_overclaim_fixture_support() -> None:
+    path = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "standardized_ingestion"
+        / "reference_cases.py"
+    )
+    spec = importlib.util.spec_from_file_location("reference_cases", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    matrix = module.method_applicability_matrix()
+
+    assert set(matrix) == {"ml", "engineering", "business"}
+    assert matrix["engineering"]["CEAF"].startswith("evaluated:")
+    for domain in ("ml", "business"):
+        assert matrix[domain]["CEAF"].startswith("not applicable:")
+    for row in matrix.values():
+        assert row["EVPPI/EVSI/ENBS"].startswith("not applicable:")
+        assert "no long" in row["wide/long/cost-outcome/perspective"]
+        assert "perspective split" in row["wide/long/cost-outcome/perspective"]
+
+
 def test_each_domain_reference_case_has_all_supported_input_surfaces() -> None:
     """Each documented community can reproduce its case through every surface."""
     path = (

--- a/todo.md
+++ b/todo.md
@@ -116,7 +116,10 @@ This document lists the actionable tasks for `voiage` development. Agents should
     *   The reference-case matrix now records the fixture-specific EVPI/CEAF
         applicability boundary and proves CEAF plus normalized net-benefit
         parity only for the paired engineering cost/outcome inputs; it does not
-        claim EVSI, EVPPI, ENBS, long-form, or perspective-split coverage.
+        claim EVSI, EVPPI, ENBS, or perspective-split coverage.
+    *   A separate explicit long net-benefit fixture now proves Croissant,
+        Frictionless, and direct Arrow normalization parity; it does not claim
+        that arbitrary long records have inferred decision semantics.
     *   The README now links the conservative Croissant/Frictionless ingestion
         surface to its profile matrix, offline policy, and cross-domain examples.
     *   Verified offline-cache entries now reject symlinks and hard links so a

--- a/todo.md
+++ b/todo.md
@@ -113,6 +113,10 @@ This document lists the actionable tasks for `voiage` development. Agents should
     *   ML and engineering reference descriptors now have executable CLI
         validation and inspection walkthroughs alongside the direct business
         DataFrame example.
+    *   The reference-case matrix now records the fixture-specific EVPI/CEAF
+        applicability boundary and proves CEAF plus normalized net-benefit
+        parity only for the paired engineering cost/outcome inputs; it does not
+        claim EVSI, EVPPI, ENBS, long-form, or perspective-split coverage.
     *   The README now links the conservative Croissant/Frictionless ingestion
         surface to its profile matrix, offline policy, and cross-domain examples.
     *   Verified offline-cache entries now reject symlinks and hard links so a


### PR DESCRIPTION
Summary: add executable CEAF and normalized net-benefit parity evidence for the paired engineering cost/outcome fixture across Croissant, Frictionless, direct Arrow, and DataFrame inputs. Publish a truthful per-community method and shape applicability matrix. Update P9 Conductor evidence, docs, changelog, and todo without claiming EVSI, EVPPI, ENBS, long-form, or perspective-split support.\n\nValidation: focused reference-case pytest; tox ingestion-conformance and docs; ty check of the example; Vale; Conductor full validation; GitHub cross-reference validation; whitespace check.\n\nRefs #468