### PR TITLE
🧪 Add test for FlaxMetamodel rmse method

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -298,6 +298,36 @@ def test_cross_validate(sample_data) -> None:
     assert cv_results["cv_mae_mean"] >= 0
 
 
+def test_flax_metamodel_rmse(sample_data) -> None:
+    """Test the rmse method of FlaxMetamodel specifically."""
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    import pytest
+
+    with patch("voiage.metamodels.FLAX_AVAILABLE", True):
+        from voiage.metamodels import FlaxMetamodel
+
+        model = FlaxMetamodel()
+
+        x, y = sample_data
+
+        # Unfitted model should raise
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet"):
+            model.rmse(x, y)
+
+        # Fitted model
+        model.state = MagicMock()
+        model.predict = MagicMock(return_value=np.array([1.0, 2.0, 3.0]))
+
+        y_true = np.array([1.0, 2.0, 4.0])
+        # RMSE between [1, 2, 4] and [1, 2, 3] is sqrt(1/3)
+        expected_rmse = float(np.sqrt(1 / 3))
+
+        result = model.rmse(x, y_true)
+        assert np.isclose(result, expected_rmse)
+
+
 def test_flax_metamodel(sample_data) -> None:
     """Test the FlaxMetamodel."""
     try:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for `rmse` method in `FlaxMetamodel`.
📊 **Coverage:** What scenarios are now tested: Calling `rmse` on an unfitted model raises a RuntimeError, and calling `rmse` on a fitted model returns the correctly calculated root mean squared error.
✨ **Result:** The improvement in test coverage: We added unit tests isolated through mocking that successfully pass regardless of whether the `flax` library is installed, closing the coverage gap.

---
*PR created automatically by Jules for task [4336404289829479912](https://jules.google.com/task/4336404289829479912) started by @edithatogo*