### PR TITLE
🧪 Add tests for unfitted RandomForestMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,27 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    x, y = sample_data
+
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:**
Added a test for `RandomForestMetamodel` that raises a `RuntimeError` when `predict()`, `score()`, and `rmse()` are called without the model having been fitted first.

📊 **Coverage:**
This covers the missing test case for `rmse()`'s guard clause at line 652 of `voiage/metamodels.py`.

✨ **Result:**
Improved test coverage and reliability by ensuring the `RandomForestMetamodel` responds correctly to erroneous unfitted operations.

---
*PR created automatically by Jules for task [17463040086103048025](https://jules.google.com/task/17463040086103048025) started by @edithatogo*