### PR TITLE
test(ingestion): add declared long-layout reference case

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a declared long net-benefit fixture with Croissant, Frictionless, and
+  direct Arrow normalization and EVPI equivalence evidence; preserve explicit
+  sample, strategy, and value bindings rather than inferring long-table roles.
+
 - Add a deterministic cross-domain method-applicability matrix and CEAF
   equivalence evidence for the engineering cost/outcome reference fixture;
   explicitly bound the ML and business fixtures to the methods and data shapes

--- a/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
+++ b/conductor/tracks/standardized-dataset-ingestion_20260723/plan.md
@@ -329,7 +329,9 @@ and a Conductor checkpoint under `conductor/workflow.md`.
   runner now fails if any supported representation differs in EVPI. The
   engineering cost/outcome fixture additionally proves normalized net-benefit
   and CEAF equivalence across Croissant, Frictionless, direct Arrow, and
-  DataFrame inputs at declared WTP values; EVSI, EVPPI, ENBS, long-form, and
+  DataFrame inputs at declared WTP values. A separate explicitly bound long
+  net-benefit fixture now proves equivalent Croissant, Frictionless, and direct
+  Arrow normalization without semantic inference; EVSI, EVPPI, ENBS, and
   perspective-split claims remain explicitly out of scope for these fixtures
   (partial; broader hosted evidence remains required).
 - [~] **P9-T5 / AC-13:** Publish the support matrix and run fixture

--- a/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
+++ b/docs/astro-site/src/content/docs/examples/standardized-ingestion-reference-cases.mdx
@@ -77,6 +77,26 @@ The scripts deliberately report a fixture as deterministic synthetic data,
 rather than presenting a substitute for a rights clearance or live provider
 receipt.
 
+## Long-layout equivalence
+
+`long-decision` records the same deterministic two-strategy samples as the
+canonical wide fixture, but declares a sample identifier, strategy label, and
+one net-benefit value per row. Its long binding explicitly names all three
+fields and fixes the strategy order; no column or label is inferred. The
+Croissant, Frictionless, and direct Arrow representations must each normalize
+to the same `ValueArray` as the wide fixture before EVPI is calculated.
+
+```python
+from examples.standardized_ingestion.reference_cases import run_long_reference_cases
+
+long_case = run_long_reference_cases()
+normalized = long_case["normalized_net_benefit"]
+assert normalized["croissant"] == normalized["frictionless"] == normalized["direct"]
+```
+
+This evidence covers declared long net-benefit rows only. It does not turn an
+arbitrary long table into a cost/outcome or perspective-specific dataset.
+
 ### CEAF equivalence
 
 The engineering fixture also supplies paired cost and outcome PSA rows for the
@@ -104,9 +124,9 @@ DataFrame surface is checked before the example returns.
 
 | Community | EVPI | CEAF | EVPPI / EVSI / ENBS | Shape coverage |
 | --- | --- | --- | --- | --- |
-| Machine learning | Evaluated on explicit wide net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide only; no long, cost/outcome, or perspective-split fixture. |
-| Engineering and operations | Evaluated at WTP 20,000. | Evaluated on paired cost/outcome PSA rows at WTP 10,000, 20,000, and 30,000. | Not applicable: no conditional or study-design inputs. | Cost/outcome wide rows; no long or perspective-split fixture. |
-| Business | Evaluated on explicit wide net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide only; no long, cost/outcome, or perspective-split fixture. |
+| Machine learning | Evaluated on explicit wide and declared long net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide and declared long net-benefit rows; no perspective-split fixture. |
+| Engineering and operations | Evaluated at WTP 20,000. | Evaluated on paired cost/outcome PSA rows at WTP 10,000, 20,000, and 30,000. | Not applicable: no conditional or study-design inputs. | Cost/outcome wide rows and declared long net-benefit rows; no perspective-split fixture. |
+| Business | Evaluated on explicit wide and declared long net-benefit samples. | Not applicable: no cost/outcome WTP surface. | Not applicable: no conditional or study-design inputs. | Wide and declared long net-benefit rows; no perspective-split fixture. |
 
 This matrix is a fixture-support boundary, not a statement that the omitted
 methods or shapes are unsupported by `voiage` generally. It prevents these

--- a/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
+++ b/docs/astro-site/src/content/docs/standardized-dataset-ingestion.mdx
@@ -238,8 +238,10 @@ comparable with the existing VOI APIs. The [reference-case method
 matrix](/examples/standardized-ingestion-reference-cases/#method-applicability-matrix)
 records the narrower evidence boundary: CEAF is demonstrated only for the
 paired engineering cost/outcome fixture, while the ML and business fixtures
-demonstrate EVPI only. It does not infer long-form or perspective-split inputs,
-or use these examples as evidence for EVPPI, EVSI, or ENBS.
+demonstrate EVPI only. A separate fixture covers explicitly declared long-form
+net-benefit rows, but the providers do not infer a long layout or
+perspective-split inputs, or use these examples as evidence for EVPPI, EVSI,
+or ENBS.
 
 ## Third-party providers
 

--- a/examples/standardized_ingestion/reference_cases.py
+++ b/examples/standardized_ingestion/reference_cases.py
@@ -46,10 +46,58 @@ def _binding() -> VOIBinding:
     )
 
 
+def _long_binding() -> VOIBinding:
+    """Bind the deterministic long-form fixture without inferring its columns."""
+    return VOIBinding(
+        role="net_benefit",
+        table_id="samples",
+        field_ids=("net_benefit",),
+        strategy_names=("A", "B"),
+        layout="long",
+        sample_id_field_id="sample_id",
+        strategy_field_id="strategy",
+        value_field_id="net_benefit",
+    )
+
+
 def _bound(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
     return NormalizedInputBundle(
         manifest=bundle.manifest.model_copy(update={"bindings": (_binding(),)}),
         tables=bundle.tables,
+    )
+
+
+def _direct_long() -> NormalizedInputBundle:
+    """Build the long-form decision table without an external descriptor."""
+    table = pa.table(
+        {
+            "sample_id": [1, 1, 2, 2, 3, 3],
+            "strategy": ["A", "B", "A", "B", "A", "B"],
+            "net_benefit": [10.0, 20.0, 30.0, 10.0, 20.0, 25.0],
+        }
+    )
+    return NormalizedInputBundle(
+        manifest=DatasetManifest(
+            dataset_id="long-decision-fixture",
+            tables=(
+                TableManifest(
+                    table_id="samples",
+                    fields=tuple(
+                        FieldManifest(field_id=field.name, dtype=str(field.type))
+                        for field in table.schema
+                    ),
+                ),
+            ),
+            provenance=SourceProvenance(
+                provider_id="direct-reference-case",
+                source_uri="urn:voiage:reference-case:direct-long",
+                descriptor_digest=_artifact("long-decision")["normalized"][
+                    "resource_sha256"
+                ],
+            ),
+            bindings=(_long_binding(),),
+        ),
+        tables={"samples": table},
     )
 
 
@@ -190,6 +238,34 @@ def _net_benefit_surfaces(
     }
 
 
+def _long_net_benefit_surfaces(
+    policy: SourceAccessPolicy,
+) -> dict[str, NormalizedInputBundle]:
+    """Materialize the same net-benefit decision through explicit long rows."""
+
+    def with_binding(bundle: NormalizedInputBundle) -> NormalizedInputBundle:
+        return NormalizedInputBundle(
+            manifest=bundle.manifest.model_copy(
+                update={"bindings": (_long_binding(),)}
+            ),
+            tables=bundle.tables,
+        )
+
+    return {
+        "croissant": with_binding(
+            default_registry().ingest(
+                _FIXTURES / "long-decision.croissant.json", policy=policy
+            )
+        ),
+        "frictionless": with_binding(
+            default_registry().ingest(
+                _FIXTURES / "long-decision.datapackage.json", policy=policy
+            )
+        ),
+        "direct": _direct_long(),
+    }
+
+
 def _cost_outcome_surfaces(
     policy: SourceAccessPolicy, bindings: tuple[VOIBinding, VOIBinding]
 ) -> dict[str, NormalizedInputBundle]:
@@ -267,6 +343,39 @@ def run_cost_outcome_reference_cases() -> dict[str, dict[str, float]]:
     if len(set(values.values())) != 1:
         raise RuntimeError("cost/outcome cases must have cross-surface EVPI parity")
     return _repeat_for_domains(values)
+
+
+def run_long_reference_cases() -> dict[str, object]:
+    """Prove that declared long rows normalize to the canonical wide decision."""
+    policy = SourceAccessPolicy(_FIXTURES)
+    wide = _net_benefit_surfaces(policy)
+    long = _long_net_benefit_surfaces(policy)
+    wide_values = {
+        surface: tuple(
+            tuple(float(value) for value in row)
+            for row in prepare_analysis_inputs(bundle).net_benefits.numpy_values
+        )
+        for surface, bundle in wide.items()
+        if surface != "dataframe"
+    }
+    long_values = {
+        surface: tuple(
+            tuple(float(value) for value in row)
+            for row in prepare_analysis_inputs(bundle).net_benefits.numpy_values
+        )
+        for surface, bundle in long.items()
+    }
+    if len(set(long_values.values())) != 1 or set(wide_values.values()) != set(
+        long_values.values()
+    ):
+        raise RuntimeError("long and wide reference cases must normalize identically")
+    values = {
+        surface: float(evpi(prepare_analysis_inputs(bundle).net_benefits))
+        for surface, bundle in long.items()
+    }
+    if len(set(values.values())) != 1:
+        raise RuntimeError("long reference cases must have cross-surface EVPI parity")
+    return {"normalized_net_benefit": long_values, "evpi": values}
 
 
 def run_cost_outcome_ceaf_reference_cases() -> dict[str, dict[str, object]]:

--- a/tests/fixtures/standardized_ingestion/long-decision.croissant.json
+++ b/tests/fixtures/standardized_ingestion/long-decision.croissant.json
@@ -1,0 +1,19 @@
+{
+  "@context": "https://mlcommons.org/croissant/1.1",
+  "distribution": [
+    {
+      "contentUrl": "long-decision.csv"
+    }
+  ],
+  "name": "long-decision-fixture",
+  "recordSet": [
+    {
+      "field": [
+        {"name": "sample_id"},
+        {"name": "strategy"},
+        {"name": "net_benefit"}
+      ],
+      "name": "samples"
+    }
+  ]
+}

--- a/tests/fixtures/standardized_ingestion/long-decision.csv
+++ b/tests/fixtures/standardized_ingestion/long-decision.csv
@@ -1,0 +1,7 @@
+sample_id,strategy,net_benefit
+1,A,10.0
+1,B,20.0
+2,A,30.0
+2,B,10.0
+3,A,20.0
+3,B,25.0

--- a/tests/fixtures/standardized_ingestion/long-decision.datapackage.json
+++ b/tests/fixtures/standardized_ingestion/long-decision.datapackage.json
@@ -1,0 +1,16 @@
+{
+  "name": "long-decision-fixture",
+  "resources": [
+    {
+      "name": "samples",
+      "path": "long-decision.csv",
+      "schema": {
+        "fields": [
+          {"name": "sample_id", "type": "integer"},
+          {"name": "strategy", "type": "string"},
+          {"name": "net_benefit", "type": "number"}
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/standardized_ingestion/long-decision.manifest.json
+++ b/tests/fixtures/standardized_ingestion/long-decision.manifest.json
@@ -1,0 +1,34 @@
+{
+  "binding": {
+    "field_ids": [
+      "net_benefit"
+    ],
+    "layout": "long",
+    "role": "net_benefit",
+    "sample_id_field_id": "sample_id",
+    "strategy_field_id": "strategy",
+    "strategy_names": [
+      "A",
+      "B"
+    ],
+    "table_id": "samples",
+    "value_field_id": "net_benefit"
+  },
+  "dataset_id": "long-decision-fixture",
+  "files": {
+    "long-decision.croissant.json": "eb3488789d950c1683defabe07eb9d68c5089ca2bce92f0d9a79f62546c86e09",
+    "long-decision.csv": "747a807344c26e9c36db56b2bfcb1d7291ddeb9b48710c3f1c460d5fc09d0527",
+    "long-decision.datapackage.json": "e1302f35f345c38d7c76c4515c663e0fd86ceeef5d1fb4e780b065503383d4f6"
+  },
+  "governance": {
+    "rights_status": "in-repository deterministic fixture; no external claim",
+    "synthetic": true,
+    "third_party_data": false
+  },
+  "normalized": {
+    "content_digest": "1eb9988c2795fbd12d993c2abcabf62f6b0f7bd61fe0ae06bb6aac82073e2d9f",
+    "resource_sha256": "747a807344c26e9c36db56b2bfcb1d7291ddeb9b48710c3f1c460d5fc09d0527",
+    "schema_fingerprint": "7936e848fb91f0689018ec83b1a58647f7ed797415596e1b7ce469b25115fc32"
+  },
+  "schema_version": "1.0.0"
+}

--- a/tests/test_standardized_ingestion_fixture_validator.py
+++ b/tests/test_standardized_ingestion_fixture_validator.py
@@ -17,6 +17,7 @@ def test_checked_in_fixture_corpus_has_current_digests() -> None:
     assert [path.name for path in manifests] == [
         "canonical-decision.manifest.json",
         "cost-outcome-decision.manifest.json",
+        "long-decision.manifest.json",
     ]
     assert validator.main([str(FIXTURE_ROOT)]) == 0
 

--- a/tests/test_standardized_ingestion_reference_cases.py
+++ b/tests/test_standardized_ingestion_reference_cases.py
@@ -76,6 +76,36 @@ def test_cost_outcome_reference_cases_are_equivalent_across_input_surfaces() -> 
     }
 
 
+def test_long_reference_cases_normalize_identically_to_wide_inputs() -> None:
+    """Long rows use the same prepared ValueArray as the explicit wide case."""
+    path = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "standardized_ingestion"
+        / "reference_cases.py"
+    )
+    spec = importlib.util.spec_from_file_location("reference_cases", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = module.run_long_reference_cases()
+
+    assert set(result["normalized_net_benefit"]) == {
+        "croissant",
+        "frictionless",
+        "direct",
+    }
+    assert (
+        len({repr(value) for value in result["normalized_net_benefit"].values()}) == 1
+    )
+    assert result["evpi"] == {
+        surface: pytest.approx(5.0)
+        for surface in ("croissant", "frictionless", "direct")
+    }
+
+
 def test_cost_outcome_ceaf_is_equivalent_across_input_surfaces() -> None:
     """CEAF is evidence only for the paired engineering cost/outcome fixture."""
     path = (

--- a/todo.md
+++ b/todo.md
@@ -83,7 +83,10 @@ This document lists the actionable tasks for `voiage` development. Agents should
     *   The reference-case matrix now records the fixture-specific EVPI/CEAF
         applicability boundary and proves CEAF plus normalized net-benefit
         parity only for the paired engineering cost/outcome inputs; it does not
-        claim EVSI, EVPPI, ENBS, long-form, or perspective-split coverage.
+        claim EVSI, EVPPI, ENBS, or perspective-split coverage.
+    *   A separate explicit long net-benefit fixture now proves Croissant,
+        Frictionless, and direct Arrow normalization parity; it does not claim
+        that arbitrary long records have inferred decision semantics.
     *   The README now links the conservative Croissant/Frictionless ingestion
         surface to its profile matrix, offline policy, and cross-domain examples.
     *   Verified offline-cache entries now reject symlinks and hard links so a


### PR DESCRIPTION
Summary: add a deterministic long net-benefit fixture represented through Croissant, Frictionless, and direct Arrow. The explicit binding fixes sample, strategy, value, and strategy order; the runner proves normalized ValueArray and EVPI parity with the existing wide fixture. Documentation and P9 evidence limit the claim to declared long rows and exclude inferred semantics, perspective splits, EVPPI, EVSI, and ENBS.\n\nValidation: focused ingestion conformance tests (24 passed); fixture validator; ty; Vale; Conductor full and GitHub cross-reference validation; manual Astro check and build using an isolated pnpm store. The tox docs wrapper encountered a local pnpm SQLite store I/O error, while its link validator and the isolated equivalent passed.\n\nDepends on #718. Refs #468.