### PR TITLE
🧪 Add dedicated unit test for VOIAnalysisConfig.to_dict()

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -93,6 +93,39 @@ def test_voi_analysis_config() -> None:
     assert default_dict["n_simulations"] == 1000
 
 
+
+def test_voi_analysis_config_to_dict() -> None:
+    """Test VOIAnalysisConfig.to_dict()."""
+    config = VOIAnalysisConfig(
+        population=100000,
+        time_horizon=10,
+        discount_rate=0.03,
+        chunk_size=1000,
+        use_jit=True,
+        backend="jax",
+        enable_caching=True,
+        streaming_window_size=5000,
+        n_regression_samples=5000,
+        regression_model="mock_model",
+        n_simulations=2000,
+    )
+
+    expected_dict = {
+        "population": 100000,
+        "time_horizon": 10,
+        "discount_rate": 0.03,
+        "chunk_size": 1000,
+        "use_jit": True,
+        "backend": "jax",
+        "enable_caching": True,
+        "streaming_window_size": 5000,
+        "n_regression_samples": 5000,
+        "regression_model": "mock_model",
+        "n_simulations": 2000,
+    }
+
+    assert config.to_dict() == expected_dict
+
 def test_streaming_config() -> None:
     """Test StreamingConfig."""
     # Test default configuration
@@ -485,6 +518,7 @@ def test_create_streaming_config() -> None:
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()
+    test_voi_analysis_config_to_dict()
     test_streaming_config()
     test_metamodel_config()
     test_optimization_config()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This pull request introduces a dedicated unit test for the `to_dict` method in the `VOIAnalysisConfig` data class (found in `voiage/config_objects.py`). Previously, `to_dict` was partially tested without a clear, exhaustive dict match asserting its full behavior.

📊 **Coverage:** What scenarios are now tested
The new `test_voi_analysis_config_to_dict` test validates the `to_dict` method's behavior with a config object loaded with complete, non-default inputs across all its attributes (`population`, `time_horizon`, `discount_rate`, `chunk_size`, `use_jit`, `backend`, `enable_caching`, `streaming_window_size`, `n_regression_samples`, `regression_model`, `n_simulations`).

✨ **Result:** The improvement in test coverage
Guarantees 100% path execution test coverage on `VOIAnalysisConfig.to_dict()` avoiding future logic regressions on this method mapping.

---
*PR created automatically by Jules for task [14139308084383253176](https://jules.google.com/task/14139308084383253176) started by @edithatogo*