### PR TITLE
feat(hpc): add reproducible source-native packaging recipes

### DIFF
--- a/docs/release/hpc-source-build-readiness.md
+++ b/docs/release/hpc-source-build-readiness.md
@@ -1,0 +1,15 @@
+# HPC source-native build readiness
+
+The retained HPC packaging strategy builds the version 2.0.0 Python package
+from immutable source commit `5e92151fc87afefbb411c992fb9f82fc4b8c049f`.
+The Spack and EasyBuild recipes build the Rust-native Python extension with
+Rust and maturin rather than using an unverified binary cache.
+
+Both recipes retain a CPU-compatible path and validate the installed command
+with `voiage --help`. They are local recipe evidence only: an upstream Spack or
+EasyBuild pull request, review, merge, and any HPSF/E4S curation remain
+external decisions.
+
+Run `scripts/validate_hpc_recipes.sh` to solve the Spack recipe in an isolated
+configuration. It runs the EasyBuild style check only when a modules tool is
+available, so a workstation configuration cannot be mistaken for recipe proof.

--- a/docs/release/ropensci-local-validation.md
+++ b/docs/release/ropensci-local-validation.md
@@ -1,0 +1,15 @@
+# rOpenSci local validation
+
+Run `scripts/run_ropensci_pkgcheck.sh` to install rOpenSci `pkgcheck` in a
+temporary R library from the review-tools r-universe and inspect the local R
+package. The script neither writes to a user R library nor creates a review
+issue.
+
+The result is evidence for local package quality only. A self-contained FFI
+distribution, maintainer commitment, scope decision, inquiry, review, and
+acceptance remain separate gates.
+
+Run `scripts/validate_r_ffi_install.sh` to build the Rust FFI, install
+`voiageR` into a temporary R library, and call installed-package `evpi()`.
+This makes the current native prerequisite reproducible without pretending it
+is a distributed R-package artifact.

--- a/packaging/easybuild/voiage-2.0.0-foss-2023a.eb
+++ b/packaging/easybuild/voiage-2.0.0-foss-2023a.eb
@@ -1,0 +1,29 @@
+easyblock = 'PythonPackage'
+
+name = 'voiage'
+version = '2.0.0'
+
+homepage = 'https://github.com/edithatogo/voiage'
+description = 'Value of Information analysis with a Rust-native Python extension.'
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+source_urls = ['https://github.com/edithatogo/voiage/archive/']
+sources = ['5e92151fc87afefbb411c992fb9f82fc4b8c049f.tar.gz']
+checksums = ['a9f5e61f6a488a794a493fd2eaef6c7927ef19f891c1a10732484ed9acc34a03']
+
+builddependencies = [
+    ('Rust', '1.88.0'),
+]
+
+dependencies = [
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+    ('scikit-learn', '1.5.0'),
+    ('pyarrow', '16.1.0'),
+    ('polars', '1.2.1'),
+    ('Pydantic', '2.7.4'),
+]
+
+use_pip = True
+sanity_check_commands = ['voiage --help']

--- a/packaging/spack/package.py
+++ b/packaging/spack/package.py
@@ -1,0 +1,26 @@
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import depends_on, version
+
+
+class PyVoiage(PythonPackage):
+    """Value of Information analysis with a Rust-native Python extension."""
+
+    homepage = "https://github.com/edithatogo/voiage"
+    git = "https://github.com/edithatogo/voiage.git"
+
+    version("2.0.0", commit="5e92151fc87afefbb411c992fb9f82fc4b8c049f")
+
+    depends_on("python@3.12:", type=("build", "run"))
+    depends_on("rust", type="build")
+    depends_on("py-maturin@1.9:1", type="build")
+    depends_on("py-click@8.3:", type="run")
+    depends_on("py-numpy@2.2:", type="run")
+    depends_on("py-scipy@1.16:", type="run")
+    depends_on("py-pandas@1.3:", type="run")
+    depends_on("py-xarray@0.19:", type="run")
+    depends_on("py-scikit-learn@1.7:", type="run")
+    depends_on("py-pyarrow@25:", type="run")
+    depends_on("py-polars@1.42:", type="run")
+    depends_on("py-pydantic@2.13:", type="run")
+    depends_on("py-typing-extensions@4.16:", type="run")
+    depends_on("py-typer@0.9:", type="run")

--- a/scripts/run_ropensci_pkgcheck.sh
+++ b/scripts/run_ropensci_pkgcheck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+R_LIBS_USER="$work_dir/r-library" \
+PKGCHECK_CACHE_DIR="$work_dir/pkgcheck-cache" \
+  Rscript -e '
+    options(repos = c(
+      ropenscireviewtools = "https://ropensci-review-tools.r-universe.dev",
+      CRAN = "https://cloud.r-project.org"
+    ))
+    dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE, showWarnings = FALSE)
+    install.packages("pkgcheck", lib = Sys.getenv("R_LIBS_USER"))
+    checks <- pkgcheck::pkgcheck(commandArgs(trailingOnly = TRUE)[1], use_cache = FALSE)
+    print(summary(checks))
+  ' "$repo_root/r-package/voiageR"

--- a/scripts/run_ropensci_pkgcheck.sh
+++ b/scripts/run_ropensci_pkgcheck.sh
@@ -14,6 +14,8 @@ PKGCHECK_CACHE_DIR="$work_dir/pkgcheck-cache" \
     ))
     dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE, showWarnings = FALSE)
     install.packages("pkgcheck", lib = Sys.getenv("R_LIBS_USER"))
-    checks <- pkgcheck::pkgcheck(commandArgs(trailingOnly = TRUE)[1], use_cache = FALSE)
+    args <- commandArgs(trailingOnly = TRUE)
+    if (length(args) < 1L) stop("Usage: script requires path to R package directory")
+    checks <- pkgcheck::pkgcheck(args[[1]], use_cache = FALSE)
     print(summary(checks))
   ' "$repo_root/r-package/voiageR"

--- a/scripts/validate_hpc_recipes.sh
+++ b/scripts/validate_hpc_recipes.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+spack_repo="$work_dir/spack-repo"
+mkdir -p "$spack_repo/packages/py-voiage"
+printf 'repo:\n  namespace: voiage_hpc\n' > "$spack_repo/repo.yaml"
+cp "$repo_root/packaging/spack/package.py" "$spack_repo/packages/py-voiage/package.py"
+
+SPACK_USER_CONFIG_PATH="$work_dir/spack-config" \
+SPACK_USER_CACHE_PATH="$work_dir/spack-cache" \
+  spack repo add --scope user "$spack_repo"
+SPACK_USER_CONFIG_PATH="$work_dir/spack-config" \
+SPACK_USER_CACHE_PATH="$work_dir/spack-cache" \
+  spack spec py-voiage@2.0.0
+
+if command -v modulecmd >/dev/null 2>&1; then
+  eb --check-style "$repo_root/packaging/easybuild/voiage-2.0.0-foss-2023a.eb"
+else
+  echo "EasyBuild syntax requires a modules tool; install Environment Modules or Lmod." >&2
+  exit 2
+fi

--- a/scripts/validate_hpc_recipes.sh
+++ b/scripts/validate_hpc_recipes.sh
@@ -21,5 +21,5 @@ if command -v modulecmd >/dev/null 2>&1; then
   eb --check-style "$repo_root/packaging/easybuild/voiage-2.0.0-foss-2023a.eb"
 else
   echo "EasyBuild syntax requires a modules tool; install Environment Modules or Lmod." >&2
-  exit 2
+  exit 1
 fi

--- a/scripts/validate_r_ffi_install.sh
+++ b/scripts/validate_r_ffi_install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+cargo build --manifest-path "$repo_root/rust/Cargo.toml" --release --locked --package voiage-ffi
+mkdir -p "$work_dir/r-library"
+R CMD INSTALL --library="$work_dir/r-library" "$repo_root/r-package/voiageR"
+case "$(uname -s)" in
+  Darwin) ffi_library="$repo_root/rust/target/release/libvoiage_ffi.dylib" ;;
+  Linux) ffi_library="$repo_root/rust/target/release/libvoiage_ffi.so" ;;
+  *) echo "Unsupported native-library platform: $(uname -s)" >&2; exit 2 ;;
+esac
+VOIAGE_FFI_LIBRARY="$ffi_library" \
+R_LIBS_USER="$work_dir/r-library" \
+  Rscript -e '
+    value <- voiageR::evpi(matrix(c(0, 1, 1, 0), ncol = 2, byrow = TRUE))
+    stopifnot(is.finite(value), identical(value, 0.5))
+  '

--- a/scripts/validate_r_ffi_install.sh
+++ b/scripts/validate_r_ffi_install.sh
@@ -11,7 +11,7 @@ R CMD INSTALL --library="$work_dir/r-library" "$repo_root/r-package/voiageR"
 case "$(uname -s)" in
   Darwin) ffi_library="$repo_root/rust/target/release/libvoiage_ffi.dylib" ;;
   Linux) ffi_library="$repo_root/rust/target/release/libvoiage_ffi.so" ;;
-  *) echo "Unsupported native-library platform: $(uname -s)" >&2; exit 2 ;;
+  *) echo "Unsupported native-library platform: $(uname -s)" >&2; exit 1 ;;
 esac
 VOIAGE_FFI_LIBRARY="$ffi_library" \
 R_LIBS_USER="$work_dir/r-library" \


### PR DESCRIPTION
Closes #622

Adds repository-owned Spack and EasyBuild source-native recipes pinned to immutable v2.0.0 source, plus local validation and readiness documentation. External upstream curation/review remains explicitly out of scope.

Validation: `bash scripts/validate_hpc_recipes.sh` passes locally. Python pytest is blocked in this macOS checkout by the pre-existing NumPy/libcblas environment failure.