### PR TITLE
🧹 Remove unused alias SklearnLinearRegression

### DIFF
--- a/voiage/analysis.py
+++ b/voiage/analysis.py
@@ -34,9 +34,8 @@ except ImportError:
 SKLEARN_AVAILABLE = False
 LinearRegression = None
 try:
-    from sklearn.linear_model import LinearRegression as SklearnLinearRegression
+    from sklearn.linear_model import LinearRegression
 
-    LinearRegression = SklearnLinearRegression
     SKLEARN_AVAILABLE = True
 except ImportError:
     # sklearn is an optional dependency, only required for EVPPI.
@@ -620,7 +619,7 @@ class DecisionAnalysis:
             y_fit = nb_values_fit[:, i]
 
             if regression_model is None:
-                model: RegressionModelProtocol = SklearnLinearRegression()
+                model: RegressionModelProtocol = LinearRegression()
             elif isinstance(regression_model, type):
                 model = regression_model()
             else:


### PR DESCRIPTION
🎯 What: Removed the unused `SklearnLinearRegression` import alias from `voiage/analysis.py`.
💡 Why: Improves readability and eliminates dead code related to unused alias assignments for `LinearRegression`.
✅ Verification: Ran `uv run ruff check` and pytest suite to verify no syntax errors and tests still pass.
✨ Result: Cleaned up code by directly importing and using `LinearRegression` from `sklearn.linear_model`.

---
*PR created automatically by Jules for task [5401602760070587870](https://jules.google.com/task/5401602760070587870) started by @edithatogo*