### PR TITLE
🧪 [testing improvement] Add tests for unfitted RandomForestMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,25 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of coverage for `rmse`, `predict`, and `score` methods in `RandomForestMetamodel` when the model has not been fitted yet.
📊 **Coverage:** The test ensures that these methods correctly raise a `RuntimeError` if invoked prior to model fitting, closing the un-covered edge case (specifically the `if self.model is None:` block).
✨ **Result:** Test coverage for `RandomForestMetamodel` is improved, explicitly handling the uninitialized state and acting as a safeguard for regression.

---
*PR created automatically by Jules for task [1218249732291479135](https://jules.google.com/task/1218249732291479135) started by @edithatogo*