### PR TITLE
🧪 Extract and dedicate test for `to_dict` in `VOIAnalysisConfig`

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -62,7 +62,22 @@ def test_voi_analysis_config() -> None:
     assert config.n_regression_samples == 5000
     assert config.n_simulations == 2000
 
-    # Test to_dict method
+
+def test_voi_analysis_config_to_dict() -> None:
+    """Test the to_dict method of VOIAnalysisConfig."""
+    # Test custom configuration
+    config = VOIAnalysisConfig(
+        population=100000,
+        time_horizon=10,
+        discount_rate=0.03,
+        chunk_size=1000,
+        use_jit=True,
+        backend="jax",
+        enable_caching=True,
+        streaming_window_size=5000,
+        n_regression_samples=5000,
+        n_simulations=2000,
+    )
     config_dict = config.to_dict()
     assert isinstance(config_dict, dict)
     assert config_dict["population"] == 100000
@@ -485,6 +500,7 @@ def test_create_streaming_config() -> None:
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()
+    test_voi_analysis_config_to_dict()
     test_streaming_config()
     test_metamodel_config()
     test_optimization_config()


### PR DESCRIPTION
🎯 **What:** Extracted testing logic for the `to_dict` method out of `test_voi_analysis_config` and into its own dedicated test, `test_voi_analysis_config_to_dict`, improving separation of concerns and explicitly testing this behavior.
📊 **Coverage:** Checks conversion to dictionary for both a fully specified custom `VOIAnalysisConfig` instance and a default instance, ensuring missing or populated optional values are handled appropriately.
✨ **Result:** Enhanced test maintainability and clarity, ensuring regressions in configuration conversion are caught more explicitly.

---
*PR created automatically by Jules for task [15178276143265002963](https://jules.google.com/task/15178276143265002963) started by @edithatogo*