### PR TITLE
🧪 Add tests for unfitted metamodels

### DIFF
--- a/fix.py
+++ b/fix.py
@@ -1,0 +1,9 @@
+import sys
+lines = []
+with open("tests/test_metamodels.py") as f:
+    lines = f.readlines()
+with open("tests/test_metamodels.py", "w") as f:
+    for i, line in enumerate(lines):
+        f.write(line)
+        if "    def test_random_forest_metamodel(sample_data) -> None:" in line:
+            pass # Actually we just need to add the happy path assert that is missing?! Wait!

--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -107,6 +107,23 @@ def test_linear_metamodel(sample_data) -> None:
     assert isinstance(rmse, float)
     assert rmse >= 0
 
+def test_random_forest_metamodel_unfitted(sample_data) -> None:
+    """Test that RandomForestMetamodel raises RuntimeError when not fitted."""
+    # Skip if sklearn is not available
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+    model = RandomForestMetamodel()
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.predict(x)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.score(x, y)
+
+    with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+        model.rmse(x, y)
 
 def test_random_forest_metamodel(sample_data) -> None:
     """Test the RandomForestMetamodel."""
@@ -195,6 +212,26 @@ def test_gam_metamodel(sample_data) -> None:
             pytest.skip(f"Skipping GAM test due to compatibility issue: {e}")
         else:
             raise
+
+def test_bart_metamodel_unfitted(sample_data) -> None:
+    """Test that BARTMetamodel raises RuntimeError when not fitted."""
+    x, y = sample_data
+
+    # Skip test if pymc or pymc-bart is not available
+    try:
+        model = BARTMetamodel(num_trees=10)
+
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.predict(x)
+
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.score(x, y)
+
+        with pytest.raises(RuntimeError, match="The model has not been fitted yet."):
+            model.rmse(x, y)
+    except ImportError:
+        pytest.skip("pymc or pymc-bart not available")
+
 
 
 def test_bart_metamodel(sample_data) -> None:


### PR DESCRIPTION
🎯 **What:** 
- The codebase was missing unit tests that ensure calling `rmse`, `predict`, or `score` on an unfitted `RandomForestMetamodel` raises a `RuntimeError`.
- Similarly, the `BARTMetamodel` was missing tests for its unfitted state.

📊 **Coverage:** 
- Added `test_random_forest_metamodel_unfitted` to verify that `RandomForestMetamodel` methods properly raise exceptions before `fit()` is called.
- Added `test_bart_metamodel_unfitted` to verify that `BARTMetamodel` methods properly raise exceptions before `fit()` is called.

✨ **Result:** 
- Coverage of edge cases for the `rmse` checks on unfitted metamodels in `metamodels.py` is now complete for Random Forest and BART metamodels, matching the behavior already tested for GAMMetamodel.

---
*PR created automatically by Jules for task [13124533091290754349](https://jules.google.com/task/13124533091290754349) started by @edithatogo*