### PR TITLE
feat(templates): add curated domain-template and adapter registry (#321, #577)

### DIFF
--- a/specs/domain-templates/registry.json
+++ b/specs/domain-templates/registry.json
@@ -1,0 +1,341 @@
+{
+  "$schema": "./schemas/v1/domain-template.schema.json",
+  "templates": [
+    {
+      "template_id": "churn_retention",
+      "version": "1.0.0",
+      "domain": "customer_success",
+      "title": "Customer Churn Retention Campaign Selection",
+      "description": "Evaluates proactive retention interventions versus status quo, valuing randomized pilot trials and customer lifetime value uncertainty.",
+      "decisions": [
+        "Status Quo (No Intervention)",
+        "Targeted Automated Discount",
+        "Dedicated Concierge Outreach"
+      ],
+      "information_actions": [
+        "Pilot Randomized Retention Trial",
+        "Feature Attribution Survey",
+        "Usage Telemetry Enrichment"
+      ],
+      "required_fields": [
+        "base_churn",
+        "discount_reduction",
+        "concierge_reduction",
+        "clv",
+        "cost_discount",
+        "cost_concierge"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs"],
+      "maturity": "stable",
+      "examples": [
+        "examples/customer_churn_retention_example.py"
+      ],
+      "rights": "Open source synthetic reference template.",
+      "privacy": "Synthetic non-PII data.",
+      "provenance": "Adapted from subscription economics and uplift modeling literature (Issue #574, #577).",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "dynamic_pricing",
+      "version": "1.0.0",
+      "domain": "pricing_revenue",
+      "title": "Dynamic Markdown and Price Elasticity Optimization",
+      "description": "Values market elasticity experiments and competitor price scrapers before committing to clearance markdowns or price adjustments.",
+      "decisions": [
+        "Maintain Regular Price",
+        "Moderate Markdown (15%)",
+        "Aggressive Markdown (30%)"
+      ],
+      "information_actions": [
+        "Regional Price Test",
+        "Competitor Scraping Feed",
+        "Conjoint Consumer Study"
+      ],
+      "required_fields": [
+        "price_elasticity",
+        "base_demand",
+        "inventory_holding_cost",
+        "competitor_markdown_prob"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs"],
+      "maturity": "experimental",
+      "examples": [
+        "examples/business_strategy_example.py"
+      ],
+      "rights": "Open source template.",
+      "privacy": "Synthetic enterprise data.",
+      "provenance": "Revenue management and pricing VOI literature.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "marketing_measurement",
+      "version": "1.0.0",
+      "domain": "marketing_growth",
+      "title": "Marketing Mix and Incrementality Testing Optimization",
+      "description": "Evaluates channel budget allocation under uncertain returns on ad spend (ROAS) and values geo-lift holdout experiments.",
+      "decisions": [
+        "Status Quo Channel Allocation",
+        "Shift 30% Budget to Performance Search",
+        "Shift 30% Budget to Top-of-Funnel Social"
+      ],
+      "information_actions": [
+        "Geo-Lift Matched Market Experiment",
+        "MTA Multi-Touch Attribution Linkage",
+        "Brand Lift Survey"
+      ],
+      "required_fields": [
+        "search_roas",
+        "social_roas",
+        "ad_decay_rate",
+        "baseline_organic_sales"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs"],
+      "maturity": "experimental",
+      "examples": [],
+      "rights": "Open source template.",
+      "privacy": "Aggregated geo metrics without user identifiers.",
+      "provenance": "Empirical marketing measurement and causal uplift VOI framework.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "inventory_replenishment",
+      "version": "1.0.0",
+      "domain": "supply_chain",
+      "title": "Safety Stock & Supply Chain Lead Time Information Valuation",
+      "description": "Optimizes order replenishment thresholds under stochastic demand and values supplier visibility telemetry feeds.",
+      "decisions": [
+        "Lean Stocking Policy (JIT)",
+        "Standard Safety Stock (1.5x Lead Time)",
+        "Buffer Stocking (3.0x Lead Time)"
+      ],
+      "information_actions": [
+        "Upstream Supplier EDI Feed",
+        "Downstream POS Demand Sensing",
+        "Warehouse IoT Inventory Audit"
+      ],
+      "required_fields": [
+        "daily_demand_mean",
+        "daily_demand_variance",
+        "supplier_lead_time_days",
+        "stockout_penalty_cost",
+        "holding_cost_per_unit"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "risk_sensitive"],
+      "maturity": "experimental",
+      "examples": [],
+      "rights": "Open source template.",
+      "privacy": "Synthetic supply chain data.",
+      "provenance": "Newsvendor and multi-echelon inventory VOI theory.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "predictive_maintenance",
+      "version": "1.0.0",
+      "domain": "operations_maintenance",
+      "title": "Asset Health Monitoring & Sensor Information Valuation",
+      "description": "Values vibration/thermal sensor deployments and nondestructive inspection testing before planned machine overhaul.",
+      "decisions": [
+        "Run to Failure (Corrective Only)",
+        "Scheduled Calendar Overhaul",
+        "Condition-Based Dynamic Servicing"
+      ],
+      "information_actions": [
+        "High-Frequency Vibration Sensor Stream",
+        "Monthly Oil Spectrometry Analysis",
+        "Ultrasonic Acoustic Inspection"
+      ],
+      "required_fields": [
+        "weibull_shape_k",
+        "weibull_scale_lambda",
+        "unplanned_downtime_cost",
+        "overhaul_cost",
+        "inspection_cost"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs"],
+      "maturity": "experimental",
+      "examples": [],
+      "rights": "Open source template.",
+      "privacy": "Synthetic machine sensor metrics.",
+      "provenance": "Reliability engineering and sensor placement VOI principles.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "fraud_credit",
+      "version": "1.0.0",
+      "domain": "risk_credit",
+      "title": "Credit Risk & Anti-Fraud Decision Threshold Policy",
+      "description": "Evaluates loan approval and transaction underwriting thresholds, valuing alternative credit bureau data feeds.",
+      "decisions": [
+        "Auto-Approve Transaction",
+        "Manual Review / Step-Up Authentication",
+        "Auto-Decline Transaction"
+      ],
+      "information_actions": [
+        "Alternative Credit Bureau Data Pull",
+        "Device Fingerprint & IP Reputation Feed",
+        "Biometric Challenge Verification"
+      ],
+      "required_fields": [
+        "default_probability",
+        "fraud_loss_given_default",
+        "merchant_fee_revenue",
+        "manual_review_cost",
+        "bureau_pull_cost"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs", "risk_sensitive"],
+      "maturity": "experimental",
+      "examples": [],
+      "rights": "Open source template.",
+      "privacy": "Synthetic anonymized scoring attributes.",
+      "provenance": "Credit scoring risk management and underwriting VOI models.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "finance_data_vendor",
+      "version": "1.0.0",
+      "domain": "finance_procurement",
+      "title": "Financial Alternative Data Vendor Procurement Valuation",
+      "description": "Quantifies the Expected Value of Information for purchasing commercial market feeds, expert calls, or satellite imagery feeds.",
+      "decisions": [
+        "Execute Trade Based on Public Data",
+        "Procure Premium Alternative Data Feed",
+        "Hedge Position Without Procurement"
+      ],
+      "information_actions": [
+        "Trial Feed Evaluation (1 Month)",
+        "Expert Network Interview Series",
+        "Commercial Satellite Geospatial Feed"
+      ],
+      "required_fields": [
+        "signal_correlation_rho",
+        "market_variance_sigma",
+        "position_size",
+        "subscription_cost_annual"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs"],
+      "maturity": "experimental",
+      "examples": [],
+      "rights": "Open source template.",
+      "privacy": "Synthetic market indicators.",
+      "provenance": "Asset management alternative data procurement and signal value literature.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "market_entry",
+      "version": "1.0.0",
+      "domain": "business_strategy",
+      "title": "New Market Entry Investment & Market Research VOI",
+      "description": "Evaluates whether to enter a new geographic or product market immediately versus commissioning target customer discovery research.",
+      "decisions": [
+        "Do Not Enter Market",
+        "Enter Market Immediately",
+        "Enter Via Joint Venture Partner"
+      ],
+      "information_actions": [
+        "Target Customer Discovery Research",
+        "Competitor Landscape In-Depth Audit",
+        "Regulatory Feasibility Study"
+      ],
+      "required_fields": [
+        "market_size",
+        "growth_rate",
+        "competition_intensity",
+        "entry_costs",
+        "unit_margin"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs"],
+      "maturity": "stable",
+      "examples": [
+        "examples/business_strategy_example.py"
+      ],
+      "rights": "Open source template.",
+      "privacy": "Synthetic business projections.",
+      "provenance": "Corporate strategy and real-options market entry VOI framework.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    },
+    {
+      "template_id": "hr_attrition",
+      "version": "1.0.0",
+      "domain": "people_analytics",
+      "title": "Talent Retention & Employee Engagement Survey VOI",
+      "description": "Values conducting pulse engagement surveys and retention compensation adjustments for key engineering talent.",
+      "decisions": [
+        "Maintain Current Compensation & Policies",
+        "Targeted Retention Equity Grant",
+        "Comprehensive Remote Work & Flexibility Policy"
+      ],
+      "information_actions": [
+        "Anonymous Team Engagement Pulse Survey",
+        "Third-Party Market Compensation Benchmark",
+        "Manager Stay-Interview Feedback Loop"
+      ],
+      "required_fields": [
+        "baseline_attrition_rate",
+        "replacement_cost_per_head",
+        "equity_grant_cost",
+        "flexibility_retention_effect"
+      ],
+      "optional_dependencies": [],
+      "capabilities": ["evpi", "evppi", "evsi", "enbs"],
+      "maturity": "experimental",
+      "examples": [],
+      "rights": "Open source template.",
+      "privacy": "Synthetic aggregated HR data without employee PII.",
+      "provenance": "Organizational behavior and human capital economic decision theory.",
+      "license": "Apache-2.0 OR MIT",
+      "maintainers": [
+        "voiage maintainers <maintainers@voiage.dev>"
+      ],
+      "compatibility": ">=2.0.0",
+      "review_date": "2026-08-22"
+    }
+  ]
+}

--- a/specs/domain-templates/schemas/v1/domain-template.schema.json
+++ b/specs/domain-templates/schemas/v1/domain-template.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://voiage.dev/specs/domain-templates/schemas/v1/domain-template.schema.json",
+  "title": "DomainTemplateV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "template_id",
+    "version",
+    "domain",
+    "title",
+    "description",
+    "decisions",
+    "information_actions",
+    "required_fields",
+    "capabilities",
+    "maturity",
+    "license",
+    "maintainers",
+    "compatibility",
+    "review_date"
+  ],
+  "properties": {
+    "template_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$",
+      "description": "Unique identifier for the domain template."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Semantic version of the domain template."
+    },
+    "domain": {
+      "type": "string",
+      "enum": [
+        "customer_success",
+        "pricing_revenue",
+        "marketing_growth",
+        "supply_chain",
+        "operations_maintenance",
+        "risk_credit",
+        "finance_procurement",
+        "business_strategy",
+        "people_analytics"
+      ],
+      "description": "Business or operational domain category."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable template title."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Detailed explanation of the decision template context and scope."
+    },
+    "decisions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Candidate actions or operational strategies compared by the template."
+    },
+    "information_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Candidate data acquisition, experiment, or survey actions."
+    },
+    "required_fields": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Required parameter or sample columns needed to execute the template."
+    },
+    "optional_dependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional Python packages or extras required for advanced estimation."
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["evpi", "evppi", "evsi", "enbs", "coss", "ceaf", "risk_sensitive"]
+      },
+      "description": "VOI method families supported by the template."
+    },
+    "maturity": {
+      "type": "string",
+      "enum": ["candidate", "experimental", "stable"],
+      "description": "Lifecycle maturity disposition of the template."
+    },
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Paths to reference scripts or notebooks implementing the template."
+    },
+    "rights": {
+      "type": "string",
+      "description": "Data rights and IP permissions applicable to the template."
+    },
+    "privacy": {
+      "type": "string",
+      "description": "Privacy and confidentiality classifications (e.g. synthetic, anonymized, public)."
+    },
+    "provenance": {
+      "type": "string",
+      "description": "Origin, methodology basis, and literature references."
+    },
+    "license": {
+      "type": "string",
+      "description": "Software and specification license identifier."
+    },
+    "maintainers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      },
+      "description": "Designated maintainers or authors."
+    },
+    "compatibility": {
+      "type": "string",
+      "description": "Compatible voiage version constraint."
+    },
+    "review_date": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "description": "Last ISO 8601 review date."
+    }
+  }
+}

--- a/specs/v2/extension-surface-policy.json
+++ b/specs/v2/extension-surface-policy.json
@@ -48,7 +48,8 @@
       "voiage/multi_domain.py",
       "voiage/parallel/**",
       "voiage/plot/**",
-      "voiage/clinical_trials.py"
+      "voiage/clinical_trials.py",
+      "voiage/domain_templates.py"
     ],
     "experimental": [
       "voiage/experimental/**",

--- a/specs/v2/python-runtime-inventory.json
+++ b/specs/v2/python-runtime-inventory.json
@@ -36,7 +36,7 @@
     },
     "optional_extension": {
       "status": "retain_or_extract_by_extension_policy",
-      "roots": ["voiage/ecosystem_integration.py", "voiage/environmental/", "voiage/experimental_design.py", "voiage/financial/", "voiage/health_economics.py", "voiage/healthcare/", "voiage/hta_integration.py", "voiage/plot/", "voiage/widgets/", "voiage/web/"]
+      "roots": ["voiage/ecosystem_integration.py", "voiage/environmental/", "voiage/experimental_design.py", "voiage/financial/", "voiage/health_economics.py", "voiage/healthcare/", "voiage/hta_integration.py", "voiage/plot/", "voiage/widgets/", "voiage/web/", "voiage/domain_templates.py"]
     },
     "experimental_namespace": {
       "status": "exclude_from_v2_stable_surface",

--- a/tests/test_domain_templates.py
+++ b/tests/test_domain_templates.py
@@ -1,0 +1,91 @@
+"""Tests for Curated Domain Template and Adapter Registry (#577)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voiage.domain_templates import (
+    DomainTemplate,
+    get_domain_template,
+    list_domain_templates,
+    load_domain_template_registry,
+    validate_domain_template_registry,
+)
+from voiage.exceptions import InputError
+
+
+def test_domain_template_registry_json_schema_validation() -> None:
+    assert validate_domain_template_registry() is True
+
+
+def test_load_all_domain_templates_coverage() -> None:
+    templates = load_domain_template_registry()
+    assert len(templates) == 9
+
+    template_ids = {t.template_id for t in templates}
+    expected_ids = {
+        "churn_retention",
+        "dynamic_pricing",
+        "marketing_measurement",
+        "inventory_replenishment",
+        "predictive_maintenance",
+        "fraud_credit",
+        "finance_data_vendor",
+        "market_entry",
+        "hr_attrition",
+    }
+    assert template_ids == expected_ids
+
+
+def test_get_domain_template_lookup_and_not_found() -> None:
+    churn = get_domain_template("churn_retention")
+    assert churn.template_id == "churn_retention"
+    assert churn.domain == "customer_success"
+    assert "evpi" in churn.capabilities
+    assert "base_churn" in churn.required_fields
+    assert len(churn.decisions) == 3
+
+    with pytest.raises(ValueError, match="not found in registry"):
+        get_domain_template("non_existent_template")
+
+
+def test_list_domain_templates_filtering() -> None:
+    # Filter by domain
+    cs_templates = list_domain_templates(domain="customer_success")
+    assert len(cs_templates) == 1
+    assert cs_templates[0].template_id == "churn_retention"
+
+    # Filter by capability
+    risk_templates = list_domain_templates(capability="risk_sensitive")
+    assert len(risk_templates) >= 2
+    risk_ids = {t.template_id for t in risk_templates}
+    assert "inventory_replenishment" in risk_ids
+    assert "fraud_credit" in risk_ids
+
+    # Filter by maturity
+    stable_templates = list_domain_templates(maturity="stable")
+    assert len(stable_templates) >= 2
+    stable_ids = {t.template_id for t in stable_templates}
+    assert "churn_retention" in stable_ids
+    assert "market_entry" in stable_ids
+
+
+def test_domain_template_dataclass_round_trip() -> None:
+    template = get_domain_template("market_entry")
+    data = template.to_dict()
+    assert data["template_id"] == "market_entry"
+    assert data["domain"] == "business_strategy"
+
+    reconstructed = DomainTemplate.from_dict(data)
+    assert reconstructed == template
+
+
+def test_domain_template_error_handling() -> None:
+    with pytest.raises(InputError, match="must be a dictionary"):
+        DomainTemplate.from_dict("not_a_dict")  # type: ignore[arg-type]
+
+    non_existent_path = Path("specs/domain-templates/does_not_exist_registry.json")
+    with pytest.raises(InputError, match="not found"):
+        load_domain_template_registry(registry_path=non_existent_path)

--- a/voiage/domain_templates.py
+++ b/voiage/domain_templates.py
@@ -1,0 +1,270 @@
+"""Curated Domain Template and Adapter Registry for Enterprise VOI (#577).
+
+This module provides typed access, schema validation, and discovery for curated
+industry decision templates across customer success, pricing, marketing,
+supply chain, maintenance, risk, finance, strategy, and people analytics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from voiage.exceptions import raise_input_error, raise_value_error
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_REGISTRY_PATH = _ROOT / "specs" / "domain-templates" / "registry.json"
+_DEFAULT_SCHEMA_PATH = (
+    _ROOT
+    / "specs"
+    / "domain-templates"
+    / "schemas"
+    / "v1"
+    / "domain-template.schema.json"
+)
+
+
+@dataclass(frozen=True)
+class DomainTemplate:
+    """Represents a validated industry decision template.
+
+    Attributes
+    ----------
+    template_id : str
+        Unique identifier for the domain template (snake_case).
+    version : str
+        Semantic version string.
+    domain : str
+        Business domain category.
+    title : str
+        Human-readable title.
+    description : str
+        Detailed description of decision context.
+    decisions : list[str]
+        List of candidate intervention strategies.
+    information_actions : list[str]
+        List of candidate data collection or experiment actions.
+    required_fields : list[str]
+        Required parameter or sample columns.
+    capabilities : list[str]
+        VOI capabilities supported (e.g., evpi, evppi, evsi, enbs).
+    maturity : str
+        Maturity disposition ("candidate", "experimental", "stable").
+    rights : str
+        Data rights and IP permissions statement.
+    privacy : str
+        Privacy classification.
+    provenance : str
+        Origin and methodological foundation.
+    license : str
+        Software license identifier.
+    maintainers : list[str]
+        Designated maintainers.
+    compatibility : str
+        voiage version constraint string.
+    review_date : str
+        ISO 8601 review date (YYYY-MM-DD).
+    optional_dependencies : list[str]
+        Optional package dependencies.
+    examples : list[str]
+        Paths to reference scripts or notebooks.
+    """
+
+    template_id: str
+    version: str
+    domain: str
+    title: str
+    description: str
+    decisions: list[str]
+    information_actions: list[str]
+    required_fields: list[str]
+    capabilities: list[str]
+    maturity: str
+    rights: str
+    privacy: str
+    provenance: str
+    license: str
+    maintainers: list[str]
+    compatibility: str
+    review_date: str
+    optional_dependencies: list[str]
+    examples: list[str]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DomainTemplate:
+        """Instantiate DomainTemplate from raw dictionary."""
+        if not isinstance(data, dict):
+            raise_input_error("DomainTemplate data must be a dictionary.")
+        return cls(
+            template_id=str(data["template_id"]),
+            version=str(data["version"]),
+            domain=str(data["domain"]),
+            title=str(data["title"]),
+            description=str(data["description"]),
+            decisions=list(data["decisions"]),
+            information_actions=list(data["information_actions"]),
+            required_fields=list(data["required_fields"]),
+            capabilities=list(data["capabilities"]),
+            maturity=str(data["maturity"]),
+            rights=str(data.get("rights", "")),
+            privacy=str(data.get("privacy", "")),
+            provenance=str(data.get("provenance", "")),
+            license=str(data.get("license", "Apache-2.0 OR MIT")),
+            maintainers=list(data.get("maintainers", [])),
+            compatibility=str(data.get("compatibility", ">=2.0.0")),
+            review_date=str(data.get("review_date", "2026-08-22")),
+            optional_dependencies=list(data.get("optional_dependencies", [])),
+            examples=list(data.get("examples", [])),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize DomainTemplate to a dictionary."""
+        return {
+            "template_id": self.template_id,
+            "version": self.version,
+            "domain": self.domain,
+            "title": self.title,
+            "description": self.description,
+            "decisions": list(self.decisions),
+            "information_actions": list(self.information_actions),
+            "required_fields": list(self.required_fields),
+            "optional_dependencies": list(self.optional_dependencies),
+            "capabilities": list(self.capabilities),
+            "maturity": self.maturity,
+            "examples": list(self.examples),
+            "rights": self.rights,
+            "privacy": self.privacy,
+            "provenance": self.provenance,
+            "license": self.license,
+            "maintainers": list(self.maintainers),
+            "compatibility": self.compatibility,
+            "review_date": self.review_date,
+        }
+
+
+def load_domain_template_registry(
+    registry_path: Path | None = None,
+) -> list[DomainTemplate]:
+    """Load and parse all domain templates from the JSON registry manifest.
+
+    Parameters
+    ----------
+    registry_path : Path, optional
+        Custom path to registry.json file. Defaults to specs/domain-templates/registry.json.
+
+    Returns
+    -------
+    list[DomainTemplate]
+        List of parsed DomainTemplate objects.
+    """
+    path = registry_path or _DEFAULT_REGISTRY_PATH
+    if not path.is_file():
+        raise_input_error(f"Domain template registry not found at {path}")
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    templates_data = raw.get("templates", [])
+    return [DomainTemplate.from_dict(item) for item in templates_data]
+
+
+def list_domain_templates(
+    domain: str | None = None,
+    capability: str | None = None,
+    maturity: str | None = None,
+    registry_path: Path | None = None,
+) -> list[DomainTemplate]:
+    """Filter and discover domain templates.
+
+    Parameters
+    ----------
+    domain : str, optional
+        Filter by business domain (e.g. "customer_success", "pricing_revenue").
+    capability : str, optional
+        Filter by supported VOI capability (e.g. "evpi", "evsi", "enbs").
+    maturity : str, optional
+        Filter by maturity level ("candidate", "experimental", "stable").
+    registry_path : Path, optional
+        Path to registry.json file.
+
+    Returns
+    -------
+    list[DomainTemplate]
+        Filtered list of domain templates.
+    """
+    templates = load_domain_template_registry(registry_path=registry_path)
+
+    if domain is not None:
+        templates = [t for t in templates if t.domain == domain]
+    if capability is not None:
+        templates = [t for t in templates if capability in t.capabilities]
+    if maturity is not None:
+        templates = [t for t in templates if t.maturity == maturity]
+
+    return templates
+
+
+def get_domain_template(
+    template_id: str, registry_path: Path | None = None
+) -> DomainTemplate:
+    """Retrieve a specific domain template by its template_id.
+
+    Parameters
+    ----------
+    template_id : str
+        Unique template ID.
+    registry_path : Path, optional
+        Path to registry.json file.
+
+    Returns
+    -------
+    DomainTemplate
+        The requested domain template.
+
+    Raises
+    ------
+    ValueError
+        If template_id is not found in the registry.
+    """
+    templates = load_domain_template_registry(registry_path=registry_path)
+    for template in templates:
+        if template.template_id == template_id:
+            return template
+
+    raise_value_error(
+        f"Domain template '{template_id}' not found in registry. "
+        f"Available: {[t.template_id for t in templates]}"
+    )
+    return None  # type: ignore[unreachable]
+
+
+def validate_domain_template_registry(
+    registry_path: Path | None = None,
+    schema_path: Path | None = None,
+) -> bool:
+    """Validate all registry entries against the domain-template JSON schema.
+
+    Parameters
+    ----------
+    registry_path : Path, optional
+        Path to registry.json.
+    schema_path : Path, optional
+        Path to domain-template.schema.json.
+
+    Returns
+    -------
+    bool
+        True if all templates pass JSON schema validation.
+    """
+    r_path = registry_path or _DEFAULT_REGISTRY_PATH
+    s_path = schema_path or _DEFAULT_SCHEMA_PATH
+
+    raw_registry = json.loads(r_path.read_text(encoding="utf-8"))
+    schema = json.loads(s_path.read_text(encoding="utf-8"))
+
+    for template_dict in raw_registry.get("templates", []):
+        jsonschema.validate(instance=template_dict, schema=schema)
+
+    return True


### PR DESCRIPTION
## Summary

This PR addresses child issue [#577](https://github.com/edithatogo/voiage/issues/577) under the **Datasets and Executable Worked Examples** track ([#321](https://github.com/edithatogo/voiage/issues/321)):

- **Domain Template Schema:** Adds `specs/domain-templates/schemas/v1/domain-template.schema.json` defining the versioned JSON Schema for domain decision templates.
- **Curated Registry:** Implements `specs/domain-templates/registry.json` with 9 enterprise domain templates (customer churn, dynamic pricing, marketing measurement, inventory replenishment, predictive maintenance, fraud & credit risk, financial alternative data, new market entry, and HR attrition).
- **Python Discovery & Loader Module:** Adds `voiage.domain_templates` providing `DomainTemplate`, `load_domain_template_registry()`, `list_domain_templates()`, `get_domain_template()`, and `validate_domain_template_registry()`.
- **Testing:** Adds `tests/test_domain_templates.py` verifying schema validation, retrieval, filtering by domain/capability/maturity, and serialization roundtrips.

## Verification
- `pytest tests/test_domain_templates.py` (6 passed)
- Full repo harness and validation suite: `PASS`