### PR TITLE
docs(transparency): add CONTRIBUTORS.md CRediT statement and AI_CONTRIBUTIONS.md ledger (#323)

### DIFF
--- a/AI_CONTRIBUTIONS.md
+++ b/AI_CONTRIBUTIONS.md
@@ -1,0 +1,30 @@
+# AI-Assisted Development & Transparency Statement
+
+`voiage` adheres to transparent, responsible disclosure of AI-assisted engineering and research tooling.
+
+## Core Governance Principles
+
+1. **Non-Authorship:** AI systems, LLMs, and automated agents are not authors, contributors, or copyright holders.
+2. **Human Accountability:** The human maintainer (@edithatogo) reviews, tests, approves, and assumes sole scientific and engineering accountability for all merged changes.
+3. **No Chain-of-Thought / Secret Storage:** Raw internal reasoning traces, API keys, credentials, and confidential personal data are never stored in repository files.
+4. **Verification Requirement:** AI-generated proposals or code suggestions are never accepted without automated test coverage, type checking, linter validation, and local/hosted CI execution.
+
+---
+
+## AI Systems & Tools Utilized
+
+| System / Tool | Provider | Purpose | Accountable Human Reviewer |
+| :--- | :--- | :--- | :--- |
+| **Antigravity CLI / Gemini 2.5 Pro** | Google DeepMind | Pair programming, test generation, schema validation, refactoring, and documentation drafting | Dylan A Mordaunt (`@edithatogo`) |
+| **GitHub Copilot** | GitHub / OpenAI | Contextual IDE code completion and snippet expansion | Dylan A Mordaunt (`@edithatogo`) |
+
+---
+
+## Transparency Ledger (Append-Only)
+
+| Release / Target | Focus Component | AI Tooling Used | Verification Method | Human Sign-Off |
+| :--- | :--- | :--- | :--- | :--- |
+| `v1.0.0` | Initial VOI Core | IDE completion | Pytest unit suite, tox matrix | Dylan A Mordaunt |
+| `v2.0.0` | Rust Polyglot ABI | Antigravity CLI / Copilot | Cargo test suite, PyO3 bindings, cross-platform CI | Dylan A Mordaunt |
+| `v2.1.0` | Stable Core & Frontier | Antigravity CLI (Gemini) | 60+ GitHub Actions checks, property tests, branch coverage | Dylan A Mordaunt |
+| `v2.2.0` (In Progress) | Enterprise Decision Suite & Assurance | Antigravity CLI (Gemini) | Exhaustive decision correctness suite, 100% branch coverage | Dylan A Mordaunt |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,45 @@
+# Contributors & CRediT Statement
+
+This document recognizes contributors to `voiage` in accordance with the [Contributor Roles Taxonomy (CRediT)](https://credit.niso.org/) standard.
+
+## Authorship & Accountability Policy
+
+- **Human Authorship:** Authorship is restricted to named human contributors who meet CRediT criteria and assume accountability for the work.
+- **Commit Counts:** Authorship and formal contribution roles are not inferred purely from automated commit counts or line volume.
+- **AI Systems:** Artificial intelligence tools, LLMs, and automated agents are not authors or CRediT contributors. All AI-assisted work is recorded in [AI_CONTRIBUTIONS.md](AI_CONTRIBUTIONS.md) and subject to human maintainer review and verification.
+
+---
+
+## Primary Maintainer & Lead Author
+
+### Dylan A Mordaunt
+- **ORCID:** [0000-0002-9775-0603](https://orcid.org/0000-0002-9775-0603)
+- **Email:** `voiage@users.noreply.github.com`
+- **Affiliation / Handle:** `@edithatogo`
+- **CRediT Roles:**
+  - **Conceptualization:** Lead. Formulated research goals, decision-theoretic foundations, and library architecture.
+  - **Methodology:** Lead. Developed mathematical formulations for Value of Information (EVPI, EVPPI, EVSI, ENBS), Value of Perspective, and frontier methods.
+  - **Software:** Lead. Designed and implemented the Rust numerical core, Python runtime, C ABI bindings, CLI, and test suites.
+  - **Formal Analysis:** Lead. Derived mathematical identities, bounds, and invariance properties across discrete and continuous state spaces.
+  - **Investigation:** Lead. Conducted simulation experiments, numerical benchmarks, and software census analysis.
+  - **Writing – Original Draft:** Lead. Authored documentation, specifications, and academic manuscript.
+  - **Writing – Review & Editing:** Lead. Reviewed all merged code, docstrings, and release artifacts.
+  - **Supervision & Project Administration:** Lead. Managed roadmaps, Conductor tracks, issue triage, and solo-maintainer governance.
+  - **Funding Acquisition:** Self-funded / independent research.
+
+---
+
+## CRediT Role Summary Table
+
+| Contributor | Conceptualization | Methodology | Software | Formal Analysis | Investigation | Writing (Draft) | Writing (Review) | Project Admin |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Dylan A Mordaunt** | **Lead** | **Lead** | **Lead** | **Lead** | **Lead** | **Lead** | **Lead** | **Lead** |
+
+---
+
+## Synchronization
+
+This record is canonically synchronized with:
+- [`CITATION.cff`](CITATION.cff)
+- [`codemeta.json`](codemeta.json)
+- [`paper/main.tex`](paper/main.tex)

--- a/tests/test_contribution_transparency.py
+++ b/tests/test_contribution_transparency.py
@@ -1,0 +1,61 @@
+"""Tests for contributor CRediT statement and AI contribution transparency (Issue #323)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import yaml
+
+ROOT = Path(__file__).parents[1]
+CONTRIBUTORS_MD = ROOT / "CONTRIBUTORS.md"
+AI_CONTRIBUTIONS_MD = ROOT / "AI_CONTRIBUTIONS.md"
+CITATION_CFF = ROOT / "CITATION.cff"
+CODEMETA_JSON = ROOT / "codemeta.json"
+
+
+def test_contributors_file_exists_and_contains_credit_roles() -> None:
+    """CONTRIBUTORS.md must exist and enumerate CRediT taxonomy roles."""
+    assert CONTRIBUTORS_MD.exists(), "CONTRIBUTORS.md must exist at root"
+    content = CONTRIBUTORS_MD.read_text(encoding="utf-8")
+
+    assert "Contributor Roles Taxonomy (CRediT)" in content
+    assert "Conceptualization" in content
+    assert "Methodology" in content
+    assert "Software" in content
+    assert "Formal Analysis" in content
+    assert "Investigation" in content
+    assert "Writing" in content
+    assert "Supervision" in content
+    assert "Dylan A Mordaunt" in content
+    assert "0000-0002-9775-0603" in content
+
+
+def test_ai_contributions_file_exists_and_declares_governance() -> None:
+    """AI_CONTRIBUTIONS.md must exist, declare non-authorship and human accountability."""
+    assert AI_CONTRIBUTIONS_MD.exists(), "AI_CONTRIBUTIONS.md must exist at root"
+    content = AI_CONTRIBUTIONS_MD.read_text(encoding="utf-8")
+
+    assert "Non-Authorship" in content
+    assert "Human Accountability" in content
+    assert "Dylan A Mordaunt" in content
+    assert "Transparency Ledger" in content
+
+
+def test_contributor_metadata_is_synchronized() -> None:
+    """Authorship records in CITATION.cff, codemeta.json, and CONTRIBUTORS.md must match."""
+    cff_data = yaml.safe_load(CITATION_CFF.read_text(encoding="utf-8"))
+    codemeta_data = json.loads(CODEMETA_JSON.read_text(encoding="utf-8"))
+
+    # Validate CITATION.cff
+    cff_authors = cff_data["authors"]
+    assert len(cff_authors) >= 1
+    assert cff_authors[0]["family-names"] == "Mordaunt"
+    assert cff_authors[0]["given-names"] == "Dylan"
+    assert "0000-0002-9775-0603" in cff_authors[0]["orcid"]
+
+    # Validate codemeta.json
+    codemeta_authors = codemeta_data["author"]
+    assert len(codemeta_authors) >= 1
+    assert codemeta_authors[0]["familyName"] == "Mordaunt"
+    assert codemeta_authors[0]["givenName"] == "Dylan"
+    assert "0000-0002-9775-0603" in codemeta_authors[0]["@id"]

--- a/tests/test_contribution_transparency.py
+++ b/tests/test_contribution_transparency.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
 import yaml
 
 ROOT = Path(__file__).parents[1]


### PR DESCRIPTION
## Summary

This PR delivers Issue #323 (`Contributor and AI contribution transparency`):
- **`CONTRIBUTORS.md`**: Formal human contributor record with publication-ready CRediT taxonomy roles synchronized with `CITATION.cff`, `codemeta.json`, and manuscript.
- **`AI_CONTRIBUTIONS.md`**: Versioned transparency statement and append-only disclosure ledger recording AI-assisted tooling (Google DeepMind Antigravity CLI / Gemini 2.5 Pro, Copilot), non-authorship, strict human verification, and solo-maintainer accountability.
- **`tests/test_contribution_transparency.py`**: Test suite validating CRediT taxonomy, governance disclosure, and metadata synchronization across citation files.

Closes #323.