### PR TITLE
chore(governance): add Gitleaks SHA-256 verification, expand harness workflows, sync voiageR docs, and clarify arXiv status

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install Gitleaks
         run: |
           curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz" -o gitleaks.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tar.gz" | sha256sum -c -
           tar -xzf gitleaks.tar.gz
           sudo mv gitleaks /usr/local/bin/
           rm gitleaks.tar.gz

--- a/README.md
+++ b/README.md
@@ -256,11 +256,10 @@ and [SECURITY.md](SECURITY.md).
   [`swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d`](https://archive.softwareheritage.org/swh:1:snp:31f89375852737bb9eb62ebc03fadfbc7ff70c2d)
 
 The canonical preprint source is [`paper/main.tex`](paper/main.tex). Repository
-automation builds, lints, audits, and packages the manuscript. Authenticated
-arXiv submission `7861466` is verified as submitted, but a permanent arXiv
-identifier and announcement have not yet been assigned. The separate
-[`paper.md`](paper.md) adaptation passes repository-owned JOSS preflight; no
-JOSS submission, review, or acceptance is claimed.
+automation builds, lints, audits, and packages the non-submitting arXiv source.
+Permanent arXiv announcement and identifier assignment remain an author-controlled
+external gate. The separate [`paper.md`](paper.md) adaptation passes repository-owned
+JOSS preflight; no JOSS submission, review, or acceptance is claimed.
 
 ## Project status and roadmap
 

--- a/r-package/voiageR/man/voiageR.Rd
+++ b/r-package/voiageR/man/voiageR.Rd
@@ -10,7 +10,7 @@ checks via reticulate.
 }
 \details{
 The package exports \code{init_voiage}, \code{evpi}, \code{evppi},
-\code{evsi}, \code{is_voiage_available}, and \code{set_voiage_env}.
+\code{evsi}, \code{enbs}, \code{is_voiage_available}, and \code{set_voiage_env}.
 
 Documentation policy:
 \itemize{

--- a/r-package/voiageR/vignettes/voiageR-getting-started.Rmd
+++ b/r-package/voiageR/vignettes/voiageR-getting-started.Rmd
@@ -113,14 +113,12 @@ custom-model parity.
 
 # Current wrapper surface
 
-The current R package exports the core analysis wrappers only:
+The current R package exports the core analysis wrappers:
 
-- `evpi()` for perfect-information value
-- `evppi()` for parameter-specific information value
-- `evsi()` for the built-in two-loop model and compatibility estimators
-
-Composite metrics such as ENBS are currently part of the Python surface and
-can be composed from the results above when needed.
+- `evpi()` for expected value of perfect information
+- `evppi()` for expected value of partial perfect information
+- `evsi()` for expected value of sample information (built-in two-loop model and estimators)
+- `enbs()` for expected net benefit of sampling
 
 # Build outputs
 

--- a/scripts/repo_harness.py
+++ b/scripts/repo_harness.py
@@ -31,9 +31,13 @@ REQUIRED_WORKFLOWS = (
     "ci.yml",
     "codeql.yml",
     "dependency-review.yml",
+    "gitleaks.yml",
     "operational-assurance.yml",
     "rust-fuzz.yml",
+    "rust-security.yml",
+    "sbom.yml",
     "scorecard.yml",
+    "zizmor.yml",
 )
 REQUIRED_CONTEXT_MARKERS = (
     "## Context Loading Order",


### PR DESCRIPTION
## Summary

This PR implements the panel review recommendations across security, packaging, and governance:

1. **Gitleaks Supply Chain Hardening**: Added cryptographic SHA-256 in-line verification when installing the Gitleaks binary in `.github/workflows/gitleaks.yml`.
2. **Expanded Repo Harness Security Workflows**: Added `gitleaks.yml`, `zizmor.yml`, `rust-security.yml`, and `sbom.yml` to `REQUIRED_WORKFLOWS` in `scripts/repo_harness.py`.
3. **`voiageR` Documentation Harmonization**: Synchronized `vignettes/voiageR-getting-started.Rmd` and `man/voiageR.Rd` to document the newly exported native `enbs()` calculation.
4. **README arXiv Status Clarification**: Updated `README.md` line 260 to describe non-submitting preprint packaging and clarify that announcement and permanent identifier assignment remain an author-controlled external gate.