### PR TITLE
🧪 Add missing test for unfitted RandomForestMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,25 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** The `rmse` method in `RandomForestMetamodel` wasn't explicitly tested for its unfitted error condition.
📊 **Coverage:** Added a test that covers unfitted prediction, score, and rmse methods in `RandomForestMetamodel` to assert that it raises `RuntimeError` gracefully.
✨ **Result:** Increased test coverage for model edge cases.

---
*PR created automatically by Jules for task [7716056357997830647](https://jules.google.com/task/7716056357997830647) started by @edithatogo*