### PR TITLE
🧪 Add tests and arguments to create_parallel_config

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -427,6 +427,23 @@ def test_create_parallel_config() -> None:
     assert config.chunk_size is None
 
 
+def test_create_parallel_config_with_args() -> None:
+    """Test create_parallel_config with custom arguments."""
+    config = create_parallel_config(
+        n_workers=4,
+        use_processes=False,
+        max_workers=8,
+        memory_limit_mb=8192,
+        chunk_size=1000,
+    )
+    assert isinstance(config, ParallelConfig)
+    assert config.n_workers == 4
+    assert config.use_processes is False
+    assert config.max_workers == 8
+    assert config.memory_limit_mb == 8192
+    assert config.chunk_size == 1000
+
+
 def test_create_financial_config() -> None:
     """Test create_financial_config factory function."""
     config = create_financial_config()
@@ -494,6 +511,7 @@ if __name__ == "__main__":
     test_parallel_config()
     test_create_healthcare_config()
     test_create_parallel_config()
+    test_create_parallel_config_with_args()
     test_factory_functions()
     test_create_optimization_config()
     test_create_streaming_config()

--- a/voiage/config_objects.py
+++ b/voiage/config_objects.py
@@ -316,9 +316,21 @@ def create_financial_config() -> FinancialConfig:
     return FinancialConfig()
 
 
-def create_parallel_config() -> ParallelConfig:
+def create_parallel_config(
+    n_workers: int | None = None,
+    use_processes: bool = True,
+    max_workers: int | None = None,
+    memory_limit_mb: float | None = None,
+    chunk_size: int | None = None,
+) -> ParallelConfig:
     """Create a parallel processing configuration."""
-    return ParallelConfig()
+    return ParallelConfig(
+        n_workers=n_workers,
+        use_processes=use_processes,
+        max_workers=max_workers,
+        memory_limit_mb=memory_limit_mb,
+        chunk_size=chunk_size,
+    )
 
 
 def create_streaming_config() -> StreamingConfig:


### PR DESCRIPTION
🎯 **What:** `create_parallel_config` factory did not accept configuration parameters, making it less robust and limiting its testability.
📊 **Coverage:** Added argument passthrough to `create_parallel_config` and created `test_create_parallel_config_with_args` to ensure all fields propagate successfully to the `ParallelConfig` object.
✨ **Result:** Improved configurability and test coverage for parallel processing configurations.

---
*PR created automatically by Jules for task [11972561613459848915](https://jules.google.com/task/11972561613459848915) started by @edithatogo*