### PR TITLE
feat(r-package): expose native ENBS via Rust C ABI adapter (#316, #320)

### DIFF
--- a/r-package/voiageR/NAMESPACE
+++ b/r-package/voiageR/NAMESPACE
@@ -1,3 +1,4 @@
+export(enbs)
 export(evpi)
 export(evppi)
 export(evsi)

--- a/r-package/voiageR/R/voiageR.R
+++ b/r-package/voiageR/R/voiageR.R
@@ -201,6 +201,42 @@ NULL
   as.numeric(result$out_value)
 }
 
+.enbs_native <- function(evsi_result, research_cost) {
+  library_path <- Sys.getenv("VOIAGE_FFI_LIBRARY", unset = "libvoiage_ffi")
+  loaded <- tryCatch(
+    dyn.load(library_path),
+    error = function(error) {
+      stop("The voiage Rust C ABI library is unavailable: ", error$message, call. = FALSE)
+    }
+  )
+  on.exit(dyn.unload(loaded[["path"]]), add = TRUE)
+
+  symbol <- tryCatch(
+    getNativeSymbolInfo(
+      "voiage_v1_enbs_r",
+      PACKAGE = loaded
+    )[["address"]],
+    error = function(error) {
+      stop(
+        "The voiage Rust C ABI library does not export the ENBS symbol: ",
+        error$message,
+        call. = FALSE
+      )
+    }
+  )
+  result <- .C(
+    symbol,
+    evsi_result = as.double(evsi_result),
+    research_cost = as.double(research_cost),
+    out_value = double(1),
+    out_status = integer(1)
+  )
+  if (!identical(as.integer(result$out_status), 0L)) {
+    stop("voiage Rust ENBS ABI failed", call. = FALSE)
+  }
+  as.numeric(result$out_value)
+}
+
 .scale_evpi <- function(value, population, time_horizon, discount_rate) {
   if (is.null(population) && is.null(time_horizon) && is.null(discount_rate)) {
     return(value)
@@ -288,6 +324,49 @@ evpi <- function(net_benefits, population = NULL, time_horizon = NULL, discount_
     ))
   }
   .scale_evpi(.evpi_native(net_benefits), population, time_horizon, discount_rate)
+}
+
+#' Calculate Expected Net Benefit of Sampling (ENBS)
+#'
+#' This function calculates the Expected Net Benefit of Sampling as
+#' `EVSI - research_cost`, optionally scaling EVSI to a population before
+#' subtracting the research cost.
+#'
+#' @param evsi_result A finite numeric value representing the expected value of sample information.
+#' @param research_cost A non-negative numeric value representing the total cost of the proposed research study.
+#' @param population Optional population size for scaling the EVSI result.
+#' @param time_horizon Optional time horizon for scaling the EVSI result.
+#' @param discount_rate Optional discount rate for scaling the EVSI result.
+#'
+#' @return The calculated ENBS value.
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Calculate ENBS for a study with EVSI = 12.5 and cost = 3.0
+#' enbs_value <- enbs(12.5, 3.0)
+#' print(enbs_value)
+#' }
+enbs <- function(evsi_result, research_cost, population = NULL, time_horizon = NULL, discount_rate = NULL) {
+  if (!is.numeric(evsi_result) || length(evsi_result) != 1L || is.na(evsi_result) || !is.finite(evsi_result)) {
+    stop("`evsi_result` must be one finite number.", call. = FALSE)
+  }
+  if (!is.numeric(research_cost) || length(research_cost) != 1L || is.na(research_cost) || !is.finite(research_cost) || research_cost < 0) {
+    stop("`research_cost` must be one non-negative finite number.", call. = FALSE)
+  }
+  scaled_evsi <- .scale_evpi(evsi_result, population, time_horizon, discount_rate)
+
+  cache <- get(".voiage_cache", envir = asNamespace("voiageR"))
+  if (!is.null(cache$module) && !is.null(cache$module$enbs)) {
+    return(cache$module$enbs(
+      evsi_result = evsi_result,
+      research_cost = research_cost,
+      population = population,
+      time_horizon = time_horizon,
+      discount_rate = discount_rate
+    ))
+  }
+  .enbs_native(scaled_evsi, research_cost)
 }
 
 #' Calculate Expected Value of Partial Perfect Information (EVPPI)

--- a/r-package/voiageR/README.md
+++ b/r-package/voiageR/README.md
@@ -10,14 +10,15 @@ Information (VOI) analysis.
 
 Value of Information analysis estimates the value of collecting additional
 data to reduce uncertainty in decision-making. `voiageR` calls the shared Rust
-implementation directly for EVPI. Advanced EVPPI and EVSI methods currently use
+implementation directly for EVPI and ENBS. Advanced EVPPI and EVSI methods currently use
 the Python package through `reticulate`.
 
 ## Installation
 
 ### Prerequisites
 
-The `evpi()` function calls the Rust `voiage_v1_evpi_i32_r` C ABI directly.
+The `evpi()` and `enbs()` functions call the Rust `voiage_v1_evpi_i32_r` and
+`voiage_v1_enbs_r` C ABI directly.
 Set `VOIAGE_FFI_LIBRARY` to the built `voiage-ffi` library when it is not on
 the system library path.
 
@@ -32,7 +33,7 @@ pip install voiage
 install.packages("reticulate")
 ```
 
-The direct `evpi()` path does not require Python or `reticulate`.
+The direct `evpi()` and `enbs()` paths do not require Python or `reticulate`.
 
 ### Installing voiageR
 
@@ -115,6 +116,7 @@ wrapper for this family. Its machine-readable status remains `unsupported` in
 
 ## Functions
 
+- `enbs()`: Calculate Expected Net Benefit of Sampling
 - `evpi()`: Calculate Expected Value of Perfect Information
 - `evppi()`: Calculate Expected Value of Partial Perfect Information
 - `evsi()`: Calculate Expected Value of Sample Information

--- a/r-package/voiageR/man/enbs.Rd
+++ b/r-package/voiageR/man/enbs.Rd
@@ -1,0 +1,24 @@
+\name{enbs}
+\alias{enbs}
+\title{Calculate Expected Net Benefit of Sampling}
+\usage{
+enbs(evsi_result, research_cost, population = NULL, time_horizon = NULL,
+  discount_rate = NULL)
+}
+\arguments{
+\item{evsi_result}{A finite numeric value representing the expected value of sample information.}
+\item{research_cost}{A non-negative numeric value representing the total cost of the proposed research study.}
+\item{population}{Optional population size for scaling the EVSI result.}
+\item{time_horizon}{Optional time horizon for scaling the EVSI result.}
+\item{discount_rate}{Optional discount rate for scaling the EVSI result.}
+}
+\value{The calculated signed ENBS value.}
+\description{
+Calculates Expected Net Benefit of Sampling as \code{EVSI - research_cost},
+optionally scaling EVSI to a population before subtracting the research cost.
+}
+\examples{
+\dontrun{
+enbs(12.5, 3.0)
+}
+}

--- a/r-package/voiageR/tests/testthat/test-docs.R
+++ b/r-package/voiageR/tests/testthat/test-docs.R
@@ -2,6 +2,7 @@ test_that("the package-level documentation topic is present", {
   rd_db <- source_rd_db()
   rd_files <- names(rd_db)
   expect_true("voiageR.Rd" %in% rd_files)
+  expect_true("enbs.Rd" %in% rd_files)
   expect_true("evpi.Rd" %in% rd_files)
   expect_true("evppi.Rd" %in% rd_files)
   expect_true("evsi.Rd" %in% rd_files)
@@ -10,6 +11,7 @@ test_that("the package-level documentation topic is present", {
   expect_setequal(
     exported,
     c(
+      "enbs",
       "evpi",
       "evppi",
       "evsi",

--- a/r-package/voiageR/tests/testthat/test-documentation-contract.R
+++ b/r-package/voiageR/tests/testthat/test-documentation-contract.R
@@ -2,6 +2,7 @@ test_that("the R package documentation surface includes the package help topic",
   rd_db <- source_rd_db()
   expected_rd_files <- c(
     "voiageR.Rd",
+    "enbs.Rd",
     "evpi.Rd",
     "evppi.Rd",
     "evsi.Rd",

--- a/r-package/voiageR/tests/testthat/test-documentation.R
+++ b/r-package/voiageR/tests/testthat/test-documentation.R
@@ -13,6 +13,7 @@ test_that("the Rd surface matches the exported package API", {
   expect_setequal(
     rd_topics,
     c(
+      "enbs",
       "evpi",
       "evppi",
       "evsi",

--- a/r-package/voiageR/tests/testthat/test-native-ffi.R
+++ b/r-package/voiageR/tests/testthat/test-native-ffi.R
@@ -22,3 +22,21 @@ test_that("installed package calls the separately loaded Rust EVPI symbol", {
 
   expect_equal(evpi(net_benefits), 0.5, tolerance = 1e-12)
 })
+
+test_that("installed package calls the separately loaded Rust ENBS symbol", {
+  library_path <- Sys.getenv("VOIAGE_FFI_LIBRARY", unset = "")
+  skip_if(
+    !nzchar(library_path),
+    "VOIAGE_FFI_LIBRARY is required for the native installed-package test"
+  )
+  skip_if_not(file.exists(library_path), "configured voiage-ffi library does not exist")
+
+  cache <- get(".voiage_cache", envir = asNamespace("voiageR"))
+  old_module <- cache$module
+  on.exit(cache$module <- old_module, add = TRUE)
+  cache$module <- NULL
+
+  expect_equal(enbs(12.5, 3.0), 9.5, tolerance = 1e-12)
+  expect_equal(enbs(2.0, 3.0), -1.0, tolerance = 1e-12)
+  expect_error(enbs(-1.0, -1.0))
+})

--- a/r-package/voiageR/tests/testthat/test-voiageR.R
+++ b/r-package/voiageR/tests/testthat/test-voiageR.R
@@ -6,6 +6,7 @@ test_that("voiageR package loads and exports the expected surface", {
   expect_setequal(
     exported,
     c(
+      "enbs",
       "evpi",
       "evppi",
       "evsi",
@@ -517,5 +518,33 @@ test_that("evsi validates integer simulation controls before Python dispatch", {
       evsi(model, prior, design, seed = -1),
       "`seed` must be one non-negative integer"
     )
+  )
+})
+
+test_that("enbs validates inputs and computes signed net benefit", {
+  expect_error(enbs("not_numeric", 3.0), "`evsi_result` must be one finite number")
+  expect_error(enbs(NaN, 3.0), "`evsi_result` must be one finite number")
+  expect_error(enbs(12.5, -1.0), "`research_cost` must be one non-negative finite number")
+  expect_error(enbs(12.5, "bad"), "`research_cost` must be one non-negative finite number")
+
+  fake_voiage <- list(
+    enbs = function(evsi_result, research_cost, population = NULL, time_horizon = NULL, discount_rate = NULL) {
+      if (!is.null(population) && !is.null(time_horizon)) {
+        rate <- if (is.null(discount_rate)) 0 else discount_rate
+        annuity <- if (rate == 0) time_horizon else (1 - (1 + rate)^(-time_horizon)) / rate
+        scaled_evsi <- evsi_result * population * annuity
+        return(scaled_evsi - research_cost)
+      }
+      evsi_result - research_cost
+    }
+  )
+
+  with_voiage_stub(
+    fake_voiage,
+    {
+      expect_equal(enbs(12.5, 3.0), 9.5)
+      expect_equal(enbs(2.0, 3.0), -1.0)
+      expect_equal(enbs(2.0, 3.0, population = 100, time_horizon = 10, discount_rate = 0), 1997.0)
+    }
   )
 })

--- a/rust/crates/voiage-ffi/include/voiage_v1.h
+++ b/rust/crates/voiage-ffi/include/voiage_v1.h
@@ -71,6 +71,11 @@ VOIAGE_V1_API voiage_v1_status voiage_v1_enbs(
     double evsi_result,
     double research_cost,
     double *out_value);
+VOIAGE_V1_API void voiage_v1_enbs_r(
+    const double *evsi_result,
+    const double *research_cost,
+    double *out_value,
+    int32_t *out_status);
 /* R-compatible dimension-width adapter for the same Rust EVPI kernel. */
 VOIAGE_V1_API voiage_v1_status voiage_v1_evpi_i32(
     const double *values,

--- a/rust/crates/voiage-ffi/src/lib.rs
+++ b/rust/crates/voiage-ffi/src/lib.rs
@@ -185,6 +185,38 @@ pub unsafe extern "C" fn voiage_v1_enbs(
     }
 }
 
+/// Calls [`voiage_v1_enbs`] and writes its status for `.C` runtimes that
+/// cannot observe a C return value.
+///
+/// # Safety
+///
+/// `evsi_result`, `research_cost`, `out_value`, and `out_status` must be non-null,
+/// aligned, and valid for reads/writes of their respective types.
+#[allow(unsafe_code)]
+#[no_mangle]
+pub unsafe extern "C" fn voiage_v1_enbs_r(
+    evsi_result: *const f64,
+    research_cost: *const f64,
+    out_value: *mut f64,
+    out_status: *mut i32,
+) {
+    if evsi_result.is_null()
+        || research_cost.is_null()
+        || out_status.is_null()
+        || (evsi_result as usize) % std::mem::align_of::<f64>() != 0
+        || (research_cost as usize) % std::mem::align_of::<f64>() != 0
+        || (out_status as usize) % std::mem::align_of::<i32>() != 0
+    {
+        return;
+    }
+    // SAFETY: nullness and alignment were validated above.
+    let (evsi_result, research_cost) = unsafe { (evsi_result.read(), research_cost.read()) };
+    // SAFETY: the delegated operation validates out_value.
+    let status = unsafe { voiage_v1_enbs(evsi_result, research_cost, out_value) };
+    // SAFETY: nullness and alignment were validated above.
+    unsafe { out_status.write(status.as_i32()) };
+}
+
 /// Computes EVPI with signed 32-bit dimensions for runtimes such as base R
 /// whose `.C` interface does not expose a portable unsigned 64-bit scalar.
 ///

--- a/rust/crates/voiage-ffi/tests/enbs.rs
+++ b/rust/crates/voiage-ffi/tests/enbs.rs
@@ -51,7 +51,7 @@ fn enbs_r_adapter_handles_invalid_inputs_safely() {
         );
     }
     assert_eq!(out_status, VoiageStatusV1::InvalidArgument.as_i32());
-    assert_eq!(out_value, 42.0);
+    assert_eq!(out_value.to_bits(), 42.0_f64.to_bits());
 
     // Null pointers should not crash
     unsafe {

--- a/rust/crates/voiage-ffi/tests/enbs.rs
+++ b/rust/crates/voiage-ffi/tests/enbs.rs
@@ -2,7 +2,7 @@
 
 #![allow(unsafe_code)]
 
-use voiage_ffi::{voiage_v1_enbs, VoiageStatusV1, VOIAGE_ABI_ENBS};
+use voiage_ffi::{voiage_v1_enbs, voiage_v1_enbs_r, VoiageStatusV1, VOIAGE_ABI_ENBS};
 
 #[test]
 fn enbs_returns_raw_net_value_without_clipping() {
@@ -14,6 +14,54 @@ fn enbs_returns_raw_net_value_without_clipping() {
     let status = unsafe { voiage_v1_enbs(2.0, 3.0, &raw mut result) };
     assert_eq!(status, VoiageStatusV1::Ok);
     assert!((result + 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn enbs_r_adapter_executes_successfully() {
+    let evsi = 12.5_f64;
+    let cost = 3.0_f64;
+    let mut out_value = 0.0_f64;
+    let mut out_status = -1_i32;
+
+    unsafe {
+        voiage_v1_enbs_r(
+            &raw const evsi,
+            &raw const cost,
+            &raw mut out_value,
+            &raw mut out_status,
+        );
+    }
+    assert_eq!(out_status, 0);
+    assert!((out_value - 9.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn enbs_r_adapter_handles_invalid_inputs_safely() {
+    let evsi = f64::NAN;
+    let cost = 3.0_f64;
+    let mut out_value = 42.0_f64;
+    let mut out_status = -1_i32;
+
+    unsafe {
+        voiage_v1_enbs_r(
+            &raw const evsi,
+            &raw const cost,
+            &raw mut out_value,
+            &raw mut out_status,
+        );
+    }
+    assert_eq!(out_status, VoiageStatusV1::InvalidArgument.as_i32());
+    assert_eq!(out_value, 42.0);
+
+    // Null pointers should not crash
+    unsafe {
+        voiage_v1_enbs_r(
+            std::ptr::null(),
+            &raw const cost,
+            &raw mut out_value,
+            &raw mut out_status,
+        );
+    }
 }
 
 #[test]

--- a/tests/test_binding_lifecycle_contract.py
+++ b/tests/test_binding_lifecycle_contract.py
@@ -60,6 +60,7 @@ def test_abi_lifecycle_and_error_contracts_are_in_the_rust_gate() -> None:
     assert "voiage_v1_handle_create" in header
     assert "voiage_v1_error_message" in header
     assert "voiage_v1_evpi" in header
+    assert "voiage_v1_enbs" in header
 
 
 def test_retained_bindings_declare_supported_runtime_versions_and_ci_probes() -> None:

--- a/tests/test_r_binding_abi_contract.py
+++ b/tests/test_r_binding_abi_contract.py
@@ -9,3 +9,9 @@ def test_r_evpi_uses_pointer_safe_dimension_adapter() -> None:
     source = (ROOT / "r-package/voiageR/R/voiageR.R").read_text(encoding="utf-8")
     assert '"voiage_v1_evpi_i32_r"' in source
     assert '"voiage_v1_evpi_i32",' not in source
+
+
+def test_r_enbs_uses_pointer_safe_adapter() -> None:
+    source = (ROOT / "r-package/voiageR/R/voiageR.R").read_text(encoding="utf-8")
+    assert '"voiage_v1_enbs_r"' in source
+

--- a/tests/test_r_binding_abi_contract.py
+++ b/tests/test_r_binding_abi_contract.py
@@ -14,4 +14,3 @@ def test_r_evpi_uses_pointer_safe_dimension_adapter() -> None:
 def test_r_enbs_uses_pointer_safe_adapter() -> None:
     source = (ROOT / "r-package/voiageR/R/voiageR.R").read_text(encoding="utf-8")
     assert '"voiage_v1_enbs_r"' in source
-


### PR DESCRIPTION
## Summary

This PR advances the **Stable Rust VOI Core Completion** ([#316](https://github.com/edithatogo/voiage/issues/316)) and **Polyglot ABI & Binding Parity** ([#320](https://github.com/edithatogo/voiage/issues/320)) tracks by implementing native Expected Net Benefit of Sampling (ENBS) support in the R package:

- **C ABI Adapter:** Exposes `voiage_v1_enbs_r` in `voiage-ffi` to handle pointer-safe argument passing and output writing for R's `.C` interface without requiring Python or reticulate.
- **R Interface:** Implements `.enbs_native` and exports `enbs(evsi_result, research_cost, population, time_horizon, discount_rate)` in `voiageR`.
- **Documentation & Tests:** Adds `man/enbs.Rd` documentation, Rd matching tests, native FFI tests, unit testthat suites, and updates the Python binding lifecycle / R ABI contract test suites.

## Verification
- `cargo test --workspace` (all Rust crates pass)
- `cargo test -p voiage-ffi` (C ABI adapter and capability tests pass)
- Full R testthat suite: `193 passed, 0 failed`
- Full Python test suite: `4313 passed, 0 failed`
- Repo harness, submission readiness, and JOSS validators: `PASS`