### PR TITLE
🧪 Add test to verify RMSE method in Metamodel Protocol

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -470,3 +470,34 @@ def test_sparse_matrix_protocol_toarray() -> None:
     result = valid_instance.toarray()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+
+def test_metamodel_protocol_rmse() -> None:
+    """Test that the Metamodel protocol requires the rmse method."""
+    from voiage.metamodels import Metamodel
+
+    class ValidMetamodel:
+        def fit(self, x: ParameterSet, y: np.ndarray) -> None:
+            pass
+
+        def predict(self, x: ParameterSet) -> np.ndarray:
+            return np.array([])
+
+        def score(self, x: ParameterSet, y: np.ndarray) -> float:
+            return 0.0
+
+        def rmse(self, x: ParameterSet, y: np.ndarray) -> float:
+            return 0.0
+
+    class InvalidMetamodelMissingRmse:
+        def fit(self, x: ParameterSet, y: np.ndarray) -> None:
+            pass
+
+        def predict(self, x: ParameterSet) -> np.ndarray:
+            return np.array([])
+
+        def score(self, x: ParameterSet, y: np.ndarray) -> float:
+            return 0.0
+
+    assert isinstance(ValidMetamodel(), Metamodel)
+    assert not isinstance(InvalidMetamodelMissingRmse(), Metamodel)


### PR DESCRIPTION
🎯 **What:** Ensure that the Metamodel Protocol properly enforces the implementation of the `rmse` method, addressing a missing testing gap.
📊 **Coverage:** A valid metamodel with `rmse` is validated, and an invalid one lacking the method is rejected.
✨ **Result:** Enhanced test coverage and reliability for Metamodel contract definitions.

---
*PR created automatically by Jules for task [10018975450484040940](https://jules.google.com/task/10018975450484040940) started by @edithatogo*