### PR TITLE
🧹 Remove unused sklearn import in main_backends.py

### DIFF
--- a/voiage/main_backends.py
+++ b/voiage/main_backends.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import hashlib
+import importlib.util
 import json
 import platform
 import sys
@@ -173,13 +174,7 @@ try:
     jax.config.update("jax_enable_x64", True)
 
     # Try to import optional dependencies
-    SKLEARN_AVAILABLE = False
-    try:
-        import sklearn  # noqa: F401
-
-        SKLEARN_AVAILABLE = True
-    except ImportError:
-        pass
+    SKLEARN_AVAILABLE = importlib.util.find_spec("sklearn") is not None
 
     class _JaxBackendImpl(Backend):
         """JAX-based computational backend."""


### PR DESCRIPTION
🎯 **What:** The unused `sklearn` import inside a `try-except` block in `voiage/main_backends.py` has been replaced with `importlib.util.find_spec`.
💡 **Why:** This removes dead code and a linter warning while maintaining the intended logic of dynamically checking whether `sklearn` is available.
✅ **Verification:** I ran `ruff check`, `ruff format`, and `pytest` (to check the functionality wasn't accidentally broken), all of which passed.
✨ **Result:** A cleaner module space for `voiage/main_backends.py` directly improving codebase maintainability without risking behavioral changes.

---
*PR created automatically by Jules for task [17001555157085602670](https://jules.google.com/task/17001555157085602670) started by @edithatogo*