### PR TITLE
🧪 [testing improvement] Add test for to_dict in VOIAnalysisConfig

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -62,7 +62,23 @@ def test_voi_analysis_config() -> None:
     assert config.n_regression_samples == 5000
     assert config.n_simulations == 2000
 
-    # Test to_dict method
+
+def test_voi_analysis_config_to_dict() -> None:
+    """Test to_dict method of VOIAnalysisConfig."""
+    # Test custom configuration
+    config = VOIAnalysisConfig(
+        population=100000,
+        time_horizon=10,
+        discount_rate=0.03,
+        chunk_size=1000,
+        use_jit=True,
+        backend="jax",
+        enable_caching=True,
+        streaming_window_size=5000,
+        n_regression_samples=5000,
+        n_simulations=2000,
+        regression_model="mock_model",
+    )
     config_dict = config.to_dict()
     assert isinstance(config_dict, dict)
     assert config_dict["population"] == 100000
@@ -74,7 +90,7 @@ def test_voi_analysis_config() -> None:
     assert config_dict["enable_caching"] is True
     assert config_dict["streaming_window_size"] == 5000
     assert config_dict["n_regression_samples"] == 5000
-    assert config_dict["regression_model"] is None
+    assert config_dict["regression_model"] == "mock_model"
     assert config_dict["n_simulations"] == 2000
 
     # Test to_dict method on default config
@@ -485,6 +501,7 @@ def test_create_streaming_config() -> None:
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()
+    test_voi_analysis_config_to_dict()
     test_streaming_config()
     test_metamodel_config()
     test_optimization_config()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Added a dedicated unit test `test_voi_analysis_config_to_dict` for the `to_dict` method in `VOIAnalysisConfig` to ensure full serialization is covered.
📊 **Coverage:** What scenarios are now tested: Covers initialization with non-default values (including `regression_model="mock_model"`) and verifies that `to_dict` outputs the expected dictionary keys and values correctly.
✨ **Result:** The improvement in test coverage: Increased reliability by specifically testing `to_dict` serialization logic in isolation, preventing regression.

---
*PR created automatically by Jules for task [1749387795006187783](https://jules.google.com/task/1749387795006187783) started by @edithatogo*