### PR TITLE
🧪 Improve coverage of create_default_config

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -376,6 +376,7 @@ def test_create_default_config() -> None:
     """Test create_default_config factory function."""
     config = create_default_config()
     assert isinstance(config, VOIAnalysisConfig)
+    assert config == VOIAnalysisConfig()
 
     # Check default values
     assert config.population is None


### PR DESCRIPTION
🎯 **What:** Adds a missing assertion checking whether create_default_config() returns a config strictly equal to VOIAnalysisConfig()
📊 **Coverage:** The factory default configuration is now strictly verified against dataclass instantiation
✨ **Result:** Better regression guarantees for config objects

---
*PR created automatically by Jules for task [14743486102514216223](https://jules.google.com/task/14743486102514216223) started by @edithatogo*