### PR TITLE
🧪 Add tests for unfitted RandomForestMetamodel

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,24 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for predict, score, and rmse when called on an unfitted RandomForestMetamodel (which raises a RuntimeError).
📊 **Coverage:** Fills testing gap for error conditions in RandomForestMetamodel methods.
✨ **Result:** Better error-handling coverage, achieving proper rmse test handling for RandomForestMetamodel prior to fitting.

---
*PR created automatically by Jules for task [13859782549129238199](https://jules.google.com/task/13859782549129238199) started by @edithatogo*