### PR TITLE
🧪 tests: Extract to_dict assertions into dedicated test

### DIFF
--- a/tests/test_config_objects.py
+++ b/tests/test_config_objects.py
@@ -62,7 +62,23 @@ def test_voi_analysis_config() -> None:
     assert config.n_regression_samples == 5000
     assert config.n_simulations == 2000
 
-    # Test to_dict method
+
+def test_voi_analysis_config_to_dict() -> None:
+    """Test to_dict method of VOIAnalysisConfig."""
+    # Test custom configuration
+    config = VOIAnalysisConfig(
+        population=100000,
+        time_horizon=10,
+        discount_rate=0.03,
+        chunk_size=1000,
+        use_jit=True,
+        backend="jax",
+        enable_caching=True,
+        streaming_window_size=5000,
+        n_regression_samples=5000,
+        n_simulations=2000,
+    )
+
     config_dict = config.to_dict()
     assert isinstance(config_dict, dict)
     assert config_dict["population"] == 100000
@@ -77,7 +93,7 @@ def test_voi_analysis_config() -> None:
     assert config_dict["regression_model"] is None
     assert config_dict["n_simulations"] == 2000
 
-    # Test to_dict method on default config
+    # Test default configuration
     default_config = VOIAnalysisConfig()
     default_dict = default_config.to_dict()
     assert default_dict["population"] is None
@@ -485,6 +501,7 @@ def test_create_streaming_config() -> None:
 if __name__ == "__main__":
     test_create_default_config()
     test_voi_analysis_config()
+    test_voi_analysis_config_to_dict()
     test_streaming_config()
     test_metamodel_config()
     test_optimization_config()


### PR DESCRIPTION
🎯 **What:** Extracted the assertions for `VOIAnalysisConfig.to_dict()` into a dedicated test function `test_voi_analysis_config_to_dict`.
📊 **Coverage:** The test coverage for the `to_dict` logic remains exactly the same as before, but the implementation is isolated into a standalone unit test to improve modularity and test discovery for the `to_dict` functionality specifically. 
✨ **Result:** Test clarity and test suite separation between configuration initialization logic and the `to_dict` method's implementation logic have been improved.

---
*PR created automatically by Jules for task [13784331444920110061](https://jules.google.com/task/13784331444920110061) started by @edithatogo*