### PR TITLE
conductor: map frontier todo workstreams to phases

### DIFF
--- a/conductor/tracks/supported_frontier_method_completion_20260723/plan.md
+++ b/conductor/tracks/supported_frontier_method_completion_20260723/plan.md
@@ -1,5 +1,30 @@
 # Implementation Plan
 
+## Todo-to-issue-to-phase mapping
+
+The following mapping is the canonical traceability boundary for the
+experimental frontier entries in `todo.md`. Each phase is scoped to the
+corresponding GitHub issue or native sub-issue; implementation status is
+evidenced by the phase marker and receipt, while scientific review, parity,
+promotion, release, and issue closure remain separate gates.
+
+| `todo.md` workstream | GitHub issue | Conductor phases |
+| --- | --- | --- |
+| Uncertainty-modelling value | #594; #774–#776 | dedicated track `uncertainty_modelling_value_20260801`: F594-1–F594-5 |
+| Implementation-information decomposition | #593; #766–#768 | F593-1–F593-4 |
+| Forecast and signal information VOI | #572; #759, #760, #762 | F572-1–F572-3 |
+| Risk-sensitive and constrained VOI | #570; #757, #758, #761 | F570-1–F570-3 |
+| Value of Flexibility | #559 | F559-1–F559-4 |
+| Deterministic sensitivity/scenario analysis | #556; #724–#728 | F556-1–F556-5 |
+| Distribution-Family Information | #557; #731–#735 | F557-1–F557-5 |
+| Portable qualitative VOI | #558; #738–#742 | F558-1–F558-5 |
+| Finite additive MCDA information value | #560; #746–#750 | F560-1–F560-5 |
+| Dependent information-source portfolio | #582; #763–#765 | dedicated track `information_source_portfolio_voi_20260801` |
+
+The Rust-first programme and its remaining workstream tracks are governed by
+the separate root track `rust_polyglot_voi_completion_20260723`; this table
+covers the experimental frontier entries only.
+
 ## Phase 1 — Governance and contract reconciliation
 
 - [x] **G1:** Verify the owning issue, native parent/children, Project 28,

--- a/todo.md
+++ b/todo.md
@@ -22,7 +22,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
 *   [ ] Complete implementation-information decomposition after experimental
     repository delivery.
     *   GitHub issue #593; delivery subissues #766--#768; umbrella track
-        `supported_frontier_method_completion_20260723`; canonical C18/M25.
+        `supported_frontier_method_completion_20260723`; phases F593-1--F593-4;
+        canonical C18/M25.
     *   The strict finite Python contract covers EVPIM, EVSIM, realizable EVPI,
         EVP, IA-EVSI, interaction, uptake changes, exact identities and CLI/API
         execution without an implementation-information independence assumption.
@@ -38,7 +39,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 *   [ ] Complete forecast and signal information VOI after experimental delivery.
     *   GitHub issue #572; native subissues #759, #760 and #762; umbrella track
-        `supported_frontier_method_completion_20260723`; canonical C18/M23.
+        `supported_frontier_method_completion_20260723`; phases F572-1--F572-3;
+        canonical C18/M23.
     *   The exact finite Python contract separates timely-oracle value, signed
         deployed value, calibration loss, regret avoided and maximum price.
     *   PR #770 exact head `c110706c` passed all hosted checks and 100% changed
@@ -49,7 +51,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 *   [ ] Complete risk-sensitive and constrained VOI after experimental delivery.
     *   GitHub issue #570; native subissues #757, #758 and #761; umbrella track
-        `supported_frontier_method_completion_20260723`; canonical C18/M22.
+        `supported_frontier_method_completion_20260723`; phases F570-1--F570-3;
+        canonical C18/M22.
     *   The exact finite Python contract covers declared expected utility,
         lower-tail CVaR, minimax regret, deterministic/chance constraints,
         matched feasible policy sets, complete ties and fail-closed assurance.
@@ -83,7 +86,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 *   [ ] Complete Value of Flexibility after experimental repository delivery.
     *   GitHub issue #559; umbrella track
-        `supported_frontier_method_completion_20260723`; draft PR #723.
+        `supported_frontier_method_completion_20260723`; phases F559-1--F559-4;
+        draft PR #723.
     *   Python timing-scenario execution, schemas, an enumerable fixture, CLI,
         documentation and dynamic-real-options compatibility repair are present
         on the branch.
@@ -94,7 +98,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
 *   [ ] Complete deterministic sensitivity and scenario analysis after
     experimental repository delivery.
     *   GitHub issue #556; delivery subissues #724--#728; umbrella track
-        `supported_frontier_method_completion_20260723`; draft PR #723.
+        `supported_frontier_method_completion_20260723`; phases F556-1--F556-5;
+        draft PR #723.
     *   Python callback and normalized-record execution, exact installed-wheel
         validation, one-way/two-way/scenario fixtures, CLI, tornado plot and
         documentation are present on the branch.
@@ -105,7 +110,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
 *   [ ] Complete Value of Distribution-Family Information after experimental
     repository delivery.
     *   GitHub issue #557; delivery subissues #731–#735; umbrella track
-        `supported_frontier_method_completion_20260723`; PR #736.
+        `supported_frontier_method_completion_20260723`; phases F557-1--F557-5;
+        PR #736.
     *   Planned contract: v1.2.0; MoSCoW: Must; canonical requirements M19/M17.
     *   Experimental Python execution, strict installed schema/CLI, exact
         fixture, complete ties, signed net VDI, provenance, estimator assurance,


### PR DESCRIPTION
Adds canonical todo-to-GitHub-issue-to-Conductor-phase mapping for experimental frontier work and annotates todo entries with phase IDs. Full Conductor, cross-reference, v1, and diff validation pass.