### PR TITLE
chore(governance): ignore R build artifacts and conductor local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,12 +163,14 @@ bindings/julia/Manifest.toml
 bindings/typescript/*.tgz
 bindings/typescript/wasm/
 r-package/**/*.Rcheck/
+*.Rcheck/
+r-package/**/*.tar.gz
 !bindings/rust/Cargo.lock
 docs/astro-site/node_modules/
 docs/astro-site/dist/
 docs/astro-site/.astro/
 docs/astro-site/src/content/docs/api-reference/generated/
-.conductor/local/
+.conductor/
 package-lock.json
 
 # Conductor tool runtime state


### PR DESCRIPTION
## Summary
- Ignore root-level and package-level R check directories and built source tarballs (`*.Rcheck/`, `r-package/**/*.tar.gz`).
- Ignore the local `.conductor/` runtime directory.

## Validation
- `uv run pytest tests/test_repo_cleanup.py` (11 passed)
- `uv run python scripts/repo_harness.py` (0 findings, PASS)