### PR TITLE
🧪 add test for VOIAnalysisConfig to_dict method

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -62,7 +62,22 @@ def test_voi_analysis_config() -> None:
     assert config.n_regression_samples == 5000
     assert config.n_simulations == 2000
 
-    # Test to_dict method
+
+def test_voi_analysis_config_to_dict() -> None:
+    """Test to_dict method of VOIAnalysisConfig."""
+    # Test custom configuration
+    config = VOIAnalysisConfig(
+        population=100000,
+        time_horizon=10,
+        discount_rate=0.03,
+        chunk_size=1000,
+        use_jit=True,
+        backend="jax",
+        enable_caching=True,
+        streaming_window_size=5000,
+        n_regression_samples=5000,
+        n_simulations=2000,
+    )
     config_dict = config.to_dict()
     assert isinstance(config_dict, dict)
     assert config_dict["population"] == 100000
@@ -77,7 +92,7 @@ def test_voi_analysis_config() -> None:
     assert config_dict["regression_model"] is None
     assert config_dict["n_simulations"] == 2000
 
-    # Test to_dict method on default config
+    # Test default configuration
     default_config = VOIAnalysisConfig()
     default_dict = default_config.to_dict()
     assert default_dict["population"] is None
@@ -485,6 +500,7 @@ def test_create_streaming_config() -> None:
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()
+    test_voi_analysis_config_to_dict()
     test_streaming_config()
     test_metamodel_config()
     test_optimization_config()


### PR DESCRIPTION
🎯 **What:** Extracted the inline `to_dict` test logic from `test_voi_analysis_config` into a dedicated `test_voi_analysis_config_to_dict` method in `tests/test_config_objects.py`.
📊 **Coverage:** This new unit test explicitly instantiates a `VOIAnalysisConfig` struct using both custom and default values, verifying that the `to_dict()` output correctly maps configuration items.
✨ **Result:** Better structural test coverage mapping of the configuration logic, ensuring no regressions when expanding configuration fields.

---
*PR created automatically by Jules for task [13529260461785017556](https://jules.google.com/task/13529260461785017556) started by @edithatogo*