### PR TITLE
Bind v2.1.0 external registry candidate evidence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Bind the exact green v2.1.0 conda-forge and Yggdrasil candidate heads to an
+  immutable Conductor receipt while preserving external merge, generated
+  registry, indexing, and publication gates.
+
 - Record the verified v2.1.0 GitHub and PyPI publication receipts while keeping
   external registry and manuscript acceptance as separate gates.
 

--- a/conductor/archive/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/archive/research_software_registry_readiness_20260721/plan.md
@@ -150,6 +150,13 @@
 
 ## Current evidence boundary
 
+- Post-archive v2.1.0 registry refresh: the immutable GitHub/PyPI release is
+  bound to exact green conda-forge candidate `331e3d9b` (staged-recipes build
+  `1571876`, Linux/macOS/Windows) and exact green Yggdrasil candidate
+  `db38b520` (Buildkite `31960`, seven platforms) in
+  `release-2.1.0-registry-candidate-receipt-20260821.json`. Both pull requests
+  remain open; maintainer merge, generated feedstock/JLL artifacts, downstream
+  registry indexing, and publication acceptance remain external gates.
 - Repository readiness audit: complete at 2026-07-22T00:41:31Z.
 - Signed public release evidence: complete; `v2.0.0` was published at
   https://github.com/edithatogo/voiage/releases/tag/v2.0.0 on 2026-07-26T11:41:47Z.

--- a/conductor/archive/research_software_registry_readiness_20260721/release-2.1.0-registry-candidate-receipt-20260821.json
+++ b/conductor/archive/research_software_registry_readiness_20260721/release-2.1.0-registry-candidate-receipt-20260821.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "observed_at": "2026-08-21T04:55:00Z",
+  "release": {
+    "version": "2.1.0",
+    "tag": "v2.1.0",
+    "commit": "964a0fc334ece9509387cd07d43776adf38be240",
+    "github_release": "https://github.com/edithatogo/voiage/releases/tag/v2.1.0",
+    "pypi_release": "https://pypi.org/project/voiage/2.1.0/"
+  },
+  "candidates": {
+    "conda_forge": {
+      "pull_request": "https://github.com/conda-forge/staged-recipes/pull/34308",
+      "state": "open",
+      "candidate_head": "331e3d9b509c7938ed298b79d2c37153f984f4b1",
+      "candidate_version": "2.1.0",
+      "hosted_evidence": {
+        "aggregate": "success",
+        "linter": "success",
+        "linux_64": "success",
+        "osx_64": "success",
+        "win_64": "success",
+        "azure_build": "1571876"
+      },
+      "acceptance": "pending_external_maintainer_merge_and_indexing"
+    },
+    "yggdrasil": {
+      "pull_request": "https://github.com/JuliaPackaging/Yggdrasil/pull/14292",
+      "state": "open",
+      "candidate_head": "db38b5200cc4ed741c5cfc682a8465395f687b41",
+      "candidate_version": "2.1.0",
+      "hosted_evidence": {
+        "aggregate": "success",
+        "buildkite_build": "31960",
+        "platforms": {
+          "aarch64-apple-darwin": "success",
+          "aarch64-linux-gnu": "success",
+          "aarch64-linux-musl": "success",
+          "x86_64-apple-darwin": "success",
+          "x86_64-linux-gnu": "success",
+          "x86_64-linux-musl": "success",
+          "x86_64-w64-mingw32": "success"
+        }
+      },
+      "acceptance": "pending_external_maintainer_merge_jll_and_indexing"
+    }
+  },
+  "boundaries": {
+    "repository_candidate_preparation": "complete",
+    "registry_acceptance": "pending_external",
+    "publication_acceptance": "separate_external_gate",
+    "frontier_maturity": "experimental"
+  }
+}

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -24,10 +24,10 @@
     {"path": "docs/astro-site/src/content/docs/examples/value-of-distributional-information.mdx", "sha256": "c99c508b5b500fb2ebbe55705d3ed3e04d4516b079e962d4506243593fb1c130"},
     {"path": "docs/astro-site/src/content/docs/examples/index.mdx", "sha256": "9c68fb38928ca889ebd9ed33ecd43821f5800d7a4fdb6c36ebbfd2cf12ad6d58"},
     {"path": "docs/astro-site/src/content/docs/cli-reference.mdx", "sha256": "054f0d78d9484b74dda394c3da1e38dc72d9a222b654dc4a29a6a7c54e047b41"},
-    {"path": "changelog.md", "sha256": "4f4b643065eb942db329daf320d86f0235e3ecb6aa75369d2eb9e1c16789232a"}
+    {"path": "changelog.md", "sha256": "680447f63bcfb46e8d1980e68eb22e79bca7d00fde1841d05b18890d14eb7381"}
   ],
   "remaining_gates": [
-    "independent implementation and scientific review",
+    "role-separated subagent scientific panel and accountable owner decision",
     "hosted exact-head assurance and cross-language parity",
     "stable promotion, release and issue closure"
   ]

--- a/specs/submission-readiness/targets.json
+++ b/specs/submission-readiness/targets.json
@@ -196,7 +196,7 @@
       "criteria_url": "https://github.com/conda-forge/staged-recipes",
       "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
       "requirements": [
-        {"id": "recipe-and-builds", "status": "satisfied", "evidence": ["conda-recipe/meta.yaml", "docs/release/binding-submission-checklist.md"]},
+        {"id": "recipe-and-builds", "status": "satisfied", "evidence": ["conda-recipe/meta.yaml", "docs/release/binding-submission-checklist.md", "conductor/archive/research_software_registry_readiness_20260721/release-2.1.0-registry-candidate-receipt-20260821.json"]},
         {"id": "maintainer-merge-indexing", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
       ],
       "acceptance_evidence": ["Merged conda-forge feedstock PR", "Installable indexed package"],
@@ -266,7 +266,7 @@
       "criteria_url": "https://docs.binarybuilder.org/stable/",
       "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
       "requirements": [
-        {"id": "recipe-submitted", "status": "satisfied", "evidence": ["docs/release/binding-submission-checklist.md"]},
+        {"id": "recipe-submitted", "status": "satisfied", "evidence": ["docs/release/binding-submission-checklist.md", "conductor/archive/research_software_registry_readiness_20260721/release-2.1.0-registry-candidate-receipt-20260821.json"]},
         {"id": "binarybuilder-acceptance", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
       ],
       "acceptance_evidence": ["Merged Yggdrasil recipe", "Registered JLL package and artifacts"],

--- a/tests/test_release_2_1_0_registry_candidates.py
+++ b/tests/test_release_2_1_0_registry_candidates.py
@@ -1,0 +1,54 @@
+"""Contract checks for the v2.1.0 external-registry candidate receipt."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RECEIPT = (
+    ROOT
+    / "conductor"
+    / "archive"
+    / "research_software_registry_readiness_20260721"
+    / "release-2.1.0-registry-candidate-receipt-20260821.json"
+)
+
+
+def test_registry_receipt_binds_exact_green_candidates() -> None:
+    """Each candidate must bind an exact head to successful hosted evidence."""
+    payload = json.loads(RECEIPT.read_text(encoding="utf-8"))
+
+    assert payload["release"]["version"] == "2.1.0"
+    assert payload["release"]["commit"] == ("964a0fc334ece9509387cd07d43776adf38be240")
+
+    conda = payload["candidates"]["conda_forge"]
+    assert conda["candidate_head"] == ("331e3d9b509c7938ed298b79d2c37153f984f4b1")
+    assert {
+        conda["hosted_evidence"][platform]
+        for platform in ("linux_64", "osx_64", "win_64")
+    } == {"success"}
+
+    yggdrasil = payload["candidates"]["yggdrasil"]
+    assert yggdrasil["candidate_head"] == ("db38b5200cc4ed741c5cfc682a8465395f687b41")
+    assert len(yggdrasil["hosted_evidence"]["platforms"]) == 7
+    assert set(yggdrasil["hosted_evidence"]["platforms"].values()) == {"success"}
+
+
+def test_registry_receipt_keeps_external_gates_fail_closed() -> None:
+    """Green candidates are not registry acceptance or stable-frontier evidence."""
+    payload = json.loads(RECEIPT.read_text(encoding="utf-8"))
+
+    assert all(
+        candidate["state"] == "open" for candidate in payload["candidates"].values()
+    )
+    assert all(
+        candidate["acceptance"].startswith("pending_external_")
+        for candidate in payload["candidates"].values()
+    )
+    assert payload["boundaries"] == {
+        "repository_candidate_preparation": "complete",
+        "registry_acceptance": "pending_external",
+        "publication_acceptance": "separate_external_gate",
+        "frontier_maturity": "experimental",
+    }

--- a/todo.md
+++ b/todo.md
@@ -4,13 +4,14 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## To Do
 
-*   [~] Release 2.1.0 with the stable core and experimental frontier boundary.
+*   [x] Release 2.1.0 with the stable core and experimental frontier boundary.
     *   [x] Correct the regressing post-2.0.1 manifest identity and synchronize
         Rust, Python, R, and Julia release metadata.
     *   [x] Bind exact-head hosted checks, signed tag, staged artifacts,
         reviewed digests, and publication receipts in order.
-    *   [ ] Reconcile external registries separately after immutable release
-        URLs and checksums exist.
+    *   [x] Reconcile the exact green conda-forge and Yggdrasil candidates
+        after immutable release URLs and checksums exist. Their maintainer
+        merges, generated registries, and indexing remain external gates.
 
 For experimental frontier items, references to scientific review mean the
 role-specific subagent review panel and separate orchestrating agent defined in


### PR DESCRIPTION
## Summary

- bind the exact green conda-forge and Yggdrasil v2.1.0 candidate heads in the archived registry-readiness Conductor track
- update the cross-venue contract and release task state
- keep external maintainer merge, generated feedstock/JLL, indexing, publication, and experimental-frontier maturity gates fail-closed

## Local validation

- `pytest` focused registry/submission suite: 14 passed
- submission-readiness validator: PASS (22 targets)
- `tox -e lint,vale,harness,typecheck,frontier-contract`: passed

## External evidence boundary

This PR records green candidate preparation only. It does not claim conda-forge or Yggdrasil acceptance, downstream indexing, publication acceptance, or promotion of M22-M31.