### PR TITLE
🧪 Add test for Metamodel rmse Protocol method

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -470,3 +470,34 @@ def test_sparse_matrix_protocol_toarray() -> None:
     result = valid_instance.toarray()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+
+def test_metamodel_protocol_rmse() -> None:
+    """Test the rmse method requirement of the Metamodel protocol."""
+    from voiage.metamodels import Metamodel
+
+    class ValidMetamodel:
+        def fit(self, x, y) -> None:
+            pass
+
+        def predict(self, x) -> np.ndarray:
+            return np.array([])
+
+        def score(self, x, y) -> float:
+            return 0.0
+
+        def rmse(self, x, y) -> float:
+            return 0.0
+
+    class InvalidMetamodel:
+        def fit(self, x, y) -> None:
+            pass
+
+        def predict(self, x) -> np.ndarray:
+            return np.array([])
+
+        def score(self, x, y) -> float:
+            return 0.0
+
+    assert isinstance(ValidMetamodel(), Metamodel)
+    assert not isinstance(InvalidMetamodel(), Metamodel)


### PR DESCRIPTION
🎯 **What:** Added structural typing test for the `rmse` method in the `Metamodel` Protocol.
📊 **Coverage:** The test verifies that structural subtyping (`isinstance`) enforces the presence of the `rmse` method when checked at runtime via `@runtime_checkable`.
✨ **Result:** Enhanced test coverage for the protocol definition.

---
*PR created automatically by Jules for task [3068343851704972330](https://jules.google.com/task/3068343851704972330) started by @edithatogo*