### PR TITLE
🧪 test: add missing rmse test for TinyGPMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -336,6 +336,43 @@ def test_flax_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+
+def test_tinygp_metamodel(sample_data) -> None:
+    """Test the TinyGPMetamodel."""
+    try:
+        from voiage.metamodels import TinyGPMetamodel
+    except ImportError:
+        pytest.skip("TinyGPMetamodel not available")
+
+    x, y = sample_data
+
+    # Try to create the model
+    try:
+        model = TinyGPMetamodel()
+    except ImportError:
+        pytest.skip("TinyGPMetamodel dependencies not available")
+
+    # Test rmse on unfitted model
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
+        model.rmse(x, y)
+
+    # Fit the model
+    model.fit(x, y)
+
+    # Test prediction
+    y_pred = model.predict(x)
+    assert isinstance(y_pred, np.ndarray)
+
+    # Test scoring
+    score = model.score(x, y)
+    assert isinstance(score, float)
+
+    # Test RMSE
+    rmse = model.rmse(x, y)
+    assert isinstance(rmse, float)
+    assert rmse >= 0
+
+
 def test_tinygp_condition_protocol() -> None:
     """Test that the _TinyGPConditionProtocol can be checked at runtime."""
     from voiage.metamodels import _TinyGPConditionProtocol


### PR DESCRIPTION
🎯 **What:** Added a missing test for the `rmse` method in `TinyGPMetamodel`.
📊 **Coverage:** Tests `rmse` calculation for both unfitted (expecting `RuntimeError`) and fitted models, as well as testing general predict/score paths for `TinyGPMetamodel`.
✨ **Result:** Improved test coverage and verification of expected behaviors for `TinyGPMetamodel`.

---
*PR created automatically by Jules for task [11916156214818697733](https://jules.google.com/task/11916156214818697733) started by @edithatogo*