### PR TITLE
🧪 Add test for Metamodel protocol with rmse method

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -470,3 +470,37 @@ def test_sparse_matrix_protocol_toarray() -> None:
     result = valid_instance.toarray()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+
+def test_metamodel_protocol() -> None:
+    """Test that the Metamodel protocol can be checked at runtime."""
+    from voiage.metamodels import Metamodel
+
+    class ValidMetamodel:
+        def fit(self, x, y) -> None:
+            pass
+
+        def predict(self, x) -> np.ndarray:
+            return np.array([])
+
+        def score(self, x, y) -> float:
+            return 0.0
+
+        def rmse(self, x, y) -> float:
+            return 0.0
+
+    class InvalidMetamodel:
+        def fit(self, x, y) -> None:
+            pass
+
+        def predict(self, x) -> np.ndarray:
+            return np.array([])
+
+        def score(self, x, y) -> float:
+            return 0.0
+
+    valid_instance = ValidMetamodel()
+    invalid_instance = InvalidMetamodel()
+
+    assert isinstance(valid_instance, Metamodel)
+    assert not isinstance(invalid_instance, Metamodel)


### PR DESCRIPTION
🎯 **What:** Added a test for the `Metamodel` protocol to ensure it enforces the presence of the `rmse` method.
📊 **Coverage:** Evaluates runtime checking of the protocol implementation via dummy classes, asserting `Metamodel` checks for `fit`, `predict`, `score`, and `rmse`.
✨ **Result:** Improved test coverage and reliability for protocol verification logic.

---
*PR created automatically by Jules for task [2448784078884878155](https://jules.google.com/task/2448784078884878155) started by @edithatogo*