### PR TITLE
Prepare stable 2.1.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,9 @@
 cff-version: 1.2.0
-message: "If you use voiage, please cite the v2.0.0 software release and the JOSS paper when published."
+message: "If you use voiage, please cite the v2.1.0 software release and the JOSS paper when published."
 title: "voiage: Value of Information Analysis"
 type: software
-version: 2.0.0
-date-released: 2026-07-26
+version: 2.1.0
+date-released: 2026-08-21
 authors:
   - family-names: Mordaunt
     given-names: Dylan
@@ -14,7 +14,7 @@ url: https://edithatogo.github.io/voiage
 identifiers:
   - type: swh
     value: swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d
-    description: Software Heritage snapshot containing the signed v2.0.0 release
+    description: Prior Software Heritage snapshot containing the signed v2.0.0 release
 license: Apache-2.0
 abstract: >-
   voiage provides Value of Information analysis through a hybrid Rust and

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python -m pip install voiage
 
 Python 3.12, 3.13, and 3.14 are supported. Wheels use the CPython 3.12 stable
 ABI and are published for the platforms listed in the
-[v2.0.0 release](https://github.com/edithatogo/voiage/releases/tag/v2.0.0).
+[v2.1.0 release](https://github.com/edithatogo/voiage/releases/tag/v2.1.0).
 
 Optional features are installed explicitly:
 
@@ -190,7 +190,7 @@ records the supported boundary and migration policy.
 
 | Surface | Source | Current use | Distribution status |
 | --- | --- | --- | --- |
-| Python | [`voiage/`](voiage/) | Primary API, CLI, orchestration, plots, reports | [PyPI v2.0.0](https://pypi.org/project/voiage/2.0.0/) and TestPyPI |
+| Python | [`voiage/`](voiage/) | Primary API, CLI, orchestration, plots, reports | [PyPI v2.1.0](https://pypi.org/project/voiage/2.1.0/) and TestPyPI |
 | Rust | [`rust/`](rust/) | Domain contracts, diagnostics, selected kernels, serialization | Crates are package-ready; consult the [release checklist](docs/release/binding-submission-checklist.md) for verified registry state |
 | R | [`r-package/voiageR/`](r-package/voiageR/) | Direct C-ABI EVPI; documented bridge for wider Python methods | [r-universe](https://edithatogo.r-universe.dev/voiageR); CRAN review remains external |
 | Julia | [`bindings/julia/`](bindings/julia/) | Direct C-ABI EVPI | Prepared for Julia General; registry entry is not yet verified |
@@ -248,7 +248,7 @@ and [SECURITY.md](SECURITY.md).
 ## Releases, citation, and archival
 
 - Latest software release:
-  [v2.0.0](https://github.com/edithatogo/voiage/releases/tag/v2.0.0)
+  [v2.1.0](https://github.com/edithatogo/voiage/releases/tag/v2.1.0)
 - Python package: [PyPI](https://pypi.org/project/voiage/)
 - Citation metadata: [`CITATION.cff`](CITATION.cff)
 - Software metadata: [`codemeta.json`](codemeta.json)

--- a/bindings/julia/Project.toml
+++ b/bindings/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Voiage"
 uuid = "8c7ad020-41fd-4d68-9c3f-5d4e11c48f1f"
 authors = ["Dylan Mordaunt <voiage@users.noreply.github.com>"]
-version = "2.0.1-rc.4"
+version = "2.1.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Prepare the non-regressing 2.1.0 release line for the stable core while
+  retaining M22–M31 and other frontier APIs at experimental maturity.
+
 - Upgrade the documentation toolchain's transitive `fast-uri`, `js-yaml`,
   `nanoid`, and `postcss` dependencies to patched releases.
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "name": "voiage",
   "description": "Value of Information analysis with selected stable Rust kernels, a broader Python interface, and direct EVPI bindings for R and Julia.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "codeRepository": "https://github.com/edithatogo/voiage",
   "issueTracker": "https://github.com/edithatogo/voiage/issues",
   "url": "https://edithatogo.github.io/voiage",
@@ -18,8 +18,8 @@
     "@id": "https://orcid.org/0000-0002-9775-0603",
     "email": "voiage@users.noreply.github.com"
   }],
-  "downloadUrl": "https://pypi.org/project/voiage/2.0.0/",
-  "releaseNotes": "https://github.com/edithatogo/voiage/releases/tag/v2.0.0",
+  "downloadUrl": "https://pypi.org/project/voiage/2.1.0/",
+  "releaseNotes": "https://github.com/edithatogo/voiage/releases/tag/v2.1.0",
   "softwareRequirements": ["Python >=3.12", "Rust toolchain for source builds"],
   "keywords": ["value of information", "decision analysis", "health economics", "uncertainty quantification"]
 }

--- a/conductor/tracks/quality_release_automation_20260723/plan.md
+++ b/conductor/tracks/quality_release_automation_20260723/plan.md
@@ -36,6 +36,14 @@
 
 - [ ] **G13:** Reconcile child-issue results, roadmap, todo, registries,
   release targets and remaining external gates. (AC-01, AC-05, AC-06)
+  - [x] Reject the regressing `2.0.1-rc.4` identity after verifying published
+    `2.0.1`, and select the backward-compatible `2.1.0` release line under the
+    owner Option A decision. — `release-lineage-decision-20260821`
+  - [~] Synchronize the Rust, Python, R and Julia manifests; obtain exact-head
+    hosted checks; create the signed tag; stage and digest-review the private
+    draft; then publish only the reviewed stable-core payload.
+  - [ ] Record PyPI and GitHub publication receipts separately from external
+    registry, archive, and publication-service acceptance.
 - [x] **G14:** Run final full local validation and hosted required checks. PR
   #822 exact head `7e12a5fbc6f7091166d7f5d64c6f2b5b45764f72` passed the
   required matrix before merge `0df988125b89f8d0bad08def0bd5b2ea03cd54f5`.

--- a/conductor/tracks/quality_release_automation_20260723/release-lineage-decision-20260821.json
+++ b/conductor/tracks/quality_release_automation_20260723/release-lineage-decision-20260821.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0",
+  "recorded_at": "2026-08-21T10:45:00+10:00",
+  "track_id": "quality_release_automation_20260723",
+  "authority": {
+    "scientist": "repository owner",
+    "maintainer": "repository owner",
+    "release_approver": "repository owner"
+  },
+  "observed_state": {
+    "pypi_latest": "2.0.1",
+    "github_release": "v2.0.1",
+    "repository_manifest_before": "2.0.1-rc.4"
+  },
+  "decision": {
+    "target": "2.1.0",
+    "rationale": "A published 2.0.1 cannot be followed by a 2.0.1 release candidate. Backward-compatible public capability additions require a non-regressing minor release.",
+    "stable_scope": "stable core",
+    "experimental_scope": "frontier APIs including M22-M31",
+    "promotes_frontier": false
+  },
+  "execution_state": {
+    "manifest_sync": "prepared",
+    "hosted_exact_head": "pending",
+    "signed_tag": "pending",
+    "private_draft": "pending",
+    "reviewed_digests": "pending",
+    "publication": "pending",
+    "external_registries": "separate_pending_gates"
+  }
+}

--- a/conductor/tracks/quality_release_automation_20260723/release-lineage-decision-20260821.md
+++ b/conductor/tracks/quality_release_automation_20260723/release-lineage-decision-20260821.md
@@ -1,0 +1,16 @@
+# Release-lineage decision — 2026-08-21
+
+PyPI and GitHub already contain stable release `2.0.1`, while the repository
+manifests had subsequently returned to `2.0.1-rc.4`. Publishing that candidate
+would regress the public version line and is therefore rejected.
+
+The owner-approved Option A release is assigned version `2.1.0`. A minor
+version accurately represents the backward-compatible public capabilities
+added since 2.0.1. The release includes the stable core while retaining all
+frontier APIs, including M22–M31, at their documented experimental maturity.
+No scientific promotion follows from the package version.
+
+Repository merge, signed tag, staged private draft, digest review, publication,
+and external registry acceptance remain distinct receipts. This decision
+authorizes the repository-owned release path but does not claim conda-forge,
+Julia General, CRAN, SciCrunch, arXiv, or journal acceptance.

--- a/r-package/voiageR/DESCRIPTION
+++ b/r-package/voiageR/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: voiageR
 Type: Package
 Title: Value of Information Analysis in R
-Version: 2.0.0.9004
-Config/voiage/Release-Version: 2.0.1-rc.4
+Version: 2.1.0
+Config/voiage/Release-Version: 2.1.0
 Authors@R: person("Dylan", "Mordaunt",
     email = "voiage@users.noreply.github.com",
     role = c("aut", "cre"),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 NeedsCompilation: no
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
-SystemRequirements: voiage-ffi shared library (version 2.0.1-rc.4 or compatible);
+SystemRequirements: voiage-ffi shared library (version 2.1.0 or compatible);
     Python (>= 3.12, optional, for EVPPI and EVSI through reticulate)
 Suggests:
     reticulate (>= 1.20),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voiage-diagnostics"
-version = "2.0.1-rc.4"
+version = "2.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-domain"
-version = "2.0.1-rc.4"
+version = "2.1.0"
 dependencies = [
  "proptest",
  "serde",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-ffi"
-version = "2.0.1-rc.4"
+version = "2.1.0"
 dependencies = [
  "voiage-diagnostics",
  "voiage-domain",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-numerics"
-version = "2.0.1-rc.4"
+version = "2.1.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-python"
-version = "2.0.1-rc.4"
+version = "2.1.0"
 dependencies = [
  "pyo3",
  "serde",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-serialization"
-version = "2.0.1-rc.4"
+version = "2.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "voiage-test-support"
-version = "2.0.1-rc.4"
+version = "2.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.1-rc.4"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/edithatogo/voiage"
 
 [workspace.dependencies]
-voiage-diagnostics = { version = "=2.0.1-rc.4", path = "crates/voiage-diagnostics" }
-voiage-domain = { version = "=2.0.1-rc.4", path = "crates/voiage-domain" }
-voiage-numerics = { version = "=2.0.1-rc.4", path = "crates/voiage-numerics" }
-voiage-serialization = { version = "=2.0.1-rc.4", path = "crates/voiage-serialization" }
+voiage-diagnostics = { version = "=2.1.0", path = "crates/voiage-diagnostics" }
+voiage-domain = { version = "=2.1.0", path = "crates/voiage-domain" }
+voiage-numerics = { version = "=2.1.0", path = "crates/voiage-numerics" }
+voiage-serialization = { version = "=2.1.0", path = "crates/voiage-serialization" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -24,7 +24,7 @@
     {"path": "docs/astro-site/src/content/docs/examples/value-of-distributional-information.mdx", "sha256": "c99c508b5b500fb2ebbe55705d3ed3e04d4516b079e962d4506243593fb1c130"},
     {"path": "docs/astro-site/src/content/docs/examples/index.mdx", "sha256": "9c68fb38928ca889ebd9ed33ecd43821f5800d7a4fdb6c36ebbfd2cf12ad6d58"},
     {"path": "docs/astro-site/src/content/docs/cli-reference.mdx", "sha256": "054f0d78d9484b74dda394c3da1e38dc72d9a222b654dc4a29a6a7c54e047b41"},
-    {"path": "changelog.md", "sha256": "e46800971201c5f0fb1d29047d1f081f305e07f7b0f77af227b8dfc361fa5509"}
+    {"path": "changelog.md", "sha256": "bf0775d7aaf54f5c487f03de0f17faaf6041e84a9c1b855434aa7fa5a134440b"}
   ],
   "remaining_gates": [
     "independent implementation and scientific review",

--- a/tests/test_joss_readiness.py
+++ b/tests/test_joss_readiness.py
@@ -398,7 +398,7 @@ def test_joss_validator_rejects_discovery_metadata_version_drift(
     codemeta = tmp_path / "codemeta.json"
     codemeta.write_text(
         codemeta.read_text(encoding="utf-8").replace(
-            '"version": "2.0.0"', '"version": "0.9.0"'
+            '"version": "2.1.0"', '"version": "0.9.0"'
         ),
         encoding="utf-8",
     )

--- a/todo.md
+++ b/todo.md
@@ -4,6 +4,14 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## To Do
 
+*   [~] Release 2.1.0 with the stable core and experimental frontier boundary.
+    *   [x] Correct the regressing post-2.0.1 manifest identity and synchronize
+        Rust, Python, R, and Julia release metadata.
+    *   [ ] Bind exact-head hosted checks, signed tag, staged artifacts,
+        reviewed digests, and publication receipts in order.
+    *   [ ] Reconcile external registries separately after immutable release
+        URLs and checksums exist.
+
 For experimental frontier items, references to scientific review mean the
 role-specific subagent review panel and separate orchestrating agent defined in
 `conductor/tracks/supported_frontier_method_completion_20260723/scientific-review-panel.md`.


### PR DESCRIPTION
## Summary

- replace the regressing post-2.0.1 release-candidate identity with the backward-compatible 2.1.0 line
- synchronize Rust, Python, R, Julia, citation, and discovery metadata
- record the owner-approved stable-core release boundary while retaining M22–M31 and other frontier APIs as experimental
- stage tag, artifact, publication, and registry gates separately in Conductor

## Local validation

- full tox matrix: 4,287–4,288 passed per Python/dependency environment; one transient DNS-only wheel-build failure reproduced across the parallel run and passed on exact focused retry under Python 3.14
- Ruff, formatting, ty, Vale, docs build/link audit, harness, JOSS readiness, version sync, and frontier contracts passed
- full Conductor validation: zero errors and zero warnings
- GitHub cross-reference validation passed
- Cargo workspace check passed with the synchronized lockfile

## Boundaries

This PR does not promote experimental frontier methods, claim external registry acceptance, revise manuscript scientific claims, create a tag, or publish artifacts. Those actions require their own exact receipts after this PR is green and merged.