### PR TITLE
🧪 [testing improvement] Add tests for RandomForestMetamodel unfitted state

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,25 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** The issue pointed out a missing test for the `score` method of the `RandomForestMetamodel` when the model has not been fitted yet. This adds tests to verify that `predict`, `score`, and `rmse` raise a `RuntimeError` as expected when called on an unfitted `RandomForestMetamodel`.
📊 **Coverage:** Unfitted state execution paths for `predict`, `score`, and `rmse` on `RandomForestMetamodel`. (The happy path for `score` was already covered in `test_random_forest_metamodel`).
✨ **Result:** Increased test coverage by ensuring that errors on unfitted models are raised properly for the `RandomForestMetamodel`, matching the coverage for other metamodels.

---
*PR created automatically by Jules for task [7420306238637607817](https://jules.google.com/task/7420306238637607817) started by @edithatogo*