### PR TITLE
feat(integrations): add enterprise model, lineage, metric, and experiment adapters (#322, #583)

### DIFF
--- a/specs/integrations/enterprise/fixtures/normative/adapters-fixture.json
+++ b/specs/integrations/enterprise/fixtures/normative/adapters-fixture.json
@@ -1,0 +1,114 @@
+{
+  "adapters": [
+    {
+      "adapter_type": "mlflow_model",
+      "adapter_version": "1.0.0",
+      "source_system": "mlflow://production-tracking-server/models/churn_risk_v2",
+      "extracted_at": "2026-08-22T10:00:00Z",
+      "metadata": {
+        "run_id": "8f3b92d8a04c4b6ea17e29a9",
+        "experiment_id": "104",
+        "artifact_uri": "s3://models/churn/v2/model.pkl"
+      },
+      "payload": {
+        "model_flavor": "xgboost",
+        "parameters": {
+          "max_depth": 6,
+          "learning_rate": 0.05
+        },
+        "metrics": {
+          "auc_roc": 0.892,
+          "brier_score": 0.084
+        },
+        "target_variable": "churn_probability"
+      }
+    },
+    {
+      "adapter_type": "openlineage_facet",
+      "adapter_version": "1.0.0",
+      "source_system": "openlineage://airflow/dags/voi_pricing_pipeline",
+      "extracted_at": "2026-08-22T10:00:00Z",
+      "metadata": {
+        "job_name": "pricing_voi_calculation",
+        "namespace": "analytics_prod"
+      },
+      "payload": {
+        "inputs": [
+          { "namespace": "snowflake://prod", "name": "dw.pricing.historical_elasticity" },
+          { "namespace": "s3://data-lake", "name": "competitor_feeds/latest.parquet" }
+        ],
+        "outputs": [
+          { "namespace": "s3://decision-cards", "name": "cards/pricing_q3_2026.json" }
+        ]
+      }
+    },
+    {
+      "adapter_type": "dbt_semantic_metric",
+      "adapter_version": "1.0.0",
+      "source_system": "dbt://models/marts/marketing/metrics.yml",
+      "extracted_at": "2026-08-22T10:00:00Z",
+      "metadata": {
+        "metric_name": "customer_acquisition_cost",
+        "grain": "month"
+      },
+      "payload": {
+        "type": "derived",
+        "expression": "total_spend / new_customers",
+        "filter": "channel = 'paid_search'",
+        "dimensions": ["channel", "geo_region"]
+      }
+    },
+    {
+      "adapter_type": "experiment_export",
+      "adapter_version": "1.0.0",
+      "source_system": "growthbook://api/v1/experiments/exp_checkout_flow",
+      "extracted_at": "2026-08-22T10:00:00Z",
+      "metadata": {
+        "experiment_id": "exp_checkout_flow_v3",
+        "status": "running"
+      },
+      "payload": {
+        "variations": ["control", "simplified_step", "one_click"],
+        "sample_sizes": { "control": 15000, "simplified_step": 15000, "one_click": 15000 },
+        "conversion_rates": { "control": 0.042, "simplified_step": 0.048, "one_click": 0.051 },
+        "lift_mean": 0.009,
+        "lift_ci_95": [0.004, 0.014]
+      }
+    },
+    {
+      "adapter_type": "causal_cate_artifact",
+      "adapter_version": "1.0.0",
+      "source_system": "econml://causal_forest_retention",
+      "extracted_at": "2026-08-22T10:00:00Z",
+      "metadata": {
+        "estimator_type": "CausalForestDML",
+        "n_trees": 500
+      },
+      "payload": {
+        "treatment": "retention_discount",
+        "outcome": "churn_reduction",
+        "heterogeneity_features": ["account_age_months", "monthly_spend", "support_tickets"],
+        "average_treatment_effect": 0.124,
+        "ate_standard_error": 0.018
+      }
+    },
+    {
+      "adapter_type": "probabilistic_forecast",
+      "adapter_version": "1.0.0",
+      "source_system": "forecast://demand_sensing/q3",
+      "extracted_at": "2026-08-22T10:00:00Z",
+      "metadata": {
+        "sku_id": "SKU-9921",
+        "forecast_horizon_weeks": 12
+      },
+      "payload": {
+        "quantiles": {
+          "p10": [120, 125, 130],
+          "p50": [160, 165, 170],
+          "p90": [210, 220, 230]
+        },
+        "mean": [162.5, 168.0, 173.5]
+      }
+    }
+  ]
+}

--- a/specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json
+++ b/specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://voiage.dev/specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json",
+  "title": "EnterpriseAdaptersV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "adapter_type",
+    "adapter_version",
+    "source_system",
+    "extracted_at",
+    "metadata",
+    "payload"
+  ],
+  "properties": {
+    "adapter_type": {
+      "type": "string",
+      "enum": [
+        "mlflow_model",
+        "openlineage_facet",
+        "dbt_semantic_metric",
+        "experiment_export",
+        "causal_cate_artifact",
+        "probabilistic_forecast"
+      ],
+      "description": "Category of enterprise stack integration adapter."
+    },
+    "adapter_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Semantic version of the adapter format."
+    },
+    "source_system": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Originating enterprise system name or URI."
+    },
+    "extracted_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 extraction timestamp."
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "General system metadata (run_id, experiment_id, environment)."
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Adapter-specific structured decision or parameter data."
+    }
+  }
+}

--- a/specs/v2/extension-surface-policy.json
+++ b/specs/v2/extension-surface-policy.json
@@ -50,7 +50,8 @@
       "voiage/plot/**",
       "voiage/clinical_trials.py",
       "voiage/domain_templates.py",
-      "voiage/decision_card.py"
+      "voiage/decision_card.py",
+      "voiage/enterprise_adapters.py"
     ],
     "experimental": [
       "voiage/experimental/**",

--- a/specs/v2/python-runtime-inventory.json
+++ b/specs/v2/python-runtime-inventory.json
@@ -36,7 +36,7 @@
     },
     "optional_extension": {
       "status": "retain_or_extract_by_extension_policy",
-      "roots": ["voiage/ecosystem_integration.py", "voiage/environmental/", "voiage/experimental_design.py", "voiage/financial/", "voiage/health_economics.py", "voiage/healthcare/", "voiage/hta_integration.py", "voiage/plot/", "voiage/widgets/", "voiage/web/", "voiage/domain_templates.py", "voiage/decision_card.py"]
+      "roots": ["voiage/ecosystem_integration.py", "voiage/environmental/", "voiage/experimental_design.py", "voiage/financial/", "voiage/health_economics.py", "voiage/healthcare/", "voiage/hta_integration.py", "voiage/plot/", "voiage/widgets/", "voiage/web/", "voiage/domain_templates.py", "voiage/decision_card.py", "voiage/enterprise_adapters.py"]
     },
     "experimental_namespace": {
       "status": "exclude_from_v2_stable_surface",

--- a/tests/test_enterprise_adapters.py
+++ b/tests/test_enterprise_adapters.py
@@ -1,0 +1,127 @@
+"""Tests for Enterprise Model, Lineage, Metric, and Experiment Adapters (#583)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voiage.enterprise_adapters import (
+    EnterpriseAdapterRecord,
+    adapt_causal_cate_artifact,
+    adapt_dbt_semantic_metric,
+    adapt_experiment_export,
+    adapt_mlflow_model_metadata,
+    adapt_openlineage_job_facet,
+    adapt_probabilistic_forecast,
+    load_enterprise_adapters_from_fixture,
+    validate_enterprise_adapter_record,
+)
+from voiage.exceptions import InputError
+
+
+def test_load_and_validate_enterprise_adapters_fixture() -> None:
+    adapters = load_enterprise_adapters_from_fixture()
+    assert len(adapters) == 6
+
+    for adapter in adapters:
+        assert validate_enterprise_adapter_record(adapter.to_dict()) is True
+
+
+def test_adapt_mlflow_model_metadata() -> None:
+    record = adapt_mlflow_model_metadata(
+        source_system="mlflow://tracking/models/churn_xgb",
+        run_id="run_123",
+        experiment_id="exp_01",
+        metrics={"auc": 0.88},
+        parameters={"max_depth": 5},
+        target_variable="churn",
+        model_flavor="xgboost",
+    )
+    assert record.adapter_type == "mlflow_model"
+    assert record.metadata["run_id"] == "run_123"
+    assert record.payload["metrics"]["auc"] == 0.88
+    assert validate_enterprise_adapter_record(record.to_dict()) is True
+
+
+def test_adapt_openlineage_job_facet() -> None:
+    record = adapt_openlineage_job_facet(
+        source_system="openlineage://airflow/dags/job_voi",
+        job_name="voi_pricing_job",
+        namespace="prod_analytics",
+        inputs=[{"namespace": "snowflake", "name": "dw.pricing"}],
+        outputs=[{"namespace": "s3", "name": "cards/pricing.json"}],
+    )
+    assert record.adapter_type == "openlineage_facet"
+    assert len(record.payload["inputs"]) == 1
+    assert validate_enterprise_adapter_record(record.to_dict()) is True
+
+
+def test_adapt_dbt_semantic_metric() -> None:
+    record = adapt_dbt_semantic_metric(
+        source_system="dbt://models/metrics.yml",
+        metric_name="cac",
+        grain="month",
+        expression="spend / new_customers",
+        filter_clause="channel = 'search'",
+        dimensions=["channel", "region"],
+    )
+    assert record.adapter_type == "dbt_semantic_metric"
+    assert record.payload["dimensions"] == ["channel", "region"]
+    assert validate_enterprise_adapter_record(record.to_dict()) is True
+
+
+def test_adapt_experiment_export() -> None:
+    record = adapt_experiment_export(
+        source_system="growthbook://experiments/exp_1",
+        experiment_id="exp_1",
+        variations=["control", "variant"],
+        sample_sizes={"control": 5000, "variant": 5000},
+        conversion_rates={"control": 0.05, "variant": 0.06},
+        lift_mean=0.01,
+        lift_ci_95=[0.002, 0.018],
+    )
+    assert record.adapter_type == "experiment_export"
+    assert record.payload["lift_mean"] == 0.01
+    assert validate_enterprise_adapter_record(record.to_dict()) is True
+
+
+def test_adapt_causal_cate_artifact() -> None:
+    record = adapt_causal_cate_artifact(
+        source_system="econml://causal_forest",
+        treatment="discount",
+        outcome="retention",
+        heterogeneity_features=["tenure", "spend"],
+        average_treatment_effect=0.15,
+        ate_standard_error=0.02,
+        estimator_type="CausalForestDML",
+    )
+    assert record.adapter_type == "causal_cate_artifact"
+    assert record.payload["treatment"] == "discount"
+    assert validate_enterprise_adapter_record(record.to_dict()) is True
+
+
+def test_adapt_probabilistic_forecast() -> None:
+    record = adapt_probabilistic_forecast(
+        source_system="forecast://demand_v1",
+        sku_id="SKU-100",
+        quantiles={"p10": [10.0, 12.0], "p90": [20.0, 22.0]},
+        mean=[15.0, 17.0],
+        forecast_horizon_weeks=2,
+    )
+    assert record.adapter_type == "probabilistic_forecast"
+    assert record.payload["quantiles"]["p10"] == [10.0, 12.0]
+    assert validate_enterprise_adapter_record(record.to_dict()) is True
+
+
+def test_enterprise_adapter_error_handling() -> None:
+    with pytest.raises(InputError, match="must be a dictionary"):
+        EnterpriseAdapterRecord.from_dict("invalid")  # type: ignore[arg-type]
+
+    non_existent = Path("specs/integrations/enterprise/schemas/v1/missing.schema.json")
+    with pytest.raises(InputError, match="not found"):
+        validate_enterprise_adapter_record({}, schema_path=non_existent)
+
+    non_existent_fixture = Path("specs/integrations/enterprise/missing_fixture.json")
+    with pytest.raises(InputError, match="not found"):
+        load_enterprise_adapters_from_fixture(fixture_path=non_existent_fixture)

--- a/voiage/enterprise_adapters.py
+++ b/voiage/enterprise_adapters.py
@@ -1,0 +1,252 @@
+"""Enterprise Model, Lineage, Metric, and Experiment Adapters (#583).
+
+This module integrates VOIAGE as decision-value middleware across modern analytics,
+experimentation, and ML stacks (MLflow, OpenLineage, dbt Semantic Layer,
+GrowthBook/Statsig, EconML/CausalML, and probabilistic forecasts) without
+requiring heavy enterprise SDKs as hard base dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from voiage.exceptions import raise_input_error
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_SCHEMA_PATH = (
+    _ROOT
+    / "specs"
+    / "integrations"
+    / "enterprise"
+    / "schemas"
+    / "v1"
+    / "enterprise-adapters.schema.json"
+)
+_DEFAULT_FIXTURE_PATH = (
+    _ROOT
+    / "specs"
+    / "integrations"
+    / "enterprise"
+    / "fixtures"
+    / "normative"
+    / "adapters-fixture.json"
+)
+
+
+def _current_iso_timestamp() -> str:
+    """Return current UTC timestamp in ISO 8601 format."""
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class EnterpriseAdapterRecord:
+    """Canonical envelope for enterprise stack adapter payloads.
+
+    Attributes
+    ----------
+    adapter_type : str
+        Integration category (e.g. mlflow_model, openlineage_facet).
+    adapter_version : str
+        Semantic version of the adapter format.
+    source_system : str
+        Originating system URI or identifier.
+    extracted_at : str
+        ISO 8601 extraction timestamp.
+    metadata : dict[str, Any]
+        Source system metadata dictionary.
+    payload : dict[str, Any]
+        Adapter-specific payload dictionary.
+    """
+
+    adapter_type: str
+    adapter_version: str
+    source_system: str
+    extracted_at: str
+    metadata: dict[str, Any]
+    payload: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize adapter record to dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EnterpriseAdapterRecord:
+        """Instantiate adapter record from dictionary."""
+        if not isinstance(data, dict):
+            raise_input_error("EnterpriseAdapterRecord data must be a dictionary.")
+        return cls(
+            adapter_type=str(data["adapter_type"]),
+            adapter_version=str(data.get("adapter_version", "1.0.0")),
+            source_system=str(data["source_system"]),
+            extracted_at=str(data.get("extracted_at", _current_iso_timestamp())),
+            metadata=dict(data.get("metadata", {})),
+            payload=dict(data.get("payload", {})),
+        )
+
+
+def adapt_mlflow_model_metadata(
+    source_system: str,
+    run_id: str,
+    experiment_id: str,
+    metrics: dict[str, float],
+    parameters: dict[str, Any],
+    target_variable: str,
+    model_flavor: str = "custom",
+) -> EnterpriseAdapterRecord:
+    """Create an adapter record from MLflow model run metadata."""
+    return EnterpriseAdapterRecord(
+        adapter_type="mlflow_model",
+        adapter_version="1.0.0",
+        source_system=source_system,
+        extracted_at=_current_iso_timestamp(),
+        metadata={"run_id": run_id, "experiment_id": experiment_id},
+        payload={
+            "model_flavor": model_flavor,
+            "metrics": metrics,
+            "parameters": parameters,
+            "target_variable": target_variable,
+        },
+    )
+
+
+def adapt_openlineage_job_facet(
+    source_system: str,
+    job_name: str,
+    namespace: str,
+    inputs: list[dict[str, str]],
+    outputs: list[dict[str, str]],
+) -> EnterpriseAdapterRecord:
+    """Create an adapter record for OpenLineage dataset and job lineage."""
+    return EnterpriseAdapterRecord(
+        adapter_type="openlineage_facet",
+        adapter_version="1.0.0",
+        source_system=source_system,
+        extracted_at=_current_iso_timestamp(),
+        metadata={"job_name": job_name, "namespace": namespace},
+        payload={"inputs": inputs, "outputs": outputs},
+    )
+
+
+def adapt_dbt_semantic_metric(
+    source_system: str,
+    metric_name: str,
+    grain: str,
+    expression: str,
+    filter_clause: str = "",
+    dimensions: list[str] | None = None,
+) -> EnterpriseAdapterRecord:
+    """Create an adapter record from dbt Semantic Layer metric definitions."""
+    return EnterpriseAdapterRecord(
+        adapter_type="dbt_semantic_metric",
+        adapter_version="1.0.0",
+        source_system=source_system,
+        extracted_at=_current_iso_timestamp(),
+        metadata={"metric_name": metric_name, "grain": grain},
+        payload={
+            "type": "derived",
+            "expression": expression,
+            "filter": filter_clause,
+            "dimensions": dimensions or [],
+        },
+    )
+
+
+def adapt_experiment_export(
+    source_system: str,
+    experiment_id: str,
+    variations: list[str],
+    sample_sizes: dict[str, int],
+    conversion_rates: dict[str, float],
+    lift_mean: float,
+    lift_ci_95: list[float],
+) -> EnterpriseAdapterRecord:
+    """Create an adapter record from A/B experiment platform exports."""
+    return EnterpriseAdapterRecord(
+        adapter_type="experiment_export",
+        adapter_version="1.0.0",
+        source_system=source_system,
+        extracted_at=_current_iso_timestamp(),
+        metadata={"experiment_id": experiment_id, "status": "exported"},
+        payload={
+            "variations": variations,
+            "sample_sizes": sample_sizes,
+            "conversion_rates": conversion_rates,
+            "lift_mean": lift_mean,
+            "lift_ci_95": lift_ci_95,
+        },
+    )
+
+
+def adapt_causal_cate_artifact(
+    source_system: str,
+    treatment: str,
+    outcome: str,
+    heterogeneity_features: list[str],
+    average_treatment_effect: float,
+    ate_standard_error: float,
+    estimator_type: str = "CausalForest",
+) -> EnterpriseAdapterRecord:
+    """Create an adapter record for CATE heterogeneous uplift estimators."""
+    return EnterpriseAdapterRecord(
+        adapter_type="causal_cate_artifact",
+        adapter_version="1.0.0",
+        source_system=source_system,
+        extracted_at=_current_iso_timestamp(),
+        metadata={"estimator_type": estimator_type},
+        payload={
+            "treatment": treatment,
+            "outcome": outcome,
+            "heterogeneity_features": heterogeneity_features,
+            "average_treatment_effect": average_treatment_effect,
+            "ate_standard_error": ate_standard_error,
+        },
+    )
+
+
+def adapt_probabilistic_forecast(
+    source_system: str,
+    sku_id: str,
+    quantiles: dict[str, list[float]],
+    mean: list[float],
+    forecast_horizon_weeks: int = 12,
+) -> EnterpriseAdapterRecord:
+    """Create an adapter record for probabilistic quantile demand forecasts."""
+    return EnterpriseAdapterRecord(
+        adapter_type="probabilistic_forecast",
+        adapter_version="1.0.0",
+        source_system=source_system,
+        extracted_at=_current_iso_timestamp(),
+        metadata={"sku_id": sku_id, "forecast_horizon_weeks": forecast_horizon_weeks},
+        payload={"quantiles": quantiles, "mean": mean},
+    )
+
+
+def validate_enterprise_adapter_record(
+    record_dict: dict[str, Any], schema_path: Path | None = None
+) -> bool:
+    """Validate a raw dictionary against the Enterprise Adapters JSON schema."""
+    s_path = schema_path or _DEFAULT_SCHEMA_PATH
+    if not s_path.is_file():
+        raise_input_error(f"Enterprise adapter schema not found at {s_path}")
+
+    schema = json.loads(s_path.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=record_dict, schema=schema)
+    return True
+
+
+def load_enterprise_adapters_from_fixture(
+    fixture_path: Path | None = None,
+) -> list[EnterpriseAdapterRecord]:
+    """Load and parse enterprise adapter records from a fixture file."""
+    f_path = fixture_path or _DEFAULT_FIXTURE_PATH
+    if not f_path.is_file():
+        raise_input_error(f"Enterprise adapter fixture not found at {f_path}")
+
+    raw = json.loads(f_path.read_text(encoding="utf-8"))
+    return [EnterpriseAdapterRecord.from_dict(item) for item in raw.get("adapters", [])]


### PR DESCRIPTION
## Summary

This PR addresses child issue [#583](https://github.com/edithatogo/voiage/issues/583) under the **Quality, Security, Release and Registry Automation** track ([#322](https://github.com/edithatogo/voiage/issues/322)):

- **Enterprise Adapter Schema:** Adds `specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json` defining the canonical envelope for modern enterprise stack integrations.
- **Normative Fixtures:** Adds `specs/integrations/enterprise/fixtures/normative/adapters-fixture.json` with normative artifacts for MLflow (models/runs), OpenLineage (job facets), dbt Semantic Layer (metrics), GrowthBook/Statsig (experiment exports), EconML/CausalML (CATE uplift artifacts), and probabilistic demand forecasts.
- **Python Integration Layer (`voiage.enterprise_adapters`):** Provides zero-hard-dependency typed adapter methods (`adapt_mlflow_model_metadata`, `adapt_openlineage_job_facet`, `adapt_dbt_semantic_metric`, `adapt_experiment_export`, `adapt_causal_cate_artifact`, `adapt_probabilistic_forecast`) and validation.
- **Testing & Governance:** Adds `tests/test_enterprise_adapters.py` and updates `specs/v2/extension-surface-policy.json` and `specs/v2/python-runtime-inventory.json`.

## Verification
- `pytest tests/test_enterprise_adapters.py tests/test_extension_policy.py tests/test_python_runtime_inventory.py` (16 passed)
- Full repo harness and validator suite: `PASS`