### PR TITLE
🧪 Add test for rmse method in RandomForestMetamodel when unfitted

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,26 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    x, y = sample_data
+
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** Added missing test for `rmse` method in `RandomForestMetamodel` when the model has not been fitted yet in `tests/test_metamodels.py`.
📊 **Coverage:** The scenario where the model raises a `RuntimeError` on calling `rmse`, `predict`, and `score` is now covered.
✨ **Result:** Improved test coverage and reliability for `RandomForestMetamodel`.

---
*PR created automatically by Jules for task [2414142242662456399](https://jules.google.com/task/2414142242662456399) started by @edithatogo*