### PR TITLE
🧪 Add tests for score and predict on unfitted FlaxMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -313,7 +313,13 @@ def test_flax_metamodel(sample_data) -> None:
     except ImportError:
         pytest.skip("FlaxMetamodel dependencies (flax/jax) not available")
 
-    # Test rmse on unfitted model
+    # Test predict, score, and rmse on unfitted model
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
+        model.score(x, y)
+
     with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
         model.rmse(x, y)
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `score()` and `predict()` methods on `FlaxMetamodel` instances were not tested for the scenario where the model has not been fitted yet, whereas the `rmse()` method was.

📊 **Coverage:** The scenarios that are now tested include calling `predict(x)` and `score(x, y)` on a `FlaxMetamodel` before it has been fitted.

✨ **Result:** The improvement in test coverage ensures that `FlaxMetamodel` behaves consistently with other metamodels (such as `GAMMetamodel`) and correctly raises a `RuntimeError` with the message "The model has not been fitted yet." when attempting to make predictions or score before fitting.

---
*PR created automatically by Jules for task [14883481320133163932](https://jules.google.com/task/14883481320133163932) started by @edithatogo*