### PR TITLE
🧪 [testing improvement] Add missing test for to_dict

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -482,6 +482,40 @@ def test_create_streaming_config() -> None:
     assert config.buffer_size is None
 
 
+
+def test_voi_analysis_config_to_dict() -> None:
+    """Test the to_dict method of VOIAnalysisConfig."""
+    config = VOIAnalysisConfig(
+        population=100000,
+        time_horizon=10,
+        discount_rate=0.03,
+        chunk_size=1000,
+        use_jit=True,
+        backend="jax",
+        enable_caching=True,
+        streaming_window_size=5000,
+        n_regression_samples=5000,
+        regression_model="some_model",
+        n_simulations=2000,
+    )
+
+    result = config.to_dict()
+
+    assert isinstance(result, dict)
+    assert result == {
+        "population": 100000,
+        "time_horizon": 10,
+        "discount_rate": 0.03,
+        "chunk_size": 1000,
+        "use_jit": True,
+        "backend": "jax",
+        "enable_caching": True,
+        "streaming_window_size": 5000,
+        "n_regression_samples": 5000,
+        "regression_model": "some_model",
+        "n_simulations": 2000,
+    }
+
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for `to_dict` in `voiage/config_objects.py`. Added `test_voi_analysis_config_to_dict` to completely test `VOIAnalysisConfig.to_dict()` logic, avoiding any coverage gaps.
  📊 **Coverage:** What scenarios are now tested: A dictionary is returned matching correctly all provided values given a customized instantiation of `VOIAnalysisConfig` including optional/special parameters.
  ✨ **Result:** The improvement in test coverage: Improved coverage and confidence in `VOIAnalysisConfig.to_dict()` accuracy.

---
*PR created automatically by Jules for task [17911915007521608903](https://jules.google.com/task/17911915007521608903) started by @edithatogo*