### PR TITLE
🧪 [testing improvement description] Add tests for create_metamodel_config

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -482,6 +482,17 @@ def test_create_streaming_config() -> None:
     assert config.buffer_size is None
 
 
+def test_create_metamodel_config() -> None:
+    """Test create_metamodel_config factory function."""
+    config = create_metamodel_config()
+    assert isinstance(config, MetamodelConfig)
+    assert config.method == "gam"
+
+    config = create_metamodel_config(method="gp")
+    assert isinstance(config, MetamodelConfig)
+    assert config.method == "gp"
+
+
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()
@@ -497,4 +508,5 @@ if __name__ == "__main__":
     test_factory_functions()
     test_create_optimization_config()
     test_create_streaming_config()
+    test_create_metamodel_config()
     print("All configuration objects tests passed!")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `create_metamodel_config` (which was the very next function in `config_objects.py` near `create_streaming_config`) was missing unit test coverage.
📊 **Coverage:** What scenarios are now tested: Both the default scenario (creating `MetamodelConfig` with default `"gam"` method) and overriding the method (with `"gp"`) are properly tested.
✨ **Result:** The improvement in test coverage helps maintain confidence when refactoring metamodel configuration defaults or types.

---
*PR created automatically by Jules for task [10493731397716326842](https://jules.google.com/task/10493731397716326842) started by @edithatogo*