### PR TITLE
build: prepare pinned Julia binary candidate for v2.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,10 @@
   dependency recipes, required Arrow features, isolated solver evidence and
   explicit native build limits.
 
+- Prepare a source-pinned v2.2.0 Julia binary recipe alongside the retained
+  v2.1.0 build evidence. New BinaryBuilder execution and registry acceptance
+  remain pending; no generated JLL identifier is assumed.
+
 - Bound confirmed maintainer declarations and journal-first sequencing to the
   recorded decision. Retained separate survey and human-authorship action gates
   and verified withdrawal receipts for the earlier pyOpenSci requests.

--- a/docs/release/yggdrasil-v2-2-candidate-20260831.md
+++ b/docs/release/yggdrasil-v2-2-candidate-20260831.md
@@ -1,0 +1,34 @@
+# Julia binary candidate for v2.2.0
+
+Issue #555 still requires repository work as well as upstream acceptance. The
+open Yggdrasil PR #14292 and its 15-platform Buildkite run target v2.1.0. The
+published v2.2.0 release is commit
+`7af563c8cb373057d30662650b3f332f39e05b83`. Its FFI adds the R-compatible
+`voiage_v1_enbs_r` wrapper; the existing Julia EVPI and ENBS entrypoints and ABI
+1.1 remain compatible. The older candidate is internally consistent but is
+not a v2.2.0 build receipt.
+
+The prepared replacement recipe is
+`packaging/yggdrasil/candidates/v2.2.0/build_tarballs.jl`. It changes only the
+version and pinned Git source. The original
+`packaging/yggdrasil/V/voiage_ffi/build_tarballs.jl` remains the exact historical
+recipe bound to the existing platform contract. Tests reject extra changes
+to compiler, product, target filters or build flags in this bounded refresh.
+
+The dated JSON receipt binds both recipes and keeps all new hosted-build,
+product, runtime and registry fields empty. Local preparation and Julia syntax
+validation do not establish BinaryBuilder execution. No upstream PR was
+updated and no registry application was sent.
+
+After protected repository delivery and separate upstream authorization, use
+the prepared bytes for `V/voiage_ffi/build_tarballs.jl` in the existing upstream
+PR. Re-run the platform matrix and verify actual products and supported host
+execution at that new head; do not reuse the old 15 passing jobs as new evidence.
+Only after the JLL is generated and accepted should the Julia package consume
+its real UUID and version with bounded compatibility, verify clean-depot
+installation without Rust, and proceed to General registration. No UUID has
+been guessed and none is added by this change.
+
+Sources: [published release](https://github.com/edithatogo/voiage/releases/tag/v2.2.0),
+[current upstream candidate](https://github.com/JuliaPackaging/Yggdrasil/pull/14292),
+and [historical build](https://buildkite.com/julialang/yggdrasil/builds/31972).

--- a/packaging/yggdrasil/candidates/v2.2.0/build_tarballs.jl
+++ b/packaging/yggdrasil/candidates/v2.2.0/build_tarballs.jl
@@ -1,0 +1,64 @@
+using BinaryBuilder
+using Pkg
+
+name = "voiage_ffi"
+version = v"2.2.0"
+
+sources = [
+    GitSource(
+        "https://github.com/edithatogo/voiage.git",
+        "7af563c8cb373057d30662650b3f332f39e05b83",
+    ),
+]
+
+script = raw"""
+cd ${WORKSPACE}/srcdir/voiage/rust
+
+# Rust's musl targets default to a static C runtime, which cannot produce the
+# shared-library product consumed by a JLL package.
+if [[ "${target}" == *-musl* ]]; then
+    export RUSTFLAGS="-C target-feature=-crt-static"
+fi
+
+cargo build \
+    --release \
+    --locked \
+    --package voiage-ffi \
+    --target "${rust_target}"
+
+if [[ "${rust_target}" == *-windows-* ]]; then
+    source_library="target/${rust_target}/release/voiage_ffi.dll"
+else
+    source_library="target/${rust_target}/release/libvoiage_ffi.${dlext}"
+fi
+
+install -Dvm 755 \
+    "${source_library}" \
+    "${libdir}/libvoiage_ffi.${dlext}"
+install_license ../LICENSE
+"""
+
+platforms = supported_platforms()
+filter!(p -> !(Sys.isfreebsd(p) && arch(p) == "aarch64"), platforms) # Rust toolchain is not available on aarch64-unknown-freebsd
+filter!(p -> arch(p) != "riscv64", platforms) # Rust toolchain is not available on riscv64
+filter!(p -> !(Sys.iswindows(p) && arch(p) == "i686"), platforms) # Rust toolchain cannot link i686-w64-mingw32 unwinding symbols
+
+products = [
+    LibraryProduct("libvoiage_ffi", :libvoiage_ffi),
+]
+
+dependencies = Dependency[]
+
+build_tarballs(
+    ARGS,
+    name,
+    version,
+    sources,
+    script,
+    platforms,
+    products,
+    dependencies;
+    julia_compat = "1.10",
+    preferred_gcc_version = v"10",
+    compilers = [:c, :rust],
+)

--- a/specs/submission-readiness/yggdrasil-v2-2-candidate-20260831.json
+++ b/specs/submission-readiness/yggdrasil-v2-2-candidate-20260831.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "voiage.yggdrasil-local-candidate.v1",
+  "prepared_on": "2026-08-31",
+  "state": "prepared_not_built_or_submitted",
+  "version": "2.2.0",
+  "source_commit": "7af563c8cb373057d30662650b3f332f39e05b83",
+  "release_url": "https://github.com/edithatogo/voiage/releases/tag/v2.2.0",
+  "recipe": {
+    "path": "packaging/yggdrasil/candidates/v2.2.0/build_tarballs.jl",
+    "sha256": "048493d4673ae415862c8b974a300cea033845ba8cba3900e14c238ed4547b7d"
+  },
+  "historical_recipe": {
+    "path": "packaging/yggdrasil/V/voiage_ffi/build_tarballs.jl",
+    "sha256": "4148f991e7e7bdbe8952c04108905322950d280c72b53e91d3a8d1290d5801a1",
+    "version": "2.1.0",
+    "source_commit": "964a0fc334ece9509387cd07d43776adf38be240",
+    "upstream_head": "2528e2efb90e4197924d45c98873ca5cdb1a9d42",
+    "build_url": "https://buildkite.com/julialang/yggdrasil/builds/31972",
+    "included_platforms_passed": 15
+  },
+  "allowed_recipe_changes": [
+    "version",
+    "GitSource revision"
+  ],
+  "validation": {
+    "julia_syntax": {
+      "status": "passed",
+      "command": [
+        "/opt/homebrew/bin/julia",
+        "--startup-file=no",
+        "-e",
+        "Meta.parseall(read(ARGS[1], String)); println(\"Julia recipe syntax parsed\")",
+        "packaging/yggdrasil/candidates/v2.2.0/build_tarballs.jl"
+      ],
+      "scope": "parse only; no BinaryBuilder execution"
+    },
+    "full_tox": {
+      "noncoverage_environments_passed": 14,
+      "noncoverage_exit_code": 0,
+      "noncoverage_seconds": 1424.15,
+      "noncoverage_log_sha256": "5e92ccc9d2b80c0d6681125297b7bc2f4c166c2a69171d5b467071419f38d1df",
+      "coverage": {
+        "passed": 4626,
+        "skipped": 15,
+        "failed": 0,
+        "percent": 95.11,
+        "pytest_seconds": 267.47,
+        "tox_seconds": 348.14,
+        "terminal_exit_code": 0,
+        "log_sha256": "50109eb8deb3ae83cfd52b90e0b9a5f44d337c8ccc00ef245001c1cfb11f6e2b"
+      },
+      "all_15_required_environments_passed": true
+    },
+    "dependency_frontier": {
+      "upgrade_exit_code": 0,
+      "strict_policy_passed": true,
+      "unrelated_dependency_changes_retained": false
+    },
+    "signed_release_tag": "git tag -v v2.2.0: good GPG signature; peeled target equals source_commit",
+    "focused_tests": {
+      "initial": "25 passed, 1 failed due to test assuming literal root version instead of dynamic metadata; corrected to actual Julia and Rust manifests",
+      "final_passed": 26,
+      "pytest_seconds": 8.04
+    },
+    "historical_contract_unchanged": true,
+    "final_vale": {
+      "passed": true,
+      "seconds": 11.07
+    }
+  },
+  "new_candidate_evidence": {
+    "upstream_head": null,
+    "platform_builds": [],
+    "product_archives": [],
+    "runtime_smokes": [],
+    "registered_jll_uuid": null,
+    "general_registration": null
+  },
+  "next_actions": [
+    "Review local candidate and complete protected repository delivery.",
+    "With separate upstream authorization, replace upstream recipe and obtain fresh platform builds, product integrity and supported runtime evidence.",
+    "After accepted JLL generation, consume actual UUID/version with bounded compat and test clean-depot installation before General registration."
+  ]
+}

--- a/tests/test_julia_binarybuilder_readiness.py
+++ b/tests/test_julia_binarybuilder_readiness.py
@@ -1,5 +1,7 @@
 """Contracts for Julia artifact packaging and General registration."""
 
+import hashlib
+import json
 from pathlib import Path
 import tomllib
 
@@ -75,3 +77,31 @@ def test_registration_documentation_preserves_the_two_external_gates() -> None:
     assert "@JuliaRegistrator register subdir=bindings/julia" in readme
     assert "JLL registration" in readme
     assert "General registry merge" in readme
+
+
+def test_current_release_candidate_preserves_historical_build_evidence() -> None:
+    receipt = json.loads(
+        (
+            ROOT / "specs/submission-readiness/yggdrasil-v2-2-candidate-20260831.json"
+        ).read_text()
+    )
+    project = tomllib.loads((ROOT / "bindings/julia/Project.toml").read_text())
+    workspace = tomllib.loads((ROOT / "rust/Cargo.toml").read_text())
+    assert receipt["version"] == project["version"] == "2.2.0"
+    assert receipt["version"] == workspace["workspace"]["package"]["version"]
+    assert receipt["source_commit"] == "7af563c8cb373057d30662650b3f332f39e05b83"
+    historical = receipt["historical_recipe"]
+    candidate = (ROOT / receipt["recipe"]["path"]).read_bytes()
+    original = (ROOT / historical["path"]).read_bytes()
+    assert hashlib.sha256(candidate).hexdigest() == receipt["recipe"]["sha256"]
+    assert hashlib.sha256(original).hexdigest() == historical["sha256"]
+    assert candidate.decode() == original.decode().replace(
+        'version = v"2.1.0"', 'version = v"2.2.0"'
+    ).replace(historical["source_commit"], receipt["source_commit"])
+    assert receipt["state"] == "prepared_not_built_or_submitted"
+    assert all(
+        value is None or value == []
+        for value in receipt["new_candidate_evidence"].values()
+    )
+    assert historical["upstream_head"] == "2528e2efb90e4197924d45c98873ca5cdb1a9d42"
+    assert historical["included_platforms_passed"] == 15


### PR DESCRIPTION
## Why

The existing Yggdrasil recipe and its successful 15-platform build receipt describe voiage 2.1.0. The published release is 2.2.0, so the old receipt cannot establish that the current source has been built or packaged for Julia.

## Changes

- Add an explicitly named v2.2.0 candidate recipe, pinned to published release commit `7af563c8cb373057d30662650b3f332f39e05b83`.
- Change only version and GitSource commit relative to the historical recipe. Keep compilers, platform exclusions, products and build flags unchanged.
- Preserve the original v2.1.0 recipe and 15-platform build receipt byte-for-byte.
- Add a hash-bound candidate receipt, a regression contract and a handoff document. Keep new build evidence, upstream update, JLL UUID and General registration fields pending rather than inventing identifiers or completion.

## Validation

All 15 required local tox environments passed before rebase. The final coverage run had 4,626 passed, 15 skipped and 95.11% coverage. The retained receipt distinguishes an initial test-contract assumption failure from its corrected passing rerun.

Fresh integration onto merged #1057 (`515529e3e7ce4d74f0c5d6d5fd5ebbeb91ee861f`) changed only changelog context; the candidate and regression logic are unchanged. Four relevant Julia/release contract modules passed all 10 tests, actual Julia `Meta.parseall` accepted the recipe, `uv lock --check` resolved 216 packages, and lint, Vale and JOSS tox environments passed (19 JOSS tests).

The signed commit contains five owned paths. The historical recipe, historical platform receipt and dependency lock are unchanged.

## Remaining work

This is a prepared local candidate, not a new BinaryBuilder build or an upstream submission. No change was made to JuliaPackaging/Yggdrasil PR #14292. Actual current-source builds, upstream acceptance, generated JLL identity, clean-depot execution and General registration remain unverified or pending.

Related to #555 and #1023. Neither issue should close automatically from this candidate-only change. Hosted checks are pending.
