### PR TITLE
🧪 [testing improvement] Add test for metamodel rmse method

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -470,3 +470,24 @@ def test_sparse_matrix_protocol_toarray() -> None:
     result = valid_instance.toarray()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+
+def test_metamodel_rmse(sample_data) -> None:
+    """Test the rmse method directly on a metamodel."""
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+
+    model = LinearMetamodel()
+    model.fit(x, y)
+
+    rmse = model.rmse(x, y)
+
+    assert isinstance(rmse, float)
+    assert rmse >= 0
+
+    # Calculate RMSE manually to ensure it matches
+    y_pred = model.predict(x)
+    expected_rmse = float(np.sqrt(np.mean((y - y_pred) ** 2)))
+    assert np.isclose(rmse, expected_rmse)


### PR DESCRIPTION
🎯 **What:** The `rmse` method in `Metamodel` classes was missing explicit test coverage.
📊 **Coverage:** A new test `test_metamodel_rmse` has been added to `tests/test_metamodels.py` which directly tests the `rmse` method of a `LinearMetamodel` instance on sample data, confirming it returns a float >= 0 and matches the expected manual computation.
✨ **Result:** Test coverage for the metamodel `rmse` method is improved and directly verified.

---
*PR created automatically by Jules for task [14554072396596016557](https://jules.google.com/task/14554072396596016557) started by @edithatogo*