### PR TITLE
🧹 Remove unused sklearn import

### DIFF
--- a/voiage/main_backends.py
+++ b/voiage/main_backends.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import hashlib
+import importlib.util
 import json
 import platform
 import sys
@@ -173,13 +174,7 @@ try:
     jax.config.update("jax_enable_x64", True)
 
     # Try to import optional dependencies
-    SKLEARN_AVAILABLE = False
-    try:
-        import sklearn  # noqa: F401
-
-        SKLEARN_AVAILABLE = True
-    except ImportError:
-        pass
+    SKLEARN_AVAILABLE = importlib.util.find_spec("sklearn") is not None
 
     class _JaxBackendImpl(Backend):
         """JAX-based computational backend."""


### PR DESCRIPTION
🎯 **What:** Removed an unused `import sklearn` statement from `voiage/main_backends.py` and replaced it with `importlib.util.find_spec("sklearn") is not None`.
💡 **Why:** The codebase just needs to check whether `sklearn` is available. Using `find_spec` avoids importing the module which is cleaner and lighter, improving code health and avoiding unnecessary imports.
✅ **Verification:** I verified the change locally using `ruff check`, `ruff format` and test suites, ensuring it doesn't negatively affect existing logic.
✨ **Result:** Improved module load health by avoiding unneeded side effects of actually importing sklearn just to check if it's there.

---
*PR created automatically by Jules for task [5552062790457898566](https://jules.google.com/task/5552062790457898566) started by @edithatogo*