### PR TITLE
🧪 Add test for TinyGPMetamodel rmse method

### DIFF
--- a/tests/test_metamodeling_comprehensive.py
+++ b/tests/test_metamodeling_comprehensive.py
@@ -256,6 +256,32 @@ def test_flax_metamodel_rmse(sample_data) -> None:
         pass
 
 
+def test_tinygp_metamodel_rmse(sample_data) -> None:
+    """Test RMSE method for TinyGPMetamodel."""
+    try:
+        from voiage.metamodels import TinyGPMetamodel
+    except ImportError:
+        pytest.skip("TinyGPMetamodel not available")
+
+    x, y = sample_data
+
+    try:
+        model = TinyGPMetamodel()
+
+        # Test rmse before fitting raises error
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
+            model.rmse(x, y)
+
+        model.fit(x, y)
+
+        # Test rmse after fitting
+        rmse_val = model.rmse(x, y)
+        assert isinstance(rmse_val, float)
+        assert rmse_val >= 0
+    except ImportError:
+        pass
+
+
 def test_tinygp_metamodel_dependency_handling(sample_data) -> None:
     """Test that TinyGPMetamodel properly handles missing dependencies."""
     try:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing test for `rmse` method in `TinyGPMetamodel`.
📊 **Coverage:** Tests that the method raises a RuntimeError when called before the model is fitted, and returns a non-negative float value when called after fitting the model.
✨ **Result:** Improved test coverage for `voiage/metamodels.py`.

---
*PR created automatically by Jules for task [14644673939357770985](https://jules.google.com/task/14644673939357770985) started by @edithatogo*