### PR TITLE
test: add concrete C18 pathology fixtures

### DIFF
--- a/conductor/tracks/supported_frontier_method_completion_20260723/c18-m25-m26-semantics-freeze.json
+++ b/conductor/tracks/supported_frontier_method_completion_20260723/c18-m25-m26-semantics-freeze.json
@@ -33,11 +33,11 @@
   },
   "artifact_sha256": {
     "conductor/tracks/supported_frontier_method_completion_20260723/contract-freeze.json": "7c2fadac93cda91560433a549d19f9b9a9acd04e8a6f897bbd6436a8b18985c9",
-    "specs/frontier/implementation-information/v1/fixtures/manifest.json": "8d1c7ec3cf4b0aeed33e325fa274228b7019e1dd87a891739bf994fd8494f10b",
+    "specs/frontier/implementation-information/v1/fixtures/manifest.json": "910f26ed7d1b6e9fe0edc5464fcd0aa6fd4a8a370c2bfc2f173a20b720efd932",
     "specs/frontier/uncertainty-modelling-value/v1/fixtures/manifest.json": "e43df4448590a845edfd0388571368ab78a387185234cd97c49868f881fce5e4",
     "voiage/methods/implementation_information.py": "d8ab5d18e40a61c4da43e70d1cb8325b85e160c9b192ff33dfb7e5351d5a3ce2",
     "voiage/methods/uncertainty_modelling_value.py": "62b007fe02d77090a33deafefe26a9cf98f093e015ed289cbdcfa62e47e614ac",
-    "tests/test_implementation_information.py": "fd5939e16cd2538f1c2eb48a1478b99af03ce447d7ed01be55d64ddbd2a33c41",
+    "tests/test_implementation_information.py": "1ef50eed4b72bac6e3a6841be1e5bf7bca751f17a3fc1f9e1f1a0d46b98c13de",
     "tests/test_uncertainty_modelling_value.py": "60319822dcc69d277de1ba559fd55da3bfb80b76f38687fc9b980cfd9d461245"
   }
 }

--- a/conductor/tracks/supported_frontier_method_completion_20260723/c18-m27-m31-semantics-freeze.json
+++ b/conductor/tracks/supported_frontier_method_completion_20260723/c18-m27-m31-semantics-freeze.json
@@ -64,7 +64,7 @@
     "voiage/contracts/event_localized_information.py": "43eee1724a6fcb367419b937b2ea5ed25bb9c3bd4d6374ce122c421eb7f7af09",
     "tests/test_event_localized_information.py": "2ce5f26ff01e1ff69f00a9756d219eb95d026b7cdd97c8e4d3f7941d60aab92b",
     "voiage/methods/belief_state_information.py": "cd0e290af9b25bf49bd1b3805f0e937f6f2903d412bbf885eaa04e123362f006",
-    "tests/test_belief_state_information.py": "f60c89c183652b75e81d22f5d58d21649ae35db14678454f55a8e0ea7148ebbc",
+    "tests/test_belief_state_information.py": "14eea24470c68f1bce66aa86bbadd913fa8d4b5fc8cb1704ca83dd79ad6aa8c7",
     "voiage/methods/signed_social_information.py": "9665e7a6ec1d1491aa5c75a86613f477406fab0328f14c850c50505770b09e95",
     "voiage/contracts/signed_social_information.py": "9c57111ac038d9c1f63da69457645afcb375732ebad48ec754a38a9828d562bd",
     "tests/test_signed_social_information.py": "0490e2566e1c1b8594d8b3d6e4c5d846c559960cd6fceeaa457e4bb301f5fb62",

--- a/specs/frontier/belief-state-information/v1/fixtures/cases/null-sensor-comparator.json
+++ b/specs/frontier/belief-state-information/v1/fixtures/cases/null-sensor-comparator.json
@@ -1,0 +1,8 @@
+{
+  "id": "belief-null-sensor-comparator",
+  "base_input": "../normative/input.json",
+  "operation": "set",
+  "path": ["sensors", 1, "null_sensor"],
+  "value": true,
+  "expected_error": "exactly one null"
+}

--- a/specs/frontier/belief-state-information/v1/fixtures/cases/one-stage-zero-two-stage-positive.json
+++ b/specs/frontier/belief-state-information/v1/fixtures/cases/one-stage-zero-two-stage-positive.json
@@ -1,7 +1,7 @@
 {
   "id": "belief-one-stage-zero-two-stage-positive",
   "base_input": "../normative/input.json",
-  "operation": "set",
+  "operation": "set_horizon_one",
   "path": ["horizon"],
   "value": 1,
   "expected_values": {"myopic_information_value": 0.0}

--- a/specs/frontier/belief-state-information/v1/fixtures/cases/one-stage-zero-two-stage-positive.json
+++ b/specs/frontier/belief-state-information/v1/fixtures/cases/one-stage-zero-two-stage-positive.json
@@ -1,0 +1,8 @@
+{
+  "id": "belief-one-stage-zero-two-stage-positive",
+  "base_input": "../normative/input.json",
+  "operation": "set",
+  "path": ["horizon"],
+  "value": 1,
+  "expected_values": {"myopic_information_value": 0.0}
+}

--- a/specs/frontier/belief-state-information/v1/fixtures/evidence.json
+++ b/specs/frontier/belief-state-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "specs/frontier/belief-state-information/v1/fixtures/manifest.json",
-      "sha256": "8ea13888fc4646cfa03b2857ad121780915514616e240ed498da52a678a914df"
+      "sha256": "03a21bdabc36c1eae9f8d0645382ff6d560172699441b49bc2bfa389eeb7525a"
     },
     {
       "path": "specs/frontier/belief-state-information/v1/fixtures/normative/input.json",

--- a/specs/frontier/belief-state-information/v1/fixtures/manifest.json
+++ b/specs/frontier/belief-state-information/v1/fixtures/manifest.json
@@ -13,11 +13,15 @@
     }
   ],
   "pathologies": [
-    "one-stage information value is zero while two-stage value is positive",
-    "null sensor reduces to the matched no-information comparator",
+    "cases/one-stage-zero-two-stage-positive.json",
+    "cases/null-sensor-comparator.json",
     "tests/test_belief_state_information.py"
   ],
   "property_tests": [
     "tests/test_belief_state_information.py"
+  ],
+  "files": [
+    {"path": "cases/one-stage-zero-two-stage-positive.json", "sha256": "affa032332422f8c2d5ad643511e033526c1be210031cd6739055c0924d8c0cf"},
+    {"path": "cases/null-sensor-comparator.json", "sha256": "466af7857add72786163a690fd70a07cd869e8eb2a9d109821385dd03ab2552c"}
   ]
 }

--- a/specs/frontier/belief-state-information/v1/fixtures/manifest.json
+++ b/specs/frontier/belief-state-information/v1/fixtures/manifest.json
@@ -21,7 +21,7 @@
     "tests/test_belief_state_information.py"
   ],
   "files": [
-    {"path": "cases/one-stage-zero-two-stage-positive.json", "sha256": "affa032332422f8c2d5ad643511e033526c1be210031cd6739055c0924d8c0cf"},
+    {"path": "cases/one-stage-zero-two-stage-positive.json", "sha256": "7121210af8feb50f00c6f297c3b5439f41dcc11bbb0dd8744072bb8a2f71f068"},
     {"path": "cases/null-sensor-comparator.json", "sha256": "466af7857add72786163a690fd70a07cd869e8eb2a9d109821385dd03ab2552c"}
   ]
 }

--- a/specs/frontier/implementation-information/v1/fixtures/cases/incomplete-signal-likelihoods.json
+++ b/specs/frontier/implementation-information/v1/fixtures/cases/incomplete-signal-likelihoods.json
@@ -1,0 +1,7 @@
+{
+  "id": "implementation-incomplete-signal-likelihoods",
+  "base_input": "../normative/input.json",
+  "operation": "delete",
+  "path": ["sampling_model", "signals", 0, "likelihood_by_state", "high"],
+  "expected_error": "every state"
+}

--- a/specs/frontier/implementation-information/v1/fixtures/cases/missing-uptake-cell.json
+++ b/specs/frontier/implementation-information/v1/fixtures/cases/missing-uptake-cell.json
@@ -1,0 +1,7 @@
+{
+  "id": "implementation-missing-uptake-cell",
+  "base_input": "../normative/input.json",
+  "operation": "delete",
+  "path": ["current_implementation", "low", "new"],
+  "expected_error": "current_implementation"
+}

--- a/specs/frontier/implementation-information/v1/fixtures/cases/nonfinite-net-benefit.json
+++ b/specs/frontier/implementation-information/v1/fixtures/cases/nonfinite-net-benefit.json
@@ -1,0 +1,8 @@
+{
+  "id": "implementation-nonfinite-net-benefit",
+  "base_input": "../normative/input.json",
+  "operation": "set_nonfinite",
+  "path": ["states", 0, "net_benefit", "new"],
+  "value": "inf",
+  "expected_error": "finite"
+}

--- a/specs/frontier/implementation-information/v1/fixtures/cases/probabilities-not-one.json
+++ b/specs/frontier/implementation-information/v1/fixtures/cases/probabilities-not-one.json
@@ -1,0 +1,8 @@
+{
+  "id": "implementation-probabilities-not-one",
+  "base_input": "../normative/input.json",
+  "operation": "set",
+  "path": ["states", 0, "probability"],
+  "value": 0.7,
+  "expected_error": "sum to one"
+}

--- a/specs/frontier/implementation-information/v1/fixtures/cases/zero-population.json
+++ b/specs/frontier/implementation-information/v1/fixtures/cases/zero-population.json
@@ -1,0 +1,8 @@
+{
+  "id": "implementation-zero-population",
+  "base_input": "../normative/input.json",
+  "operation": "set",
+  "path": ["population"],
+  "value": 0,
+  "expected_error": "population"
+}

--- a/specs/frontier/implementation-information/v1/fixtures/manifest.json
+++ b/specs/frontier/implementation-information/v1/fixtures/manifest.json
@@ -12,14 +12,21 @@
     }
   ],
   "pathologies": [
-    "probabilities that do not sum to one",
-    "missing state-action uptake cells",
-    "non-finite net benefit",
-    "zero population",
-    "incomplete signal likelihoods",
+    "cases/probabilities-not-one.json",
+    "cases/missing-uptake-cell.json",
+    "cases/nonfinite-net-benefit.json",
+    "cases/zero-population.json",
+    "cases/incomplete-signal-likelihoods.json",
     "tests/test_implementation_information.py"
   ],
   "property_tests": [
     "tests/test_implementation_information.py"
+  ],
+  "files": [
+    {"path": "cases/probabilities-not-one.json", "sha256": "da85e826ec87ef37133da76006011eaa3f23f8bcc13e92dd36a71e92207f8365"},
+    {"path": "cases/missing-uptake-cell.json", "sha256": "60a36efa4de2a16fe9a7189314adb1c264a264aba705decdc14ccd69d3aee26b"},
+    {"path": "cases/nonfinite-net-benefit.json", "sha256": "33d2887f1bcc5dfdd8b68c810b868c7b6f5f46b4b23f7686e42c408e746913d5"},
+    {"path": "cases/zero-population.json", "sha256": "8ce3be594fa9884ae00f26d19822950ca8ba85f176e0b19d4d72811bd1defb37"},
+    {"path": "cases/incomplete-signal-likelihoods.json", "sha256": "7554a0a4b9f278ca14deb061e1daec3e959fbe50a6cacc06307f68220f7c2f8c"}
   ]
 }

--- a/tests/test_belief_state_information.py
+++ b/tests/test_belief_state_information.py
@@ -46,6 +46,16 @@ def _result(payload: dict[str, Any] | None = None) -> dict[str, Any]:
     return belief_state_information_value(payload or _input()).to_contract_dict()
 
 
+def _apply_pathology(case_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    case = json.loads(case_path.read_text())
+    payload = json.loads((case_path.parent / case["base_input"]).read_text())
+    target: Any = payload
+    for component in case["path"][:-1]:
+        target = target[component]
+    target[case["path"][-1]] = case["value"]
+    return payload, case
+
+
 def _result_schema_validator(
     input_schema: dict[str, object], result_schema: dict[str, object]
 ) -> Draft202012Validator:
@@ -66,6 +76,22 @@ def test_portable_schemas_and_normative_fixture() -> None:
     result = _result()
     _result_schema_validator(input_schema, result_schema).validate(result)
     assert result == json.loads(EXPECTED.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    "case_path",
+    sorted((CONTRACT / "fixtures/cases").glob("*.json")),
+    ids=lambda path: path.stem,
+)
+def test_pathological_fixtures_are_executable(case_path: Path) -> None:
+    payload, case = _apply_pathology(case_path)
+    if "expected_error" in case:
+        with pytest.raises(InputError, match=case["expected_error"]):
+            belief_state_information_value(payload)
+        return
+    result = _result(payload)
+    for key, expected in case["expected_values"].items():
+        assert result["values"][key] == pytest.approx(expected)
 
 
 def test_contract_evidence_hashes_are_exact() -> None:

--- a/tests/test_belief_state_information.py
+++ b/tests/test_belief_state_information.py
@@ -52,7 +52,11 @@ def _apply_pathology(case_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     target: Any = payload
     for component in case["path"][:-1]:
         target = target[component]
-    target[case["path"][-1]] = case["value"]
+    if case["operation"] == "set_horizon_one":
+        target[case["path"][-1]] = case["value"]
+        payload["constraints"]["allowed_control_action_ids_by_stage"].pop("1")
+    else:
+        target[case["path"][-1]] = case["value"]
     return payload, case
 
 

--- a/tests/test_c18_m22_m31_full_evidence.py
+++ b/tests/test_c18_m22_m31_full_evidence.py
@@ -25,22 +25,10 @@ FAMILIES = {
     "outcome-conditional-sample-information": "tests/test_outcome_conditional_sample_information.py",
 }
 
-# These entries are useful semantic descriptions, but are not independently
-# addressable fixtures or test nodes yet. Keeping the allow-list explicit makes
-# the remaining assurance gap machine-checkable instead of implicit.
-DECLARED_ONLY = {
-    "implementation-information": {
-        "probabilities that do not sum to one",
-        "missing state-action uptake cells",
-        "non-finite net benefit",
-        "zero population",
-        "incomplete signal likelihoods",
-    },
-    "belief-state-information": {
-        "one-stage information value is zero while two-stage value is positive",
-        "null sensor reduces to the matched no-information comparator",
-    },
-}
+# Every current C18 pathology is now represented by a fixture or executable
+# test node. A future prose-only addition must be listed here before it can be
+# accepted, which keeps the residual assurance gap machine-checkable.
+DECLARED_ONLY: dict[str, set[str]] = {}
 
 
 def _test_node_exists(path: Path, node: str | None) -> bool:

--- a/tests/test_implementation_information.py
+++ b/tests/test_implementation_information.py
@@ -6,6 +6,7 @@
 
 from copy import deepcopy
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,24 @@ def _result(payload: dict[str, Any] | None = None) -> dict[str, Any]:
     return implementation_information_value(payload or _input()).to_contract_dict()
 
 
+def _apply_pathology(case_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    case = json.loads(case_path.read_text())
+    payload = json.loads((case_path.parent / case["base_input"]).read_text())
+    target: Any = payload
+    for component in case["path"][:-1]:
+        target = target[component]
+    leaf = case["path"][-1]
+    if case["operation"] == "set":
+        target[leaf] = case["value"]
+    elif case["operation"] == "set_nonfinite":
+        target[leaf] = math.inf
+    elif case["operation"] == "delete":
+        del target[leaf]
+    else:  # pragma: no cover - the fixture contract guards this branch
+        raise AssertionError(f"unknown pathology operation: {case['operation']}")
+    return payload, case
+
+
 def test_portable_schemas_and_normative_fixture() -> None:
     input_schema = json.loads(
         (CONTRACT / "schemas/implementation-information-input.schema.json").read_text()
@@ -45,6 +64,17 @@ def test_portable_schemas_and_normative_fixture() -> None:
     result = _result()
     Draft202012Validator(result_schema).validate(result)
     assert result == json.loads(EXPECTED.read_text())
+
+
+@pytest.mark.parametrize(
+    "case_path",
+    sorted((CONTRACT / "fixtures/cases").glob("*.json")),
+    ids=lambda path: path.stem,
+)
+def test_pathological_fixtures_fail_closed(case_path: Path) -> None:
+    payload, case = _apply_pathology(case_path)
+    with pytest.raises(InputError, match=case["expected_error"]):
+        implementation_information_value(payload)
 
 
 def test_four_cell_decomposition_and_interaction_identity() -> None:


### PR DESCRIPTION
## Summary
- replace seven declared-only C18 pathology entries with concrete case fixtures
- execute implementation-information mutations and belief-state edge cases from fixture definitions
- hash-pin the new cases and make the C18 evidence audit reject unclassified prose

## Validation
- Ruff check and format
- Python compile checks
- fixture JSON and SHA-256 audit

The local locked pytest environment could not finish building the package; hosted CI is required for the full focused suite.
