### PR TITLE
conductor: reconcile closed ingestion epic

### DIFF
--- a/conductor/github-cross-references.json
+++ b/conductor/github-cross-references.json
@@ -3808,7 +3808,7 @@
       "issue": {
         "number": 325,
         "url": "https://github.com/edithatogo/voiage/issues/325",
-        "state": "open"
+        "state": "closed"
       },
       "parent_issue_url": null,
       "subissues": [


### PR DESCRIPTION
Reconciles the Conductor GitHub cross-reference manifest after closing #325 and implemented child issues #326-#333, #467, and #468. Successor gates #752/#753 remain open. Validators pass locally.