### PR TITLE
🧪 Add missing ecosystem_service_value assertion in test_create_environmental_config

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -402,6 +402,7 @@ def test_create_environmental_config() -> None:
     assert config.water_cost == 0.002
     assert config.biodiversity_impact_factor == 0.01
     assert config.social_cost_of_carbon == 50
+    assert config.ecosystem_service_value == 100
 
 
 def test_create_healthcare_config() -> None:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The factory function `create_environmental_config` in `voiage/config_objects.py` creates an `EnvironmentalConfig` object that has a default property `ecosystem_service_value`. The corresponding test in `tests/test_config_objects.py` was asserting the default values for all other properties except `ecosystem_service_value`.

📊 **Coverage:** What scenarios are now tested
The unit test `test_create_environmental_config` now asserts the expected default value for `ecosystem_service_value` in the `EnvironmentalConfig` instance created by the factory function. 

✨ **Result:** The improvement in test coverage
Complete coverage of all default properties configured in `EnvironmentalConfig` by the factory function, ensuring no property goes unverified.

---
*PR created automatically by Jules for task [13917279035637386235](https://jules.google.com/task/13917279035637386235) started by @edithatogo*