### PR TITLE
🧪 Add test for unfitted RandomForestMetamodel methods

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -136,6 +136,25 @@ def test_random_forest_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+
+    model = RandomForestMetamodel()
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+
 def test_gam_metamodel_unfitted(sample_data) -> None:
     """Test that GAMMetamodel raises RuntimeError when not fitted."""
     x, y = sample_data


### PR DESCRIPTION
🎯 **What:** 
Added a test for the `rmse` method in `RandomForestMetamodel` that correctly asserts a `RuntimeError` is raised when the model is not yet fitted. This addresses the testing gap identified in `voiage/metamodels.py:650`.

📊 **Coverage:** 
- The `rmse` method now correctly fails if the model hasn't been fitted.
- Added similar assertions for `predict` and `score` methods on an unfitted `RandomForestMetamodel` for complete coverage.

✨ **Result:** 
Improved test coverage and confidence in the `RandomForestMetamodel` implementation by validating expected failure conditions.

---
*PR created automatically by Jules for task [7210898025045590352](https://jules.google.com/task/7210898025045590352) started by @edithatogo*