### PR TITLE
test: add measured optional acceleration profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ paper/paper.tex
 *.fls
 *.run.xml
 *.synctex.gz
+
+# Optional local mutation-feedback report (not a CI gate).
+/coverage/gremlins/

--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,10 @@
   v2.1.0 build evidence. New BinaryBuilder execution and registry acceptance
   remain pending; no generated JLL identifier is assumed.
 
+- Add optional measured test-feedback profiles with dependency-aware selection
+  and bounded mutation and coverage experiments. Preserve the full clean CI
+  suite and its existing coverage and release gates.
+
 - Bound confirmed maintainer declarations and journal-first sequencing to the
   recorded decision. Retained separate survey and human-authorship action gates
   and verified withdrawal receipts for the earlier pyOpenSci requests.

--- a/docs/release/test-acceleration-profiles.md
+++ b/docs/release/test-acceleration-profiles.md
@@ -1,0 +1,108 @@
+# Bounded local test feedback
+
+Issue #1028 adds an optional `test-acceleration` extra and the `test-feedback`
+tox environment. Neither belongs to the required tox matrix. Full clean
+coverage, mutation, supported Python, release, and hosted checks remain the
+promotion authority. Selective runs cannot establish whole-suite correctness.
+
+```sh
+uv sync --extra ci --extra test-acceleration
+uv run --no-sync python scripts/test_acceleration.py testmon tests
+# Equivalent isolated environment:
+tox -e test-feedback -- testmon tests
+```
+
+## Selection and invalidation
+
+The runner uses serial pytest-testmon with the C coverage core. It disables
+pytest-cov and gremlins, clears inherited pytest options and shard selection,
+and accepts only existing paths below `tests/`. A process lock prevents two
+local profiles from sharing a database concurrently. Inspect a stale lock
+before removing it; a timeout is not evidence that a process stopped.
+
+The local database lives below `.conductor/local/test-acceleration/`. Its
+signature includes the checkout path, interpreter, installed distributions,
+selected paths, tracked and unignored file inventory, and non-Python file
+contents. Dependency, configuration, fixture, native-source and test-inventory
+changes rebuild the baseline. Testmon tracks edits to existing Python code.
+Failed or interrupted runs invalidate the completed-run signature. Exit code 5
+is accepted only for an empty selection against an unchanged successful
+baseline. A cold empty collection remains an error.
+
+Run ordinary tests after changes involving runtime-generated code, subprocess
+behavior, dynamic imports, environment-dependent behavior or external state.
+Testmon dependency tracking cannot prove these cases safe. `pytest-picked` is
+not installed: direct filename selection adds no dependency information beyond
+this profile and can miss affected consumers.
+
+## Bounded experiments
+
+```sh
+uv run --no-sync python scripts/test_acceleration.py ordinary tests/test_mutation_score.py
+uv run --no-sync python scripts/test_acceleration.py gremlins
+uv run --no-sync python scripts/test_acceleration.py ctrace tests/test_mutation_score.py
+uv run --no-sync python scripts/test_acceleration.py sysmon tests/test_mutation_score.py
+uv run --no-sync python scripts/evaluate_http_replay.py
+```
+
+Gremlins always targets only the mutation-score policy, its existing tests,
+comparison and boolean operators, and one worker. It is an experiment alongside
+the required Mutmut gate, not a replacement. Keep surviving mutants and tool
+failures visible; neither is a successful mutation outcome.
+
+The experiment was executed with Python 3.14.6; other interpreter combinations
+are not claimed as measured. The coverage profiles use isolated
+branch-coverage files and emit the actual
+measurement-core diagnostic. Python 3.12 and 3.13 cannot use sysmon for branch
+coverage. Dynamic contexts, tracing plugins and some concurrency modes are
+incompatible; testmon therefore explicitly uses ctrace. A measured sysmon
+result does not change CI's coverage core or thresholds.
+
+The HTTP experiment accesses only public PyPI metadata for one fixed package
+version, with no proxy or credential handler. It rejects other request URLs,
+methods and bodies, removes transport headers, verifies the replay digest,
+and deletes its temporary cassette. Replay runs with recording disabled.
+The generated in-process mock remains the preferred deterministic unit-test
+transport. Real response replay is reserved for explicitly scoped public
+integration investigation; never record application traffic or private data.
+
+Freezegun is deliberately excluded. Scientific-review expiry checks already
+accept `at_time` or `now`, exercised by explicit dated tests. Global clock
+freezing could alter asyncio, timeouts and concurrency and provides no benefit
+for these existing injectable clocks.
+
+Reports retain actual executed counts, pytest collection counts where emitted,
+subprocess time and the total measured runner phase (including signatures). Absolute timing depends on host load;
+no speed threshold or broad performance claim follows from one sample.
+
+## Primary tool references
+
+- [Testmon configuration](https://www.testmon.org/)
+- [Gremlins configuration](https://pytest-gremlins.readthedocs.io/en/latest/guide/configuration/)
+- [Coverage measurement cores](https://coverage.readthedocs.io/en/latest/config.html#run-core)
+- [VCR filtering](https://vcrpy.readthedocs.io/en/latest/advanced.html)
+
+## Observed trial
+
+The dated receipt is
+`specs/submission-readiness/test-acceleration-evaluation-20260831.json`.
+The final policy slice includes the new zero-denominator regression:
+
+| Local profile | Collected | Executed | Pytest process | Measured runner phase |
+|---|---:|---:|---:|---:|
+| Ordinary | 16 | 16 | 43.54 s | 48.80 s |
+| Cold testmon | 16 | 16 | 36.81 s | 39.06 s |
+| Unchanged warm testmon | 16 | 0 | 20.22 s | 23.37 s |
+
+The warm run reused the successful signature without invalidation. These are
+single observations under shared host load, not a portable speed comparison.
+The final gremlins trial killed all 29 generated comparison/boolean mutants,
+with no survivors, timeouts or errors. The full report is retained beside the
+receipt; the existing Mutmut gate remains unchanged.
+
+Both coverage cores reported 48/48 statements and 10/10 branches. Their raw
+trace arcs differed, so only the reportable totals are equivalent. Sysmon took
+52.07 s versus 48.19 s for ctrace on the same slice; there is no measured reason
+to promote it. Gremlins initially exposed a dynamic-context incompatibility;
+explicit ctrace removed that warning and exposed missing candidate/baseline
+zero-denominator assertions, now covered by an additional regression.

--- a/scripts/evaluate_http_replay.py
+++ b/scripts/evaluate_http_replay.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Compare one public metadata request with temporary replay and mock transport.
+
+This explicit opt-in experiment never records application traffic. Its only
+network target is public, version-specific PyPI metadata. The cassette is
+removed on exit; reports retain only response hashes and timing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import time
+from typing import Any
+import urllib.request
+
+URL = "https://pypi.org/pypi/pytest-testmon/2.2.0/json"
+
+
+def permitted_request(request: Any) -> Any:
+    """Reject anything outside the fixed public, credential-free request."""
+    if request.method != "GET" or request.uri != URL or request.body:
+        raise ValueError("only the fixed public PyPI metadata GET may be recorded")
+    if any(
+        name.lower() in ("authorization", "cookie", "proxy-authorization")
+        for name in request.headers
+    ):
+        raise ValueError("credential-bearing requests must not be recorded")
+    request.headers = {}
+    return request
+
+
+def public_response(response: dict[str, Any]) -> dict[str, Any]:
+    """Retain only public JSON and remove all transport headers."""
+    response["headers"] = {}
+    return response
+
+
+def main() -> None:
+    """Perform a bounded experiment only when explicitly invoked."""
+    import httpx
+    import vcr
+
+    rows = []
+    # No proxy or credential handlers; redirects fail the cassette URI allowlist.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    with tempfile.TemporaryDirectory(prefix="voiage-public-replay-") as directory:
+        cassette = str(Path(directory) / "public.json")
+        recorder = vcr.VCR(
+            serializer="json",
+            before_record_request=permitted_request,
+            before_record_response=public_response,
+            filter_headers=["authorization", "cookie", "proxy-authorization"],
+        )
+        expected = None
+        for mode in ("once", "none"):
+            started = time.perf_counter()
+            with recorder.use_cassette(cassette, record_mode=mode) as tape:
+                with opener.open(URL, timeout=20) as response:
+                    payload = response.read()
+                assert json.loads(payload)["info"]["version"] == "2.2.0"
+                assert len(tape.requests) == 1
+                digest = hashlib.sha256(payload).hexdigest()
+                if expected is not None:
+                    assert digest == expected
+                expected = digest
+            rows.append(
+                {
+                    "profile": "public_record"
+                    if mode == "once"
+                    else "network_disabled_replay",
+                    "wall_seconds": round(time.perf_counter() - started, 6),
+                    "checks": 3,
+                    "response_sha256": digest,
+                }
+            )
+        started = time.perf_counter()
+        # Unit tests should keep small generated response contracts in-process.
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(200, json={"info": {"version": "2.2.0"}})
+        )
+        with httpx.Client(transport=transport) as client:
+            response = client.get(URL)
+            assert response.status_code == 200
+            assert response.json()["info"]["version"] == "2.2.0"
+        rows.append(
+            {
+                "profile": "in_process_mock",
+                "wall_seconds": round(time.perf_counter() - started, 6),
+                "checks": 2,
+            }
+        )
+    result = {
+        "url": URL,
+        "measurements": rows,
+        "cassette_retained": False,
+        "credentials_or_restricted_payloads": False,
+        "decision": "Retain in-process transports for deterministic unit tests; temporary VCR is useful only for explicitly scoped public integration investigations.",
+    }
+    output = (
+        Path(__file__).resolve().parents[1]
+        / ".conductor/local/http-replay-evaluation.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_acceleration.py
+++ b/scripts/test_acceleration.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Run bounded, serial local feedback without weakening the ordinary test gates."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import subprocess
+import sys
+import time
+
+from defusedxml import ElementTree
+
+
+def fingerprint(
+    root: Path, files: list[str], targets: list[str], packages: list[str]
+) -> str:
+    """Invalidate on environment, inventory, config and non-Python resource changes."""
+    digest = hashlib.sha256()
+    digest.update(
+        json.dumps(
+            [
+                str(root.resolve()),
+                sys.version,
+                platform.platform(),
+                targets,
+                sorted(packages),
+            ]
+        ).encode()
+    )
+    for name in sorted(set(files)):
+        digest.update(name.encode() + b"\0")
+        path = root / name
+        # Testmon observes Python source changes; resources and native code need
+        # an explicit reset because Python line coverage cannot track them.
+        if (
+            path.suffix != ".py"
+            or path.name == "conftest.py"
+            or name == "scripts/test_acceleration.py"
+        ):
+            digest.update(path.read_bytes() if path.is_file() else b"<missing>")
+    return digest.hexdigest()
+
+
+def invalidate_cache(cache: Path, current: str) -> bool:
+    """Discard only this runner's database if the completed-run signature differs."""
+    cache.mkdir(parents=True, exist_ok=True)
+    manifest = cache / "fingerprint"
+    if manifest.is_file() and manifest.read_text() == current:
+        return False
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        (cache / ("testmon" + suffix)).unlink(missing_ok=True)
+    manifest.unlink(missing_ok=True)
+    return True
+
+
+def validate_targets(root: Path, targets: list[str]) -> list[str]:
+    """Allow test paths, never arbitrary pytest options or node selections."""
+    for target in targets:
+        path = Path(target)
+        if path.is_absolute() or target.startswith("-") or "::" in target:
+            raise ValueError(
+                "targets must be repository test paths, not pytest options"
+            )
+        resolved = (root / path).resolve()
+        if not resolved.is_relative_to(root / "tests") or not resolved.exists():
+            raise ValueError("targets must exist below repository tests/")
+    return targets
+
+
+def main() -> int:
+    """Execute one isolated profile and retain measured, non-authorizing evidence."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "profile", choices=("ordinary", "testmon", "gremlins", "ctrace", "sysmon")
+    )
+    parser.add_argument("targets", nargs="*", default=["tests"])
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    try:
+        targets = validate_targets(root, args.targets)
+    except ValueError as error:
+        parser.error(str(error))
+    cache = root / ".conductor/local/test-acceleration"
+    cache.mkdir(parents=True, exist_ok=True)
+    # A separate process lock prevents serial invocations from corrupting the
+    # shared selective database. A stale lock fails closed; inspect before removal.
+    lock = cache / "running"
+    try:
+        lock.mkdir()
+    except FileExistsError:
+        parser.error(
+            f"profile already running or stale lock requires inspection: {lock}"
+        )
+    try:
+        return run_profile(root, cache, args.profile, targets)
+    finally:
+        lock.rmdir()
+
+
+def run_profile(root: Path, cache: Path, profile: str, targets: list[str]) -> int:
+    """Run pytest with fixed plugin and trace settings; record actual JUnit counts."""
+    # Missing terminal evidence is safer than a stale success after a crash.
+    (cache / f"{profile}.json").unlink(missing_ok=True)
+    if profile == "gremlins":
+        (root / "coverage/gremlins/gremlins.json").unlink(missing_ok=True)
+    total_started = time.perf_counter()
+    packages = sorted(
+        f"{p.metadata['Name']}=={p.version}" for p in importlib.metadata.distributions()
+    )
+    files = subprocess.check_output(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],  # noqa: S607
+        cwd=root,
+        text=True,
+    ).splitlines()
+    current = fingerprint(root, files, targets, packages)
+    reset = invalidate_cache(cache, current) if profile == "testmon" else False
+    env = os.environ.copy()
+    for key in (
+        "PYTEST_ADDOPTS",
+        "PYTEST_PLUGINS",
+        "COVERAGE_PROCESS_START",
+        "COVERAGE_CORE",
+        "VOIAGE_TEST_SHARD_INDEX",
+        "VOIAGE_TEST_SHARD_COUNT",
+    ):
+        env.pop(key, None)
+    if profile in ("testmon", "gremlins"):
+        env["COVERAGE_CORE"] = "ctrace"
+    if profile == "testmon":
+        # Testmon switches dynamic contexts; sysmon cannot support that safely.
+        env["COVERAGE_CORE"] = "ctrace"
+        (cache / "fingerprint").unlink(missing_ok=True)
+    env["TESTMON_DATAFILE"] = str(cache / "testmon")
+    env["PYTHONPATH"] = str(root)
+    junit = cache / f"{profile}.xml"
+    junit.unlink(missing_ok=True)
+    pytest_args = [
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        *targets,
+        "--junitxml",
+        str(junit),
+    ]
+    if profile != "gremlins":
+        pytest_args += ["-p", "no:gremlins"]
+    if profile != "testmon":
+        pytest_args += ["-p", "no:pytest-testmon"]
+    prefix = [sys.executable, "-m", "pytest"]
+    if profile == "testmon":
+        pytest_args += ["--testmon"]
+    if profile == "gremlins":
+        # Never let gremlins discover the entire runtime or mutate arbitrary paths.
+        pytest_args = [
+            "-o",
+            "addopts=",
+            "-p",
+            "no:pytest_cov",
+            "tests/test_mutation_score.py",
+            "--junitxml",
+            str(junit),
+            "--gremlins",
+            "--gremlin-targets=voiage/mutation_policy.py",
+            "--gremlin-operators=comparison,boolean",
+            "--gremlin-workers=1",
+            "-p",
+            "no:pytest-testmon",
+            "--gremlin-report=json",
+        ]
+    if profile in ("ctrace", "sysmon"):
+        env["COVERAGE_CORE"] = profile
+        (cache / "coverage.ini").write_text("[run]\n")
+        prefix = [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "--rcfile",
+            str(cache / "coverage.ini"),
+            "--debug=core",
+            "--branch",
+            "--include=*/voiage/mutation_policy.py",
+            "--data-file",
+            str(cache / f".coverage-{profile}"),
+            "-m",
+            "pytest",
+        ]
+    command = [*prefix, *pytest_args]
+    started = time.perf_counter()
+    result = subprocess.run(  # noqa: S603 - fixed interpreter/profile and validated test paths
+        command,
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=3600,
+        check=False,
+    )
+    elapsed = time.perf_counter() - started
+    output = result.stdout + result.stderr
+    (cache / f"{profile}.log").write_text(output)
+    print(output)
+    counts = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+    if junit.exists():
+        for suite in ElementTree.parse(junit).getroot().iter("testsuite"):
+            for key in counts:
+                counts[key] += int(suite.get(key, "0"))
+    # Exit 5 only means cached no-selection when testmon reused a successful
+    # baseline; never translate failed collection or an empty cold run to success.
+    cached_empty = (
+        profile == "testmon"
+        and not reset
+        and result.returncode in (0, 5)
+        and counts["tests"] == 0
+        and counts["errors"] == 0
+    )
+    passed = junit.exists() and (
+        (result.returncode == 0 and counts["tests"] > 0) or cached_empty
+    )
+    collected = re.search(r"collected (\d+) items?", output)
+    if profile == "testmon":
+        if passed:
+            (cache / "fingerprint").write_text(current)
+        else:
+            (cache / "fingerprint").unlink(missing_ok=True)
+    evidence = {
+        "profile": profile,
+        "command": command,
+        "wall_seconds": round(elapsed, 4),
+        "total_wall_seconds": round(time.perf_counter() - total_started, 4),
+        "collected": int(collected.group(1)) if collected else None,
+        "exit_code": result.returncode,
+        "cached_empty": cached_empty,
+        "cache_invalidated": reset,
+        "counts": counts,
+        "python": sys.version,
+        "packages": packages,
+        "fingerprint": current,
+        "local_feedback_only": True,
+        "coverage_core": env.get("COVERAGE_CORE"),
+    }
+    if profile == "gremlins":
+        report_path = root / "coverage/gremlins/gremlins.json"
+        if report_path.is_file():
+            evidence["mutation_summary"] = json.loads(report_path.read_text())[
+                "summary"
+            ]
+    (cache / f"{profile}.json").write_text(json.dumps(evidence, indent=2) + "\n")
+    print(json.dumps({k: v for k, v in evidence.items() if k != "packages"}))
+    return 0 if passed else (result.returncode or 1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_acceleration.py
+++ b/scripts/test_acceleration.py
@@ -86,7 +86,7 @@ def main() -> int:
     try:
         targets = validate_targets(root, args.targets)
     except ValueError as error:
-        parser.error(str(error))
+        return parser.error(str(error))
     cache = root / ".conductor/local/test-acceleration"
     cache.mkdir(parents=True, exist_ok=True)
     # A separate process lock prevents serial invocations from corrupting the

--- a/specs/submission-readiness/dependency-frontier-environment-20260829/README.md
+++ b/specs/submission-readiness/dependency-frontier-environment-20260829/README.md
@@ -1,0 +1,16 @@
+# Historical dependency audit inputs
+
+These inputs preserve the 29 August audit
+`specs/submission-readiness/dependency-frontier-audit-20260829.json` without
+rewriting its recorded 216 packages and 60 declared requirements. The manifest
+binds exact bytes from the commit that introduced that audit. Both files were
+unchanged at the pre-acceleration base `27488e81`.
+
+The lock is shared with the existing reproduction-environment snapshot because
+the bytes are identical; this does not establish the paper's release identity
+or certify a new reproduction. The historical configuration is retained here.
+Tests verify both digests before checking the historical counts.
+
+Current dependency changes use the root configuration and lock, independently
+validated by frozen-lock CI and the strict dependency-frontier command. An
+optional extra must not alter this historical receipt.

--- a/specs/submission-readiness/dependency-frontier-environment-20260829/manifest.json
+++ b/specs/submission-readiness/dependency-frontier-environment-20260829/manifest.json
@@ -1,0 +1,14 @@
+{
+  "source_commit": "6e1dfc4ecd0699af365a1d5feaa7ed24a9431b21",
+  "source_description": "Commit that introduced the dated dependency-frontier audit; both source files are byte-identical at pre-acceleration base 27488e817238d6fe63016f2f5a5b15f91b1acda7.",
+  "files": {
+    "pyproject.toml": {
+      "path": "specs/submission-readiness/dependency-frontier-environment-20260829/pyproject.toml",
+      "sha256": "2ae0033c68442724d0f116590896853811693d09742b56b5e614db81a316972a"
+    },
+    "uv.lock": {
+      "path": "paper/reproduction-environment/uv.lock",
+      "sha256": "e5bfefe59aa2920d5b28e9beaa5a6e05cc8b08e4a91e74ed8589d7fc3354f7c5"
+    }
+  }
+}

--- a/specs/submission-readiness/dependency-frontier-environment-20260829/pyproject.toml
+++ b/specs/submission-readiness/dependency-frontier-environment-20260829/pyproject.toml
@@ -53,13 +53,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Local feedback experiments only; not a replacement for CI or coverage.
-test-acceleration = [
-    "pytest-testmon>=2.2.0,<3",
-    "pytest-gremlins>=1.9.0,<2",
-    "coverage>=7.16.0,<8",
-    "vcrpy>=8.3.0,<9",
-]
 # The built-in descriptor adapters deliberately use only the base Arrow/JSON
 # stack.  These named extras reserve stable installation surfaces for future
 # enhanced validators without coupling them to the calculation runtime.
@@ -95,7 +88,7 @@ dev = [
     "maturin>=1.9,<2.0",
     "mutmut==3.6.0",
     "scalene>=2.3.0,<3.0",
-    "ruff>=0.16.3,<0.17.0",
+    "ruff>=0.15.22,<0.16.0",
     "bandit>=1.9.4,<2.0",
     "nox>=2026.7.11,<2027",
     "ty>=0.0.61,<1.0",

--- a/specs/submission-readiness/test-acceleration-evaluation-20260831.json
+++ b/specs/submission-readiness/test-acceleration-evaluation-20260831.json
@@ -1,0 +1,565 @@
+{
+  "schema_version": "voiage.test-acceleration-evaluation.v1",
+  "issue": 1028,
+  "observed_on": "2026-08-31",
+  "base_commit": "27488e817238d6fe63016f2f5a5b15f91b1acda7",
+  "scope": "Opt-in local feedback; no stable CI, coverage, release or mutation gate replaced.",
+  "dependency_frontier": {
+    "upgrade_command_exit_code": 0,
+    "strict_audit_exit_code": 0,
+    "unrelated_upgrade_changes_retained": false,
+    "new_extra": "test-acceleration",
+    "runtime_requirements_changed": false
+  },
+  "tool_versions": {
+    "pytest-testmon": "2.2.0",
+    "pytest-gremlins": "1.9.0",
+    "coverage": "7.16.0",
+    "vcrpy": "8.3.0"
+  },
+  "selection_measurements": [
+    {
+      "profile": "ordinary",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/ordinary.xml",
+        "-p",
+        "no:gremlins",
+        "-p",
+        "no:pytest-testmon"
+      ],
+      "wall_seconds": 43.5372,
+      "total_wall_seconds": 48.8016,
+      "collected": 16,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": false,
+      "counts": {
+        "tests": 16,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "1fd3c26c40ef3964348c2e820df17223b3713eb4e2719c3e1804ffa02415d3ba",
+      "local_feedback_only": true,
+      "coverage_core": null,
+      "measurement": "ordinary"
+    },
+    {
+      "profile": "testmon",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/testmon.xml",
+        "-p",
+        "no:gremlins",
+        "--testmon"
+      ],
+      "wall_seconds": 36.8062,
+      "total_wall_seconds": 39.0621,
+      "collected": 16,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": true,
+      "counts": {
+        "tests": 16,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "1fd3c26c40ef3964348c2e820df17223b3713eb4e2719c3e1804ffa02415d3ba",
+      "local_feedback_only": true,
+      "coverage_core": "ctrace",
+      "measurement": "testmon_cold"
+    },
+    {
+      "profile": "testmon",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/testmon.xml",
+        "-p",
+        "no:gremlins",
+        "--testmon"
+      ],
+      "wall_seconds": 20.2215,
+      "total_wall_seconds": 23.3727,
+      "collected": 16,
+      "exit_code": 0,
+      "cached_empty": true,
+      "cache_invalidated": false,
+      "counts": {
+        "tests": 0,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "1fd3c26c40ef3964348c2e820df17223b3713eb4e2719c3e1804ffa02415d3ba",
+      "local_feedback_only": true,
+      "coverage_core": "ctrace",
+      "measurement": "testmon_warm"
+    }
+  ],
+  "coverage_core_measurements": [
+    {
+      "profile": "ctrace",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "coverage",
+        "run",
+        "--rcfile",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/coverage.ini",
+        "--debug=core",
+        "--branch",
+        "--include=*/voiage/mutation_policy.py",
+        "--data-file",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/.coverage-ctrace",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/ctrace.xml",
+        "-p",
+        "no:gremlins",
+        "-p",
+        "no:pytest-testmon"
+      ],
+      "wall_seconds": 48.1851,
+      "total_wall_seconds": 53.27,
+      "collected": 15,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": false,
+      "counts": {
+        "tests": 15,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "a2e0f847949a34107f59585ea52553f9073afb3e017a57f4ece20f23891f8ad3",
+      "local_feedback_only": true
+    },
+    {
+      "profile": "sysmon",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "coverage",
+        "run",
+        "--rcfile",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/coverage.ini",
+        "--debug=core",
+        "--branch",
+        "--include=*/voiage/mutation_policy.py",
+        "--data-file",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/.coverage-sysmon",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/sysmon.xml",
+        "-p",
+        "no:gremlins",
+        "-p",
+        "no:pytest-testmon"
+      ],
+      "wall_seconds": 52.0701,
+      "total_wall_seconds": 59.0187,
+      "collected": 15,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": false,
+      "counts": {
+        "tests": 15,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "a2e0f847949a34107f59585ea52553f9073afb3e017a57f4ece20f23891f8ad3",
+      "local_feedback_only": true
+    }
+  ],
+  "http_replay": {
+    "url": "https://pypi.org/pypi/pytest-testmon/2.2.0/json",
+    "measurements": [
+      {
+        "profile": "public_record",
+        "wall_seconds": 0.633637,
+        "checks": 3,
+        "response_sha256": "bf92b5708ff15ddc3c23377fca2eb910af5cb55bb496fff253b74661884d946a"
+      },
+      {
+        "profile": "network_disabled_replay",
+        "wall_seconds": 0.00803,
+        "checks": 3,
+        "response_sha256": "bf92b5708ff15ddc3c23377fca2eb910af5cb55bb496fff253b74661884d946a"
+      },
+      {
+        "profile": "in_process_mock",
+        "wall_seconds": 0.001053,
+        "checks": 2
+      }
+    ],
+    "cassette_retained": false,
+    "credentials_or_restricted_payloads": false,
+    "decision": "Retain in-process transports for deterministic unit tests; temporary VCR is useful only for explicitly scoped public integration investigations."
+  },
+  "coverage_equivalence": {
+    "totals": {
+      "ctrace": {
+        "covered_lines": 48,
+        "num_statements": 48,
+        "percent_covered": 100.0,
+        "percent_covered_display": "100",
+        "missing_lines": 0,
+        "excluded_lines": 2,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100",
+        "num_branches": 10,
+        "num_partial_branches": 0,
+        "covered_branches": 10,
+        "missing_branches": 0,
+        "percent_branches_covered": 100.0,
+        "percent_branches_covered_display": "100"
+      },
+      "sysmon": {
+        "covered_lines": 48,
+        "num_statements": 48,
+        "percent_covered": 100.0,
+        "percent_covered_display": "100",
+        "missing_lines": 0,
+        "excluded_lines": 2,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100",
+        "num_branches": 10,
+        "num_partial_branches": 0,
+        "covered_branches": 10,
+        "missing_branches": 0,
+        "percent_branches_covered": 100.0,
+        "percent_branches_covered_display": "100"
+      }
+    },
+    "totals_equal": true,
+    "raw_arcs_equal": false
+  },
+  "limitations": [
+    "Measurements are bounded to the mutation-score policy tests and shared-host load; no whole-suite or portable speedup claimed.",
+    "Testmon cannot establish safety for subprocess state, dynamic imports or external behavior.",
+    "Python 3.12 and 3.13 sysmon branch coverage is unsupported; dynamic contexts require ctrace.",
+    "Raw ctrace/sysmon arc encodings differ; statement and reportable branch totals agree."
+  ],
+  "decisions": {
+    "testmon": "optional_serial_local_feedback_with_invalidation",
+    "gremlins": "bounded_trial_only_existing_mutmut_gate_retained",
+    "vcrpy": "temporary_explicit_public_integration_only",
+    "unit_http": "keep_in_process_transports",
+    "sysmon": "not_promoted_no_speed_advantage_observed",
+    "freezegun": "not_added_existing_scientific_review_at_time_and_now_injection_works_without_global_clock_effects",
+    "pytest_picked": "not_added_testmon_already_supplies_dependency_aware_selection"
+  },
+  "mutation_trial": {
+    "status": "completed",
+    "initial_default_core": {
+      "total": 29,
+      "killed": 23,
+      "survived": 6,
+      "qualified": false,
+      "reason": "sysmon dynamic-context warning; no selection-confidence claim"
+    },
+    "corrected_ctrace_before_new_regression": {
+      "total": 29,
+      "killed": 27,
+      "survived": 2,
+      "timeouts": 0,
+      "errors": 0
+    },
+    "remediation": "Added boundary assertions that a zero-eligible candidate or baseline cannot establish a non-decreasing score.",
+    "final_summary": {
+      "total": 29,
+      "zapped": 29,
+      "survived": 0,
+      "timeout": 0,
+      "error": 0,
+      "pardoned": 0,
+      "percentage": 100.0
+    },
+    "final_report_sha256": "8affb23f0d7e3a9568ae4c2aa97d146590bc1331e8fac2c2a3ba6a4b383c2720",
+    "final_execution": {
+      "profile": "gremlins",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/gremlins.xml",
+        "--gremlins",
+        "--gremlin-targets=voiage/mutation_policy.py",
+        "--gremlin-operators=comparison,boolean",
+        "--gremlin-workers=1",
+        "-p",
+        "no:pytest-testmon",
+        "--gremlin-report=json"
+      ],
+      "wall_seconds": 295.5321,
+      "total_wall_seconds": 302.1773,
+      "collected": 16,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": false,
+      "counts": {
+        "tests": 16,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "2502f6f7d09273041ee4d4f58a4b8cc34a1284569813a2f5cf049aee230a27b0",
+      "local_feedback_only": true
+    },
+    "final_report": "specs/submission-readiness/test-acceleration-gremlins-20260831.json"
+  },
+  "validation": {
+    "focused_runner_tests": 22,
+    "full_tox": "all_15_required_environments_passed_across_initial_run_and_documented_repair_reruns",
+    "first_joss_lane": "failed_historical_root_lock_binding; integrated dependency-lane immutable snapshot fix passes focused tests",
+    "focused_script_coverage": {
+      "combined_percent": 98,
+      "statements": 178,
+      "missing_statements": 2,
+      "branches": 58,
+      "partial_branches": 3,
+      "runner_percent": 97,
+      "http_experiment_percent": 100,
+      "scope": "22 safety tests plus actual bounded public HTTP experiment; isolated coverage files, not whole-suite coverage"
+    },
+    "historical_binding_joss_rerun": "passed",
+    "vale_and_lint_rerun": "passed",
+    "first_full_tox": {
+      "seconds": 2585.46,
+      "passed_environments": 11,
+      "failed_environments": [
+        "joss_historical_lock_binding",
+        "py314_property_deadline"
+      ],
+      "interrupted_skipped_environments": [
+        "max_versions",
+        "coverage_report"
+      ],
+      "terminal_outcome": "failed_not_full_pass"
+    },
+    "py314_unchanged_property_rerun": "passed",
+    "py314_full_environment_rerun": "passed",
+    "latest_dependency_frontier": "strict_policy_passed",
+    "max_versions_rerun": "passed",
+    "first_recovered_coverage": {
+      "passed": 4647,
+      "skipped": 15,
+      "failed": 1,
+      "failure": "Historical frontier audit compared its recorded 216 packages to the current optional-extra 220-package lock; preserve receipt and bind historical claims to original source snapshots.",
+      "coverage_percent": 95.11,
+      "pytest_seconds": 405.62,
+      "tox_seconds": 503.53,
+      "terminal_outcome": "failed_not_full_pass",
+      "log_sha256": "6282230e1bfabed34506dc6ad1014177c20517d466044d54f43dcd4a1b5d1368"
+    },
+    "historical_frontier_repair": {
+      "source_commit": "6e1dfc4ecd0699af365a1d5feaa7ed24a9431b21",
+      "historical_audit_rewritten": false,
+      "focused_tests_passed": 26,
+      "current_uv_lock_check": "passed; 220 packages",
+      "manifest": "specs/submission-readiness/dependency-frontier-environment-20260829/manifest.json",
+      "lint_and_vale": "passed"
+    },
+    "borrowed_dependency_integration": {
+      "pull_request": 1057,
+      "focused_runner_frontier_joss_replay_tests": 62,
+      "result": "passed",
+      "pytest_seconds": 7.01,
+      "scope": "Borrowed historical reproduction repair is integrated locally for validation and excluded from the acceleration commit.",
+      "final_full_coverage": "passed with final reviewed reproduction verifier and hosted replay workflow integration"
+    },
+    "final_coverage": {
+      "passed": 4672,
+      "skipped": 15,
+      "failed": 0,
+      "coverage_percent": 95.11,
+      "pytest_seconds": 360.81,
+      "tox_seconds": 384.33,
+      "terminal_exit_code": 0,
+      "log_sha256": "a92025dff405b4612f3d01a8bb6e72e4dc12ef6a63e17f7212794852a9acca22"
+    },
+    "final_integrated_joss": {
+      "passed": 19,
+      "pytest_seconds": 6.55,
+      "tox_seconds": 8.04
+    }
+  },
+  "selection_measurement_test_source": {
+    "path": "tests/test_mutation_score.py",
+    "sha256": "658331ec0c8dd681393292fb4c5ae1a3ef36eead9354358931bb169bf2e43d2d"
+  },
+  "current_test_source_sha256": "658331ec0c8dd681393292fb4c5ae1a3ef36eead9354358931bb169bf2e43d2d",
+  "initial_selection_measurements": [
+    {
+      "profile": "ordinary",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/ordinary.xml",
+        "-p",
+        "no:gremlins",
+        "-p",
+        "no:pytest-testmon"
+      ],
+      "wall_seconds": 36.4546,
+      "total_wall_seconds": 39.3569,
+      "collected": 15,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": false,
+      "counts": {
+        "tests": 15,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "a2e0f847949a34107f59585ea52553f9073afb3e017a57f4ece20f23891f8ad3",
+      "local_feedback_only": true,
+      "measurement": "ordinary"
+    },
+    {
+      "profile": "testmon",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/testmon.xml",
+        "-p",
+        "no:gremlins",
+        "--testmon"
+      ],
+      "wall_seconds": 34.4435,
+      "total_wall_seconds": 37.0941,
+      "collected": 15,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": true,
+      "counts": {
+        "tests": 15,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "a2e0f847949a34107f59585ea52553f9073afb3e017a57f4ece20f23891f8ad3",
+      "local_feedback_only": true,
+      "measurement": "testmon_cold"
+    },
+    {
+      "profile": "testmon",
+      "command": [
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "-p",
+        "no:pytest_cov",
+        "tests/test_mutation_score.py",
+        "--junitxml",
+        "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/.conductor/local/test-acceleration/testmon.xml",
+        "-p",
+        "no:gremlins",
+        "--testmon"
+      ],
+      "wall_seconds": 17.7525,
+      "total_wall_seconds": 20.6103,
+      "collected": 15,
+      "exit_code": 0,
+      "cached_empty": false,
+      "cache_invalidated": false,
+      "counts": {
+        "tests": 0,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0
+      },
+      "python": "3.14.6 (main, Aug  4 2026, 19:23:56) [Clang 22.1.3 ]",
+      "fingerprint": "a2e0f847949a34107f59585ea52553f9073afb3e017a57f4ece20f23891f8ad3",
+      "local_feedback_only": true,
+      "measurement": "testmon_warm"
+    }
+  ],
+  "initial_selection_measurement_test_source": {
+    "revision": "before_new_zero_denominator_test",
+    "path": "tests/test_mutation_score.py",
+    "sha256": "c3def37470d88f0fcd2948b01fad7d5db59a0f223a70efe4055f7a24b0e9bbc1"
+  },
+  "source_hashes": {
+    "scripts/test_acceleration.py": "7e6e6d1455adb0957dedb80a7202955b95b8eceb73893c10811c5f5249483667",
+    "scripts/evaluate_http_replay.py": "5b845495674750f9d83919a1099cf78e018f31e3540ab75c9b5133dcaecc9676",
+    "tests/test_test_acceleration.py": "df0defc3968669bb8f3ec675e02bbf864fa365f388f7ca3b275e6be683563034",
+    "tests/test_mutation_score.py": "658331ec0c8dd681393292fb4c5ae1a3ef36eead9354358931bb169bf2e43d2d",
+    "pyproject.toml": "170331f8e54d6096607901540bc92468b907fca4c88434c017b5be64c0023105",
+    "tox.ini": "418f2121c4466d937226462f141ddf0365ed21f64756718e15a7e1d5e7ad0aba",
+    "uv.lock": "c95cb2374eb1519cd310e4ce09dd1e580ba4ee7812769bbdc0a7ac715a6665dd",
+    "tests/test_dependency_frontier_audit.py": "d2731048ca17c506546958d5fc1809c159c064d9b8649c3832c76a3dd36984bf",
+    "specs/submission-readiness/dependency-frontier-environment-20260829/pyproject.toml": "2ae0033c68442724d0f116590896853811693d09742b56b5e614db81a316972a",
+    "specs/submission-readiness/dependency-frontier-environment-20260829/manifest.json": "299b85729f4e2519bd27c2bbcbe68e65a12a3924a0b0b6eaa15134dd7cfff3c1"
+  }
+}

--- a/specs/submission-readiness/test-acceleration-gremlins-20260831.json
+++ b/specs/submission-readiness/test-acceleration-gremlins-20260831.json
@@ -1,0 +1,530 @@
+{
+  "summary": {
+    "total": 29,
+    "zapped": 29,
+    "survived": 0,
+    "timeout": 0,
+    "error": 0,
+    "pardoned": 0,
+    "percentage": 100.0
+  },
+  "files": {
+    "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py": {
+      "total": 29,
+      "zapped": 29,
+      "survived": 0,
+      "percentage": 100.0
+    }
+  },
+  "results": [
+    {
+      "gremlin_id": "mutation_policy_b425_g001",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 41,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "> to >=",
+      "killing_test": "unknown",
+      "execution_time_ms": 6752.558249980211,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g002",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 41,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "> to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 9932.277790969238,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g003",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 42,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "> to >=",
+      "killing_test": "unknown",
+      "execution_time_ms": 15694.322291994467,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g004",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 42,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "> to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 7692.547290935181,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g005",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 43,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": ">= to >",
+      "killing_test": "unknown",
+      "execution_time_ms": 8568.181707989424,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g006",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 43,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": ">= to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 8535.32050002832,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g007",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 41,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "and to or",
+      "killing_test": "unknown",
+      "execution_time_ms": 6787.902166019194,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g008",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 40,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "or to and",
+      "killing_test": "unknown",
+      "execution_time_ms": 6429.98937505763,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g009",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 50,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "<= to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 5975.289874942973,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g010",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 50,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "<= to >",
+      "killing_test": "unknown",
+      "execution_time_ms": 8551.55591701623,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g011",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 50,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "and to or",
+      "killing_test": "unknown",
+      "execution_time_ms": 9401.074790977873,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g012",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 49,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "or to and",
+      "killing_test": "unknown",
+      "execution_time_ms": 5436.106708017178,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g013",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 54,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "== to !=",
+      "killing_test": "unknown",
+      "execution_time_ms": 6842.146291979589,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g014",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 55,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "> to >=",
+      "killing_test": "unknown",
+      "execution_time_ms": 6124.727832968347,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g015",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 55,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "> to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 5353.540041018277,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g016",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 56,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": ">= to >",
+      "killing_test": "unknown",
+      "execution_time_ms": 4839.5526660606265,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g017",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 56,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": ">= to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 6795.385500066914,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g018",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 12,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "True to False",
+      "killing_test": "unknown",
+      "execution_time_ms": 10315.235375077464,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[True]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[-1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1.5]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[None]",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed",
+        "tests/test_mutation_score.py::test_threshold_accepts_positive_fraction_and_closed_upper_boundary",
+        "tests/test_mutation_score.py::test_cli_reports_counts_and_returns_pass_or_fail",
+        "tests/test_mutation_score.py::test_cli_enforces_hosted_broad_baseline",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g019",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 99,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "not x to x",
+      "killing_test": "unknown",
+      "execution_time_ms": 11190.391459036618,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[-1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1.5]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[None]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[True]",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed",
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g020",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 99,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to <=",
+      "killing_test": "unknown",
+      "execution_time_ms": 6630.256125004962,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[-1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1.5]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[None]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[True]",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed",
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g021",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 99,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to >",
+      "killing_test": "unknown",
+      "execution_time_ms": 7726.841542054899,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[-1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1.5]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[None]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[True]",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed",
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g022",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 99,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "or to and",
+      "killing_test": "unknown",
+      "execution_time_ms": 5717.134166974574,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[-1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1.5]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[1]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[None]",
+        "tests/test_mutation_score.py::test_invalid_counts_fail_closed[True]",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed",
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g023",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 115,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to <=",
+      "killing_test": "unknown",
+      "execution_time_ms": 7267.513707978651,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed",
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g024",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 115,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to >",
+      "killing_test": "unknown",
+      "execution_time_ms": 4934.610375086777,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed",
+        "tests/test_mutation_score.py::test_score_counts_every_non_skipped_unresolved_mutant",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes0]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes1]",
+        "tests/test_mutation_score.py::test_score_fails_below_threshold_interrupted_or_empty[changes2]",
+        "tests/test_mutation_score.py::test_unreported_mutmut_statuses_cannot_inflate_score",
+        "tests/test_mutation_score.py::test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score",
+        "tests/test_mutation_score.py::test_broad_baseline_ratchets_score_and_unresolved_debt"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g025",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 122,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to <=",
+      "killing_test": "unknown",
+      "execution_time_ms": 5786.030333023518,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_threshold_accepts_positive_fraction_and_closed_upper_boundary",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g026",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 122,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to >",
+      "killing_test": "unknown",
+      "execution_time_ms": 5016.512333997525,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_threshold_accepts_positive_fraction_and_closed_upper_boundary",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g027",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 122,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 6323.438875027932,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_threshold_accepts_positive_fraction_and_closed_upper_boundary",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g028",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 122,
+      "status": "zapped",
+      "operator": "comparison",
+      "description": "< to <",
+      "killing_test": "unknown",
+      "execution_time_ms": 6152.280999929644,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_threshold_accepts_positive_fraction_and_closed_upper_boundary",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed"
+      ]
+    },
+    {
+      "gremlin_id": "mutation_policy_b425_g029",
+      "file_path": "/Volumes/PortableSSD/GitHub/.worktrees/voiage-goal-test-acceleration-20260831/voiage/mutation_policy.py",
+      "line_number": 122,
+      "status": "zapped",
+      "operator": "boolean",
+      "description": "not x to x",
+      "killing_test": "unknown",
+      "execution_time_ms": 9057.428458007053,
+      "selected_tests": [
+        "tests/test_mutation_score.py::test_threshold_accepts_positive_fraction_and_closed_upper_boundary",
+        "tests/test_mutation_score.py::test_inconsistent_total_and_invalid_threshold_fail_closed"
+      ]
+    }
+  ]
+}

--- a/tests/test_dependency_frontier_audit.py
+++ b/tests/test_dependency_frontier_audit.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 import tomllib
+
+import pytest
 
 ROOT = Path(__file__).parents[1]
 AUDIT_PATH = (
@@ -16,13 +19,27 @@ def _audit() -> dict[str, object]:
     return json.loads(AUDIT_PATH.read_text(encoding="utf-8"))
 
 
+SNAPSHOT = Path("specs/submission-readiness/dependency-frontier-environment-20260829")
+
+
+def _historical_inputs(root: Path) -> dict[str, bytes]:
+    manifest = json.loads((root / SNAPSHOT / "manifest.json").read_text())
+    result = {}
+    for name, artifact in manifest["files"].items():
+        content = (root / artifact["path"]).read_bytes()
+        assert hashlib.sha256(content).hexdigest() == artifact["sha256"]
+        result[name] = content
+    return result
+
+
 def test_dependency_audit_binds_the_refreshed_lock_and_declared_frontier() -> None:
     audit = _audit()
+    inputs = _historical_inputs(ROOT)
     assert audit["lock_refresh"]["resolved_packages"] == sum(
-        line == "[[package]]" for line in (ROOT / "uv.lock").read_text().splitlines()
+        line == "[[package]]" for line in inputs["uv.lock"].decode().splitlines()
     )
 
-    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    config = tomllib.loads(inputs["pyproject.toml"].decode())
     declared = len(config["project"]["dependencies"])
     declared += sum(
         len(items) for items in config["project"]["optional-dependencies"].values()
@@ -60,3 +77,25 @@ def test_preview_lanes_are_non_blocking_and_fail_closed_for_promotion() -> None:
     assert states["DEP-008"] == "resolved"
     assert states["DEP-002"] == "resolved_preview_observed"
     assert all(finding["required_disposition"] for finding in findings)
+
+
+@pytest.mark.parametrize("changed", ["uv.lock", "pyproject.toml"])
+def test_historical_frontier_rejects_changed_bytes(
+    tmp_path: Path, changed: str
+) -> None:
+    manifest_path = SNAPSHOT / "manifest.json"
+    manifest = json.loads((ROOT / manifest_path).read_text())
+    (tmp_path / SNAPSHOT).mkdir(parents=True)
+    (tmp_path / manifest_path).write_bytes((ROOT / manifest_path).read_bytes())
+    for artifact in manifest["files"].values():
+        path = Path(artifact["path"])
+        (tmp_path / path).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / path).write_bytes((ROOT / path).read_bytes())
+    # A legitimate current optional extra cannot invalidate historical inputs.
+    (tmp_path / "pyproject.toml").write_bytes((ROOT / "pyproject.toml").read_bytes())
+    (tmp_path / "uv.lock").write_bytes((ROOT / "uv.lock").read_bytes())
+    assert _historical_inputs(tmp_path) == _historical_inputs(ROOT)
+    target = tmp_path / manifest["files"][changed]["path"]
+    target.write_bytes(target.read_bytes() + b"\n# changed historical bytes\n")
+    with pytest.raises(AssertionError):
+        _historical_inputs(tmp_path)

--- a/tests/test_mutation_score.py
+++ b/tests/test_mutation_score.py
@@ -223,3 +223,21 @@ def test_cli_enforces_hosted_broad_baseline(tmp_path: Path) -> None:
     )
     assert failed.returncode == 2
     assert json.loads(failed.stdout)["non_decreasing"] is False
+
+
+def test_empty_candidate_or_baseline_cannot_establish_non_decreasing_score() -> None:
+    """A zero eligible denominator cannot establish the baseline ratchet."""
+    empty = mutation_score_from_mapping(
+        _stats(
+            killed=0,
+            survived=0,
+            no_tests=0,
+            suspicious=0,
+            timeout=0,
+            segfault=0,
+            total=3,
+        )
+    )
+    nonempty = mutation_score_from_mapping(_stats())
+    assert empty.report(90.0, baseline=nonempty)["non_decreasing"] is False
+    assert nonempty.report(90.0, baseline=empty)["non_decreasing"] is False

--- a/tests/test_test_acceleration.py
+++ b/tests/test_test_acceleration.py
@@ -1,0 +1,269 @@
+"""Safety boundaries for local selective test feedback."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.test_acceleration import fingerprint, invalidate_cache, validate_targets
+
+
+def fixture_repository(tmp_path: Path) -> Path:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests/test_a.py").write_text("def test_a(): pass\n")
+    (tmp_path / "uv.lock").write_text("version=1\n")
+    (tmp_path / "specs").mkdir()
+    (tmp_path / "specs/data.json").write_text("{}")
+    return tmp_path
+
+
+def test_invalidation_covers_dependencies_inventory_and_data(tmp_path: Path) -> None:
+    root = fixture_repository(tmp_path)
+    files = ["tests/test_a.py", "uv.lock", "specs/data.json"]
+    initial = fingerprint(root, files, ["tests"], ["pytest==9"])
+    # Existing Python edits are tracked by testmon, not by full-cache resets.
+    (root / files[0]).write_text("def test_a(): assert True\n")
+    assert fingerprint(root, files, ["tests"], ["pytest==9"]) == initial
+    for path in ("uv.lock", "specs/data.json"):
+        old = (root / path).read_text()
+        (root / path).write_text(old + "\n")
+        assert fingerprint(root, files, ["tests"], ["pytest==9"]) != initial
+        (root / path).write_text(old)
+    assert (
+        fingerprint(root, [*files, "tests/test_new.py"], ["tests"], ["pytest==9"])
+        != initial
+    )
+    assert fingerprint(root, files, ["tests/test_a.py"], ["pytest==9"]) != initial
+    assert fingerprint(root, files, ["tests"], ["pytest==10"]) != initial
+
+
+def test_bad_or_missing_manifest_discards_database(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    for name in ("testmon", "testmon-wal", "testmon-shm"):
+        (cache / name).write_text("stale")
+    assert invalidate_cache(cache, "new")
+    assert not (cache / "testmon").exists()
+    (cache / "fingerprint").write_text("new")
+    assert not invalidate_cache(cache, "new")
+    assert invalidate_cache(cache, "changed")
+
+
+@pytest.mark.parametrize(
+    "target", ["../other", "/outside/test.py", "-n", "tests/test_a.py::test_a"]
+)
+def test_selection_rejects_options_and_escape(tmp_path: Path, target: str) -> None:
+    root = fixture_repository(tmp_path)
+    with pytest.raises(ValueError):
+        validate_targets(root, [target])
+
+
+def test_selection_accepts_existing_repository_tests(tmp_path: Path) -> None:
+    root = fixture_repository(tmp_path)
+    assert validate_targets(root, ["tests/test_a.py"]) == ["tests/test_a.py"]
+
+
+def test_replay_rejects_nonpublic_and_credential_bearing_requests() -> None:
+    from types import SimpleNamespace
+
+    from scripts.evaluate_http_replay import URL, permitted_request, public_response
+
+    good = SimpleNamespace(method="GET", uri=URL, body=None, headers={})
+    assert permitted_request(good) is good
+    for overrides in (
+        {"method": "POST"},
+        {"uri": "https://private.invalid/"},
+        {"body": b"sensitive"},
+        {"headers": {"Authorization": "redacted"}},
+    ):
+        request = SimpleNamespace(method="GET", uri=URL, body=None, headers={})
+        request.__dict__.update(overrides)
+        with pytest.raises(ValueError):
+            permitted_request(request)
+    assert (
+        public_response(
+            {"headers": {"Set-Cookie": ["private"]}, "body": {"string": "{}"}}
+        )["headers"]
+        == {}
+    )
+
+
+@pytest.mark.parametrize(
+    "profile", ["ordinary", "testmon", "gremlins", "ctrace", "sysmon"]
+)
+def test_profile_isolation_and_measured_counts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, profile: str
+) -> None:
+    import json
+    import subprocess
+
+    from scripts import test_acceleration as runner
+
+    root = fixture_repository(tmp_path)
+    cache = root / "cache"
+    cache.mkdir()
+    monkeypatch.setenv("PYTEST_ADDOPTS", "-n auto --cov")
+    monkeypatch.setenv("VOIAGE_TEST_SHARD_INDEX", "1")
+    monkeypatch.setenv("VOIAGE_TEST_SHARD_COUNT", "2")
+    monkeypatch.setenv("COVERAGE_CORE", "sysmon")
+    monkeypatch.setattr(runner.importlib.metadata, "distributions", lambda: [])
+    monkeypatch.setattr(
+        runner.subprocess, "check_output", lambda *a, **kw: "tests/test_a.py\nuv.lock"
+    )
+
+    def execute(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        env = kwargs["env"]
+        assert isinstance(env, dict)
+        assert "PYTEST_ADDOPTS" not in env
+        assert "VOIAGE_TEST_SHARD_INDEX" not in env
+        assert "--cov" not in command
+        assert "-n" not in command
+        assert env.get("COVERAGE_CORE") == (
+            "ctrace"
+            if profile in ("testmon", "gremlins")
+            else profile
+            if profile in ("ctrace", "sysmon")
+            else None
+        )
+        if profile == "gremlins":
+            assert "--gremlin-targets=voiage/mutation_policy.py" in command
+            assert "tests/test_a.py" not in command
+        Path(command[command.index("--junitxml") + 1]).write_text(
+            '<testsuites><testsuite tests="2" failures="0" errors="0" skipped="0"/></testsuites>'
+        )
+        return subprocess.CompletedProcess(
+            command, 0, "collected 2 items\n2 passed", ""
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", execute)
+    assert runner.run_profile(root, cache, profile, ["tests/test_a.py"]) == 0
+    report = json.loads((cache / f"{profile}.json").read_text())
+    assert report["counts"]["tests"] == report["collected"] == 2
+    assert report["total_wall_seconds"] >= report["wall_seconds"]
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "existing_baseline", "expected"),
+    [(5, True, 0), (5, False, 5), (2, True, 2), (0, False, 1), (0, True, 0)],
+)
+def test_cached_empty_requires_successful_unchanged_baseline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exit_code: int,
+    existing_baseline: bool,
+    expected: int,
+) -> None:
+    import subprocess
+
+    from scripts import test_acceleration as runner
+
+    root = fixture_repository(tmp_path)
+    cache = root / "cache"
+    cache.mkdir()
+    monkeypatch.setattr(runner.importlib.metadata, "distributions", lambda: [])
+    monkeypatch.setattr(
+        runner.subprocess, "check_output", lambda *a, **kw: "tests/test_a.py"
+    )
+    signature = fingerprint(root, ["tests/test_a.py"], ["tests"], [])
+    if existing_baseline:
+        (cache / "fingerprint").write_text(signature)
+
+    def execute(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        assert not (cache / "fingerprint").exists()
+        Path(command[command.index("--junitxml") + 1]).write_text(
+            '<testsuites><testsuite tests="0" failures="0" errors="0" skipped="0"/></testsuites>'
+        )
+        return subprocess.CompletedProcess(command, exit_code, "", "")
+
+    monkeypatch.setattr(runner.subprocess, "run", execute)
+    assert runner.run_profile(root, cache, "testmon", ["tests"]) == expected
+    assert (cache / "fingerprint").exists() == (expected == 0)
+
+
+def test_timeout_removes_stale_profile_and_mutation_reports_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import subprocess
+
+    from scripts import test_acceleration as runner
+
+    root = fixture_repository(tmp_path)
+    cache = root / "cache"
+    cache.mkdir()
+    (cache / "gremlins.json").write_text('{"exit_code": 0}')
+    report = root / "coverage/gremlins/gremlins.json"
+    report.parent.mkdir(parents=True)
+    report.write_text('{"summary": {"total": 29, "zapped": 29}}')
+    unrelated = report.parent / "keep.json"
+    unrelated.write_text("unrelated")
+    monkeypatch.setattr(runner.importlib.metadata, "distributions", lambda: [])
+    monkeypatch.setattr(
+        runner.subprocess, "check_output", lambda *a, **kw: "tests/test_a.py"
+    )
+
+    def timeout(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        assert not report.exists()
+        assert not (cache / "gremlins.json").exists()
+        raise subprocess.TimeoutExpired(command, 1)
+
+    monkeypatch.setattr(runner.subprocess, "run", timeout)
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.run_profile(root, cache, "gremlins", ["tests"])
+    assert not report.exists()
+    assert not (cache / "gremlins.json").exists()
+    assert unrelated.read_text() == "unrelated"
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_cli_holds_lock_and_releases_it_on_runner_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fails: bool
+) -> None:
+    from scripts import test_acceleration as runner
+
+    root = fixture_repository(tmp_path)
+    monkeypatch.setattr(runner, "__file__", str(root / "scripts/test_acceleration.py"))
+    monkeypatch.setattr(
+        runner.sys, "argv", ["test_acceleration.py", "ordinary", "tests"]
+    )
+    lock = root / ".conductor/local/test-acceleration/running"
+
+    def execute(repo: Path, cache: Path, profile: str, targets: list[str]) -> int:
+        assert lock.is_dir()
+        assert repo == root
+        assert profile == "ordinary"
+        assert targets == ["tests"]
+        if fails:
+            raise RuntimeError("runner interrupted")
+        return 0
+
+    monkeypatch.setattr(runner, "run_profile", execute)
+    if fails:
+        with pytest.raises(RuntimeError, match="interrupted"):
+            runner.main()
+    else:
+        assert runner.main() == 0
+    assert not lock.exists()
+
+
+def test_cli_refuses_existing_lock_and_invalid_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts import test_acceleration as runner
+
+    root = fixture_repository(tmp_path)
+    monkeypatch.setattr(runner, "__file__", str(root / "scripts/test_acceleration.py"))
+    lock = root / ".conductor/local/test-acceleration/running"
+    lock.mkdir(parents=True)
+    for target in ("tests", "../escape"):
+        monkeypatch.setattr(
+            runner.sys, "argv", ["test_acceleration.py", "ordinary", target]
+        )
+        with pytest.raises(SystemExit) as error:
+            runner.main()
+        assert error.value.code == 2
+    assert lock.exists()

--- a/tox.ini
+++ b/tox.ini
@@ -187,3 +187,11 @@ python =
     3.12: py312
     3.13: py313
     3.14: py314
+
+[testenv:test-feedback]
+description = Opt-in serial local feedback; never replaces required full-suite CI
+extras =
+    ci
+    test-acceleration
+commands =
+    python scripts/test_acceleration.py {posargs:testmon tests}

--- a/uv.lock
+++ b/uv.lock
@@ -2936,12 +2936,38 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-gremlins"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/b6/74470cd5b97eb0cf5f3d7e2ef7feb2d6136b5cbe2df6e070299c5faf5e7c/pytest_gremlins-1.9.0.tar.gz", hash = "sha256:12966b4d24146b46d58aa1dc8a6d0881918863ca4454a44d109b295f22d27c24", size = 4013393, upload-time = "2026-07-01T12:55:33.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/f7/f582cd587ebdfad6e7f6426ca3220b051d7adb41c824576851732843777a/pytest_gremlins-1.9.0-py3-none-any.whl", hash = "sha256:26997e1e6ac0cbdef70c68ddadbbd2bf93c7d41e143d9f2d84ec318b7d552b67", size = 118421, upload-time = "2026-07-01T12:55:31.708Z" },
+]
+
+[[package]]
 name = "pytest-integration"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/e0/c823048dc0866f2e0fa2e4a34cd6ec290697b238b7672b30cb07c65e59cc/pytest_integration-0.2.3.tar.gz", hash = "sha256:b00988a5de8a6826af82d4c7a3485b43fbf32c11235e9f4a8b7225eef5fbcf65", size = 3295, upload-time = "2022-11-17T10:34:50.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/41/9b393be6252635e4d39c3e62805018c42bfcc486b42246b582b755ff9ad3/pytest_integration-0.2.3-py3-none-any.whl", hash = "sha256:7f59ed1fa1cc8cb240f9495b68bc02c0421cce48589f78e49b7b842231604b12", size = 4456, upload-time = "2022-11-17T10:34:47.341Z" },
+]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108, upload-time = "2025-12-01T07:30:24.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199, upload-time = "2025-12-01T07:30:23.623Z" },
 ]
 
 [[package]]
@@ -3981,6 +4007,19 @@ wheels = [
 ]
 
 [[package]]
+name = "vcrpy"
+version = "8.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d5/8a1f8eb603e2d35fbb0ecd1e309d0c5c18a0ecfc8c0a8f04088bbc8f833b/vcrpy-8.3.0.tar.gz", hash = "sha256:46d64e77e8d95e5c76c7d9a94ff05d8b38b2ae4e1d4869eb0235024b6fcb5212", size = 96117, upload-time = "2026-07-04T14:27:01.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/77/cb4219be91508399cbcb6143bad89462cfb16f6c638458f454a5d46ac95a/vcrpy-8.3.0-py3-none-any.whl", hash = "sha256:bd66e6143746778157f00e2a922527a8d96b2fdc350be8988a45a29c843815b9", size = 46530, upload-time = "2026-07-04T14:27:00.546Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "21.7.7"
 source = { registry = "https://pypi.org/simple" }
@@ -4078,6 +4117,12 @@ plotting = [
     { name = "matplotlib" },
     { name = "seaborn" },
 ]
+test-acceleration = [
+    { name = "coverage" },
+    { name = "pytest-gremlins" },
+    { name = "pytest-testmon" },
+    { name = "vcrpy" },
+]
 web = [
     { name = "fastapi" },
     { name = "httpx" },
@@ -4089,6 +4134,7 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4,<2.0" },
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.39.9,<2.0" },
     { name = "click", specifier = ">=8.3.3,<9" },
+    { name = "coverage", marker = "extra == 'test-acceleration'", specifier = ">=7.16.0,<8" },
     { name = "defusedxml", marker = "extra == 'ci'", specifier = ">=0.7.1,<1.0" },
     { name = "defusedxml", marker = "extra == 'ecosystem'", specifier = ">=0.7.1,<1.0" },
     { name = "docutils", marker = "extra == 'ci'", specifier = ">=0.23,<1" },
@@ -4124,7 +4170,9 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'ci'", specifier = ">=9.1.1,<10.0" },
     { name = "pytest-benchmark", marker = "extra == 'ci'", specifier = ">=5.2.3,<6.0" },
     { name = "pytest-cov", marker = "extra == 'ci'", specifier = ">=7.1.0,<8.0" },
+    { name = "pytest-gremlins", marker = "extra == 'test-acceleration'", specifier = ">=1.9.0,<2" },
     { name = "pytest-integration", marker = "extra == 'ci'", specifier = ">=0.2.3,<0.3" },
+    { name = "pytest-testmon", marker = "extra == 'test-acceleration'", specifier = ">=2.2.0,<3" },
     { name = "pytest-xdist", marker = "extra == 'ci'", specifier = ">=3.8.0,<4.0" },
     { name = "pyyaml", marker = "extra == 'ci'", specifier = ">=6.0.3,<7.0" },
     { name = "rfc8785", marker = "extra == 'ci'", specifier = ">=0.1,<0.2" },
@@ -4143,10 +4191,11 @@ requires-dist = [
     { name = "types-setuptools", marker = "extra == 'dev'", specifier = ">=83.0.0.20260716" },
     { name = "typing-extensions", specifier = ">=4.16.0" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.51.0,<1.0" },
+    { name = "vcrpy", marker = "extra == 'test-acceleration'", specifier = ">=8.3.0,<9" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.16,<3.0" },
     { name = "xarray", specifier = ">=0.19,<2025.0" },
 ]
-provides-extras = ["ci", "croissant", "deep-learning", "dev", "docs", "ecosystem", "excel", "experimental", "frictionless", "ingestion", "jax", "performance", "plotting", "web"]
+provides-extras = ["ci", "croissant", "deep-learning", "dev", "docs", "ecosystem", "excel", "experimental", "frictionless", "ingestion", "jax", "performance", "plotting", "test-acceleration", "web"]
 
 [[package]]
 name = "vulture"
@@ -4191,6 +4240,81 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/22/581a0b44349d5babe526c958f365b8126e0fbd8fc2810e80446c47358050/wrapt-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef4e2d6e399ce6eecc80179a6b9ef6544f121288f95fc132bc36c9d9503903af", size = 96374, upload-time = "2026-08-30T04:39:42.335Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9b32d5e4f0a179cef5075cc79b79d6d3482c44c434c12969e48c6719e06d95", size = 96178, upload-time = "2026-08-30T04:39:43.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94", size = 227806, upload-time = "2026-08-30T04:39:45.264Z" },
+    { url = "https://files.pythonhosted.org/packages/08/75/c8dfba5e0caf17cd0718a0cbbe76cb85e637a2d65183fb728232419f6fca/wrapt-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39cd68df4dff79f5336f9c745c06259d204bcb42d504040c9c91eac9e2abb39c", size = 229004, upload-time = "2026-08-30T04:39:47.068Z" },
+    { url = "https://files.pythonhosted.org/packages/42/05/d4853fbd33e5860b10d5aec690f563547a92a82e61fb8bb2d4ece1ce3570/wrapt-2.4.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2a9f1a2f75bb95257cc5744e255e10a5a86e923f328b40ad3dbf9d8d03430013", size = 208934, upload-time = "2026-08-30T04:39:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/66/23d0e8de9b411fd198af5121627587563657370c8d509fbe5ea8adb3df79/wrapt-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8763ad01e3725b7751a4575f38bbcc19c0aa0822fec91c5c5bd21ce3ce7e1d2b", size = 225709, upload-time = "2026-08-30T04:39:50.287Z" },
+    { url = "https://files.pythonhosted.org/packages/01/37/3b357bc90530d510ae59ae7ac48265c482ae899e47637ca4436645688b40/wrapt-2.4.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9125c6dbe8b88c00dd8ef4fc1e55757e8eb4720b6b2b2cc610a45bd32bd28c57", size = 207090, upload-time = "2026-08-30T04:39:51.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0c/d8a5c6dbcc2d221308223bcea4130c6332454a855cb4dbd5dcb2360b13b2/wrapt-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:28f5de1526831b8f173889a436e289fe181ede8c66c9feb669d1aca8fd602eaf", size = 216269, upload-time = "2026-08-30T04:39:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/92/93/cc9fc8fef1d3d25edaa1c2dc2337b556dc1d0613ddc1c4a6fe9ee08ad705/wrapt-2.4.0-cp312-cp312-win32.whl", hash = "sha256:a9ca1cdb3f7facb4990c7739ea5afbaceeb6728d066feedde03a4cfe83b29b03", size = 91187, upload-time = "2026-08-30T04:39:55.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b464316489fb2fca0669ea0f8f07290054a0f26fc72982d3e4cf95469628ba9", size = 96423, upload-time = "2026-08-30T04:39:56.81Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/e838ac6463a1a1a1817b2f184ee2aa20c54692b80368c5063403c8d2461c/wrapt-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:db1285071ea09a7767fac608e7b5c7b03c09833b06186875a359905fbc659d29", size = 93003, upload-time = "2026-08-30T04:39:58.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/f9de4e11582ff96ad2199eeeceaa17faa27bbdc599243f520070c4f3de07/wrapt-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5c5c4c728cd22a36e4b8bb5df4a7d3bccaa865d27725b36eeb3b6f18fb2e1bc2", size = 96041, upload-time = "2026-08-30T04:39:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ab/1dbf50802bea3b46192fd0dc39bb0eb2e77a064c813b2bbd88d2888ad49f/wrapt-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7de5b8d94417e55c02be50cc226e0ae1209bbc73813bf691dff3979c94438115", size = 96269, upload-time = "2026-08-30T04:40:01.182Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a3/a3b5cde1cd06e04b6e95134eb3187a0a7da607a530e7795b221d4e4fa819/wrapt-2.4.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6436e2bda993a3eb69a1b317fc831c8ebcafb5704c390859ebd49f81218c4bbb", size = 225787, upload-time = "2026-08-30T04:40:02.715Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f7/d100f6c348b7669f19119cf890dcd4764623e2233af065586d110e0cd99e/wrapt-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e084558fbd112d2e1e34b0f5c71e45a3405bdad51a17150368a959bcf6697964", size = 226649, upload-time = "2026-08-30T04:40:04.647Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c6/3af8df515d5d7e92306957536f3468c6bdfecbe3659f99dbf09a468c2c4c/wrapt-2.4.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e78c947e18fadfd690c9420c30a96d221feeb93fc8f1cc00509b370ac16c3114", size = 206760, upload-time = "2026-08-30T04:40:06.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/40d355552bd3eb6c5186e26051c19b573d24d7896de42caa7937d6b5ca9f/wrapt-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:08d8378c4514ac8dcc0ace76044cf87a873e6a52b5e6109834c8fb9037f4441b", size = 223467, upload-time = "2026-08-30T04:40:07.829Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ab/d198eebdb39f0d7e182e771e590a36673489cd58cebdad8aa273dcf28e04/wrapt-2.4.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:93180c2199784dd6a1075b33f9ed636bd0966821edbece6b3d5379b1c4f0bb7d", size = 205358, upload-time = "2026-08-30T04:40:09.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0e/974a60672ad507d39a3d8a1c6351ef37fe65b07240d000ceba5d2b83e9e9/wrapt-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d5e5eb76fb87e62752af751d2dcd9d1cd986b12037d2e1363d109ba716029e8", size = 214654, upload-time = "2026-08-30T04:40:10.923Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5a/8b2db70206db0a4246758e0472ce344cb9636217113ef70640fc8d2ce874/wrapt-2.4.0-cp313-cp313-win32.whl", hash = "sha256:49bb5a572469e0e18163a8ec2aa972135a0929899ecbe627665f274506e1b5b4", size = 91171, upload-time = "2026-08-30T04:40:12.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1e/e782b511c680dbe7369c92e7d981484aacca0cda584da1f28a84cd9a8e1a/wrapt-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:b1737f46b1e4a81eb93500a7f2854319e1c7a86e8863fb050b7b4daadd5a4178", size = 96178, upload-time = "2026-08-30T04:40:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/095ba31123fa5dd482d6183c05200b061314aabbd5442c010aba4b03ff1c/wrapt-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:f1e9e088094f4895f84ab043e7d59401df137d663efbf1e80c82144882960830", size = 92949, upload-time = "2026-08-30T04:40:15.935Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/dd/1f269e4daf0c992f675e1ca2de6b1683b761c6d0aeb6c7b4b412486823ea/wrapt-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:788e473d1a6786d29d577b1e2bd95e214c09cdafde84907c522c31069c9acfac", size = 96386, upload-time = "2026-08-30T04:40:17.584Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/7ecef06d33c0121c68d66a8a695efe67ebaa57218c1c61c585eca2a6117a/wrapt-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:947bd4b3438167b3638bf5477cb83a068a586ffb6d331ac427f39839c2b93b3c", size = 96532, upload-time = "2026-08-30T04:40:19.116Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e3/8fdc9eba0e6cbbfe8303e1e807d734691309a27970b2ea458d099f1a46b0/wrapt-2.4.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3a69161cae7f0dca44c89c1d14146b4a0508a0c3cad98b3f2db1f4e9016c94ba", size = 228775, upload-time = "2026-08-30T04:40:20.604Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/77/4ac5882abfb29bf9821c5fa5cf9f30241a194e0f47faa2682b9b29765278/wrapt-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0536f5d85ff6a157ebe7e0fe08c5479943742cf1ce59569075a66159efcbc495", size = 229029, upload-time = "2026-08-30T04:40:22.186Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c5/8a3608311a02faf3e5c072da38d06a7c623150fc258e29f18fe377d91703/wrapt-2.4.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5f041ed6a4d571010944bd6cfad9072db463e1851877b6d3227467a44af37456", size = 210436, upload-time = "2026-08-30T04:40:23.953Z" },
+    { url = "https://files.pythonhosted.org/packages/de/90/e0cbc43f435fd39df25460e9f173e7b96f3dac5c7f66be41c7227166f021/wrapt-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f7fed45dbadf5d98a52bfff9624d3cca00affeb9543d493c9632b7a53cdd35c9", size = 226586, upload-time = "2026-08-30T04:40:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6c/7e5f2143228635ec139ef6df733dc477049f7d96a0c49deb23944a73ed6a/wrapt-2.4.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5cc2e7c7b6032e11a2b367a9baadaf0c5241feff2d8205260d87f1aa6dbdf84b", size = 208880, upload-time = "2026-08-30T04:40:27.128Z" },
+    { url = "https://files.pythonhosted.org/packages/10/16/1de84402bb7a0916e10739bf6586e031244172b299e87c8cff2a04baf9ff/wrapt-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:72826910a1cf5a081234720fd43011304b899acfee219af49148155b4d795533", size = 216689, upload-time = "2026-08-30T04:40:28.844Z" },
+    { url = "https://files.pythonhosted.org/packages/20/19/cd6bd5050381a541b44be97c4e0994eed60c5f439f4314f95eb5777d6c1a/wrapt-2.4.0-cp314-cp314-win32.whl", hash = "sha256:0eca69c9e93518240abe8801fb9b2726116a6e48172e4564c2651a2e14521747", size = 91581, upload-time = "2026-08-30T04:40:30.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f8/b642f3184619adde676ad449030bcbeae6cc78ea07a92f0b5fddeec4c4e6/wrapt-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:63b94f401d7ae3a9a3027472fd3a3ff38afd2ed293b2f0b3b84a6d133a9f99a3", size = 96510, upload-time = "2026-08-30T04:40:32.1Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3b/3415a18b91221261eeac85bf8ee23dfb0e2a39d76b9703a797efca177439/wrapt-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:6b3e082d43f592fcd381aee46354a11ce887a813ce5bbcedd9766fd681723c09", size = 93648, upload-time = "2026-08-30T04:40:33.563Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/90/80cf6a09e9599a11249775928df9bb790b82471e4312b847a861ffb2c2ed/wrapt-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09064c7be688c38c3ff125ce86bc26b69b5d78dd56062c3ddd9c814b2a25f1e1", size = 99615, upload-time = "2026-08-30T04:40:35.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/da/c1d3245abb911a42584f8f7e9781995bdc41345c7affba75cf7e376c85ac/wrapt-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4f8ddff4bbb75916be36da5169b8b9d475b59a1bd24acdb7551bb2c71be9aaac", size = 100031, upload-time = "2026-08-30T04:40:36.641Z" },
+    { url = "https://files.pythonhosted.org/packages/84/46/8ec4941d0abbb010df7caf0a34840ca0128177389843b0f5ef2f9ee48ac5/wrapt-2.4.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9f8017443595870aa31f46125553a5c55ce95a26a267b96261baee6ba566d83", size = 269389, upload-time = "2026-08-30T04:40:38.212Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b5/a0ae1b431cc1f49a545d32b8b678a5788c50583ecf0ecb85dc0c7f95b4f6/wrapt-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:328eb2d978ca3a6ae25f8d8fe560bf8f4bc9778b5932e7b142664eef05b92e8f", size = 281081, upload-time = "2026-08-30T04:40:40.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/24/dfaf53dd3bdb0703524a9367b48e2a64ea86433fcc854b5f14be6a8e0e39/wrapt-2.4.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7a057d376d994da6bd1bbf955ecfda699aa7353826f98847f5605e1801abdfd4", size = 249637, upload-time = "2026-08-30T04:40:41.657Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/27/bdd82044d7503c2bfa78afcc89881f82a1b82b5d2013aabab853d339ce2a/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3367a5212212c9393e0d3ca6ae029b3a8fa40c5896e4a985d43fe8a4b8322f0d", size = 275322, upload-time = "2026-08-30T04:40:43.408Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/82/04f4228eb3fb348d660dd1ea7225e53665b1809df2273ff4861d4d33b741/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c4fca1e63af6675af3df7cdfcd5a0c878b5e655c7e48611ced9dc8d62183a11d", size = 247292, upload-time = "2026-08-30T04:40:45.457Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/20/67b2968fa9200458446c51b36a435adb6906083428b70fafb4caf92d4dc2/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:694005fdc3002ade0f21641408c588028abde03c85961f3ba7727d8bead3ed6b", size = 264586, upload-time = "2026-08-30T04:40:47.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/0db9ba03e08a7663f52455e95520c723f567bc037bffc6699950fcc456c4/wrapt-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:332d9bad7e9b718974bb2a576504c4956f45b4a0fcd7b3bb7827279167550464", size = 93752, upload-time = "2026-08-30T04:40:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/87/ced171220935c696b157207385fa6be5675558a74655479f071d95a00f1d/wrapt-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d57264c9dfcf37d2bf0b0fbec68d0f6184fc5617267619ada04d03e8b0231f3", size = 99890, upload-time = "2026-08-30T04:40:50.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/af/4a10c9a6d3b7ae41f830978c28d33a59ceb29537bd6875d2abfe78db4b41/wrapt-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f43af38a642c3d6062e9740d8f5cc0feb5dbe0da516702df892147393b8cb14d", size = 96033, upload-time = "2026-08-30T04:40:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/df/3a0b6225ab88bd47090df70391c059a3308057638f8fc0ae32e8ac9d1886/wrapt-2.4.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:430fde1a116df3ceb5c29035de1da6609b70e680d9b8ce3ee624422f3fe0978c", size = 96389, upload-time = "2026-08-30T04:40:53.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6f/803b0d0e14de11781f0e938e6f7d6e29e79652139fe70d7513460357ac78/wrapt-2.4.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:7d28f8f35a02d49f75f57fa4e755db4ba33f65841c0de64cd65b253916f5bf06", size = 96557, upload-time = "2026-08-30T04:40:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e8/46571e1218d0494604a7aadc4c898c738c4b179052327ee1e57e278cebd6/wrapt-2.4.0-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:efd9a4be6785295e471f71efdf5682bd11d5b822b9665e6e1b4844917cf2f7ac", size = 229230, upload-time = "2026-08-30T04:40:56.703Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2e/0cab15fcaec56096a5734feace3620bc01edc885653be04bd756f84a6784/wrapt-2.4.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75529a2fb569a671cf162f762c1b576f569f571b55ec7f3481258ca842ba507f", size = 229444, upload-time = "2026-08-30T04:40:58.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/a92c049371a2675f98a0381ab2951f984866d1ba4de0e0771d6a31fdaa2b/wrapt-2.4.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66e7512c0d324cc37bba1def2be1fc365cbb685d3aa393a8f6f4d2d00202881d", size = 212482, upload-time = "2026-08-30T04:41:00.224Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/3b/8b5b57d0ff24edcd3421dbaeb4e94c89be3616824e47708f4e13f25ae3d7/wrapt-2.4.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:5f3bdfc35c83b562fcaebc0f24593045e5ed9f3b633adafd35222718a0ec38fa", size = 227017, upload-time = "2026-08-30T04:41:01.918Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/20/124b40bfd9585848db5a5aa6741d0c8dbf378dd995c6c2d95f090d9cf540/wrapt-2.4.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:d5f45bead708e2c0014be5e98531ce7202916b098a208c7be83c6ceb0a2559fa", size = 210498, upload-time = "2026-08-30T04:41:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/89db9d5a80a9f2af52b24bdfdb5392be80bc0f0fd39fc39d1aab72afd0bd/wrapt-2.4.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:d294576fddac636589e4deccfe782e8f429da10f167c1985c4d51071de3672b7", size = 217046, upload-time = "2026-08-30T04:41:05.473Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/0b/021c9d6ce64c639894bffdaa7a895ddd4187abfefb2873ce55e536cd9d56/wrapt-2.4.0-cp315-cp315-win32.whl", hash = "sha256:0191d717dfbb8e519e7bfd4775e5b9bd57e359b3a09ab5db1ea47f6025b4d845", size = 91591, upload-time = "2026-08-30T04:41:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d3/6ebd944041cea0ac4a108a4739510ed2dc891a3f3216e4f7bf0650f5b5a6/wrapt-2.4.0-cp315-cp315-win_amd64.whl", hash = "sha256:e8df31a126a0a247c1aa379e30873839de03912dea09ca360c680f3625d815df", size = 96517, upload-time = "2026-08-30T04:41:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/96/84/7c5e52e450f80ba76fd0282dccf7c79cd004ebd8ccabd0903064d3d2c56e/wrapt-2.4.0-cp315-cp315-win_arm64.whl", hash = "sha256:e9e7e94472f0e3f1447caf27e1939eb384d0e87972a35a05f5c2e0968e9c01af", size = 93652, upload-time = "2026-08-30T04:41:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/35/89/f08ff45d7646de29750932805cc3b1e86b6ac3128015b293ed45fa8efe86/wrapt-2.4.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:8828369b7d3e93c547cc8ad931b5a57b4e8d174035c82762fb1091e7d05ac9f5", size = 99610, upload-time = "2026-08-30T04:41:11.933Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c2/f9a3c40901a36c6bb7ecaff8e1e54af78fa7fa0b95a0e54d13d3a24c8a0a/wrapt-2.4.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:413e757dce7a43fcda8bb8441994b1127492ffac6a5803af777d44516df8c6e2", size = 100064, upload-time = "2026-08-30T04:41:13.492Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/e2437f17f2a1ec292056e2fcafe1248269ebc39502f2ffe79424bf86f8a6/wrapt-2.4.0-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:75944792cf6b99262d649d55710bf5901f7013fbb212c7a1d736b97a20517607", size = 269421, upload-time = "2026-08-30T04:41:15.238Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d0/c98d6548dc4c7d12ab9baa192234ca1a57e141afd283252b448faddbd9ef/wrapt-2.4.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:648d1d4f94e8a0a1656675c755f40d2f0ee5fe92c449ab45326f4ecc2738cbe8", size = 281452, upload-time = "2026-08-30T04:41:16.939Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/57/673168e00aa03725148ce621ed201b75df4e787a57acd48fecefd2725600/wrapt-2.4.0-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a112a1bfdd2621e4344cb0a32dbaab80636b32dac1b055d03fbb2a67d806d1db", size = 250358, upload-time = "2026-08-30T04:41:18.716Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0b/f2e576de5bf53ef5b578470104ea93f33e273a704c825131bc1719fffc42/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0972cd025f4c86fa2d8abd953d9f875779935343af58b4ce019ff89573fc65bd", size = 275654, upload-time = "2026-08-30T04:41:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/9347b2e236346b1ba4cb28b82b205b8a377bb2da9417cb81bbe3d25816d7/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:c246aaed719dcdb62eeb7b8d9306a6237777226ef3baad35919c4ae134c91ce7", size = 248662, upload-time = "2026-08-30T04:41:22.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/36/3b84d9e1ac8393bf2c94272760a2d361dc394ac30301e6d6dbd6583ade2d/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:1656de3835f760781c9b974bce07d8c04edb9c9ad7ad67264aee69cd68a1db09", size = 264813, upload-time = "2026-08-30T04:41:24.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a2/de7b1de1702667b4a048318e301e26887268c17b07c8b9797cea06b10aee/wrapt-2.4.0-cp315-cp315t-win32.whl", hash = "sha256:d8e6e1e5dc684dfce7c33fc8b67a08ba2af94f3a45cfc70d5c1d6a839d2caf97", size = 93753, upload-time = "2026-08-30T04:41:25.793Z" },
+    { url = "https://files.pythonhosted.org/packages/09/50/4e7ef58c4eb058861ceddc0d1f94a6ed87f62e1cb27783c60b2897ef7e58/wrapt-2.4.0-cp315-cp315t-win_amd64.whl", hash = "sha256:85ed3c67fd39e8d9a36c224758cb6f2f4eb277d07ea677930caa0008c18ec002", size = 99888, upload-time = "2026-08-30T04:41:27.305Z" },
+    { url = "https://files.pythonhosted.org/packages/68/64/d15740c763dd0ddea2338ad42e3bd4a84f8702e16083e7ff61674c504a13/wrapt-2.4.0-cp315-cp315t-win_arm64.whl", hash = "sha256:36b56a4fba13b34ed8ff307557325fff215de0a58b5dbaef2c50e4d8aa39dbd1", size = 96039, upload-time = "2026-08-30T04:41:29.062Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Issue #1028 requests measured, optional ways to shorten local test feedback without reducing clean CI coverage. The experiments also exposed a historical dependency-audit test that incorrectly compared its immutable receipt against the current optional-extra lock.

## Changes

- Add a named `test-acceleration` extra and optional `test-feedback` tox environment. Keep the default full CI suite and runtime dependencies unchanged.
- Add serial testmon profiles with dependency/configuration/test-inventory invalidation, path validation, inherited-environment controls, cache locking, and fail-closed receipt handling.
- Evaluate a bounded mutation-policy target, CTracer versus sysmon, and one fixed public PyPI JSON response versus an in-process HTTP transport. Temporary cassettes contain no authenticated or restricted traffic. Preserve prior failure evidence and explicit exclusions for Freezegun and pytest-picked.
- Bind the unchanged historical dependency audit to hash-verified historical project/lock snapshots, with separate live lock validation and tamper challenges. Reuse the immutable paper lock merged in #1057.
- Document the measured profiles, their limitations, and the unchanged full-suite gate.

## Measurements and limits

The bounded 16-test profile executed all 16 tests normally and on a cold testmon run; an unchanged warm run collected 16 and executed zero. Measured total times were 48.80s ordinary, 39.06s cold testmon, and 23.37s warm testmon. These are local samples, not a general speed claim.

On the separate 15-test coverage comparison, CTracer took 48.19s and sysmon 52.07s with identical reportable statement/branch coverage. Sysmon is not promoted: its dynamic-context incompatibility made the initial mutation experiment unsuitable. The final explicit-CTracer mutation run killed 29/29 mutants with zero survivors, errors, or timeouts after adding a meaningful zero-denominator regression.

The fixed public HTTP sample recorded/replayed identical response bytes; replay took 0.00803s and the in-process transport 0.001053s. No production transport or remote test policy changes follow from this narrow experiment.

## Validation

- All 15 required local tox environments passed before rebase, including the final integrated dependency fixes: coverage run had 4,672 passed, 15 skipped and 95.11% coverage. Earlier historical-binding failures and a property-test deadline failure remain recorded; checks and deadlines were not weakened.
- Rebased onto merged #1057 (`515529e3e7ce4d74f0c5d6d5fd5ebbeb91ee861f`). The implementation commit is unchanged by range-diff; only changelog context required reconciliation.
- Fresh integration: 67 focused acceleration/history/JOSS/replay tests passed; `uv lock --check` resolved 220 packages; lint, Vale and JOSS tox environments passed (19 JOSS tests).
- All three commits are signed. This PR contains only the 16 acceleration-owned paths; no duplicate #1057 changes.

Related to #1028. Keep the issue open until protected delivery and its remaining acceptance criteria are reconciled. Hosted checks are pending; this PR does not claim a venue submission or external acceptance.

## Integration onto merged dependency and HPC controls

Rebased onto `66f51d2140eeba084e659086da91ed35adba4afb` after PR #1060. The implementation and explicit invalid-target fix are unchanged by range-diff; only changelog context changed. The merged Ruff range and resolved version remain intact alongside the optional acceleration extra. All three rebased commits are signed.

Fresh integration validation: 83 focused acceleration, mutation-policy, historical-frontier, JOSS and replay tests passed; `uv lock --check` passed with 220 packages; lint, Vale, typecheck, harness and JOSS tox environments passed. The earlier full 15-environment result remains retained evidence; this integration did not rerun the full matrix. Fresh hosted checks are pending for `5751aca8cbfb1d914ce480d6d82e99c38687f502`.

Integration after Julia candidate merge: signed head `d5daa1d2a4b2f7b9e073eb92f6f98f87bdbf606f` rebased onto `15e514a53bec23b2a220ccfee7cf6c4d363a363e`. The sole changelog conflict preserves both entries; implementation and CodeQL patches are unchanged. Fresh validation: 83 focused tests passed; lint, Vale, typecheck, harness and JOSS tox environments passed; frozen lock check resolves 220 packages. The earlier full-matrix evidence remains retained; hosted checks must run anew for this head.
