### PR TITLE
🧪 Add test for unfitted RandomForestMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,25 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This adds a test to ensure that the `score`, `predict`, and `rmse` methods of `RandomForestMetamodel` properly raise a `RuntimeError` when they are called before the model has been fitted.

📊 **Coverage:** What scenarios are now tested
The unfitted scenario for `predict`, `score`, and `rmse` in `RandomForestMetamodel` is now tested.

✨ **Result:** The improvement in test coverage
Prevents regressions where the model state verification could be accidentally removed.

---
*PR created automatically by Jules for task [11688830757600856247](https://jules.google.com/task/11688830757600856247) started by @edithatogo*