### PR TITLE
feat(bindings): add industry decision contract binding dispositions (#320, #579)

### DIFF
--- a/specs/abi/industry-decision-binding-dispositions.json
+++ b/specs/abi/industry-decision-binding-dispositions.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1.0.0",
+  "contract_id": "industry-decision-contract-binding-parity",
+  "issue": 579,
+  "track": "polyglot_abi_binding_parity_20260723",
+  "updated_at": "2026-08-22T10:00:00Z",
+  "contracts": {
+    "decision_problem": {
+      "schema": "specs/core-api/schemas/v1/decision-problem.schema.json",
+      "dispositions": {
+        "python": {
+          "status": "implemented",
+          "symbol": "voiage.schema.DecisionProblem",
+          "interchange": "json_and_arrow"
+        },
+        "rust": {
+          "status": "implemented",
+          "symbol": "voiage_core::schema::DecisionProblem",
+          "interchange": "native_and_c_abi"
+        },
+        "r": {
+          "status": "implemented",
+          "symbol": "voiageR::decision_problem",
+          "interchange": "json_and_c_abi"
+        },
+        "julia": {
+          "status": "implemented",
+          "symbol": "Voiage.DecisionProblem",
+          "interchange": "json_and_c_abi"
+        },
+        "mojo": {
+          "status": "upstream_blocked",
+          "reason": "Mojo standard package distribution is an external upstream boundary"
+        }
+      }
+    },
+    "decision_cards": {
+      "schema": "specs/decision-cards/schemas/v1/decision-card.schema.json",
+      "dispositions": {
+        "python": {
+          "status": "implemented",
+          "symbol": "voiage.decision_card.DecisionCard",
+          "interchange": "json_and_sha256_bundle"
+        },
+        "rust": {
+          "status": "contract_only",
+          "symbol": "voiage_ffi::decision_card",
+          "interchange": "json"
+        },
+        "r": {
+          "status": "contract_only",
+          "symbol": "voiageR::decision_card",
+          "interchange": "json"
+        },
+        "julia": {
+          "status": "contract_only",
+          "symbol": "Voiage.DecisionCard",
+          "interchange": "json"
+        },
+        "mojo": {
+          "status": "upstream_blocked",
+          "reason": "Mojo standard package distribution is an external upstream boundary"
+        }
+      }
+    },
+    "enterprise_adapters": {
+      "schema": "specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json",
+      "dispositions": {
+        "python": {
+          "status": "implemented",
+          "symbol": "voiage.enterprise_adapters.EnterpriseAdapterRecord",
+          "interchange": "json"
+        },
+        "rust": {
+          "status": "contract_only",
+          "symbol": "specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json",
+          "interchange": "json"
+        },
+        "r": {
+          "status": "contract_only",
+          "symbol": "specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json",
+          "interchange": "json"
+        },
+        "julia": {
+          "status": "contract_only",
+          "symbol": "specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json",
+          "interchange": "json"
+        },
+        "mojo": {
+          "status": "upstream_blocked",
+          "reason": "Mojo standard package distribution is an external upstream boundary"
+        }
+      }
+    },
+    "domain_templates": {
+      "schema": "specs/domain-templates/schemas/v1/domain-template.schema.json",
+      "dispositions": {
+        "python": {
+          "status": "implemented",
+          "symbol": "voiage.domain_templates.DomainTemplate",
+          "interchange": "json"
+        },
+        "rust": {
+          "status": "contract_only",
+          "symbol": "specs/domain-templates/schemas/v1/domain-template.schema.json",
+          "interchange": "json"
+        },
+        "r": {
+          "status": "contract_only",
+          "symbol": "specs/domain-templates/schemas/v1/domain-template.schema.json",
+          "interchange": "json"
+        },
+        "julia": {
+          "status": "contract_only",
+          "symbol": "specs/domain-templates/schemas/v1/domain-template.schema.json",
+          "interchange": "json"
+        },
+        "mojo": {
+          "status": "upstream_blocked",
+          "reason": "Mojo standard package distribution is an external upstream boundary"
+        }
+      }
+    }
+  }
+}

--- a/specs/v2/extension-surface-policy.json
+++ b/specs/v2/extension-surface-policy.json
@@ -52,7 +52,8 @@
       "voiage/domain_templates.py",
       "voiage/decision_card.py",
       "voiage/enterprise_adapters.py",
-      "voiage/ml_policy_voi.py"
+      "voiage/ml_policy_voi.py",
+      "voiage/binding_dispositions.py"
     ],
     "experimental": [
       "voiage/experimental/**",

--- a/specs/v2/python-runtime-inventory.json
+++ b/specs/v2/python-runtime-inventory.json
@@ -36,7 +36,7 @@
     },
     "optional_extension": {
       "status": "retain_or_extract_by_extension_policy",
-      "roots": ["voiage/ecosystem_integration.py", "voiage/environmental/", "voiage/experimental_design.py", "voiage/financial/", "voiage/health_economics.py", "voiage/healthcare/", "voiage/hta_integration.py", "voiage/plot/", "voiage/widgets/", "voiage/web/", "voiage/domain_templates.py", "voiage/decision_card.py", "voiage/enterprise_adapters.py", "voiage/ml_policy_voi.py"]
+      "roots": ["voiage/ecosystem_integration.py", "voiage/environmental/", "voiage/experimental_design.py", "voiage/financial/", "voiage/health_economics.py", "voiage/healthcare/", "voiage/hta_integration.py", "voiage/plot/", "voiage/widgets/", "voiage/web/", "voiage/domain_templates.py", "voiage/decision_card.py", "voiage/enterprise_adapters.py", "voiage/ml_policy_voi.py", "voiage/binding_dispositions.py"]
     },
     "experimental_namespace": {
       "status": "exclude_from_v2_stable_surface",

--- a/tests/test_industry_decision_binding_dispositions.py
+++ b/tests/test_industry_decision_binding_dispositions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -53,7 +54,7 @@ def test_contract_binding_parity_to_dict() -> None:
     assert data["dispositions"]["python"]["status"] == "implemented"
 
 
-def test_error_handling() -> None:
+def test_error_handling(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="not found in manifest"):
         get_binding_disposition("non_existent_contract", "python")
 
@@ -66,3 +67,33 @@ def test_error_handling() -> None:
 
     with pytest.raises(InputError, match="not found"):
         validate_binding_dispositions_manifest(manifest_path=non_existent_path)
+
+    # Test empty contracts manifest
+    empty_manifest = tmp_path / "empty_manifest.json"
+    empty_manifest.write_text(json.dumps({"contracts": {}}))
+    with pytest.raises(InputError, match="contains no contracts"):
+        validate_binding_dispositions_manifest(manifest_path=empty_manifest)
+
+    # Test unknown language
+    bad_lang_manifest = tmp_path / "bad_lang.json"
+    bad_lang_manifest.write_text(
+        json.dumps(
+            {"contracts": {"c1": {"dispositions": {"ruby": {"status": "implemented"}}}}}
+        )
+    )
+    with pytest.raises(InputError, match="Unknown language"):
+        validate_binding_dispositions_manifest(manifest_path=bad_lang_manifest)
+
+    # Test invalid status
+    bad_status_manifest = tmp_path / "bad_status.json"
+    bad_status_manifest.write_text(
+        json.dumps(
+            {
+                "contracts": {
+                    "c1": {"dispositions": {"python": {"status": "invalid_status_xyz"}}}
+                }
+            }
+        )
+    )
+    with pytest.raises(InputError, match="Invalid status"):
+        validate_binding_dispositions_manifest(manifest_path=bad_status_manifest)

--- a/tests/test_industry_decision_binding_dispositions.py
+++ b/tests/test_industry_decision_binding_dispositions.py
@@ -1,0 +1,68 @@
+"""Tests for Industry Decision Contract Binding Parity (#579)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voiage.binding_dispositions import (
+    get_binding_disposition,
+    load_industry_decision_binding_dispositions,
+    validate_binding_dispositions_manifest,
+)
+from voiage.exceptions import InputError
+
+
+def test_manifest_validation() -> None:
+    assert validate_binding_dispositions_manifest() is True
+
+
+def test_load_all_contract_dispositions() -> None:
+    contracts = load_industry_decision_binding_dispositions()
+    assert len(contracts) >= 4
+    assert "decision_problem" in contracts
+    assert "decision_cards" in contracts
+    assert "enterprise_adapters" in contracts
+    assert "domain_templates" in contracts
+
+    # Check DecisionProblem parity
+    dp = contracts["decision_problem"]
+    assert dp.dispositions["python"].status == "implemented"
+    assert dp.dispositions["rust"].status == "implemented"
+    assert dp.dispositions["r"].status == "implemented"
+    assert dp.dispositions["julia"].status == "implemented"
+    assert dp.dispositions["mojo"].status == "upstream_blocked"
+
+
+def test_get_binding_disposition() -> None:
+    py_dp = get_binding_disposition("decision_problem", "python")
+    assert py_dp.status == "implemented"
+    assert py_dp.symbol == "voiage.schema.DecisionProblem"
+
+    mojo_dp = get_binding_disposition("decision_problem", "mojo")
+    assert mojo_dp.status == "upstream_blocked"
+    assert "external upstream boundary" in mojo_dp.reason
+
+
+def test_contract_binding_parity_to_dict() -> None:
+    contracts = load_industry_decision_binding_dispositions()
+    dp = contracts["decision_problem"]
+    data = dp.to_dict()
+    assert data["contract_id"] == "decision_problem"
+    assert data["dispositions"]["python"]["status"] == "implemented"
+
+
+def test_error_handling() -> None:
+    with pytest.raises(ValueError, match="not found in manifest"):
+        get_binding_disposition("non_existent_contract", "python")
+
+    with pytest.raises(ValueError, match="not configured"):
+        get_binding_disposition("decision_problem", "non_existent_language")
+
+    non_existent_path = Path("specs/abi/missing.json")
+    with pytest.raises(InputError, match="not found"):
+        load_industry_decision_binding_dispositions(manifest_path=non_existent_path)
+
+    with pytest.raises(InputError, match="not found"):
+        validate_binding_dispositions_manifest(manifest_path=non_existent_path)

--- a/voiage/binding_dispositions.py
+++ b/voiage/binding_dispositions.py
@@ -1,0 +1,161 @@
+"""Polyglot ABI and Binding Parity: Industry Decision Contracts (#579).
+
+This module exposes the disposition of industry decision contracts (DecisionProblem,
+Decision Cards, Enterprise Adapters, and Domain Templates) across Rust, Python,
+R, Julia, and Mojo.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+from voiage.exceptions import raise_input_error, raise_value_error
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_MANIFEST_PATH = (
+    _ROOT / "specs" / "abi" / "industry-decision-binding-dispositions.json"
+)
+
+
+@dataclass(frozen=True)
+class LanguageBindingDisposition:
+    """Disposition of a specific contract in a target language environment.
+
+    Attributes
+    ----------
+    language : str
+        Target language ("python", "rust", "r", "julia", "mojo").
+    status : str
+        Implementation state ("implemented", "contract_only", "adapter", "unsupported", "upstream_blocked").
+    symbol : str
+        Exported symbol, type, or schema reference.
+    interchange : str
+        Supported data interchange format (e.g. "json", "json_and_arrow", "c_abi").
+    reason : str
+        Explanatory rationale for unsupported or upstream-blocked states.
+    """
+
+    language: str
+    status: str
+    symbol: str = ""
+    interchange: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ContractBindingParity:
+    """Binding parity record for a canonical industry decision contract."""
+
+    contract_id: str
+    schema_path: str
+    dispositions: dict[str, LanguageBindingDisposition]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize contract parity record to dictionary."""
+        return {
+            "contract_id": self.contract_id,
+            "schema_path": self.schema_path,
+            "dispositions": {
+                lang: {
+                    "status": disp.status,
+                    "symbol": disp.symbol,
+                    "interchange": disp.interchange,
+                    "reason": disp.reason,
+                }
+                for lang, disp in self.dispositions.items()
+            },
+        }
+
+
+def load_industry_decision_binding_dispositions(
+    manifest_path: Path | None = None,
+) -> dict[str, ContractBindingParity]:
+    """Load and parse binding parity dispositions for all industry contracts."""
+    path = manifest_path or _DEFAULT_MANIFEST_PATH
+    if not path.is_file():
+        raise_input_error(f"Binding dispositions manifest not found at {path}")
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    contracts_data = raw.get("contracts", {})
+
+    results: dict[str, ContractBindingParity] = {}
+    for cid, cdata in contracts_data.items():
+        disps: dict[str, LanguageBindingDisposition] = {}
+        for lang, ldata in cdata.get("dispositions", {}).items():
+            disps[lang] = LanguageBindingDisposition(
+                language=lang,
+                status=str(ldata.get("status", "unsupported")),
+                symbol=str(ldata.get("symbol", "")),
+                interchange=str(ldata.get("interchange", "")),
+                reason=str(ldata.get("reason", "")),
+            )
+        results[cid] = ContractBindingParity(
+            contract_id=cid,
+            schema_path=str(cdata.get("schema", "")),
+            dispositions=disps,
+        )
+
+    return results
+
+
+def get_binding_disposition(
+    contract_id: str,
+    language: str,
+    manifest_path: Path | None = None,
+) -> LanguageBindingDisposition:
+    """Retrieve the disposition of a specific contract in a given language."""
+    all_contracts = load_industry_decision_binding_dispositions(
+        manifest_path=manifest_path
+    )
+    if contract_id not in all_contracts:
+        raise_value_error(
+            f"Contract '{contract_id}' not found in manifest. "
+            f"Available: {list(all_contracts.keys())}"
+        )
+
+    contract = all_contracts[contract_id]
+    if language not in contract.dispositions:
+        raise_value_error(
+            f"Language '{language}' not configured for contract '{contract_id}'. "
+            f"Configured: {list(contract.dispositions.keys())}"
+        )
+
+    return contract.dispositions[language]
+
+
+def validate_binding_dispositions_manifest(
+    manifest_path: Path | None = None,
+) -> bool:
+    """Validate that the manifest has required keys and valid status values."""
+    path = manifest_path or _DEFAULT_MANIFEST_PATH
+    if not path.is_file():
+        raise_input_error(f"Binding dispositions manifest not found at {path}")
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    valid_statuses = {
+        "implemented",
+        "contract_only",
+        "adapter",
+        "unsupported",
+        "upstream_blocked",
+    }
+    valid_languages = {"python", "rust", "r", "julia", "mojo"}
+
+    contracts = raw.get("contracts", {})
+    if not contracts:
+        raise_input_error("Manifest contains no contracts.")
+
+    for cid, cdata in contracts.items():
+        disps = cdata.get("dispositions", {})
+        for lang, ldata in disps.items():
+            if lang not in valid_languages:
+                raise_input_error(f"Unknown language '{lang}' in contract '{cid}'")
+            if ldata.get("status") not in valid_statuses:
+                raise_input_error(
+                    f"Invalid status '{ldata.get('status')}' for {lang} in {cid}"
+                )
+
+    return True


### PR DESCRIPTION
## Summary

This PR addresses child issue [#579](https://github.com/edithatogo/voiage/issues/579) under the **Polyglot ABI and Binding Parity** track ([#320](https://github.com/edithatogo/voiage/issues/320)):

- **Binding Dispositions Manifest:** Creates `specs/abi/industry-decision-binding-dispositions.json` defining explicit, versioned status and capability mappings across Rust, Python, R, Julia, and Mojo for `decision_problem`, `decision_cards`, `enterprise_adapters`, and `domain_templates`.
- **Python Discovery Layer (`voiage.binding_dispositions`):** Provides typed accessors (`load_industry_decision_binding_dispositions`, `get_binding_disposition`, `validate_binding_dispositions_manifest`) for runtime capability discovery.
- **Testing & Governance:** Adds `tests/test_industry_decision_binding_dispositions.py` and updates `specs/v2/extension-surface-policy.json` and `specs/v2/python-runtime-inventory.json`.

## Verification
- `pytest tests/test_industry_decision_binding_dispositions.py tests/test_extension_policy.py tests/test_python_runtime_inventory.py` (13 passed)
- Full repo harness and validator suite: `PASS`