### PR TITLE
release: prepare stable v2.0.1 maintenance line

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,9 +2,9 @@ name: Benchmark Tracking
 
 on:
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
 
 permissions:
   contents: read

--- a/.github/workflows/bindings-ci.yml
+++ b/.github/workflows/bindings-ci.yml
@@ -4,7 +4,7 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
     paths:
       - "bindings/julia/**"
       - "r-package/**"
@@ -14,7 +14,7 @@ on:
       - "specs/core-api/fixtures/**"
       - "specs/numerical-reference/**"
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
     paths:
       - "bindings/julia/**"
       - "r-package/**"

--- a/.github/workflows/c15-cross-platform.yml
+++ b/.github/workflows/c15-cross-platform.yml
@@ -2,9 +2,9 @@ name: C15 Cross-platform Assurance
 
 on:
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Security Analysis"
 
 on:
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/dependency-frontier.yml
+++ b/.github/workflows/dependency-frontier.yml
@@ -2,9 +2,9 @@ name: Dependency Assurance
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   workflow_dispatch:
   schedule:
     - cron: '17 5 * * 1'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/operational-assurance.yml
+++ b/.github/workflows/operational-assurance.yml
@@ -2,9 +2,9 @@ name: Operational Assurance
 
 on:
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/python-rust-bridge.yml
+++ b/.github/workflows/python-rust-bridge.yml
@@ -2,7 +2,7 @@ name: Python Rust Bridge CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
     paths:
       - ".github/workflows/python-rust-bridge.yml"
       - "build_backend.py"
@@ -16,7 +16,7 @@ on:
       - "tests/test_rust_workspace_contract.py"
       - "tests/packaging/**"
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
     paths:
       - ".github/workflows/python-rust-bridge.yml"
       - "build_backend.py"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -659,9 +659,18 @@ jobs:
             sleep 20
           done
           mkdir testpypi-dist
-          python -m pip download --no-deps --only-binary=:all: \
-            --index-url https://test.pypi.org/simple/ \
-            --dest testpypi-dist "voiage==$PYTHON_VERSION"
+          for attempt in 1 2 3 4 5 6; do
+            if python -m pip download --no-deps --only-binary=:all: \
+              --index-url https://test.pypi.org/simple/ \
+              --dest testpypi-dist "voiage==$PYTHON_VERSION"; then
+              break
+            fi
+            if [[ "$attempt" == "6" ]]; then
+              echo "TestPyPI Simple API did not expose the reviewed release" >&2
+              exit 1
+            fi
+            sleep 20
+          done
           reviewed="$(find reviewed-dist -maxdepth 1 -name '*manylinux*x86_64.whl' -print -quit)"
           downloaded="$(find testpypi-dist -maxdepth 1 -name '*.whl' -print -quit)"
           test -n "$reviewed"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,9 +2,9 @@ name: GitHub Actions Audit
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   schedule:
     - cron: "31 4 * * 1"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,10 @@ the required CI, security, coverage, documentation, and contract checks pass.
         ```
 
 5.  **Push and Open a Pull Request:**
-    *   Push your branch to your fork and open a pull request against the `main` branch of the original repository.
+    *   Push your branch to your fork and open a pull request against the
+        `main` branch of the original repository. Stable patch-release work
+        instead targets its protected maintenance branch (for example,
+        `2.0.x`) so later features on `main` cannot enter the patch release.
 
 For a more detailed walkthrough of the Conductor workflow, docs structure, and
 testing expectations, see the [How to contribute guide](https://edithatogo.github.io/voiage/developer-guide/how-to-contribute/).

--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
-version = "2.0.1-rc.4"
+version = "2.0.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/changelog.md
+++ b/changelog.md
@@ -105,6 +105,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added a bounded retry around the TestPyPI Simple API download so propagation
+  lag after the JSON API exposes a reviewed release does not create a false
+  negative in the supported-Python smoke matrix.
 - Prepared the `v2.0.1-rc.4` TestPyPI candidate with explicit ecosystem version
   projections, a deterministic aggregate root for dependency-only Python SBOM
   input, and a source-bound UUIDv5 CycloneDX serial number required by GitHub

--- a/changelog.md
+++ b/changelog.md
@@ -105,6 +105,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Prepared the stable `v2.0.1` patch from the exact reviewed RC4 maintenance
+  lineage, synchronized Rust, Python, R, and Julia release identities, and
+  extended the protected workflow matrix to `2.0.x` without importing later
+  features from `main`. R, Julia, and crates.io publication remain separate
+  ecosystem-specific tag flows.
 - Added a bounded retry around the TestPyPI Simple API download so propagation
   lag after the JSON API exposes a reviewed release does not create a false
   negative in the supported-Python smoke matrix.

--- a/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/quality-and-security.mdx
@@ -48,12 +48,14 @@ publishes the signed SLSA bundle as a `.intoto.jsonl` release asset so
 independent tools can discover provenance without privileged access to
 GitHub's attestation store.
 
-The protected `main` ruleset requires pull requests, resolved review threads,
-successful required checks, signed commits, and linear history. The required
-approval count is zero for the single-maintainer operating model; CODEOWNERS
-still routes review responsibility without creating an impossible independent
-approval gate. Hosted settings must be verified through the GitHub API because
-they are not represented by files in the checkout.
+The protected `main` and stable maintenance-branch ruleset requires pull
+requests, resolved review threads, successful required checks, signed commits,
+and linear history. Maintenance branches such as `2.0.x` receive the same
+required pull-request workflows and exact-commit post-merge assurance as
+`main`. The required approval count is zero for the single-maintainer operating
+model; CODEOWNERS still routes review responsibility without creating an
+impossible independent approval gate. Hosted settings must be verified through
+the GitHub API because they are not represented by files in the checkout.
 
 OpenSSF's aggregate Scorecard is interpreted check by check. Independent human
 review and multi-organisation contributor diversity are useful signals, but a

--- a/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/versioning-and-release-policy.mdx
@@ -47,6 +47,12 @@ Binding manifests are expected to match the canonical version exactly:
 - `rust/Cargo.toml`
 - `r-package/voiageR/DESCRIPTION`
 
+Stable patch releases are prepared from a protected maintenance branch cut
+from the reviewed release-candidate lineage. The patch pull request receives
+the same automated ruleset as `main`, while later features already merged to
+`main` remain reserved for the next minor release. The stable tag is created
+only from the exact maintenance merge commit after its post-merge checks pass.
+
 ## Release tags and package registries
 
 The repository keeps ecosystem-specific tag and registry conventions:
@@ -92,3 +98,7 @@ uv run python scripts/validate_version_sync.py
 4. Let the tag workflow build and attest a private draft
 5. Review exact artifact digests, then dispatch TestPyPI publication
 6. Permit PyPI and the public GitHub Release only after the TestPyPI smoke gate
+
+Synchronizing R, Julia, and Rust manifests in a Python release does not publish
+those ecosystems. Their distinct `r-v*`, `julia-v*`, and `rust-v*` tag flows
+remain separate, with their own registry and external-review gates.

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 2.0.0.9004
-Config/voiage/Release-Version: 2.0.1-rc.4
+Version: 2.0.1
+Config/voiage/Release-Version: 2.0.1
 Authors@R: person("Dylan", "Mordaunt",
     email = "voiage@users.noreply.github.com",
     role = c("aut", "cre"),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 NeedsCompilation: no
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
-SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.4 or compatible);
+SystemRequirements: voiage-ffi shared library (version 2.0.1 or compatible);
     Python (>= 3.12, optional, for EVPPI and EVSI through reticulate)
 Suggests:
     reticulate (>= 1.20),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "2.0.1-rc.4"
+version = "2.0.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "2.0.1-rc.4"
+version = "2.0.1"
 dependencies = [
  "proptest",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-ffi"
-version = "2.0.1-rc.4"
+version = "2.0.1"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "2.0.1-rc.4"
+version = "2.0.1"
 dependencies = [
  "proptest",
  "voiage-diagnostics",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-python"
-version = "2.0.1-rc.4"
+version = "2.0.1"
 dependencies = [
  "pyo3",
  "serde",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-serialization"
-version = "2.0.1-rc.4"
+version = "2.0.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-test-support"
-version = "2.0.1-rc.4"
+version = "2.0.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.1-rc.4"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/edithatogo/voiage"
 
 [workspace.dependencies]
-voiage-diagnostics = { version = "=2.0.1-rc.4", path = "crates/voiage-diagnostics" }
-voiage-domain = { version = "=2.0.1-rc.4", path = "crates/voiage-domain" }
-voiage-numerics = { version = "=2.0.1-rc.4", path = "crates/voiage-numerics" }
-voiage-serialization = { version = "=2.0.1-rc.4", path = "crates/voiage-serialization" }
+voiage-diagnostics = { version = "=2.0.1", path = "crates/voiage-diagnostics" }
+voiage-domain = { version = "=2.0.1", path = "crates/voiage-domain" }
+voiage-numerics = { version = "=2.0.1", path = "crates/voiage-numerics" }
+voiage-serialization = { version = "=2.0.1", path = "crates/voiage-serialization" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/tests/test_polyglot_cicd_contract.py
+++ b/tests/test_polyglot_cicd_contract.py
@@ -36,6 +36,39 @@ def test_required_pr_workflows_support_merge_queue() -> None:
         assert "merge_group:" in _text(name), name
 
 
+def test_protected_branches_receive_required_pr_workflows() -> None:
+    """Stable maintenance PRs must produce the same automated gate contexts."""
+    for name in (
+        "benchmark.yml",
+        "bindings-ci.yml",
+        "c15-cross-platform.yml",
+        "ci.yml",
+        "codeql.yml",
+        "dependency-frontier.yml",
+        "dependency-review.yml",
+        "operational-assurance.yml",
+        "python-rust-bridge.yml",
+        "zizmor.yml",
+    ):
+        assert "branches: [main, 2.0.x]" in _text(name), name
+
+
+def test_maintenance_merges_receive_exact_commit_assurance() -> None:
+    """Post-merge checks must run on the protected maintenance commit."""
+    for name in (
+        "benchmark.yml",
+        "bindings-ci.yml",
+        "c15-cross-platform.yml",
+        "ci.yml",
+        "codeql.yml",
+        "dependency-frontier.yml",
+        "operational-assurance.yml",
+        "python-rust-bridge.yml",
+        "zizmor.yml",
+    ):
+        assert _text(name).count("branches: [main, 2.0.x]") >= 2, name
+
+
 def test_release_uses_pep740_and_exact_testpypi_promotion() -> None:
     """TestPyPI is an attested multi-version promotion gate, not a token smoke."""
     release = _text("release.yml")

--- a/tests/test_python_release_workflow.py
+++ b/tests/test_python_release_workflow.py
@@ -435,9 +435,10 @@ def test_testpypi_smoke_is_bounded_and_blocks_pypi() -> None:
         "resolve-tag",
         "test-pypi-smoke",
     ]
-    assert "for attempt in 1 2 3 4 5 6" in rendered
+    assert rendered.count("for attempt in 1 2 3 4 5 6") >= 3
     assert "sleep 20" in rendered
     assert "https://test.pypi.org/simple/" in rendered
+    assert "TestPyPI Simple API did not expose the reviewed release" in rendered
     assert "--no-deps" in rendered
     assert "test.pypi.org/integrity/voiage/${PYTHON_VERSION}" in rendered
     assert "pypi-attestations==0.0.30" in rendered

--- a/todo.md
+++ b/todo.md
@@ -171,6 +171,13 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Prepare stable `v2.0.1` from the protected RC4 maintenance lineage.
+    *   Synchronize Cargo-derived Python, Rust, R, and Julia manifest versions
+        without creating binding- or crate-publication tags.
+    *   Run required pull-request and exact-commit post-merge assurance on the
+        protected `2.0.x` branch before creating the signed stable tag.
+    *   Keep later `main` features reserved for the next minor release.
+
 *   [x] Bound TestPyPI JSON-to-Simple API propagation lag.
     *   Retry the exact reviewed wheel download for the same bounded six
         attempts used by the TestPyPI JSON and installation gates.

--- a/todo.md
+++ b/todo.md
@@ -171,6 +171,12 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## Done
 
+*   [x] Bound TestPyPI JSON-to-Simple API propagation lag.
+    *   Retry the exact reviewed wheel download for the same bounded six
+        attempts used by the TestPyPI JSON and installation gates.
+    *   Preserve failure after the propagation window and all exact-hash,
+        provenance, and black-box smoke requirements.
+
 *   [x] Preserve strict TestPyPI attestation verification through its Integrity
     API.
     *   Retrieve each provenance object from TestPyPI and verify it against the


### PR DESCRIPTION
## Summary

- backport the bounded TestPyPI Simple API propagation retry from the reviewed RC4 follow-up
- promote the exact RC4 maintenance lineage to stable `2.0.1` across Cargo-derived Python, Rust, R, and Julia manifests
- extend required pull-request and post-merge workflow coverage to the protected `2.0.x` branch
- document that later `main` features remain reserved for the next minor release and that non-Python registries use separate tags

## Release boundary

This PR targets protected `2.0.x`, not `main`. It contains no later feature commits. It synchronizes polyglot manifests but does not publish R, Julia, or crates.io releases.

## Verification

- `uv run tox`: all environments passed; Python 3.12 and 3.13 each passed 2,503 tests, Python 3.14 and maximum dependencies each passed 2,504 tests, minimum dependencies passed 2,503 tests, and coverage was 91.85%
- `uv run python scripts/repo_harness.py`: 29 workflows, zero findings
- `cargo check --workspace --all-targets --all-features --locked --manifest-path rust/Cargo.toml`
- focused version, release, SBOM, CI/CD, and polyglot contract tests: 96 passed
- TestPyPI and PyPI `2.0.1` JSON endpoints both returned 404 before publication

After this PR is squash-merged, the exact maintenance merge commit must pass its post-merge workflows before the signed stable tag is created.
