### PR TITLE
conductor: reconcile research registry EVSI readiness

### DIFF
--- a/conductor/tracks/research_software_registry_readiness_20260721/index.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/index.md
@@ -1,6 +1,10 @@
 # research_software_registry_readiness_20260721
 
-Status: in progress; signed public v2.0.0 release evidence, Software Heritage
+Status: repository-owned release and JOSS-readiness deliverables are complete
+through the merged v2 scientific EVSI contract; human adoption, AI attestation,
+JOSS/arXiv submission, curation, indexing, and registry acceptance remain
+external gates, so the track remains active. Signed public v2.0.0 release
+evidence, Software Heritage
 archival, crates.io publication, and the release-bound JOSS PDF are recorded.
 The prior arXiv submission is absent and replacement submission `7870358`
 remains incomplete. Demonstrated research use, human engagement,

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -4,7 +4,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-07-21T00:00:00Z",
-  "updated_at": "2026-07-27T04:32:23Z",
+  "updated_at": "2026-08-01T12:30:00Z",
   "description": "Track archival, identifier, language-registry, arXiv, and evidence-gated JOSS readiness from the signed v1.0.0 release through the exact v2 review candidate.",
   "owner_repo": "edithatogo/voiage",
   "github_parent_issue": "https://github.com/edithatogo/voiage/issues/296",

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -97,13 +97,16 @@
   target, structured metadata and section validation, claim ledger,
   SourceRight queued-reference sidecars, selected Authentext checks, and
   review-only Textstat workflow.
-- [~] Reproduce and remediate the panel's scientific EVSI finding: move the
+- [x] Reproduce and remediate the panel's scientific EVSI finding: move the
   validated normal-normal study model into the public package, correct the
   built-in estimator so current, predictive, and posterior calculations use
   one coherent fitted Gaussian prior; retain correlations through a numerically
   guarded joint update; add explicit custom two-loop callbacks; and remove
   stable scientific claims from generic estimators that lack complete
-  method-specific validation.
+  method-specific validation. Implemented and published in merged v2
+  contract PR #480 (`8a49bcf3`), with focused scientific and changed-coverage
+  tests passing; remaining JOSS, adoption, AI-attestation, and registry gates
+  are external.
 - [x] Synthesize and prioritize the panel findings from manuscript purpose and
   structure through paragraph, claim, citation, and sentence-level changes.
 - [x] Implement the evidence-supported revisions and rerun the repository-owned

--- a/tests/test_research_registry_readiness.py
+++ b/tests/test_research_registry_readiness.py
@@ -49,6 +49,11 @@ def test_registry_track_records_native_paper_issue_hierarchy() -> None:
     assert all(issue in specification for issue in submission_contract_issues)
     assert hpc_packaging_issue in plan
     assert hpc_packaging_issue in specification
+    assert "- [x] Reproduce and remediate the panel's scientific EVSI finding" in plan
+    index = (track / "index.md").read_text()
+    assert "merged v2 scientific EVSI contract" in index
+    assert "the track remains active" in index
+    assert "JOSS/arXiv submission, curation, indexing, and registry acceptance" in index
     assert handoff["arxiv_preprint_evidence"]["review_pr"].endswith("/pull/311")
     assert handoff["arxiv_preprint_evidence"]["prior_submission_id"] == "7861466"
     assert handoff["arxiv_preprint_evidence"]["submission_id"] == "7870358"


### PR DESCRIPTION
Reconciles the completed v2 scientific EVSI remediation in the research-software registry Conductor track. Keeps human adoption, AI attestation, JOSS/arXiv, curation, indexing, and registry acceptance as explicit external gates.