### PR TITLE
🧪 [Add dedicated unit test for VOIAnalysisConfig.to_dict]

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -62,7 +62,23 @@ def test_voi_analysis_config() -> None:
     assert config.n_regression_samples == 5000
     assert config.n_simulations == 2000
 
-    # Test to_dict method
+
+def test_voi_analysis_config_to_dict() -> None:
+    """Test VOIAnalysisConfig to_dict method."""
+    # Test custom configuration with regression_model
+    config = VOIAnalysisConfig(
+        population=100000,
+        time_horizon=10,
+        discount_rate=0.03,
+        chunk_size=1000,
+        use_jit=True,
+        backend="jax",
+        enable_caching=True,
+        streaming_window_size=5000,
+        n_regression_samples=5000,
+        regression_model="mock_model",
+        n_simulations=2000,
+    )
     config_dict = config.to_dict()
     assert isinstance(config_dict, dict)
     assert config_dict["population"] == 100000
@@ -74,12 +90,11 @@ def test_voi_analysis_config() -> None:
     assert config_dict["enable_caching"] is True
     assert config_dict["streaming_window_size"] == 5000
     assert config_dict["n_regression_samples"] == 5000
-    assert config_dict["regression_model"] is None
+    assert config_dict["regression_model"] == "mock_model"
     assert config_dict["n_simulations"] == 2000
 
-    # Test to_dict method on default config
-    default_config = VOIAnalysisConfig()
-    default_dict = default_config.to_dict()
+    # Test default configuration
+    default_dict = VOIAnalysisConfig().to_dict()
     assert default_dict["population"] is None
     assert default_dict["time_horizon"] is None
     assert default_dict["discount_rate"] is None
@@ -485,6 +500,7 @@ def test_create_streaming_config() -> None:
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()
+    test_voi_analysis_config_to_dict()
     test_streaming_config()
     test_metamodel_config()
     test_optimization_config()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The issue mentioned a missing test for `to_dict` in `VOIAnalysisConfig`. Although the `test_voi_analysis_config` function had some assertions checking the `to_dict` result, this functionality wasn't properly isolated in a dedicated test.

📊 **Coverage:** What scenarios are now tested
A new test `test_voi_analysis_config_to_dict` was added which explicitly tests the conversion of a custom and a default config to a dict. Added an explicit check with `regression_model=\"mock_model\"` to cover more ground.

✨ **Result:** The improvement in test coverage
More robust, clear testing of `to_dict` implementation.

---
*PR created automatically by Jules for task [6796590629609272869](https://jules.google.com/task/6796590629609272869) started by @edithatogo*