### PR TITLE
🧪 Add coverage test for _TinyGPProtocol condition method

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -470,3 +470,10 @@ def test_sparse_matrix_protocol_toarray() -> None:
     result = valid_instance.toarray()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+
+def test_tinygp_protocol_call_condition() -> None:
+    """Test that the _TinyGPProtocol.condition can be called (for coverage)."""
+    from voiage.metamodels import _TinyGPProtocol
+
+    _TinyGPProtocol.condition(None, None, None)  # type: ignore[arg-type]


### PR DESCRIPTION
🎯 **What:** The `condition` method on `_TinyGPProtocol` in `voiage/metamodels.py` was missing test coverage because it's just a protocol signature.
📊 **Coverage:** A new test `test_tinygp_protocol_call_condition` directly calls this method with mocked None arguments, ensuring the method definition is hit.
✨ **Result:** Test coverage for this file has increased.

---
*PR created automatically by Jules for task [7367281863775709125](https://jules.google.com/task/7367281863775709125) started by @edithatogo*