### PR TITLE
🧪 Add tests for TinyGPMetamodel RMSE

### DIFF
--- a/tests/test_metamodeling_comprehensive.py
+++ b/tests/test_metamodeling_comprehensive.py
@@ -395,8 +395,20 @@ def test_calculate_diagnostics_with_metamodels_without_methods(sample_data) -> N
 
     # Test with TinyGPMetamodel if available
     try:
+        from voiage.metamodels import TinyGPMetamodel
+
         model = TinyGPMetamodel()
         model.fit(x, y)
+
+        # Test score and rmse directly
+        score = model.score(x, y)
+        assert isinstance(score, float)
+        assert score <= 1.0
+
+        rmse = model.rmse(x, y)
+        assert isinstance(rmse, float)
+        assert rmse >= 0.0
+
         # This should work even if TinyGPMetamodel doesn't implement score/rmse
         # because calculate_diagnostics will compute them manually
         diagnostics = calculate_diagnostics(model, x, y)

--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -372,6 +372,27 @@ def test_tinygp_protocol() -> None:
     assert not isinstance(InvalidGP(), _TinyGPProtocol)
 
 
+def test_tinygp_metamodel_unfitted(sample_data) -> None:
+    """Test that TinyGPMetamodel raises RuntimeError when not fitted."""
+    x, y = sample_data
+
+    try:
+        from voiage.metamodels import TinyGPMetamodel
+
+        model = TinyGPMetamodel()
+
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.predict(x)
+
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.score(x, y)
+
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.rmse(x, y)
+    except ImportError:
+        pytest.skip("tinygp not available")
+
+
 def test_safe_r2_score_normal():
     """Test _safe_r2_score with normal inputs."""
     y_true = np.array([3, -0.5, 2, 7])


### PR DESCRIPTION
🎯 What: Added tests for the missing rmse method coverage in TinyGPMetamodel (for both fitted and unfitted scenarios).
📊 Coverage: The scenarios covered are calling predict, score, and rmse before fitting (which should raise RuntimeError) and calling score and rmse after fitting successfully.
✨ Result: Enhanced test coverage for metamodel functionality to prevent regressions.

---
*PR created automatically by Jules for task [7009543208855279987](https://jules.google.com/task/7009543208855279987) started by @edithatogo*