### PR TITLE
🧪 [testing improvement] Add test for rmse fallback in calculate_diagnostics

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -260,6 +260,31 @@ def test_calculate_diagnostics(sample_data) -> None:
     assert diagnostics["n_samples"] == len(y)
 
 
+def test_calculate_diagnostics_missing_methods(sample_data) -> None:
+    """Test calculate_diagnostics when metamodel lacks score and rmse methods."""
+    x, y = sample_data
+
+    class MinimalModel:
+        def predict(self, x):
+            return np.ones(len(next(iter(x.parameters.values())))) * np.mean(y)
+
+    model = MinimalModel()
+
+    # Calculate diagnostics
+    diagnostics = calculate_diagnostics(model, x, y)
+
+    # Check that all expected keys are present
+    expected_keys = {"r2", "rmse", "mae", "mean_residual", "std_residual", "n_samples"}
+    assert set(diagnostics.keys()) == expected_keys
+
+    # Check types
+    assert isinstance(diagnostics["r2"], float)
+    assert isinstance(diagnostics["rmse"], float)
+
+    # Check that values are computed correctly
+    assert diagnostics["rmse"] >= 0
+
+
 def test_cross_validate(sample_data) -> None:
     """Test the cross_validate function."""
     # Skip if sklearn is not available


### PR DESCRIPTION
🎯 **What:** Added missing test for the scenario where a metamodel lacks `.rmse()` or `.score()` methods and `calculate_diagnostics` falls back to `_safe_rmse` and `_safe_r2_score`.
📊 **Coverage:** Added `test_calculate_diagnostics_missing_methods` which uses a mock model missing `.rmse()` and `.score()` to ensure valid float values are returned from the fallback computations.
✨ **Result:** Improved test reliability and coverage for the metamodel diagnostic function.

---
*PR created automatically by Jules for task [1928180887129064958](https://jules.google.com/task/1928180887129064958) started by @edithatogo*