### PR TITLE
🧪 Add test for RandomForestMetamodel rmse when unfitted

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,25 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** The RandomForestMetamodel lacked a test confirming that predict, score, and rmse correctly raise a RuntimeError when the model is not yet fitted.
📊 **Coverage:** The `test_random_forest_metamodel_unfitted` test verifies this gap, completing coverage for the unfitted state checks.
✨ **Result:** Test coverage and robustness is improved, preventing regressions.

---
*PR created automatically by Jules for task [6412700509887511200](https://jules.google.com/task/6412700509887511200) started by @edithatogo*