### PR TITLE
Formalize panel assessments for remaining gates

### DIFF
--- a/conductor/index.md
+++ b/conductor/index.md
@@ -16,6 +16,8 @@
 - [VOP–VOIAGE GitHub Project](https://github.com/users/edithatogo/projects/28)
 - [GitHub Cross-References](./github-cross-references.json)
 - [Single-maintainer review policy](./single-maintainer-review-policy.md)
+- [Panel gate policy](./panel-gate-policy.json)
+- [Panel gate assessment (2026-08-20)](./panel-gate-assessment-20260820.md)
 - [Tracks Registry](./tracks.md)
 - [Tracks Directory](./tracks/)
 - [Archive Directory](./archive/)

--- a/conductor/panel-gate-assessment-20260820.md
+++ b/conductor/panel-gate-assessment-20260820.md
@@ -1,0 +1,73 @@
+# Panel gate assessment — 20 August 2026
+
+This packet applies `conductor/panel-gate-policy.json` to the merged C18
+M22–M31 candidate. It is an advisory Conductor assessment, not a scientific,
+promotion, release, publication, registry, or issue-closure approval.
+
+## Candidate binding
+
+- Candidate: `main` at `a70def2569083cf958d78d086771e5c96069e127`
+- Scope: C18 M22–M31 semantics, reference fixtures, executable evidence, and
+  the recorded panel rerun in
+  `conductor/tracks/supported_frontier_method_completion_20260723/`.
+- PR #883 is merged with hosted checks green. This changes the candidate from
+  preparation to a merged experimental baseline; it does not change maturity.
+
+## Role-separated panel
+
+The orchestrator delegates four separated advisory reports to subagents:
+
+1. estimand/domain semantics;
+2. numerical, reference, property, and pathology assurance;
+3. API, cross-language, and packaging readiness; and
+4. governance, provenance, publication, and promotion boundaries.
+
+Each report must include status, evidence paths, limitations, options,
+trade-offs, contingencies, fallback, recommendation, dissent, and a
+re-review trigger. Disagreement is preserved; it is not converted into a
+majority-vote approval.
+
+## Assessment and options
+
+The panel evidence supports repository-owned executable evidence for the
+declared finite experimental contracts. It does not establish broad empirical
+scientific validity, complete independently reproducible pathology corpora,
+cross-language parity, stable promotion, or any external acceptance.
+
+| Option | Consequence | Recommendation |
+| --- | --- | --- |
+| A — conditional experimental acceptance | Keep M22–M31 experimental; remediate fixture/hash and independent-reference gaps; rerun affected roles. | **Recommended**: preserves useful implementation evidence without overstating validity. |
+| B — staged promotion | Promote only families with complete evidence and retain the rest as experimental. | Defer: creates maturity fragmentation before parity and accountable promotion receipts exist. |
+| C — full no-go | Defer all further promotion until the entire corpus and parity evidence are complete. | Safe fallback if any role reports a blocking semantic disagreement. |
+
+## Gate disposition
+
+- Scientific validity: **pending accountable decision**; panel assessment is
+  conditional and experimental-only.
+- Stable promotion: **blocked** until scientific decision, complete evidence,
+  parity where claimed, and a maintainer promotion receipt.
+- Cross-language parity: **not started as a promotion claim**; run only after
+  Python semantics are frozen and record unsupported bindings explicitly.
+- Hosted exact-head assurance: **satisfied for the merged C18 baseline**;
+  receipts must be invalidated if `main` changes.
+- Release: **blocked** pending promotion and security/provenance evidence.
+- Publication and registries: **blocked/external**; no submission or
+  acceptance is inferred.
+- GitHub issue/project closure: **pending reconciliation**; no parent or child
+  issue is closed by this packet.
+
+## Contingencies and fallback
+
+- Missing per-case fixture IDs, hashes, or independent derivations keep the
+  affected families experimental and create bounded remediation tasks.
+- Any semantic dissent keeps the affected gate pending and triggers a focused
+  panel rerun; parity is not a substitute for unresolved Python semantics.
+- Missing installed Rust/R/Julia artifacts produce unsupported/unverified
+  receipts rather than parity claims.
+- Missing credentials or destination receipts stops release/publication work at
+  a local, dated packet; no external action is taken.
+
+The next repository-owned gate is targeted remediation of the assurance
+panel's fixture/hash and manifest-to-test dissent, followed by a candidate-bound
+panel rerun. The accountable scientific and maintainer decisions remain
+separate gates.

--- a/conductor/panel-gate-policy.json
+++ b/conductor/panel-gate-policy.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "1.0",
+  "policy_id": "voiage-panel-gate-policy",
+  "accountability_model": "single-maintainer",
+  "purpose": "Replace repository-owned independent-review preparation with a separated panel of advisory agents while preserving accountable maintainer and external decisions.",
+  "assessment": {
+    "mode": "role-separated-panel-of-agents",
+    "orchestrator": "conductor-panel-orchestrator",
+    "roles": [
+      "estimand-and-domain-semantics",
+      "numerical-reference-property-and-pathology-assurance",
+      "api-cross-language-and-packaging-readiness",
+      "governance-provenance-publication-and-promotion"
+    ],
+    "required_report_fields": [
+      "status",
+      "evidence_refs",
+      "findings",
+      "limitations",
+      "options",
+      "tradeoffs",
+      "contingencies",
+      "fallback",
+      "recommendation",
+      "dissent",
+      "re_review_trigger"
+    ],
+    "conflict_policy": "preserve_dissent_and_keep_the_gate_pending",
+    "candidate_binding": "reports must name the exact commit and tree they assessed",
+    "authorization_boundary": "panel output is advisory evidence and never an approval, release, publication, registry submission, or issue-closure receipt"
+  },
+  "gates": [
+    {
+      "id": "scientific-validity",
+      "scope": "repository-owned scientific and estimand assessment",
+      "assessment_delegate": "role-separated-panel-of-agents",
+      "accountable_decision": "maintainer scientific decision or explicitly required external authority",
+      "panel_can_authorize": false,
+      "current_status": "pending",
+      "preconditions": ["exact candidate packet", "per-family contracts and executable evidence", "dissent register"],
+      "contingency": "retain experimental maturity and schedule targeted remediation and re-review"
+    },
+    {
+      "id": "stable-promotion",
+      "scope": "maturity promotion and stable-claim boundary",
+      "assessment_delegate": "role-separated-panel-of-agents",
+      "accountable_decision": "maintainer promotion receipt",
+      "panel_can_authorize": false,
+      "current_status": "blocked",
+      "preconditions": ["scientific decision", "complete reference/pathology evidence", "cross-language parity where claimed", "release evidence"],
+      "contingency": "promote no families; preserve candidate or experimental labels"
+    },
+    {
+      "id": "cross-language-parity",
+      "scope": "Rust, R, Julia, and other binding parity",
+      "assessment_delegate": "role-separated-panel-of-agents",
+      "accountable_decision": "maintainer acceptance of exact shared-fixture receipts",
+      "panel_can_authorize": false,
+      "current_status": "blocked-until-python-semantics-stabilize",
+      "preconditions": ["frozen Python semantics", "installed binding artifacts", "exact shared fixtures"],
+      "contingency": "record each unavailable binding as unsupported/unverified; do not infer parity"
+    },
+    {
+      "id": "hosted-exact-head",
+      "scope": "required hosted checks and exact-head assurance",
+      "assessment_delegate": "role-separated-panel-of-agents",
+      "accountable_decision": "maintainer merge decision",
+      "panel_can_authorize": false,
+      "current_status": "satisfied-for-merged-c18-baseline",
+      "preconditions": ["checks bound to exact head", "resolved findings", "local evidence snapshot"],
+      "contingency": "rebase, refresh checks, and invalidate stale receipts"
+    },
+    {
+      "id": "release",
+      "scope": "release, signing, and artifact publication",
+      "assessment_delegate": "role-separated-panel-of-agents",
+      "accountable_decision": "maintainer release decision and protected credentials",
+      "panel_can_authorize": false,
+      "current_status": "blocked",
+      "preconditions": ["promotion receipt", "security and provenance evidence", "exact release artifacts"],
+      "contingency": "prepare a local release packet only; do not tag or publish"
+    },
+    {
+      "id": "publication-and-registry",
+      "scope": "arXiv/JOSS, CRAN, PyPI, crates.io, conda-forge, SciCrunch, and other registries",
+      "assessment_delegate": "role-separated-panel-of-agents",
+      "accountable_decision": "maintainer submission plus destination authority/curation",
+      "panel_can_authorize": false,
+      "current_status": "blocked-external",
+      "preconditions": ["release packet", "rights and metadata evidence", "destination-specific receipt"],
+      "contingency": "archive a dated shadow packet and record no submission or acceptance"
+    },
+    {
+      "id": "github-issue-and-project-closure",
+      "scope": "parent issues, sub-issues, project fields, and closure comments",
+      "assessment_delegate": "role-separated-panel-of-agents",
+      "accountable_decision": "maintainer closure decision",
+      "panel_can_authorize": false,
+      "current_status": "pending-reconciliation",
+      "preconditions": ["merged implementation", "all acceptance evidence", "PR and Conductor cross-reference"],
+      "contingency": "leave issues open with an evidence-linked status comment"
+    }
+  ]
+}

--- a/conductor/single-maintainer-review-policy.md
+++ b/conductor/single-maintainer-review-policy.md
@@ -7,10 +7,12 @@ orchestrator. The panel produces structured reports, disagreement registers,
 limitations, and evidence hashes; it does not provide independent human
 approval or replace the maintainer's accountable decision.
 
-The maintainer remains responsible for scientific validity, maturity promotion,
-release, publication, registry submission, and issue closure. External venues,
-other repositories, and human-only approvals retain their own requirements and
-are not rewritten by this policy.
+The policy covers every repository-owned review gate: scientific validity,
+maturity promotion, cross-language parity, hosted exact-head assurance,
+release, publication/registry preparation, and GitHub issue/project closure.
+The maintainer remains responsible for the accountable decision at each gate.
+External venues, other repositories, and destination-specific human-only
+approvals retain their own requirements and are not rewritten by this policy.
 
 A gate remains pending when the panel identifies unresolved findings, the exact
 candidate changes, parity is incomplete, or an external receipt is absent.

--- a/conductor/tracks/supported_frontier_method_completion_20260723/scientific-review-panel-readiness-20260803.md
+++ b/conductor/tracks/supported_frontier_method_completion_20260723/scientific-review-panel-readiness-20260803.md
@@ -1,17 +1,19 @@
 # Scientific-review panel readiness — #841 / #843–#849
 
 This packet prepares the role-based subagent panel described in
-`scientific-review-panel.md`. It is deliberately fail-closed: the candidate is
-not frozen while PR #854 hosted checks are still moving, and no panel output
-can substitute for an accountable scientific or maintainer decision.
+`scientific-review-panel.md`. It is deliberately fail-closed: PR #854 is now
+merged, so the candidate can be bound to the merged exact head, but no panel
+output can substitute for an accountable scientific or maintainer decision.
 
 ## Execution order
 
-1. Freeze the exact candidate after PR #854 reaches a stable exact head.
+1. Freeze the exact candidate at the merged PR #854 exact head and invalidate
+   this packet if `main` advances.
 2. Hash the packet, fixtures, schemas, installed parity evidence, issue/project
    reconciliation, and prior review reports.
-3. Commission independent reports from all five required roles before sharing
-   the orchestrator synthesis.
+3. Commission separated reports from the four required panel roles before
+   sharing the orchestrator synthesis. These are advisory agent reports, not
+   independent human attestations.
 4. Record findings, severity, dissent, remediation ownership, and re-review
    requirements without downgrading or deleting findings.
 5. Produce an orchestrator recommendation limited to the four protocol verdicts.
@@ -30,5 +32,7 @@ can substitute for an accountable scientific or maintainer decision.
 - `adjudication-preparation.json` and `scientific-approval-preparation.json` — templates only until
   accountable decisions exist.
 
-The packet must remain `not_started` until the candidate is frozen and all
-required reports are present. The current state is preparation-only.
+The packet is now candidate-bound to the merged baseline, but remains
+`preparation-only` until all reports are present. The resulting recommendation
+must keep the methods experimental unless the separate accountable scientific
+and promotion decisions are recorded.

--- a/tests/test_panel_gate_policy.py
+++ b/tests/test_panel_gate_policy.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 POLICY = ROOT / "conductor" / "panel-gate-policy.json"
 ASSESSMENT = ROOT / "conductor" / "panel-gate-assessment-20260820.md"

--- a/tests/test_panel_gate_policy.py
+++ b/tests/test_panel_gate_policy.py
@@ -1,0 +1,55 @@
+"""Executable contract for the single-maintainer panel-gate workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "conductor" / "panel-gate-policy.json"
+ASSESSMENT = ROOT / "conductor" / "panel-gate-assessment-20260820.md"
+
+
+def test_policy_covers_all_remaining_gate_classes() -> None:
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    assert policy["accountability_model"] == "single-maintainer"
+    assessment = policy["assessment"]
+    assert assessment["mode"] == "role-separated-panel-of-agents"
+    assert len(assessment["roles"]) == 4
+    required = set(assessment["required_report_fields"])
+    assert {
+        "options",
+        "tradeoffs",
+        "contingencies",
+        "fallback",
+        "recommendation",
+        "dissent",
+    } <= required
+
+    expected = {
+        "scientific-validity",
+        "stable-promotion",
+        "cross-language-parity",
+        "hosted-exact-head",
+        "release",
+        "publication-and-registry",
+        "github-issue-and-project-closure",
+    }
+    gates = {gate["id"]: gate for gate in policy["gates"]}
+    assert set(gates) == expected
+    for gate in gates.values():
+        assert gate["assessment_delegate"] == "role-separated-panel-of-agents"
+        assert gate["panel_can_authorize"] is False
+        assert gate["accountable_decision"]
+        assert gate["current_status"]
+        assert gate["preconditions"]
+        assert gate["contingency"]
+
+
+def test_policy_and_assessment_preserve_experimental_boundary() -> None:
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    assert "experimental" in ASSESSMENT.read_text(encoding="utf-8")
+    assert "never an approval" in policy["assessment"]["authorization_boundary"]
+    assert policy["gates"][0]["current_status"] == "pending"
+    assert all(gate["panel_can_authorize"] is False for gate in policy["gates"])


### PR DESCRIPTION
## Summary
- formalize a role-separated advisory panel for every remaining repository-owned gate
- preserve accountable maintainer and external scientific, release, publication, registry, and closure decisions
- bind the next C18 M22-M31 assessment to merged main and retain the experimental boundary
- add executable policy coverage

## Validation
- `python3` JSON policy contract validation
- `git diff --check`
- `uv run --frozen --extra ci python scripts/validate_conductor_github_cross_references.py .`

The full pytest invocation requires the repository CI environment; the local transient environment did not have the locked dependency set available.
