### PR TITLE
🧪 Add test for score on unfitted FlaxMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -313,7 +313,9 @@ def test_flax_metamodel(sample_data) -> None:
     except ImportError:
         pytest.skip("FlaxMetamodel dependencies (flax/jax) not available")
 
-    # Test rmse on unfitted model
+    # Test score and rmse on unfitted model
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
+        model.score(x, y)
     with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
         model.rmse(x, y)
 


### PR DESCRIPTION
🎯 **What:** The `FlaxMetamodel.score` method did not have a test ensuring it raises a `RuntimeError` when the model is not fitted.
📊 **Coverage:** Unfitted state for the `score` method on `FlaxMetamodel`.
✨ **Result:** The codebase is now more robust with proper error handling validation for the `score` method on unfitted models.

---
*PR created automatically by Jules for task [11076410918228670656](https://jules.google.com/task/11076410918228670656) started by @edithatogo*