### PR TITLE
🧪 Add test for unfitted RandomForestMetamodel behavior

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,24 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** Added a missing test for `RandomForestMetamodel` methods (`predict`, `score`, `rmse`) when the model has not been fitted yet. This addresses the testing gap for the `rmse` method raising a `RuntimeError`.

📊 **Coverage:** Covered the unfitted edge cases (raising `RuntimeError`) for `predict`, `score`, and `rmse` methods in `RandomForestMetamodel`.

✨ **Result:** Improved test coverage and reliability for `RandomForestMetamodel`.

---
*PR created automatically by Jules for task [6121801079534238892](https://jules.google.com/task/6121801079534238892) started by @edithatogo*