### PR TITLE
🧪 Add missing ecosystem_service_value test for EnvironmentalConfig

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -402,6 +402,7 @@ def test_create_environmental_config() -> None:
     assert config.water_cost == 0.002
     assert config.biodiversity_impact_factor == 0.01
     assert config.social_cost_of_carbon == 50
+    assert config.ecosystem_service_value == 100
 
 
 def test_create_healthcare_config() -> None:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `EnvironmentalConfig` tests were missing coverage for the `ecosystem_service_value` parameter initialized by the `create_environmental_config` factory function.

📊 **Coverage:** What scenarios are now tested
Added an assertion to `test_create_environmental_config` in `tests/test_config_objects.py` to ensure the `ecosystem_service_value` equals the default value `100`.

✨ **Result:** The improvement in test coverage
The test for the `create_environmental_config` function now correctly asserts all property assignments returned by the function.

---
*PR created automatically by Jules for task [12371336570148622266](https://jules.google.com/task/12371336570148622266) started by @edithatogo*