### PR TITLE
docs: add user guides, method documentation, and API references for industry modules

### DIFF
--- a/docs/astro-site/astro.config.mjs
+++ b/docs/astro-site/astro.config.mjs
@@ -70,6 +70,10 @@ export default defineConfig({
           items: [{ autogenerate: { directory: "methods" } }],
         },
         {
+          label: "Integrations & Adapters",
+          items: [{ autogenerate: { directory: "integrations" } }],
+        },
+        {
           label: "Cross-Domain Usage",
           link: "/cross-domain-usage/",
         },

--- a/docs/astro-site/src/content/docs/api-reference/binding-dispositions.mdx
+++ b/docs/astro-site/src/content/docs/api-reference/binding-dispositions.mdx
@@ -1,0 +1,15 @@
+---
+title: Binding Dispositions API
+description: API reference for voiage.binding_dispositions
+---
+
+## Classes
+
+- `LanguageBindingDisposition` — Status (`implemented`, `contract_only`, `adapter`, `unsupported`, `upstream_blocked`), exported symbol, data interchange format, and rationales.
+- `ContractBindingParity` — Container mapping language targets to dispositions.
+
+## Functions
+
+- `load_industry_decision_binding_dispositions(manifest_path=None) -> dict[str, ContractBindingParity]`
+- `get_binding_disposition(contract_id: str, language: str, manifest_path=None) -> LanguageBindingDisposition`
+- `validate_binding_dispositions_manifest(manifest_path=None) -> bool`

--- a/docs/astro-site/src/content/docs/api-reference/decision-cards.mdx
+++ b/docs/astro-site/src/content/docs/api-reference/decision-cards.mdx
@@ -1,0 +1,23 @@
+---
+title: Decision Cards API
+description: API reference for voiage.decision_card
+---
+
+The `voiage.decision_card` module provides typed data structures for decision provenance, governance sign-off, and cryptographic result bundling.
+
+## Classes
+
+- `DecisionProblemSnapshot` — Snapshot of decision alternatives and criteria.
+- `SelectedPolicy` — Chosen policy, expected net benefit, and rationale.
+- `InformationValuation` — EVPI, EVPPI, EVSI, ENBS, and recommended trial action.
+- `ResidualUncertainty` — Post-decision risk quantiles and key variance drivers.
+- `HumanApproval` — Approver name, timestamp, and formal review rationale.
+- `Governance` — Card ownership, reviewer list, expiry dates, and approvals.
+- `Lineage` — Model versions, input hashes, dataset tags, and bundle hashes.
+- `DecisionCard` — Top-level auditable container with `to_markdown()`, `to_html()`, `to_json()`, and `compute_hash()`.
+- `DecisionBundle` — Container binding a `DecisionCard` with raw input payloads and SHA-256 verification via `verify_integrity()`.
+
+## Functions
+
+- `create_decision_card(...) -> DecisionCard` — Convenience constructor with ISO 8601 timestamps and default lineage.
+- `validate_decision_card(card_dict: dict, schema_path: Path | None = None) -> bool` — Validates dictionary against `specs/decision-cards/schemas/v1/decision-card.schema.json`.

--- a/docs/astro-site/src/content/docs/api-reference/decision-studio.mdx
+++ b/docs/astro-site/src/content/docs/api-reference/decision-studio.mdx
@@ -1,0 +1,17 @@
+---
+title: Decision Studio API
+description: API reference for voiage.decision_studio
+---
+
+## Classes
+
+- `ScenarioResult` — `scenario_name`, `optimal_choice`, `expected_payoff`, `parameter_adjustments`.
+- `DecisionStudioSession` — Full interactive session state with `render_markdown_report()`, `render_html_dashboard()`, and `to_dict()`.
+
+## Functions
+
+- `compute_expected_loss(payoffs: dict[str, float]) -> dict[str, float]` — Opportunity loss (regret) relative to the best choice.
+- `compute_mcda_scores(criteria_matrix: dict, weights: dict) -> dict[str, float]` — Weighted multi-criteria scores.
+- `create_decision_studio_session(...) -> DecisionStudioSession`
+- `validate_decision_studio_session(session_dict: dict, schema_path=None) -> bool`
+- `load_decision_studio_fixture(fixture_path=None) -> DecisionStudioSession`

--- a/docs/astro-site/src/content/docs/api-reference/domain-templates.mdx
+++ b/docs/astro-site/src/content/docs/api-reference/domain-templates.mdx
@@ -1,0 +1,37 @@
+---
+title: Domain Templates API
+description: API reference for voiage.domain_templates
+---
+
+The `voiage.domain_templates` module handles domain template discovery, JSON schema validation, and lifecycle serialization.
+
+## Types
+
+### `DomainTemplate`
+Immutable dataclass representing an industry decision problem template.
+
+- `template_id: str` — Identifier (snake_case)
+- `version: str` — Semantic version string
+- `domain: str` — Vertical category (e.g., `customer_success`, `pricing_revenue`)
+- `title: str` — Human-readable description
+- `decisions: list[str]` — Candidate interventions
+- `information_actions: list[str]` — Candidate studies / data collection trials
+- `required_fields: list[str]` — Parameter or dataset requirements
+- `capabilities: list[str]` — Supported VOI algorithms (`evpi`, `evppi`, `evsi`, `enbs`)
+- `maturity: str` — `candidate`, `experimental`, or `stable`
+- `to_dict() -> dict[str, Any]` — Serialize to dictionary
+- `from_dict(data: dict[str, Any]) -> DomainTemplate` — Parse from dictionary
+
+## Functions
+
+### `load_domain_template_registry(registry_path: Path | None = None) -> list[DomainTemplate]`
+Loads all domain templates from the normative `specs/domain-templates/registry.json` manifest.
+
+### `list_domain_templates(domain=None, capability=None, maturity=None, registry_path=None) -> list[DomainTemplate]`
+Filters and discovers templates by domain, VOI capability, or maturity status.
+
+### `get_domain_template(template_id: str, registry_path: Path | None = None) -> DomainTemplate`
+Retrieves a single template by ID; raises `ValueError` if not found.
+
+### `validate_domain_template_registry(registry_path=None, schema_path=None) -> bool`
+Validates all entries against `specs/domain-templates/schemas/v1/domain-template.schema.json`.

--- a/docs/astro-site/src/content/docs/api-reference/enterprise-adapters.mdx
+++ b/docs/astro-site/src/content/docs/api-reference/enterprise-adapters.mdx
@@ -1,0 +1,20 @@
+---
+title: Enterprise Adapters API
+description: API reference for voiage.enterprise_adapters
+---
+
+## Classes
+
+### `EnterpriseAdapterRecord`
+Canonical envelope storing `adapter_type`, `adapter_version`, `source_system`, `extracted_at`, `metadata`, and `payload`.
+
+## Functions
+
+- `adapt_mlflow_model_metadata(...) -> EnterpriseAdapterRecord`
+- `adapt_openlineage_job_facet(...) -> EnterpriseAdapterRecord`
+- `adapt_dbt_semantic_metric(...) -> EnterpriseAdapterRecord`
+- `adapt_experiment_export(...) -> EnterpriseAdapterRecord`
+- `adapt_causal_cate_artifact(...) -> EnterpriseAdapterRecord`
+- `adapt_probabilistic_forecast(...) -> EnterpriseAdapterRecord`
+- `validate_enterprise_adapter_record(record_dict: dict) -> bool`
+- `load_enterprise_adapters_from_fixture(fixture_path: Path | None = None) -> list[EnterpriseAdapterRecord]`

--- a/docs/astro-site/src/content/docs/api-reference/ml-policy-voi.mdx
+++ b/docs/astro-site/src/content/docs/api-reference/ml-policy-voi.mdx
@@ -1,0 +1,17 @@
+---
+title: ML & Policy VOI API
+description: API reference for voiage.ml_policy_voi
+---
+
+## Classes
+
+- `CandidateModelEvaluation` — Per-model metrics: `model_id`, `predictive_metric_score`, `expected_decision_value`, `policy_regret`.
+- `DecisionFocusedModelValueResult` — Evaluation results, model upgrade value, and refresh recommendations.
+- `UpliftVOIResult` — Heterogeneous policy net values, budget utilization, uplift EVPI, and subgroup EVPPI.
+
+## Functions
+
+- `evaluate_decision_focused_model_value(...) -> DecisionFocusedModelValueResult`
+- `compute_policy_uplift_voi(...) -> UpliftVOIResult`
+- `validate_decision_focused_model_value(record_dict: dict) -> bool`
+- `validate_policy_uplift_voi(record_dict: dict) -> bool`

--- a/docs/astro-site/src/content/docs/developer-guide/binding-dispositions.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/binding-dispositions.mdx
@@ -1,0 +1,34 @@
+---
+title: Polyglot ABI & Binding Dispositions
+description: Cross-language parity matrix and contract dispositions across Rust, Python, R, Julia, and Mojo
+sidebar:
+  order: 15
+---
+
+`voiage.binding_dispositions` documents the normative implementation disposition of industry decision contracts across supported polyglot runtimes.
+
+## Binding Parity Matrix
+
+The normative manifest is stored at `specs/abi/industry-decision-binding-dispositions.json`.
+
+| Canonical Contract | Python | Rust | R | Julia | Mojo |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `decision_problem` | `implemented` (PyO3) | `implemented` (Native/C ABI) | `implemented` (C ABI) | `implemented` (C ABI) | `upstream_blocked` |
+| `decision_cards` | `implemented` (JSON/SHA256) | `contract_only` | `contract_only` | `contract_only` | `upstream_blocked` |
+| `enterprise_adapters` | `implemented` (JSON) | `contract_only` | `contract_only` | `contract_only` | `upstream_blocked` |
+| `domain_templates` | `implemented` (JSON) | `contract_only` | `contract_only` | `contract_only` | `upstream_blocked` |
+
+## Inspection API
+
+```python
+from voiage.binding_dispositions import (
+    load_industry_decision_binding_dispositions,
+    get_binding_disposition,
+    validate_binding_dispositions_manifest,
+)
+
+assert validate_binding_dispositions_manifest() is True
+
+disp = get_binding_disposition("decision_cards", "python")
+print(f"Python Decision Cards: status={disp.status}, symbol={disp.symbol}")
+```

--- a/docs/astro-site/src/content/docs/integrations/enterprise-adapters.mdx
+++ b/docs/astro-site/src/content/docs/integrations/enterprise-adapters.mdx
@@ -1,0 +1,67 @@
+---
+title: Enterprise Stack Adapters
+description: Zero-dependency adapters for MLflow, OpenLineage, dbt Semantic Layer, Statsig, and CATE estimators
+sidebar:
+  order: 1
+---
+
+`voiage.enterprise_adapters` integrates VOIAGE as decision-value middleware across modern analytics, experimentation, and ML infrastructure without forcing heavy enterprise SDKs as hard dependencies.
+
+## Overview
+
+```mermaid
+graph LR
+    MLflow[MLflow Model Registry] -->|adapt_mlflow_model_metadata| EA[Enterprise Adapters]
+    dbt[dbt Semantic Layer] -->|adapt_dbt_semantic_metric| EA
+    OL[OpenLineage Facets] -->|adapt_openlineage_job_facet| EA
+    AB[Statsig / GrowthBook] -->|adapt_experiment_export| EA
+    CATE[EconML / CausalML] -->|adapt_causal_cate_artifact| EA
+    EA --> Voiage[VOIAGE Decision Kernel]
+```
+
+## Example Usage
+
+```python
+from voiage.enterprise_adapters import (
+    adapt_mlflow_model_metadata,
+    adapt_openlineage_job_facet,
+    adapt_dbt_semantic_metric,
+    adapt_experiment_export,
+    adapt_causal_cate_artifact,
+    validate_enterprise_adapter_record,
+)
+
+# Adapt an MLflow model run
+mlflow_rec = adapt_mlflow_model_metadata(
+    source_system="mlflow://production.registry/models/churn_risk_xgb",
+    run_id="run_98234abcf",
+    experiment_id="exp_retention_q3",
+    metrics={"auc_roc": 0.884, "brier_score": 0.112},
+    parameters={"max_depth": 6, "learning_rate": 0.05},
+    target_variable="is_churned",
+)
+assert validate_enterprise_adapter_record(mlflow_rec.to_dict()) is True
+
+# Adapt a dbt Semantic Layer metric
+dbt_rec = adapt_dbt_semantic_metric(
+    source_system="dbt://analytics_warehouse/metrics/net_customer_revenue",
+    metric_name="net_customer_revenue",
+    grain="month",
+    expression="sum(revenue) - sum(discounts)",
+    dimensions=["region", "customer_tier"],
+)
+
+# Adapt an A/B experimentation platform payload (Statsig / GrowthBook)
+ab_rec = adapt_experiment_export(
+    source_system="statsig://experiments/checkout_redesign_v2",
+    experiment_id="exp_checkout_02",
+    variations=["control", "treatment_1"],
+    sample_sizes={"control": 12500, "treatment_1": 12480},
+    conversion_rates={"control": 0.042, "treatment_1": 0.049},
+    lift_mean=0.007,
+    lift_ci_95=[0.002, 0.012],
+)
+```
+
+## Envelope Schema & Provenance
+Every adapter outputs an `EnterpriseAdapterRecord` conforming to `specs/integrations/enterprise/schemas/v1/enterprise-adapters.schema.json`.

--- a/docs/astro-site/src/content/docs/methods/decision-focused-model-value.mdx
+++ b/docs/astro-site/src/content/docs/methods/decision-focused-model-value.mdx
@@ -9,11 +9,12 @@ Standard ML benchmarks evaluate models on predictive accuracy or AUC-ROC. In ope
 
 ## Mathematical Formulation
 
-For candidate model $m$ with predicted probabilities $\hat{p}_{m, i}$ on unit $i$:
+For candidate model `m` with predicted probabilities `p_{m, i}` on unit `i`:
 
-$$\text{Decision Value}(m) = \sum_{i=1}^{N} \mathbb{I}(\hat{p}_{m, i} \ge \tau) \cdot (y_i \cdot V_{\text{payoff}} - C_{\text{intervention}})$$
-
-$$\text{Policy Regret}(m) = V_{\text{Oracle}} - \text{Decision Value}(m)$$
+```text
+Decision Value(m) = Sum_i I(p_{m, i} >= tau) * (y_i * Payoff - Cost)
+Policy Regret(m) = Oracle Value - Decision Value(m)
+```
 
 ## Usage Example
 

--- a/docs/astro-site/src/content/docs/methods/decision-focused-model-value.mdx
+++ b/docs/astro-site/src/content/docs/methods/decision-focused-model-value.mdx
@@ -1,0 +1,42 @@
+---
+title: Decision-Focused Model Value
+description: Evaluating ML/LLM models by downstream economic decision loss, policy regret, and refresh triggers
+sidebar:
+  order: 34
+---
+
+Standard ML benchmarks evaluate models on predictive accuracy or AUC-ROC. In operational decision-making, predictive accuracy often diverges from business value. `evaluate_decision_focused_model_value` measures models by net realized payoff, policy regret against an oracle EVPI ceiling, and automated retraining triggers.
+
+## Mathematical Formulation
+
+For candidate model $m$ with predicted probabilities $\hat{p}_{m, i}$ on unit $i$:
+
+$$\text{Decision Value}(m) = \sum_{i=1}^{N} \mathbb{I}(\hat{p}_{m, i} \ge \tau) \cdot (y_i \cdot V_{\text{payoff}} - C_{\text{intervention}})$$
+
+$$\text{Policy Regret}(m) = V_{\text{Oracle}} - \text{Decision Value}(m)$$
+
+## Usage Example
+
+```python
+import numpy as np
+from voiage.ml_policy_voi import evaluate_decision_focused_model_value
+
+y_true = np.array([1, 0, 1, 1, 0, 0, 1, 0, 1, 0])
+preds = {
+    "xgb_v1": np.array([0.9, 0.1, 0.8, 0.7, 0.2, 0.1, 0.85, 0.3, 0.95, 0.1]),
+    "lr_baseline": np.array([0.6, 0.4, 0.55, 0.65, 0.45, 0.3, 0.6, 0.5, 0.7, 0.4]),
+}
+
+res = evaluate_decision_focused_model_value(
+    candidate_predictions=preds,
+    actual_outcomes=y_true,
+    intervention_cost=100.0,
+    intervention_payoff=500.0,
+    current_production_model_id="lr_baseline",
+    regret_refresh_threshold=500.0,
+)
+
+print(f"Optimal Model: {res.selected_model}")
+print(f"Incremental Value: ${res.downstream_metrics['value_of_model_upgrade']:,.2f}")
+print(f"Refresh Recommended: {res.refresh_recommendation['should_refresh']}")
+```

--- a/docs/astro-site/src/content/docs/methods/policy-uplift-voi.mdx
+++ b/docs/astro-site/src/content/docs/methods/policy-uplift-voi.mdx
@@ -1,0 +1,41 @@
+---
+title: Policy and Uplift VOI
+description: Valuing heterogeneous treatment effects (CATE), budget-constrained targeting, and subgroup EVPPI
+sidebar:
+  order: 35
+---
+
+`compute_policy_uplift_voi` values personalized decision policies driven by heterogeneous treatment effect models (e.g. Causal Forests, Meta-learners, EconML) under finite intervention budgets.
+
+## Features
+
+- Computes optimal targeted allocation under hard budget limits.
+- Evaluates clairvoyant Uplift EVPI across posterior CATE trajectories.
+- Decomposes uncertainty into subgroup-specific EVPPI for targeted data gathering.
+
+```python
+import numpy as np
+from voiage.ml_policy_voi import compute_policy_uplift_voi
+
+# 100 simulations across 500 customers
+np.random.seed(42)
+cate_draws = np.random.normal(loc=0.08, scale=0.04, size=(100, 500))
+
+subgroups = {
+    "enterprise_tier": np.array([True] * 100 + [False] * 400),
+    "smb_tier": np.array([False] * 100 + [True] * 400),
+}
+
+uplift_res = compute_policy_uplift_voi(
+    cate_samples=cate_draws,
+    intervention_cost=50.0,
+    payoff_multiplier=1200.0,
+    budget_constraint=5000.0,
+    subgroups=subgroups,
+)
+
+print(f"Targeted Units: {uplift_res.units_targeted} / 500")
+print(f"Optimal Policy Net Value: ${uplift_res.optimal_policy_value:,.2f}")
+print(f"Uplift EVPI: ${uplift_res.uplift_evpi:,.2f}")
+print(f"Enterprise Subgroup EVPPI: ${uplift_res.subgroup_evppi['enterprise_tier']:,.2f}")
+```

--- a/docs/astro-site/src/content/docs/user-guide/decision-cards.mdx
+++ b/docs/astro-site/src/content/docs/user-guide/decision-cards.mdx
@@ -1,0 +1,80 @@
+---
+title: Decision Cards & Verifiable Bundles
+description: Auditable decision registry, governance sign-off, residual risk, and SHA-256 signed bundles
+sidebar:
+  order: 5
+---
+
+`voiage.decision_card` transforms raw numerical VOI calculations into tamper-evident, auditable business decision artifacts complete with stakeholder sign-offs, lineage tracking, and executive Markdown/HTML rendering.
+
+## Creating a Decision Card
+
+```python
+from voiage.decision_card import (
+    create_decision_card,
+    DecisionProblemSnapshot,
+    SelectedPolicy,
+    InformationValuation,
+    ResidualUncertainty,
+    HumanApproval,
+    DecisionBundle,
+    validate_decision_card,
+)
+
+# 1. Define decision components
+prob = DecisionProblemSnapshot(
+    problem_id="prob_cs_retention_2026",
+    title="Q3 Enterprise Churn Prevention",
+    alternatives=["Status Quo", "Automated Discount", "Concierge Outreach"],
+    criterion="Expected Net Benefit ($)",
+)
+
+policy = SelectedPolicy(
+    name="Concierge Outreach",
+    rationale="Highest expected net benefit with positive NPV after intervention cost.",
+    expected_net_benefit=185000.0,
+    baseline_comparison="+$65,000 over Status Quo",
+)
+
+voi = InformationValuation(
+    evpi=24000.0,
+    evsi={"pilot_500_trial": 16500.0},
+    enbs={"pilot_500_trial": 11500.0},
+    recommended_information_action="Execute pilot_500_trial before full rollout",
+)
+
+approval = HumanApproval(
+    approver="Jane Doe <vp-cx@company.org>",
+    approved_at="2026-08-22T10:30:00Z",
+    rationale="Pilot budget approved based on positive ENBS.",
+)
+
+# 2. Instantiate and validate
+card = create_decision_card(
+    decision_id="dec_card_cs_2026_01",
+    title="Customer Retention Policy & Trial Commissioning",
+    decision_problem=prob,
+    selected_policy=policy,
+    information_valuation=voi,
+    owner="Growth Operations Team",
+    reviewers=["cx-analytics@company.org"],
+    human_approval=approval,
+    status="approved",
+)
+
+assert validate_decision_card(card.to_dict()) is True
+
+# 3. Create a tamper-evident bundle with SHA-256 integrity verification
+bundle = DecisionBundle(card=card, input_payload={"n_customers": 5000, "clv_mean": 2400})
+assert bundle.verify_integrity() is True
+
+# 4. Export artifacts
+md_report = card.to_markdown()
+html_card = card.to_html()
+```
+
+## Governance & Lineage Guarantees
+
+- **Deterministic Cryptographic Hashing:** `card.compute_hash()` provides SHA-256 fingerprinting over all decision context, policy rationales, and VOI metrics.
+- **Tamper Evidence:** `DecisionBundle.verify_integrity()` validates both inputs and card payloads.
+- **Formal Lifecycle:** Cards track state (`draft`, `proposed`, `approved`, `superseded`, `expired`).

--- a/docs/astro-site/src/content/docs/user-guide/decision-studio.mdx
+++ b/docs/astro-site/src/content/docs/user-guide/decision-studio.mdx
@@ -1,0 +1,72 @@
+---
+title: Local Decision Studio & Reporting
+description: Offline-first interactive scenario exploration, Expected Opportunity Loss (EOL), MCDA, and HTML dashboards
+sidebar:
+  order: 6
+---
+
+`voiage.decision_studio` offers a local, offline-capable studio session manager for evaluating parameter sensitivities, regret/opportunity loss matrices, multi-criteria trade-offs, and self-contained HTML/Markdown executive dashboards.
+
+## Example Workflow
+
+```python
+from voiage.decision_studio import (
+    create_decision_studio_session,
+    validate_decision_studio_session,
+)
+
+base_payoffs = {
+    "Status Quo": 120000.0,
+    "Automated Discount": 145000.0,
+    "Concierge Outreach": 185000.0,
+}
+
+scenarios = {
+    "High Churn Surge": {
+        "Status Quo": 0.8,
+        "Automated Discount": 1.1,
+        "Concierge Outreach": 1.3,
+    },
+    "Budget Contraction": {
+        "Status Quo": 1.0,
+        "Automated Discount": 0.9,
+        "Concierge Outreach": 0.7,
+    },
+}
+
+mcda_matrix = {
+    "Status Quo": {"financial_roi": 50.0, "customer_satisfaction": 40.0},
+    "Automated Discount": {
+        "financial_roi": 70.0,
+        "customer_satisfaction": 65.0,
+    },
+    "Concierge Outreach": {
+        "financial_roi": 85.0,
+        "customer_satisfaction": 95.0,
+    },
+}
+mcda_weights = {"financial_roi": 0.6, "customer_satisfaction": 0.4}
+
+session = create_decision_studio_session(
+    session_id="studio_cs_2026_q3",
+    title="Customer Success Campaign Studio",
+    decision_problem_id="prob_cs_retention_2026",
+    decision_card_id="dec_card_cs_2026_01",
+    base_payoffs=base_payoffs,
+    scenarios_adjustments=scenarios,
+    evpi=24000.0,
+    status_quo_choice="Status Quo",
+    mcda_criteria_matrix=mcda_matrix,
+    mcda_weights=mcda_weights,
+)
+
+assert validate_decision_studio_session(session.to_dict()) is True
+
+# Generate deliverables
+md_report = session.render_markdown_report()
+html_dashboard = session.render_html_dashboard()
+```
+
+## Generated Outputs
+1. **Interactive HTML Dashboard:** Standalone, dependency-free CSS-styled single file.
+2. **Executive Markdown Report:** Formatted table with EOL (Expected Opportunity Loss) and scenario rankings.

--- a/docs/astro-site/src/content/docs/user-guide/domain-templates.mdx
+++ b/docs/astro-site/src/content/docs/user-guide/domain-templates.mdx
@@ -1,0 +1,50 @@
+---
+title: Curated Domain Templates
+description: Cross-industry decision problem templates with schema validation and metadata registry
+sidebar:
+  order: 4
+---
+
+`voiage.domain_templates` provides standardized, pre-parameterized decision templates across 8 industry verticals: customer success, pricing and revenue, marketing, predictive maintenance, supply chain, fintech credit underwriting, corporate strategy R&D, and people analytics.
+
+## Overview
+
+Each template specifies the intervention alternatives, information-gathering experiments (EVPI, EVPPI, EVSI, ENBS), required parameter columns, and provenance evidence without lock-in.
+
+```python
+from voiage.domain_templates import (
+    list_domain_templates,
+    get_domain_template,
+    validate_domain_template_registry,
+)
+
+# Validate the registry against its JSON schema
+assert validate_domain_template_registry() is True
+
+# List available templates for Customer Success
+cs_templates = list_domain_templates(domain="customer_success")
+for t in cs_templates:
+    print(f"{t.template_id}: {t.title} ({t.maturity})")
+
+# Load a specific dynamic pricing template
+pricing_tpl = get_domain_template("dynamic_pricing")
+print("Candidate Decisions:", pricing_tpl.decisions)
+print("Candidate Studies:", pricing_tpl.information_actions)
+```
+
+## Available Curated Templates
+
+| Template ID | Domain | Decisions | Key VOI Actions | Maturity |
+| :--- | :--- | :--- | :--- | :--- |
+| `churn_retention` | Customer Success | Status Quo, Discount, Concierge | Pilot Trial, Survey, Telemetry | `stable` |
+| `dynamic_pricing` | Pricing & Revenue | Regular Price, 15% Markdown, 30% Markdown | Regional Price Test, Competitor Scraping | `stable` |
+| `marketing_attribution` | Marketing & Growth | Baseline Spend, Reallocate Paid, Shift Organic | Geo-Lift Incrementality Experiment | `stable` |
+| `predictive_maintenance` | Manufacturing & IoT | Run to Failure, Preventive, Sensor Retrofit | Vibration Telemetry, Pilot Inspection | `stable` |
+| `inventory_reorder` | Supply Chain | Periodic Review, Continuous, Multi-Echelon | Supplier SLA Trial, Demand Feed | `stable` |
+| `credit_underwriting` | Fintech & Risk | Standard Rules, Alternative ML, Tiered Limit | Bureau Credit Signal, Employer Verification | `stable` |
+| `portfolio_r_and_d` | Corporate Strategy | Kill Project, Maintain Core, Accelerate | Phased Feasibility Study, Market Survey | `stable` |
+| `talent_attrition` | People Analytics | Passive Monitoring, Comp Adjustment, Retention | Pulse Survey, Stay Interviews | `stable` |
+
+## See Also
+- [API Reference: Domain Templates](/voiage/api-reference/domain-templates)
+- [Cross-Domain Usage](/voiage/cross-domain-usage)


### PR DESCRIPTION
## Summary

This PR expands the Astro/Starlight documentation site with user guides, API references, and method pages for recently delivered enterprise modules:
- **Domain Templates**: User guide and API reference for `voiage.domain_templates`.
- **Decision Cards & Bundles**: User guide and API reference for `voiage.decision_card`.
- **Enterprise Stack Adapters**: Integrations guide and API reference for `voiage.enterprise_adapters`.
- **Decision-Focused Model Value & Policy Uplift VOI**: Method documentation and API reference for `voiage.ml_policy_voi`.
- **Polyglot Binding Dispositions**: Developer guide and API reference for `voiage.binding_dispositions`.
- **Local Decision Studio & Reporting**: User guide and API reference for `voiage.decision_studio`.
- Updated `docs/astro-site/astro.config.mjs` navigation configuration with the `integrations/` sidebar group.