### PR TITLE
Record verified v2.1.0 publication receipts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Record the verified v2.1.0 GitHub and PyPI publication receipts while keeping
+  external registry and manuscript acceptance as separate gates.
+
 - Prepare the non-regressing 2.1.0 release line for the stable core while
   retaining M22–M31 and other frontier APIs at experimental maturity.
 

--- a/conductor/tracks/quality_release_automation_20260723/plan.md
+++ b/conductor/tracks/quality_release_automation_20260723/plan.md
@@ -39,11 +39,15 @@
   - [x] Reject the regressing `2.0.1-rc.4` identity after verifying published
     `2.0.1`, and select the backward-compatible `2.1.0` release line under the
     owner Option A decision. — `release-lineage-decision-20260821`
-  - [~] Synchronize the Rust, Python, R and Julia manifests; obtain exact-head
+  - [x] Synchronize the Rust, Python, R and Julia manifests; obtain exact-head
     hosted checks; create the signed tag; stage and digest-review the private
-    draft; then publish only the reviewed stable-core payload.
-  - [ ] Record PyPI and GitHub publication receipts separately from external
-    registry, archive, and publication-service acceptance.
+    draft; then publish only the reviewed stable-core payload. — PR #996,
+    `release-2.1.0-publication-receipt-20260821`
+  - [x] Record PyPI and GitHub publication receipts separately from external
+    registry, archive, and publication-service acceptance. —
+    `release-2.1.0-publication-receipt-20260821`
+  - [ ] Reconcile each external registry, archive, and publication-service
+    decision only after its destination supplies an authoritative receipt.
 - [x] **G14:** Run final full local validation and hosted required checks. PR
   #822 exact head `7e12a5fbc6f7091166d7f5d64c6f2b5b45764f72` passed the
   required matrix before merge `0df988125b89f8d0bad08def0bd5b2ea03cd54f5`.

--- a/conductor/tracks/quality_release_automation_20260723/release-2.1.0-publication-receipt-20260821.json
+++ b/conductor/tracks/quality_release_automation_20260723/release-2.1.0-publication-receipt-20260821.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1.0",
+  "recorded_at": "2026-08-21T14:10:00+10:00",
+  "track_id": "quality_release_automation_20260723",
+  "release": {
+    "version": "2.1.0",
+    "tag": "v2.1.0",
+    "commit": "964a0fc334ece9509387cd07d43776adf38be240",
+    "tree": "a519104fbe1854909a13b12ea71fefa9f1484036",
+    "tag_object": "df1d46619144ea24bb51615aac7287f275a35998",
+    "tag_signature_verified": true,
+    "stable_scope": "stable core",
+    "experimental_scope": "frontier APIs including M22-M31",
+    "frontier_promoted": false
+  },
+  "pull_request": {
+    "number": 996,
+    "url": "https://github.com/edithatogo/voiage/pull/996",
+    "head": "1bfb0906fdb1894028b130abf4715119a65d2e7a",
+    "merged_at": "2026-08-21T03:50:34Z",
+    "hosted_checks": {
+      "success": 60,
+      "skipped": 4,
+      "neutral": 1,
+      "failed": 0,
+      "pending": 0
+    }
+  },
+  "workflows": {
+    "private_draft": {
+      "run_id": 32444844908,
+      "url": "https://github.com/edithatogo/voiage/actions/runs/32444844908",
+      "event": "push",
+      "conclusion": "success"
+    },
+    "publication": {
+      "run_id": 32445295284,
+      "url": "https://github.com/edithatogo/voiage/actions/runs/32445295284",
+      "event": "workflow_dispatch",
+      "head": "964a0fc334ece9509387cd07d43776adf38be240",
+      "conclusion": "success",
+      "completed_at": "2026-08-21T04:06:19Z"
+    }
+  },
+  "reviewed_digests": {
+    "voiage-2.1.0-cp312-abi3-macosx_11_0_arm64.whl": "2c1582cfda4e187d0260faf39533439cb63d38e57a3520d6f5b1392edeba1a2f",
+    "voiage-2.1.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "81a649675bc43179efbfccac57bd53226b5f81dc2d82dd7ffc5c8a051c257724",
+    "voiage-2.1.0-cp312-abi3-win_amd64.whl": "e085f6176d2639dd1648a8b9023108d9ee488734a6aac9e78c94571487b8deae",
+    "voiage-2.1.0.tar.gz": "f0844694c628a92d29a532170f5a5672acfe210efe1d797359a4dc18c11ab901"
+  },
+  "github": {
+    "url": "https://github.com/edithatogo/voiage/releases/tag/v2.1.0",
+    "published_at": "2026-08-21T04:06:15Z",
+    "draft": false,
+    "prerelease": false,
+    "immutable": true
+  },
+  "pypi": {
+    "url": "https://pypi.org/project/voiage/2.1.0/",
+    "latest_version": "2.1.0",
+    "artifacts": [
+      {
+        "filename": "voiage-2.1.0-cp312-abi3-macosx_11_0_arm64.whl",
+        "sha256": "2c1582cfda4e187d0260faf39533439cb63d38e57a3520d6f5b1392edeba1a2f"
+      },
+      {
+        "filename": "voiage-2.1.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "sha256": "81a649675bc43179efbfccac57bd53226b5f81dc2d82dd7ffc5c8a051c257724"
+      },
+      {
+        "filename": "voiage-2.1.0-cp312-abi3-win_amd64.whl",
+        "sha256": "e085f6176d2639dd1648a8b9023108d9ee488734a6aac9e78c94571487b8deae"
+      },
+      {
+        "filename": "voiage-2.1.0.tar.gz",
+        "sha256": "f0844694c628a92d29a532170f5a5672acfe210efe1d797359a4dc18c11ab901"
+      }
+    ]
+  },
+  "external_gates": {
+    "registry_acceptance": "pending",
+    "publication_acceptance": "pending",
+    "manuscript_scope_changed": false
+  }
+}

--- a/conductor/tracks/quality_release_automation_20260723/release-2.1.0-publication-receipt-20260821.md
+++ b/conductor/tracks/quality_release_automation_20260723/release-2.1.0-publication-receipt-20260821.md
@@ -1,0 +1,19 @@
+# v2.1.0 publication receipt
+
+The stable-core v2.1.0 release is published from merge commit
+`964a0fc334ece9509387cd07d43776adf38be240`. PR #996 passed 60 hosted checks,
+with four governed skips, one neutral result, and no failures or pending jobs.
+The signed annotated `v2.1.0` tag was verified locally and by GitHub.
+
+Tag run 32444844908 built and attested three CPython 3.12 stable-ABI wheels and
+one source distribution, then created a private draft. The payload's checksum
+file, release manifest, wheel metadata, source commit, and GitHub attestations
+were independently rechecked before publication. Publication run 32445295284
+required those exact reviewed hashes, exercised the TestPyPI artifacts on
+Python 3.12, 3.13, and 3.14, and then published the same bytes to PyPI and the
+immutable GitHub release.
+
+This receipt authorizes no scientific or maturity promotion. M22–M31 and all
+other frontier APIs retain their experimental classifications. Conda-forge,
+Yggdrasil, CRAN, Julia General, SciCrunch, archival, and manuscript acceptance
+remain separate external gates and are not inferred from this release.

--- a/conductor/tracks/quality_release_automation_20260723/release-lineage-decision-20260821.json
+++ b/conductor/tracks/quality_release_automation_20260723/release-lineage-decision-20260821.json
@@ -20,12 +20,14 @@
     "promotes_frontier": false
   },
   "execution_state": {
-    "manifest_sync": "prepared",
-    "hosted_exact_head": "pending",
-    "signed_tag": "pending",
-    "private_draft": "pending",
-    "reviewed_digests": "pending",
-    "publication": "pending",
+    "updated_at": "2026-08-21T14:10:00+10:00",
+    "receipt": "release-2.1.0-publication-receipt-20260821.json",
+    "manifest_sync": "completed",
+    "hosted_exact_head": "passed",
+    "signed_tag": "verified",
+    "private_draft": "staged_and_reviewed",
+    "reviewed_digests": "verified",
+    "publication": "completed",
     "external_registries": "separate_pending_gates"
   }
 }

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -24,7 +24,7 @@
     {"path": "docs/astro-site/src/content/docs/examples/value-of-distributional-information.mdx", "sha256": "c99c508b5b500fb2ebbe55705d3ed3e04d4516b079e962d4506243593fb1c130"},
     {"path": "docs/astro-site/src/content/docs/examples/index.mdx", "sha256": "9c68fb38928ca889ebd9ed33ecd43821f5800d7a4fdb6c36ebbfd2cf12ad6d58"},
     {"path": "docs/astro-site/src/content/docs/cli-reference.mdx", "sha256": "054f0d78d9484b74dda394c3da1e38dc72d9a222b654dc4a29a6a7c54e047b41"},
-    {"path": "changelog.md", "sha256": "bf0775d7aaf54f5c487f03de0f17faaf6041e84a9c1b855434aa7fa5a134440b"}
+    {"path": "changelog.md", "sha256": "4f4b643065eb942db329daf320d86f0235e3ecb6aa75369d2eb9e1c16789232a"}
   ],
   "remaining_gates": [
     "independent implementation and scientific review",

--- a/tests/test_release_2_1_0_receipt.py
+++ b/tests/test_release_2_1_0_receipt.py
@@ -1,0 +1,40 @@
+"""Contract checks for the immutable v2.1.0 publication receipt."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = (
+    ROOT
+    / "conductor"
+    / "tracks"
+    / "quality_release_automation_20260723"
+    / "release-2.1.0-publication-receipt-20260821.json"
+)
+
+
+def test_release_2_1_0_receipt_binds_immutable_publication() -> None:
+    """The receipt must bind the reviewed payload to both public destinations."""
+    payload = json.loads(RECEIPT.read_text(encoding="utf-8"))
+
+    assert payload["release"]["version"] == "2.1.0"
+    assert payload["release"]["tag"] == "v2.1.0"
+    assert payload["release"]["commit"] == ("964a0fc334ece9509387cd07d43776adf38be240")
+    assert payload["release"]["tag_signature_verified"] is True
+    assert payload["release"]["frontier_promoted"] is False
+    assert payload["github"]["immutable"] is True
+    assert payload["github"]["draft"] is False
+    assert payload["pypi"]["latest_version"] == "2.1.0"
+    assert payload["external_gates"]["registry_acceptance"] == "pending"
+    assert payload["external_gates"]["publication_acceptance"] == "pending"
+
+    expected = payload["reviewed_digests"]
+    published = {
+        artifact["filename"]: artifact["sha256"]
+        for artifact in payload["pypi"]["artifacts"]
+    }
+    assert published == expected
+    assert len([name for name in expected if name.endswith(".whl")]) == 3
+    assert len([name for name in expected if name.endswith(".tar.gz")]) == 1

--- a/todo.md
+++ b/todo.md
@@ -7,7 +7,7 @@ This document lists the actionable tasks for `voiage` development. Agents should
 *   [~] Release 2.1.0 with the stable core and experimental frontier boundary.
     *   [x] Correct the regressing post-2.0.1 manifest identity and synchronize
         Rust, Python, R, and Julia release metadata.
-    *   [ ] Bind exact-head hosted checks, signed tag, staged artifacts,
+    *   [x] Bind exact-head hosted checks, signed tag, staged artifacts,
         reviewed digests, and publication receipts in order.
     *   [ ] Reconcile external registries separately after immutable release
         URLs and checksums exist.


### PR DESCRIPTION
## Summary

- bind PR #996 exact-head checks and merged source identity to the signed v2.1.0 tag
- record private-draft and publication workflow runs plus reviewed wheel/sdist hashes
- record the immutable GitHub release and live PyPI 2.1.0 files
- retain M22–M31 as experimental and keep registry/manuscript acceptance as separate external gates

## Validation

- receipt contract test passed
- version synchronization passed at 2.1.0
- full Conductor validation passed with zero errors and warnings
- GitHub cross-reference validation passed
- diff check passed