### PR TITLE
build(hpc): resolve dated Rust compiler and backend graphs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@
 
 ## Unreleased
 
+- Resolve the local HPC dependency graph with checksum-bound dated Rust and
+  separate stable compiler backends; native cluster builds remain pending.
+
 - Verified the complete R distribution check, including PDF and HTML manuals;
   retained its two NOTEs and the separate submission gate.
 

--- a/docs/astro-site/src/content/docs/developer-guide/hpc-deployment.mdx
+++ b/docs/astro-site/src/content/docs/developer-guide/hpc-deployment.mdx
@@ -12,8 +12,9 @@ separate evidence states.
 
 Spack users can audit the local `packaging/spack-overlay/` repository, which
 supplies missing catalogue versions and their build dependencies. It resolves
-three individual dependency graphs; the complete voiage graph remains blocked
-by the dated Rust nightly required by Polars and stable-Rust constraints.
+three individual dependency graphs and the complete voiage graph on the
+recorded macOS arm64 host. The latter keeps stable Rust and Polars' dated
+nightly in separate compiler/backend instances.
 PyArrow's candidate requests CSV, dataset, filesystem and Parquet support, but
 no native build or installed Arrow round trip has yet been verified.
 
@@ -39,12 +40,14 @@ export SPACK_USER_CACHE_PATH="$PWD/.conductor/local/hpc-overlay-run/cache"
 spack repo add --scope user "$PWD/packaging/spack-overlay"
 spack config --scope user add repos:builtin:commit:d4f7c711a6a42f1c4d551c8fd10fce9a11340a81
 spack config --scope user add "bootstrap:root:$PWD/.conductor/local/hpc-overlay-run/bootstrap"
+cp packaging/spack-overlay/concretizer.yaml "$SPACK_USER_CONFIG_PATH/concretizer.yaml"
 spack spec py-voiage@2.2.0
 ```
 
-Retain the nonzero result and full solver output while the compiler constraint
-remains unresolved. The overlay guide and receipt also retain the successful
-individual Typer, Pydantic and PyArrow graphs. The standalone
+Retain the exit status and full solver output. The bounded minimal-duplication
+configuration keeps only Rust and its three build tools separate, preserving
+all runtime dependency types. The overlay guide and receipt retain the
+complete graph and the individual Typer, Pydantic and PyArrow graphs. The standalone
 `bash scripts/validate_hpc_recipes.sh --spec` command uses the original recipe
 without this overlay, so its missing-version errors describe that older path.
 

--- a/docs/release/hpc-distribution-handoff.md
+++ b/docs/release/hpc-distribution-handoff.md
@@ -134,9 +134,10 @@ and interchange modules. The retained catalogue-only failure above remains
 historical evidence; it is not the current overlay result.
 
 The overlay's `solver-receipt.json` and complete `solver-logs/` record three
-successful individual graphs: Typer, Pydantic and PyArrow. The complete voiage
-graph still fails on the required `nightly-2026-04-01` Rust toolchain and its
-conflict with numeric stable-Rust constraints. The Python 3.13 LibCST path also
+successful individual graphs: Typer, Pydantic and PyArrow. The dated compiler follow-up now resolves the complete voiage graph on
+macOS arm64 with distinct stable Rust 1.96.0 and exact `nightly-2026-04-01`
+nodes. Its beta stage0 and source archive are checksum-bound; only Rust,
+rust-bootstrap, Maturin and setuptools-rust permit two build-tool instances. The Python 3.13 LibCST path also
 needs a separate pyyaml-ft recipe. None of these graph results proves a build.
 
 Use the isolated configuration, cache and bootstrap commands in the

--- a/packaging/spack-overlay/README.md
+++ b/packaging/spack-overlay/README.md
@@ -10,6 +10,11 @@ The overlay preserves the copied Spack copyright notices, licence files,
 patches and historical recipe versions. `manifest.json` binds every recipe and the retained architecture patch.
 `source-audit.json` and `transitive-source-audit.json` record the downloaded,
 hash-verified Python source archives and their build requirements.
+`rust-source-audit.json` verifies the downloaded dated compiler source against
+its official checksum and binds its embedded stage0 to the dated beta manifest.
+Bootstrap binary digests are official metadata; those binaries were not
+downloaded or installed. `rust-backend-source-audit.json` verifies the two
+unchanged Python build-tool sources.
 `arrow-source-audit.json` binds the Apache Arrow C++ archive to the official
 SHA-512 sidecar. Its release signature has not been verified.
 
@@ -45,6 +50,7 @@ export SPACK_USER_CACHE_PATH="$PWD/.conductor/local/hpc-overlay-run/cache"
 spack repo add --scope user "$PWD/packaging/spack-overlay"
 spack config --scope user add repos:builtin:commit:d4f7c711a6a42f1c4d551c8fd10fce9a11340a81
 spack config --scope user add "bootstrap:root:$PWD/.conductor/local/hpc-overlay-run/bootstrap"
+cp packaging/spack-overlay/concretizer.yaml "$SPACK_USER_CONFIG_PATH/concretizer.yaml"
 spack spec py-typer@0.27.2
 spack spec py-pydantic@2.13.4
 spack spec py-voiage@2.2.0
@@ -68,10 +74,28 @@ core, and PyArrow 25 with Arrow 25 separately. Each command returned zero;
 manifest. The complete solver outputs in `solver-logs/` contain no local
 filesystem paths and allow independent inspection of the dependency graphs.
 
-The complete voiage spec returned one. The remaining reported constraints
-are the unavailable `rust@nightly-2026-04-01` and its incompatibility with
-numeric stable-Rust requirements in the unified build graph. A separate,
-checksum-bound dated toolchain strategy and native runtime validation are
-required. Selecting an unpinned nightly or dropping the source constraint
-would not resolve that evidence gap. Successful individual graphs do not
-prove the full graph or any package build.
+The dated-toolchain follow-up resolves the complete voiage graph on the recorded
+macOS arm64 host. `solver-logs/voiage.json` retains the full concrete DAG.
+It contains stable Rust 1.96.0 for Pydantic Core and a distinct exact
+`nightly-2026-04-01` for Polars. Polars explicitly binds `RUSTC` and `CARGO`
+to its direct dependency's prefix. The dated compiler uses beta stage0 from
+5 March 2026 and retains the nightly release channel during source builds.
+
+`concretizer.yaml` keeps unification enabled and minimal duplication. Only
+Rust, rust-bootstrap, Maturin and setuptools-rust gain a maximum of two nodes.
+Maturin's build/run Rust edge and setuptools-rust's run Rust edge require
+separate backend instances; preserving those edges prevents a backend from
+silently selecting the other compiler. Pydantic Core keeps its Rust 1.88
+minimum and explicitly selects the stable 1.x range, because Spack otherwise
+allows a named nightly to satisfy an open numeric lower bound. No dependency
+minimum or upstream dependency type is removed.
+
+The earlier missing-catalogue failure remains under
+`history/pre-dated-rust-69873911/`. Failed intermediate separation attempts
+are retained with their diagnostic receipt. The initial single-nightly solve
+was not accepted as evidence of separate stable and nightly toolchains.
+
+A concrete graph is not a native build. Rust source compilation, bootstrap
+binary verification and execution, all native Python dependencies, installed
+Arrow/numerical smoke tests, Linux foss stacks and module loading remain
+unverified. No upstream submission or completion of issue #1025 is claimed.

--- a/packaging/spack-overlay/concretizer.yaml
+++ b/packaging/spack-overlay/concretizer.yaml
@@ -1,0 +1,9 @@
+concretizer:
+  unify: true
+  duplicates:
+    strategy: minimal
+    max_dupes:
+      rust: 2
+      rust-bootstrap: 2
+      py-maturin: 2
+      py-setuptools-rust: 2

--- a/packaging/spack-overlay/dated-rust-diagnostics.json
+++ b/packaging/spack-overlay/dated-rust-diagnostics.json
@@ -1,0 +1,30 @@
+{
+  "scope": "Historical intermediate solver attempts, before the final recipe/configuration manifest. These logs document why duplication and stable selection were required; they are not final-candidate validation.",
+  "attempts": [
+    {
+      "path": "solver-logs/dated-rust-single-nightly.log",
+      "sha256": "0a193f2b7e1593ff3d23f58c2ccc0593a526d3a22d7bb5c1ebe11bc55bcdf025",
+      "exit_code": 0,
+      "explanation": "Only rust:2 was allowed and open numeric ranges permitted the single dated nightly; rejected as stable/nightly separation evidence."
+    },
+    {
+      "path": "solver-logs/dated-rust-stable-requirements-failed.log",
+      "sha256": "ea2888f5eb6f9e7de66e30e1f137a5bed696a2ce620738ebce53f3e540dd19d2",
+      "exit_code": 1,
+      "explanation": "Package requirements attempted stable 1.x for Maturin and Pydantic Core; shared backend run edges still forced one compiler."
+    },
+    {
+      "path": "solver-logs/dated-rust-stable-edge-failed.log",
+      "sha256": "bc806d3bf72d839d1a5e3b4fc126e61518d049811ac2ea1b78f675c3dff47b9c",
+      "exit_code": 1,
+      "explanation": "Pydantic Core stable 1.x direct build edge retained with rust:2; backend instances remained shared."
+    },
+    {
+      "path": "solver-logs/dated-rust-three-tools-failed.log",
+      "sha256": "39015570af86c92098e723e156aa31e7acc185ba55967f5c76d9a7e9e2e3780d",
+      "exit_code": 1,
+      "explanation": "Two nodes allowed for Rust, bootstrap and Maturin, but setuptools-rust still shared its runtime Rust edge."
+    }
+  ],
+  "final_strategy": "Only Rust, rust-bootstrap, Maturin and setuptools-rust permit two instances under minimal duplication; all other dependency types and minimum versions remain intact."
+}

--- a/packaging/spack-overlay/history/pre-dated-rust-69873911/README.md
+++ b/packaging/spack-overlay/history/pre-dated-rust-69873911/README.md
@@ -1,0 +1,11 @@
+# Historical overlay solver evidence
+
+These receipts and logs describe the recipes at commit
+`698739117b280416958cb5c1e1f8b2d624b3c182`, before the dated Rust extension.
+Recipe paths in this historical manifest refer to
+`packaging/spack-overlay/` at that commit, not to the current recipe bytes.
+The solver receipt's log paths resolve within this directory.
+
+The complete graph failed then. This retained result does not override the
+newer graph and manifest in the parent overlay directory. Neither result
+establishes a native HPC build.

--- a/packaging/spack-overlay/history/pre-dated-rust-69873911/manifest.json
+++ b/packaging/spack-overlay/history/pre-dated-rust-69873911/manifest.json
@@ -8,28 +8,19 @@
     "packages/py-annotated-doc/package.py": "5238e58c461846aca7b8f0d7879a41efa546eab7458d5c5396437756e58f10dc",
     "packages/py-click/package.py": "bdbe6166b9516b13c9f1e112a9560ab4ac79b86fb9cf3992ccba369d078fc3fa",
     "packages/py-libcst/package.py": "9a57b5e2beb4b01e8b8971671eaf28c94e2ed2c0775b328dbd8b1aae5782a388",
-    "packages/py-maturin/package.py": "dee957e7a313ef427abc99963625fa4b439a4f7b349521d62a9237aa74d93181",
     "packages/py-polars/package.py": "324eaeed9d22ce727fc0d24eab4eaa5ce14c4d6e4243d120da9863846bcc00a5",
-    "packages/py-polars-runtime-32/package.py": "c58dbd37dade1cf656550c4db093e8211497faa1290d3fd6237ae8520cf1a514",
+    "packages/py-polars-runtime-32/package.py": "af27d3022242cf02c2afcdebc8f125c967121b53b14b513a9e0a77165bd0b2d3",
     "packages/py-pyarrow/package.py": "b84c9f6c6eb62431e456208546686bc5aae0156fbef3661da1a3e3b5bc4c1810",
     "packages/py-pydantic/package.py": "6b55621d3bfcb54677eef5110abf1420d27166ef370363dddf1c35592f32fb93",
-    "packages/py-pydantic-core/package.py": "e3869c8240cb78a952cf9d6e091433add71d829bb2e73efbd7844cb7b6fa03dc",
-    "packages/py-setuptools-rust/package.py": "4b83a05205564d868b448151975b748442dd1fee7eb00ea379a24c8afc028a00",
+    "packages/py-pydantic-core/package.py": "019cb02021df138b8d19f29ca6080b9ce9aa829ef2c0cd19872fc7559ed77a36",
     "packages/py-typer/package.py": "e13b10d527710d0ca77b12cc910f6db703f63a35cf18ea79e2be1eb51fc44d11",
     "packages/py-typing-extensions/package.py": "bc339c7bbb0f4eb478484269204bbccf4d755d03565ddb397552ed7006a1ed30",
-    "packages/py-voiage/package.py": "8f7e7f3b05d857943f9191dada49d91cdafa244aaa3d6d559088e0100489abf7",
-    "packages/rust/package.py": "9168b5c867d937cf558512f179b4deaa4d78a285dae8f19874cdb626cb77dd82",
-    "packages/rust-bootstrap/package.py": "9fa3514b619fcb45b0a4fc4107493e16397c336a13018ac9a08b79999a4ed02b"
+    "packages/py-voiage/package.py": "8f7e7f3b05d857943f9191dada49d91cdafa244aaa3d6d559088e0100489abf7"
   },
   "native_builds_executed": false,
   "module_load_executed": false,
   "upstream_submitted": false,
   "patch_sha256": {
     "packages/py-pyarrow/for_aarch64.patch": "aed6630a6298b6309d2241a99943b49993453fb089c1d864b4a459559d69bd3c"
-  },
-  "support_sha256": {
-    "concretizer.yaml": "83488e72ea09aa7ad1c2db9cb115f7bbf5e6ce3ceade87d3b6d776355e5a69a4",
-    "rust-source-audit.json": "0e17803e2bd39637bfa4d122e4ddcf3a699742ae1dc2ab4281224e12007c1471",
-    "rust-backend-source-audit.json": "0fbaea54166ab7389192f126225705c30865e2736bba76e0991c0e6de9472c23"
   }
 }

--- a/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/pyarrow.log
+++ b/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/pyarrow.log
@@ -1,0 +1,93 @@
+ -   py-pyarrow@25.0.0 build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+[e]      ^apple-clang@21.0.0 build_system=bundle platform=darwin os=tahoe target=aarch64
+ -       ^arrow@25.0.0~brotli~bz2~compute+csv~cuda+dataset+filesystem~gandiva~glog~hdfs+ipc~ipo~jemalloc~lz4~orc+parquet+python+shared~snappy~tensorflow~zlib~zstd build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^boost@1.90.0~atomic~charconv~chrono~clanglibcpp~container~context~contract~conversion~date_time~debug~exception~fiber+filesystem~graph~graph_parallel~icu~iostreams~json~locale~log~math~mpi~mqtt5+multithreaded~nowide~numpy~openmethod~pic~program_options~python~random~regex~serialization+shared~signals2~singlethreaded~stacktrace+system~taggedlayout~test~thread~timer~type_erasure~url~versionedlayout~wave build_system=generic cxxstd=11 patches:=a440f96 visibility=hidden platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^flatbuffers@24.12.23~ipo~python+shared build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
+ -           ^gmake@4.4.1~guile build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^ninja@1.13.2+re2c build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^re2c@4.4 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^openssl@3.6.1~docs+shared build_system=generic certs=mozilla platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^ca-certificates-mozilla@2026-03-19 build_system=generic platform=darwin os=tahoe target=m1
+ -               ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^less@692 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^rapidjson@1.2.0-2024-08-16~doc~ipo build_system=cmake build_type=Release commit=7c73dd7de7c4f14379b781418c6e947ad464c818 generator=make patches:=ee123c7 platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
+ -           ^re2@2024-07-02~icu~ipo+pic+shared build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
+ -               ^abseil-cpp@20260107.1~ipo+shared build_system=cmake build_type=Release cxxstd=17 generator=make platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
+ -           ^thrift@0.22.0~c_glib+cpp~ipo~java~javascript~libevent~nodejs~openssl~python~qt5+shared~zlib build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^bison@3.8.2~color build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^flex@2.6.3+lex~nls build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^findutils@4.10.0 build_system=autotools patches:=440b954 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^utf8proc@2.10.0~ipo+shared build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^xsimd@13.2.0~ipo build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -       ^cmake@3.31.11~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^curl@8.20.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^nghttp2@1.67.1 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^ncurses@6.6~symlinks+termlib abi=none build_system=autotools patches:=7a351bc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^zlib-ng@2.3.3+compat+new_strategies+opt+pic+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -       ^compiler-wrapper@1.1.0 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^pkgconf@2.5.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^gnuconfig@2025-07-10 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-cython@3.2.4 build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -       ^py-libcst@1.8.6 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-pyyaml@6.0.3+libyaml build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^libyaml@0.2.5 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^py-setuptools-rust@1.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-semantic-version@2.10.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^rust@1.96.0~dev~docs+src build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^libgit2@1.9.1~curl~ipo+mmap+ssh build_system=cmake build_type=Release generator=make https=system platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^pcre@8.45~jit+multibyte+pic+shared+static+utf build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^libssh2@1.11.1+shared build_system=autotools crypto=openssl platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^rust-bootstrap@1.96.0 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-numpy@2.4.6 build_system=python_pip patches:=873745d platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^openblas@0.3.33~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared~static build_system=makefile patches:=723ddc1 symbol_suffix=none threads=none platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0 %fortran=gcc@16.2.0
+ -           ^py-meson-python@0.19.0 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^meson@1.11.1 build_system=python_pip patches:=0f0b1bd platform=darwin os=tahoe target=m1
+ -               ^py-pyproject-metadata@0.11.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-pip@26.1.2 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-scikit-build-core@0.12.2~pyproject build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0 %fortran=gcc@16.2.0
+[e]          ^gcc@16.2.0+binutils+bootstrap~graphite+libsanitizer~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=darwin os=tahoe target=aarch64
+ -           ^gcc-runtime@16.2.0 build_system=generic platform=darwin os=tahoe target=m1
+ -           ^py-hatch-vcs@0.5.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-hatchling@1.29.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-pluggy@1.6.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-trove-classifiers@2026.6.1.19 build_system=python_pip platform=darwin os=tahoe target=m1
+ -                   ^py-calver@2025.10.20 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-packaging@26.2 build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-flit-core@3.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-pathspec@1.1.1 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-setuptools@82.0.1 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-setuptools-scm@9.2.2+toml build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^git@2.53.0+man+nls+perl+subtree~tcltk build_system=autotools patches:=67fa971 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^autoconf@2.72 build_system=autotools platform=darwin os=tahoe target=m1
+ -               ^automake@1.18.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^diffutils@3.12 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^libiconv@1.18 build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^libidn2@2.3.8 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^libunistring@1.4.2 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^libtool@2.5.4 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^file@5.46+static build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^m4@1.4.21+sigsegv build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^libsigsegv@2.15 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^openssh@10.3p1+gssapi build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^krb5@1.22.2+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^libedit@3.1-20251016 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^libxcrypt@4.5.2~obsolete_api build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^pcre2@10.44~jit+multibyte+pic build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -       ^py-wheel@0.45.1 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^python@3.14.5+bz2+ctypes+dbm~debug~freethreading+libxml2+lzma~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~static~tests~tkinter+uuid+zlib+zstd build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+[e]          ^apple-libuuid@1353.100.2 build_system=bundle platform=darwin os=tahoe target=aarch64
+ -           ^bzip2@1.0.8~debug~pic+shared build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^expat@2.8.1~libbsd build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^gdbm@1.26 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^gettext@1.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^libxml2@2.15.3+pic~python+shared build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^tar@1.35 build_system=autotools zip=pigz platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^pigz@2.8 build_system=makefile platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^libffi@3.5.2 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^readline@8.3 build_system=autotools patches:=21f0a03,72dee13,e273643 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^sqlite@3.53.1+column_metadata+fts+rtree build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^xz@5.8.3~pic build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -       ^python-venv@1.0 build_system=generic platform=darwin os=tahoe target=m1
+

--- a/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/pydantic.log
+++ b/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/pydantic.log
@@ -1,0 +1,76 @@
+ -   py-pydantic@2.13.4~dotenv build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-annotated-types@0.7.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-hatch-fancy-pypi-readme@25.1.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-hatchling@1.29.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-packaging@26.2 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-pathspec@1.1.1 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-pluggy@1.6.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-setuptools@82.0.1 build_system=generic platform=darwin os=tahoe target=m1
+ -               ^py-setuptools-scm@9.2.2+toml build_system=python_pip platform=darwin os=tahoe target=m1
+ -                   ^git@2.53.0+man+nls+perl+subtree~tcltk build_system=autotools patches:=67fa971 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                       ^autoconf@2.72 build_system=autotools platform=darwin os=tahoe target=m1
+ -                       ^automake@1.18.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                       ^libidn2@2.3.8 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                           ^libunistring@1.4.2 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                       ^libtool@2.5.4 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                           ^file@5.46+static build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                           ^findutils@4.10.0 build_system=autotools patches:=440b954 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                       ^m4@1.4.21+sigsegv build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                           ^libsigsegv@2.15 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                       ^openssh@10.3p1+gssapi build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                           ^krb5@1.22.2+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                               ^bison@3.8.2~color build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                           ^libedit@3.1-20251016 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                           ^libxcrypt@4.5.2~obsolete_api build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                       ^pcre2@10.44~jit+multibyte+pic build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^py-trove-classifiers@2026.6.1.19 build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-calver@2025.10.20 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-pip@26.1.2 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-pydantic-core@2.46.4 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-maturin@1.13.1 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^py-setuptools-rust@1.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -                   ^py-semantic-version@2.10.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^rust@1.96.0~dev~docs+src build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^cmake@3.31.11~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^curl@8.20.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^nghttp2@1.67.1 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^libgit2@1.9.1~curl~ipo+mmap+ssh build_system=cmake build_type=Release generator=make https=system platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^pcre@8.45~jit+multibyte+pic+shared+static+utf build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^libssh2@1.11.1+shared build_system=autotools crypto=openssl platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^ninja@1.13.2+re2c build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^re2c@4.4 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^rust-bootstrap@1.96.0 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-typing-extensions@4.16.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-flit-core@3.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-typing-inspection@0.4.2 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-wheel@0.45.1 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^python@3.14.5+bz2+ctypes+dbm~debug~freethreading+libxml2+lzma~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~static~tests~tkinter+uuid+zlib+zstd build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+[e]          ^apple-clang@21.0.0 build_system=bundle platform=darwin os=tahoe target=aarch64
+[e]          ^apple-libuuid@1353.100.2 build_system=bundle platform=darwin os=tahoe target=aarch64
+ -           ^bzip2@1.0.8~debug~pic+shared build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^diffutils@3.12 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^compiler-wrapper@1.1.0 build_system=generic platform=darwin os=tahoe target=m1
+ -           ^expat@2.8.1~libbsd build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^gnuconfig@2025-07-10 build_system=generic platform=darwin os=tahoe target=m1
+ -           ^gdbm@1.26 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^gettext@1.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^libiconv@1.18 build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^libxml2@2.15.3+pic~python+shared build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^tar@1.35 build_system=autotools zip=pigz platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^pigz@2.8 build_system=makefile platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^gmake@4.4.1~guile build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^libffi@3.5.2 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^ncurses@6.6~symlinks+termlib abi=none build_system=autotools patches:=7a351bc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^openssl@3.6.1~docs+shared build_system=generic certs=mozilla platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^ca-certificates-mozilla@2026-03-19 build_system=generic platform=darwin os=tahoe target=m1
+ -               ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^less@692 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^pkgconf@2.5.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^readline@8.3 build_system=autotools patches:=21f0a03,72dee13,e273643 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^sqlite@3.53.1+column_metadata+fts+rtree build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^xz@5.8.3~pic build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^zlib-ng@2.3.3+compat+new_strategies+opt+pic+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -       ^python-venv@1.0 build_system=generic platform=darwin os=tahoe target=m1
+

--- a/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/typer.log
+++ b/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/typer.log
@@ -1,0 +1,69 @@
+ -   py-typer@0.27.2 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-annotated-doc@0.0.5 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-pdm-backend@2.4.7 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-pip@26.1.2 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-rich@15.0.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-markdown-it-py@4.0.0~linkify build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-mdurl@0.1.2 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-poetry-core@2.3.2 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^py-pygments@2.19.2 build_system=python_pip platform=darwin os=tahoe target=m1
+ -               ^py-hatchling@1.29.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -                   ^py-packaging@26.2 build_system=python_pip platform=darwin os=tahoe target=m1
+ -                   ^py-pathspec@1.1.1 build_system=python_pip platform=darwin os=tahoe target=m1
+ -                   ^py-pluggy@1.6.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -                       ^py-setuptools-scm@9.2.2+toml build_system=python_pip platform=darwin os=tahoe target=m1
+ -                           ^git@2.53.0+man+nls+perl+subtree~tcltk build_system=autotools patches:=67fa971 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                               ^autoconf@2.72 build_system=autotools platform=darwin os=tahoe target=m1
+ -                               ^automake@1.18.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                               ^curl@8.20.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                                   ^nghttp2@1.67.1 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                               ^libidn2@2.3.8 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                                   ^libunistring@1.4.2 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                               ^libtool@2.5.4 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                                   ^file@5.46+static build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                                   ^findutils@4.10.0 build_system=autotools patches:=440b954 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                               ^m4@1.4.21+sigsegv build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                                   ^libsigsegv@2.15 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                               ^openssh@10.3p1+gssapi build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                                   ^krb5@1.22.2+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                                       ^bison@3.8.2~color build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                                   ^libedit@3.1-20251016 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                                   ^libxcrypt@4.5.2~obsolete_api build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                               ^pcre2@10.44~jit+multibyte+pic build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^py-trove-classifiers@2026.6.1.19 build_system=python_pip platform=darwin os=tahoe target=m1
+ -                       ^py-calver@2025.10.20 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-shellingham@1.5.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-setuptools@82.0.1 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^py-typing-extensions@4.16.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -           ^py-flit-core@3.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
+ -       ^py-wheel@0.45.1 build_system=generic platform=darwin os=tahoe target=m1
+ -       ^python@3.14.5+bz2+ctypes+dbm~debug~freethreading+libxml2+lzma~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~static~tests~tkinter+uuid+zlib+zstd build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+[e]          ^apple-clang@21.0.0 build_system=bundle platform=darwin os=tahoe target=aarch64
+[e]          ^apple-libuuid@1353.100.2 build_system=bundle platform=darwin os=tahoe target=aarch64
+ -           ^bzip2@1.0.8~debug~pic+shared build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^diffutils@3.12 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^compiler-wrapper@1.1.0 build_system=generic platform=darwin os=tahoe target=m1
+ -           ^expat@2.8.1~libbsd build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^gnuconfig@2025-07-10 build_system=generic platform=darwin os=tahoe target=m1
+ -           ^gdbm@1.26 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^gettext@1.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^libiconv@1.18 build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^libxml2@2.15.3+pic~python+shared build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -               ^tar@1.35 build_system=autotools zip=pigz platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^pigz@2.8 build_system=makefile platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^gmake@4.4.1~guile build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^libffi@3.5.2 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^ncurses@6.6~symlinks+termlib abi=none build_system=autotools patches:=7a351bc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^openssl@3.6.1~docs+shared build_system=generic certs=mozilla platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -               ^ca-certificates-mozilla@2026-03-19 build_system=generic platform=darwin os=tahoe target=m1
+ -               ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -                   ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -                   ^less@692 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^pkgconf@2.5.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^readline@8.3 build_system=autotools patches:=21f0a03,72dee13,e273643 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^sqlite@3.53.1+column_metadata+fts+rtree build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^xz@5.8.3~pic build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
+ -           ^zlib-ng@2.3.3+compat+new_strategies+opt+pic+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -           ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -       ^python-venv@1.0 build_system=generic platform=darwin os=tahoe target=m1
+

--- a/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/voiage.log
+++ b/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-logs/voiage.log
@@ -1,0 +1,199 @@
+==> Error: failed to concretize `py-voiage@2.2.0` for the following reasons:
+     1. Cannot satisfy 'rust@nightly-2026-04-01'
+     2. Cannot satisfy 'rust@nightly-2026-04-01' (version 1.96.0 does not match)
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     3. Cannot satisfy 'rust@1.88:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.88: when @1.12.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     4. Cannot satisfy 'rust@1.83:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.83: when @1.10.2: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     5. Cannot satisfy 'rust@1.74:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.74: when @1.7.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     6. Cannot satisfy 'rust@1.70:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.70: when @1.5.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     7. Cannot satisfy 'rust@1.67:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.67: when @1.4.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     8. Cannot satisfy 'rust@1.64:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.64: when @0.15.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     9. Cannot satisfy 'rust@1.62:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.62: when @0.14.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+    10. Cannot satisfy 'rust@1.59:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.59: when @0.13.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 

--- a/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-receipt.json
+++ b/packaging/spack-overlay/history/pre-dated-rust-69873911/solver-receipt.json
@@ -1,9 +1,9 @@
 {
   "schema": "voiage.spack-overlay-solver.v1",
-  "recorded_at": "2026-08-31T15:39:23.487595+00:00",
+  "recorded_at": "2026-08-31T15:05:35.116206+00:00",
   "catalogue_commit": "d4f7c711a6a42f1c4d551c8fd10fce9a11340a81",
   "host": "macOS arm64",
-  "manifest_sha256": "300ad4cc5aa3294be9897f1ca50c38bbe8aa51b1d2f18d4e44ae10f85054498a",
+  "manifest_sha256": "a11f5b085e98324ffd380937ffa3bae62a2915ce3135f43fefab492379f584fb",
   "results": [
     {
       "spec": "py-typer@0.27.2",
@@ -28,26 +28,14 @@
     },
     {
       "spec": "py-voiage@2.2.0",
-      "exit_code": 0,
-      "status": "concretized",
+      "exit_code": 1,
+      "status": "failed",
       "log_path": "solver-logs/voiage.log",
-      "log_sha256": "b9a4fc227e6b61818adbeaab4fa424d11534162494920e32329eb07b8148e16f"
+      "log_sha256": "8896ae9098869b530c6670fa693f0412396e5242bbb598095e66bc37b8e69dd9",
+      "reason": "The catalogue has no rust@nightly-2026-04-01; its exact dated constraint also conflicts with numeric stable-Rust requirements in the unified build graph."
     }
   ],
   "builds_executed": false,
   "module_load_executed": false,
-  "spack_version": "1.2.2",
-  "prior_failure_evidence": "history/pre-dated-rust-69873911/solver-receipt.json",
-  "concrete_dag": {
-    "path": "solver-logs/voiage.json",
-    "sha256": "08b3516df1c77b174bb4251290575aa9bdd47522509210f96d3efabdf5ca5b02",
-    "nodes": 139,
-    "duplicated_build_tools": {
-      "py-maturin": 2,
-      "py-setuptools-rust": 2,
-      "rust": 2,
-      "rust-bootstrap": 2
-    },
-    "runtime_compiler_edges": "Polars dated and Pydantic Core stable Rust are build-only; backend run edges preserved."
-  }
+  "spack_version": "1.2.2"
 }

--- a/packaging/spack-overlay/manifest.json
+++ b/packaging/spack-overlay/manifest.json
@@ -18,7 +18,7 @@
     "packages/py-typer/package.py": "e13b10d527710d0ca77b12cc910f6db703f63a35cf18ea79e2be1eb51fc44d11",
     "packages/py-typing-extensions/package.py": "bc339c7bbb0f4eb478484269204bbccf4d755d03565ddb397552ed7006a1ed30",
     "packages/py-voiage/package.py": "8f7e7f3b05d857943f9191dada49d91cdafa244aaa3d6d559088e0100489abf7",
-    "packages/rust/package.py": "9168b5c867d937cf558512f179b4deaa4d78a285dae8f19874cdb626cb77dd82",
+    "packages/rust/package.py": "c6379f7a29de431875d7adc2a94661e56fa69b96f3dfb791cbea085d05558fdc",
     "packages/rust-bootstrap/package.py": "9fa3514b619fcb45b0a4fc4107493e16397c336a13018ac9a08b79999a4ed02b"
   },
   "native_builds_executed": false,

--- a/packaging/spack-overlay/packages/py-maturin/package.py
+++ b/packaging/spack-overlay/packages/py-maturin/package.py
@@ -1,0 +1,101 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import default_args, depends_on, license, maintainers, version
+
+
+class PyMaturin(PythonPackage):
+    """Build and publish crates with pyo3, rust-cpython and cffi bindings
+    as well as rust binaries as python packages.
+    """
+
+    tags = ["build-tools"]
+
+    homepage = "https://github.com/pyo3/maturin"
+    pypi = "maturin/maturin-0.13.7.tar.gz"
+
+    maintainers("teaguesterling")
+
+    license("Apache-2.0 OR MIT")
+
+    version(
+        "1.13.1",
+        sha256="9a87ff3b8e4d1c6eac33ebfe8e261e8236516d98d45c0323550621819b5a1a2f",
+    )
+    version(
+        "1.10.2",
+        sha256="259292563da89850bf8f7d37aa4ddba22905214c1e180b1c8f55505dfd8c0e81",
+    )
+    version(
+        "1.9.6",
+        sha256="2c2ae37144811d365509889ed7220b0598487f1278c2441829c3abf56cc6324a",
+    )
+    version(
+        "1.9.1",
+        sha256="97b52fb19d20c1fdc70e4efdc05d79853a4c9c0051030c93a793cd5181dc4ccd",
+    )
+    version(
+        "1.8.3",
+        sha256="304762f86fd53a8031b1bf006d12572a2aa0a5235485031113195cc0152e1e12",
+    )
+    version(
+        "1.8.2",
+        sha256="e31abc70f6f93285d6e63d2f4459c079c94c259dd757370482d2d4ceb9ec1fa0",
+    )
+    version(
+        "1.6.0",
+        sha256="b955025c24c8babc808db49e0ff90db8b4b1320dcc16b14eb26132841737230d",
+    )
+    version(
+        "1.5.1",
+        sha256="3dd834ece80edb866af18cbd4635e0ecac40139c726428d5f1849ae154b26dca",
+    )
+    version(
+        "1.4.0",
+        sha256="ed12e1768094a7adeafc3a74ebdb8dc2201fa64c4e7e31f14cfc70378bf93790",
+    )
+    version(
+        "1.1.0",
+        sha256="4650aeaa8debd004b55aae7afb75248cbd4d61cd7da2dcf4ead8b22b58cecae0",
+    )
+    version(
+        "0.14.17",
+        sha256="fb4e3311e8ce707843235fbe8748a05a3ae166c3efd6d2aa335b53dfc2bd3b88",
+    )
+    version(
+        "0.13.7",
+        sha256="c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77",
+    )
+
+    with default_args(type="build"):
+        depends_on("py-setuptools@77:", when="@1.9.6:")
+        depends_on("py-setuptools")
+        depends_on("py-setuptools-rust@1.11:", when="@1.8.6:")
+        depends_on("py-setuptools-rust@1.4:")
+
+        depends_on("py-wheel@0.36.2:", when="@:1.8.3")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-tomli@1.1:", when="^python@:3.10")
+        # from Cargo.toml
+        for rust, maturin in [
+            ("1.88", "1.12.0"),
+            ("1.83", "1.10.2"),
+            ("1.74", "1.7.0"),
+            ("1.70", "1.5.0"),
+            ("1.67", "1.4.0"),
+            ("1.64", "0.15.0"),
+            ("1.62", "0.14.3"),
+            ("1.59", "0.13.3"),
+        ]:
+            depends_on(f"rust@{rust}:", when=f"@{maturin}:")
+
+    # May be an accidental dependency, remove in the future
+    # https://git.alpinelinux.org/aports/commit/?id=7ad298b467403b96a6b97d050170e367f147a75f
+    # https://patchwork.yoctoproject.org/project/oe-core/patch/8803dc101b641c948805cab9e5784c38f43b0e51.1702791173.git.tim.orling@konsulko.com/
+    # This seems to still be an issue for others
+    depends_on("bzip2")
+    depends_on("c", type="build")

--- a/packaging/spack-overlay/packages/py-polars-runtime-32/package.py
+++ b/packaging/spack-overlay/packages/py-polars-runtime-32/package.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from spack_repo.builtin.build_systems.python import PythonPackage
-from spack.package import depends_on, license, version
+from spack.package import EnvironmentModifications, depends_on, license, version
 
 
 class PyPolarsRuntime32(PythonPackage):
@@ -9,9 +9,17 @@ class PyPolarsRuntime32(PythonPackage):
     homepage = "https://pola.rs"
     pypi = "polars-runtime-32/polars_runtime_32-1.42.1.tar.gz"
     license("MIT")
-    version("1.42.1", sha256="4d4809e1c1b9a6611f6944f27b24abea902b5159e6b6fa262fd716e947af5afd")
+    version(
+        "1.42.1",
+        sha256="4d4809e1c1b9a6611f6944f27b24abea902b5159e6b6fa262fd716e947af5afd",
+    )
     depends_on("python@3.10:", type=("build", "run"))
     depends_on("py-maturin@1.3.2:", type="build")
     # Source rust-toolchain.toml: no unversioned nightly or stable substitution.
     depends_on("rust@nightly-2026-04-01", type="build")
     import_modules = ["_polars_runtime_32"]
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # Bind the direct dated toolchain, not a stable compiler from another backend.
+        env.set("RUSTC", str(self.spec["rust"].prefix.bin.rustc))
+        env.set("CARGO", str(self.spec["rust"].prefix.bin.cargo))

--- a/packaging/spack-overlay/packages/py-pydantic-core/package.py
+++ b/packaging/spack-overlay/packages/py-pydantic-core/package.py
@@ -23,7 +23,7 @@ class PyPydanticCore(PythonPackage):
     version("2.23.2", sha256="95d6bf449a1ac81de562d65d180af5d8c19672793c81877a2eda8fde5d08f2fd")
     version("2.18.4", sha256="ec3beeada09ff865c344ff3bc2f427f5e6c26401cc6113d77e372c3fdac73864")
 
-    depends_on("rust@1.88:", type="build", when="@2.46.4:")
+    depends_on("rust@1.88:1", type="build", when="@2.46.4:")
     depends_on("py-maturin@1.10:1", type="build", when="@2.46.4:")
 
     with default_args(type="build"):

--- a/packaging/spack-overlay/packages/py-setuptools-rust/package.py
+++ b/packaging/spack-overlay/packages/py-setuptools-rust/package.py
@@ -1,0 +1,83 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import Version, depends_on, license, version
+
+
+class PySetuptoolsRust(PythonPackage):
+    """Setuptools rust extension plugin."""
+
+    tags = ["build-tools"]
+
+    homepage = "https://github.com/PyO3/setuptools-rust"
+    pypi = "setuptools-rust/setuptools_rust-1.11.1.tar.gz"
+
+    license("MIT")
+
+    version(
+        "1.12.0",
+        sha256="d94a93f0c97751c17014565f07bdc324bee45d396cd1bba83d8e7af92b945f0c",
+    )
+    version(
+        "1.11.1",
+        sha256="7dabc4392252ced314b8050d63276e05fdc5d32398fc7d3cce1f6a6ac35b76c0",
+    )
+    version(
+        "1.9.0",
+        sha256="704df0948f2e4cc60c2596ad6e840ea679f4f43e58ed4ad0c1857807240eab96",
+    )
+    version(
+        "1.8.1",
+        sha256="94b1dd5d5308b3138d5b933c3a2b55e6d6927d1a22632e509fcea9ddd0f7e486",
+    )
+    version(
+        "1.7.0",
+        sha256="c7100999948235a38ae7e555fe199aa66c253dc384b125f5d85473bf81eae3a3",
+    )
+    version(
+        "1.6.0",
+        sha256="c86e734deac330597998bfbc08da45187e6b27837e23bd91eadb320732392262",
+    )
+    version(
+        "1.5.1",
+        sha256="0e05e456645d59429cb1021370aede73c0760e9360bbfdaaefb5bced530eb9d7",
+    )
+    version(
+        "1.4.1",
+        sha256="18ff850831f58ee21d5783825c99fad632da21e47645e9427fd7dec048029e76",
+    )
+    version(
+        "1.2.0",
+        sha256="0a4ada479e8c7e3d8bd7cb56e1a29acc2b2bb98c2325051b0cdcb57d7f056de8",
+    )
+    version(
+        "0.12.1",
+        sha256="647009e924f0ae439c7f3e0141a184a69ad247ecb9044c511dabde232d3d570e",
+    )
+
+    depends_on("py-setuptools@62.4:", when="@1.4.0:", type=("build", "run"))
+    depends_on("py-setuptools@46.1:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-setuptools-scm", when="@1.7.0:", type="build")
+    depends_on("py-semantic-version@2.8.2:2", when="@1.2.0:", type=("build", "run"))
+    depends_on("py-semantic-version@2.6.0:", type=("build", "run"))
+    depends_on("rust", type="run")
+
+    # Historical dependencies
+    depends_on(
+        "py-typing-extensions@3.7.4.3:", when="@1.2.0:1.7.0", type=("build", "run")
+    )
+    depends_on("py-setuptools-scm+toml@6.3.2:", when="@1.2.0:1.4.1", type="build")
+    depends_on("py-setuptools-scm+toml@3.4.3:", when="@:1.1", type="build")
+    depends_on("py-tomli@1.2.1:", when="@:1.9 ^python@:3.10", type=("build", "run"))
+    depends_on("py-toml@0.9.0:", type=("build", "run"), when="@0.12.1")
+
+    def url_for_version(self, version):
+        if version >= Version("1.10.0"):
+            name = "setuptools_rust"
+        else:
+            name = "setuptools-rust"
+        return f"https://files.pythonhosted.org/packages/source/s/setuptools-rust/{name}-{version}.tar.gz"

--- a/packaging/spack-overlay/packages/rust-bootstrap/package.py
+++ b/packaging/spack-overlay/packages/rust-bootstrap/package.py
@@ -1,0 +1,265 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import platform
+import re
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import (
+    Executable,
+    Version,
+    depends_on,
+    find,
+    license,
+    maintainers,
+    run_before,
+    version,
+)
+
+
+class RustBootstrap(Package):
+    """Binary bootstrap Rust compiler."""
+
+    tags = ["build-tools"]
+
+    homepage = "https://www.rust-lang.org"
+    url = "https://static.rust-lang.org/dist/rust-1.65.0-aarch64-apple-darwin.tar.gz"
+
+    maintainers("alecbcs")
+    license("Apache-2.0 OR MIT")
+
+    skip_version_audit = ["platform=windows"]
+
+    # List binary rust releases for multiple operating systems and architectures.
+    # These binary versions are not intended to stay up-to-date. Instead we
+    # should update these binary releases as bootstrapping requirements are
+    # modified by new releases of Rust.
+    rust_releases = {
+        "beta-2026-03-05": {
+            "darwin": {
+                "x86_64": "6f9025bdce1af6874e0b442a7903074621a037d23dc77e79f9b75fba653115a9",
+                "aarch64": "c665bde9d7e1c6ad3edac04b794e5ce2b8480b28b49ca3d8f4e3a494e1c0d056",
+            },
+            "linux": {
+                "x86_64": "6ac3648729b590296c433607fe7d7f6cf7aff3ed459b4dd64188164beb528961",
+                "aarch64": "3f995e93b1fbde48b3fe07c71ea8d77ee1e90367d8158f9f49390d4bc3dbd3fc",
+            },
+        },
+        "1.96.0": {
+            "darwin": {
+                "x86_64": "63a6d717a5e5392ac43f0a1593e7aabe6128c8685d318cb890603b1688cb3339",
+                "aarch64": "f04a974f3579d3524f6b9bc6490a27c9fb358050e7cd8a641945f30bf24c1dce",
+            },
+            "linux": {
+                "x86_64": "c295047583a56238ea06b43f849f4b877fa12bfd4c7103f8d9a74c94c9c4e108",
+                "aarch64": "371eadcca97062219cbd8593628eb5d2802bc370515d085fedce1b56b2baed57",
+                "powerpc64le": "fea8e9155c69740415f1c96fa8879e61b16238e26cfee62d15f4f93aa83cb8d5",
+            },
+        },
+        "1.92.0": {
+            "darwin": {
+                "x86_64": "fc6868991e61e9262272effbb8956b23428430f5f4300c1b48eaae3969f8af2a",
+                "aarch64": "235a6cca2dd4881130a9ae61ad1149bbf28bba184dd4621700f0c98c97457716",
+            },
+            "linux": {
+                "x86_64": "6e5efd6c25953b2732d4e6b1842512536650c68cf72a8b99a0fc566012dd6ca5",
+                "aarch64": "c812028423c3d7dd7ba99f66101e9e1aa3f66eab44a1285f41c363825d49dca4",
+                "powerpc64le": "e2fe00a3c91f21c52947ebf96b4da016c9def5ccfedd1c335f30746db58bbf35",
+            },
+        },
+        "1.86.0": {
+            "darwin": {
+                "x86_64": "bf8121850b2f6a46566f6c2bbe9fa889b915b1039febf36853ea9d9c4256c67d",
+                "aarch64": "01271f83549c3b5191334a566289aa41615ea8f8f530f49548733585f21c7e5a",
+            },
+            "linux": {
+                "x86_64": "f6a8c0d8b8a8a737c40eee78abe286a3cbe984d96b63de9ae83443360e3264bf",
+                "aarch64": "460058cd78f06875721427a42a5ce6a8b8ef2c0c3225fccfae149d9345572ff4",
+                "powerpc64le": "9b104428e2b0377dbdb9dc094eb4d9f4893ada0b80d2b315f0c4ea2135ed9007",
+            },
+        },
+        "1.85.0": {
+            "darwin": {
+                "x86_64": "69a36d239e38cc08c6366d1d85071847406645346c6f2d2e0dfaf64b58050d3d",
+                "aarch64": "3ff45cefaf9a002069902acf3a6332113b76b530bb31803fe5cfd30f7ef8ba03",
+            },
+            "linux": {
+                "x86_64": "be4ba7b777100c851ab268e95f70f405d28d7813ba60a9bdcf4e88c88acf8602",
+                "aarch64": "0306c30bee00469fbec4b07bb04ea0308c096454354c3dc96a92b729f1c2acd1",
+                "powerpc64le": "d0761bf0e1786a46dddfe60cc9397b899f680b86e6aebd7ca16b2a70a9dd631b",
+            },
+        },
+        "1.82.0": {
+            "darwin": {
+                "x86_64": "b1a289cabc523f259f65116a41374ac159d72fbbf6c373bd5e545c8e835ceb6a",
+                "aarch64": "49b6d36b308addcfd21ae56c94957688338ba7b8985bff57fc626c8e1b32f62c",
+            },
+            "linux": {
+                "x86_64": "0265c08ae997c4de965048a244605fb1f24a600bbe35047b811c638b8fcf676b",
+                "aarch64": "d7db04fce65b5f73282941f3f1df5893be9810af17eb7c65b2e614461fe31a48",
+                "powerpc64le": "44f3a1e70be33f91927ae8d89a11843a79b8b6124d62a9ddd9030a5275ebc923",
+            },
+        },
+        "1.81.0": {
+            "darwin": {
+                "x86_64": "f74d8ad24cc3cbfb825da98a08d98319565e4d18ec2c3e9503bf0a33c81ba767",
+                "aarch64": "60a41dea4ae0f4006325745a6400e6fdc3e08ad3f924fac06f04c238cf23f4ec",
+            },
+            "linux": {
+                "x86_64": "4ca7c24e573dae2f382d8d266babfddc307155e1a0a4025f3bc11db58a6cab3e",
+                "aarch64": "ef4da9c1ecd56bbbb36f42793524cce3062e6a823ae22cb679a945c075c7755b",
+                "powerpc64le": "bf98b27de08a2fd5a2202a2b621b02bfde2a6fde397df2a735d018aeffcdc5e2",
+            },
+        },
+        "1.78.0": {
+            "darwin": {
+                "x86_64": "6c91ed3bd90253961fcb4a2991b8b22e042e2aaa9aba9f389f1e17008171d898",
+                "aarch64": "3be74c31ee8dc4f1d49e2f2888228de374138eaeca1876d0c1b1a61df6023b3b",
+            },
+            "linux": {
+                "x86_64": "1307747915e8bd925f4d5396ab2ae3d8d9c7fad564afbc358c081683d0f22e87",
+                "aarch64": "131eda738cd977fff2c912e5838e8e9b9c260ecddc1247c0fe5473bf09c594af",
+                "powerpc64le": "c5aedb12c552daa18072e386697205fb7b91cef1e8791fe6fb74834723851388",
+            },
+        },
+        "1.76.0": {
+            "darwin": {
+                "x86_64": "7bdbe085695df8e46389115e99eda7beed37a9494f6b961b45554c658e53b8e7",
+                "aarch64": "17496f15c3cb6ff73d5c36f5b54cc110f1ac31fa09521a7991c0d7ddd890dceb",
+            },
+            "linux": {
+                "x86_64": "9d589d2036b503cc45ecc94992d616fb3deec074deb36cacc2f5c212408f7399",
+                "aarch64": "2e8313421e8fb673efdf356cdfdd4bc16516f2610d4f6faa01327983104c05a0",
+                "powerpc64le": "44b3494675284d26b04747a824dc974e32fd8fd46fc0aa06a7c8ebe851332d2c",
+            },
+        },
+        "1.75.0": {
+            "darwin": {
+                "x86_64": "ad066e4dec7ae5948c4e7afe68e250c336a5ab3d655570bb119b3eba9cf22851",
+                "aarch64": "878ecf81e059507dd2ab256f59629a4fb00171035d2a2f5638cb582d999373b1",
+            },
+            "linux": {
+                "x86_64": "473978b6f8ff216389f9e89315211c6b683cf95a966196e7914b46e8cf0d74f6",
+                "aarch64": "30828cd904fcfb47f1ac43627c7033c903889ea4aca538f53dcafbb3744a9a73",
+                "powerpc64le": "2599cdfea5860b4efbceb7bca69845a96ac1c96aa50cf8261151e82280b397a0",
+            },
+        },
+        "1.73.0": {
+            "darwin": {
+                "x86_64": "ece9646bb153d4bc0f7f1443989de0cbcd8989a7d0bf3b7fb9956e1223954f0c",
+                "aarch64": "9c96e4c57328fb438ee2d87aa75970ce89b4426b49780ccb3c16af0d7c617cc6",
+            },
+            "linux": {
+                "x86_64": "aa4cf0b7e66a9f5b7c623d4b340bb1ac2864a5f2c2b981f39f796245dc84f2cb",
+                "aarch64": "e54d7d886ba413ae573151f668e76ea537f9a44406d3d29598269a4a536d12f6",
+                "powerpc64le": "8fa215ee3e274fb64364e7084613bc570369488fa22cf5bc8e0fe6dc810fe2b9",
+            },
+        },
+        "1.70.0": {
+            "darwin": {
+                "x86_64": "e5819fdbfc7f1a4d5d82cb4c3b7662250748450b45a585433bfb75648bc45547",
+                "aarch64": "75cbc356a06c9b2daf6b9249febda0f0c46df2a427f7cc8467c7edbd44636e53",
+            },
+            "linux": {
+                "x86_64": "8499c0b034dd881cd9a880c44021632422a28dc23d7a81ca0a97b04652245982",
+                "aarch64": "3aa012fc4d9d5f17ca30af41f87e1c2aacdac46b51adc5213e7614797c6fd24c",
+                "powerpc64le": "ba8cb5e3078b1bc7c6b27ab53cfa3af14001728db9a047d0bdf29b8f05a4db34",
+            },
+        },
+        "1.65.0": {
+            "darwin": {
+                "x86_64": "139087a3937799415fd829e5a88162a69a32c23725a44457f9c96b98e4d64a7c",
+                "aarch64": "7ddc335bd10fc32d3039ef36248a5d0c4865db2437c8aad20a2428a6cf41df09",
+            },
+            "linux": {
+                "x86_64": "8f754fdd5af783fe9020978c64e414cb45f3ad0a6f44d045219bbf2210ca3cb9",
+                "aarch64": "f406136010e6a1cdce3fb6573506f00d23858af49dd20a46723c3fa5257b7796",
+                "powerpc64le": "3f1d0d5bb13213348dc65e373f8c412fc0a12ee55abc1c864f7e0300932fc687",
+            },
+        },
+        "1.60.0": {
+            "darwin": {
+                "x86_64": "0b10dc45cddc4d2355e38cac86d71a504327cb41d41d702d4050b9847ad4258c",
+                "aarch64": "b532672c278c25683ca63d78e82bae829eea1a32308e844954fb66cfe34ad222",
+            },
+            "linux": {
+                "x86_64": "b8a4c3959367d053825e31f90a5eb86418eb0d80cacda52bfa80b078e18150d5",
+                "aarch64": "99c419c2f35d4324446481c39402c7baecd7a8baed7edca9f8d6bbd33c05550c",
+                "powerpc64le": "80125e90285b214c2b1f56ab86a09c8509aa17aec9d7127960a86a7008e8f7de",
+            },
+        },
+    }
+
+    # Normalize architectures returned by platform to those used by the
+    # Rust project.
+    rust_targets = {
+        "aarch64": "aarch64",
+        "amd64": "x86_64",
+        "arm64": "aarch64",
+        "powerpc64le": "powerpc64le",
+        "ppc64le": "powerpc64le",
+        "x86_64": "x86_64",
+    }
+
+    # Convert operating system names into the format used for Rust
+    # download server.
+    rust_os = {"darwin": "apple-darwin", "linux": "unknown-linux-gnu"}
+
+    # Determine system os and architecture/target.
+    os = platform.system().lower()
+    target = rust_targets.get(platform.machine().lower(), platform.machine().lower())
+
+    # Pre-release versions of the bootstrap compiler.
+    # Note: These versions are unchecksumed since they will change
+    # periodically as new versions are released.
+    version("nightly")
+
+    # Stable releases of the bootstrap compiler.
+    # Construct releases for current system configuration.
+    for release in rust_releases:
+        if os in rust_releases[release] and target in rust_releases[release][os]:
+            version(release, sha256=rust_releases[release][os][target])
+
+    # rust-ldd and libLLVM both depend on zlib, which is not vendored.
+    depends_on("zlib-api")
+    depends_on("zlib-ng +shared", when="^[virtuals=zlib-api] zlib-ng")
+    depends_on("zlib +shared", when="^[virtuals=zlib-api] zlib")
+    depends_on("patchelf@0.13:", when="platform=linux", type="build")
+
+    def url_for_version(self, version):
+        if self.os not in ("linux", "darwin"):
+            return None
+
+        if str(version) == "beta-2026-03-05":
+            triple = f"{self.target}-{self.rust_os[self.os]}"
+            return f"https://static.rust-lang.org/dist/2026-03-05/rust-beta-{triple}.tar.xz"
+
+        # Allow maintainers to checksum multiple architectures via
+        # `spack checksum rust-bootstrap@1.70.0-darwin-aarch64`.
+        match = re.search(r"(\S+)-(\S+)-(\S+)", str(version))
+        if match:
+            version = Version(match.group(1))
+            os = self.rust_os[match.group(2)]
+            target = self.rust_targets[match.group(3)]
+        else:
+            os = self.rust_os[self.os]
+            target = self.target
+
+        ext = "gz" if version <= Version("1.92.0") else "xz"
+        url = "https://static.rust-lang.org/dist/rust-{0}-{1}-{2}.tar.{3}"
+        return url.format(version, target, os, ext)
+
+    @run_before("install", when="platform=linux")
+    def fixup_rpaths(self):
+        # set rpaths of libLLVM.so and rust-ldd to zlib's lib directory
+        rpaths = self.spec["zlib-api"].libs.directories
+
+        for binary in find(self.stage.source_path, ["libLLVM.so.*", "rust-lld"]):
+            patchelf = Executable("patchelf")
+            patchelf("--add-rpath", ":".join(rpaths), binary)
+
+    def install(self, spec, prefix):
+        install_script = Executable("./install.sh")
+        install_args = [f"--prefix={prefix}", "--without=rust-docs"]
+        install_script(*install_args)

--- a/packaging/spack-overlay/packages/rust/package.py
+++ b/packaging/spack-overlay/packages/rust/package.py
@@ -1,0 +1,336 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import re
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import (
+    EnvironmentModifications,
+    Executable,
+    ProcessError,
+    Spec,
+    Version,
+    conflicts,
+    depends_on,
+    join_path,
+    license,
+    maintainers,
+    variant,
+    version,
+    which,
+)
+
+
+class Rust(Package):
+    """The Rust programming language toolchain."""
+
+    homepage = "https://www.rust-lang.org"
+    url = "https://static.rust-lang.org/dist/rustc-1.42.0-src.tar.gz"
+    git = "https://github.com/rust-lang/rust.git"
+
+    tags = ["build-tools"]
+
+    maintainers("alecbcs")
+
+    license("Apache-2.0 OR MIT")
+
+    # When adding a version of Rust you may need to add an additional version
+    # to rust-bootstrap as the minimum bootstrapping requirements increase.
+    # As a general rule of thumb Rust can be built with either the previous major
+    # version or the current version of the compiler as shown above.
+    #
+    # Pre-release versions.
+    # Historical floating versions remain upstream metadata. The dated candidate
+    # below uses a verified checksum; do not disable checksum verification.
+    version("master", branch="master", submodules=True)
+    version("nightly")
+    version(
+        "nightly-2026-04-01",
+        sha256="9de9d7a01a3bd2ec3581fec866453061036914f6df153d0b25d5fdc54a28f035",
+    )
+
+    # Stable versions.
+    version(
+        "1.96.0",
+        sha256="b99ce16cdf0ecfc761b585ac84d131b46733465a02f8ecd0ff2de9713c62ee09",
+    )
+    version(
+        "1.92.0",
+        sha256="9e0d2ca75c7e275fdc758255bf4b03afb3d65d1543602746907c933b6901c3b8",
+    )
+    version(
+        "1.86.0",
+        sha256="022a27286df67900a044d227d9db69d4732ec3d833e4ffc259c4425ed71eed80",
+    )
+    version(
+        "1.85.0",
+        sha256="2f4f3142ffb7c8402139cfa0796e24baaac8b9fd3f96b2deec3b94b4045c6a8a",
+    )
+    version(
+        "1.83.0",
+        sha256="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e",
+    )
+    version(
+        "1.81.0",
+        sha256="872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7",
+    )
+    version(
+        "1.78.0",
+        sha256="ff544823a5cb27f2738128577f1e7e00ee8f4c83f2a348781ae4fc355e91d5a9",
+    )
+    version(
+        "1.76.0",
+        sha256="9e5cff033a7f0d2266818982ad90e4d3e4ef8f8ee1715776c6e25073a136c021",
+    )
+    version(
+        "1.75.0",
+        sha256="5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088",
+    )
+    version(
+        "1.74.0",
+        sha256="882b584bc321c5dcfe77cdaa69f277906b936255ef7808fcd5c7492925cf1049",
+    )
+    version(
+        "1.73.0",
+        sha256="96d62e6d1f2d21df7ac8acb3b9882411f9e7c7036173f7f2ede9e1f1f6b1bb3a",
+    )
+    version(
+        "1.70.0",
+        sha256="b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c",
+    )
+    version(
+        "1.65.0",
+        sha256="5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038",
+    )
+    version(
+        "1.60.0",
+        sha256="20ca826d1cf674daf8e22c4f8c4b9743af07973211c839b85839742314c838b7",
+    )
+
+    variant(
+        "dev",
+        default=False,
+        description="Include rust developer tools like rustfmt, clippy, and rust-analyzer.",
+    )
+    variant("docs", default=False, description="Build Rust core documentation.")
+    variant("src", default=True, description="Include standard library source files.")
+
+    # Core dependencies
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("curl+nghttp2")
+    depends_on("libgit2")
+    depends_on("libssh2")
+    depends_on("ninja", type="build")
+    depends_on("openssl")
+    depends_on("pkgconfig", type="build")
+    depends_on("python", type="build")
+    depends_on("zlib-api")
+
+    # cmake dependency comes from LLVM. Rust has their own fork of LLVM, with tags corresponding
+    # to each Rust release, so it's easy to loop through tags and grep for "cmake_minimum_required"
+    depends_on("cmake@3.4.3:", type="build", when="@:1.51")
+    depends_on("cmake@3.13.4:", type="build", when="@1.52:1.72")
+    depends_on("cmake@3.20.0:", type="build", when="@1.73:")
+
+    # Compiling Rust requires a previous version of Rust.
+    # The easiest way to bootstrap a Rust environment is to
+    # download the binary distribution of the compiler and build with that.
+
+    # Pre-release version dependencies
+    depends_on("rust-bootstrap@nightly", type="build", when="@master")
+    depends_on("rust-bootstrap@nightly", type="build", when="@=nightly")
+    depends_on(
+        "rust-bootstrap@=beta-2026-03-05", type="build", when="@=nightly-2026-04-01"
+    )
+    depends_on("cmake@3.20:", type="build", when="@=nightly-2026-04-01")
+
+    # Stable version dependencies
+    depends_on("rust-bootstrap@1.95:1.96", type="build", when="@1.96")
+    depends_on("rust-bootstrap@1.91:1.92", type="build", when="@1.92")
+    depends_on("rust-bootstrap@1.85:1.86", type="build", when="@1.86")
+    depends_on("rust-bootstrap@1.84:1.85", type="build", when="@1.85")
+    depends_on("rust-bootstrap@1.82:1.83", type="build", when="@1.83")
+    depends_on("rust-bootstrap@1.80:1.81", type="build", when="@1.81")
+    depends_on("rust-bootstrap@1.77:1.78", type="build", when="@1.78")
+    depends_on("rust-bootstrap@1.75:1.76", type="build", when="@1.76")
+    depends_on("rust-bootstrap@1.74:1.75", type="build", when="@1.75")
+    depends_on("rust-bootstrap@1.73:1.74", type="build", when="@1.74")
+    depends_on("rust-bootstrap@1.72:1.73", type="build", when="@1.73")
+    depends_on("rust-bootstrap@1.69:1.70", type="build", when="@1.70")
+    depends_on("rust-bootstrap@1.64:1.65", type="build", when="@1.65")
+    depends_on("rust-bootstrap@1.59:1.60", type="build", when="@1.60")
+
+    # src/llvm-project/llvm/cmake/modules/CheckCompilerVersion.cmake
+    conflicts("%gcc@:7.3", when="@1.73:", msg="Host GCC version must be at least 7.4")
+    # https://github.com/rust-lang/llvm-project/commit/4d039a7a71899038b3bc6ed6fe5a8a48d915caa0
+    conflicts("%gcc@13:", when="@:1.63", msg="Rust<1.64 not compatible with GCC>=13")
+    conflicts("%intel", msg="Rust not compatible with Intel Classic compilers")
+    conflicts("%oneapi", msg="Rust not compatible with Intel oneAPI compilers")
+
+    extendable = True
+    executables = [r"^rustc(-[\d.]*)?$", r"^cargo(-[\d.]*)?$"]
+
+    phases = ["configure", "build", "install"]
+
+    def url_for_version(self, version):
+        if str(version) == "nightly-2026-04-01":
+            return (
+                "https://static.rust-lang.org/dist/2026-04-01/rustc-nightly-src.tar.xz"
+            )
+        ext = "gz" if version <= Version("1.92.0") else "xz"
+        return f"https://static.rust-lang.org/dist/rustc-{version}-src.tar.{ext}"
+
+    @classmethod
+    def determine_version(csl, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.match(r"(rustc|cargo) (\S+)", output)
+        return match.group(2) if match else None
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        rustc_candidates = [x for x in exes if "rustc" in os.path.basename(x)]
+        cargo_candidates = [x for x in exes if "cargo" in os.path.basename(x)]
+        extra_attributes = {}
+        if rustc_candidates:
+            extra_attributes.setdefault("compilers", {})["rust"] = rustc_candidates[0]
+
+        if cargo_candidates:
+            extra_attributes["cargo"] = cargo_candidates[0]
+
+        return "", extra_attributes
+
+    @classmethod
+    def validate_detected_spec(cls, spec, extra_attributes):
+        if "cargo" not in extra_attributes:
+            raise RuntimeError(f"discarding {spec} since 'cargo' is missing")
+
+        if not extra_attributes.get("compilers", {}).get("rust"):
+            raise RuntimeError(f"discarding {spec} since 'rustc' is missing")
+
+    def setup_dependent_package(self, module, dependent_spec):
+        module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # Manually instruct Cargo dependency libssh2-sys to build with
+        # the Spack installed libssh2 package. For more info see
+        # https://github.com/alexcrichton/ssh2-rs/issues/173
+        env.set("LIBSSH2_SYS_USE_PKG_CONFIG", "1")
+
+        # Manually inject the path of ar for build.
+        ar = which("ar", required=True)
+        env.set("AR", ar.path)
+
+        # Manually inject the path of openssl's certs for build
+        # if certs are present on system via Spack or via external
+        # openssl.
+        def get_test_path(p):
+            certs = join_path(p, "cert.pem")
+            if os.path.exists(certs):
+                return certs
+            return None
+
+        # find certs, don't set if no file is found in case
+        # ca-certificates isn't installed
+        certs = None
+        openssl = self.spec["openssl"]
+        if openssl.external:
+            try:
+                output = which("openssl", required=True)(
+                    "version", "-d", output=str, error=str
+                )
+                openssl_dir = re.match('OPENSSLDIR: "([^"]+)"', output)
+                if openssl_dir:
+                    certs = get_test_path(openssl_dir.group(1))
+            except ProcessError:
+                pass
+
+        if certs is None:
+            certs = get_test_path(join_path(openssl.prefix, "etc/openssl"))
+
+        if certs is not None:
+            env.set("CARGO_HTTP_CAINFO", certs)
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        env.set("CARGO_HOME", join_path(dependent_spec.package.stage.path, "cargo"))
+
+        # Until we get a little more integration with cargo or offload solving to spack
+        # (how to do this is TBD), we need it to fall back to older package versions
+        # when the latest version doesn't support our rust toolchain version. This
+        # option allows Spack to be slightly behind the latest rust in CI.
+        #
+        # This is safe as long as rust is using static libraries and there are not ABI
+        # dependencies among rust packages in Spack.
+        #
+        # This is supported in Cargo 1.84 and higher.
+        if self.spec.satisfies("@1.84:"):
+            env.set("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
+
+    def configure(self, spec, prefix):
+        opts = []
+
+        # Set prefix to install into spack prefix.
+        opts.append(f"install.prefix={prefix}")
+
+        # Set relative path to put system configuration files
+        # under the Spack package prefix.
+        opts.append("install.sysconfdir=etc")
+
+        # Build extended suite of tools so dependent packages
+        # packages can build using cargo.
+        opts.append("build.extended=true")
+
+        # Build docs if specified by the +docs variant.
+        opts.append(f"build.docs={str(spec.satisfies('+docs')).lower()}")
+
+        # Set binary locations for bootstrap rustc and cargo.
+        opts.append(f"build.cargo={spec['rust-bootstrap'].prefix.bin.cargo}")
+        opts.append(f"build.rustc={spec['rust-bootstrap'].prefix.bin.rustc}")
+
+        # Disable bootstrap LLVM download.
+        opts.append("llvm.download-ci-llvm=false")
+        if spec.satisfies("@=nightly-2026-04-01"):
+            opts.append("rust.download-rustc=false")
+
+        # Use vendored resources to perform offline build.
+        opts.append("build.vendor=true")
+
+        # Convert opts to '--set key=value' format.
+        flags = [flag for opt in opts for flag in ("--set", opt)]
+
+        # Core rust tools to install.
+        tools = ["cargo"]
+
+        # Add additional tools as directed by the package variants.
+        if spec.satisfies("+dev"):
+            tools.extend(["clippy", "rustdoc", "rustfmt", "rust-analyzer"])
+
+        if spec.satisfies("+src"):
+            tools.append("src")
+
+        # Compile tools into flag for configure.
+        flags.append(f"--tools={','.join(tools)}")
+
+        # by default a `-nightly` suffix we be applied even on
+        # non-nightly stable builds
+        if self.spec.satisfies("@=nightly-2026-04-01"):
+            flags.append("--release-channel=nightly")
+        elif not self.spec.satisfies("@=nightly"):
+            flags.append("--release-channel=stable")
+
+        configure(*flags)
+
+    def build(self, spec, prefix):
+        python("./x.py", "build", "-j", str(make_jobs))
+
+    def install(self, spec, prefix):
+        python("./x.py", "install", "-j", str(make_jobs))
+
+    # known issue: https://github.com/rust-lang/rust/issues/132604
+    unresolved_libraries = ["libz.so.*"]

--- a/packaging/spack-overlay/packages/rust/package.py
+++ b/packaging/spack-overlay/packages/rust/package.py
@@ -186,7 +186,7 @@ class Rust(Package):
         return f"https://static.rust-lang.org/dist/rustc-{version}-src.tar.{ext}"
 
     @classmethod
-    def determine_version(csl, exe):
+    def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str, error=str)
         match = re.match(r"(rustc|cargo) (\S+)", output)
         return match.group(2) if match else None
@@ -247,6 +247,7 @@ class Rust(Package):
                 if openssl_dir:
                     certs = get_test_path(openssl_dir.group(1))
             except ProcessError:
+                # A failed external query falls back to the package certificate path.
                 pass
 
         if certs is None:

--- a/packaging/spack-overlay/rust-backend-source-audit.json
+++ b/packaging/spack-overlay/rust-backend-source-audit.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "maturin",
+    "version": "1.13.1",
+    "url": "https://files.pythonhosted.org/packages/39/16/b284a7bc4af3dd87717c784278c1b8cb18606ad1f6f7a671c47bfd9c3df0/maturin-1.13.1.tar.gz",
+    "sha256": "9a87ff3b8e4d1c6eac33ebfe8e261e8236516d98d45c0323550621819b5a1a2f",
+    "bytes": 340369,
+    "download_hash_verified": true,
+    "purpose": "Verify source identity for unchanged upstream build-tool recipe; no install."
+  },
+  {
+    "name": "setuptools-rust",
+    "version": "1.12.0",
+    "url": "https://files.pythonhosted.org/packages/bc/c4/8d3d282cee60d3ea0369fa15ce27387810040360adb4133e31990a7a2aba/setuptools_rust-1.12.0.tar.gz",
+    "sha256": "d94a93f0c97751c17014565f07bdc324bee45d396cd1bba83d8e7af92b945f0c",
+    "bytes": 310984,
+    "download_hash_verified": true,
+    "purpose": "Verify source identity for unchanged upstream build-tool recipe; no install."
+  }
+]

--- a/packaging/spack-overlay/rust-source-audit.json
+++ b/packaging/spack-overlay/rust-source-audit.json
@@ -1,0 +1,59 @@
+{
+  "recorded_at": "2026-08-31T15:27:56.326849+00:00",
+  "compiler": {
+    "version": "nightly-2026-04-01",
+    "reported_version": "1.96.0-nightly (48cc71ee8 2026-03-31)",
+    "source_commit": "48cc71ee88cd0f11217eced958b9930970da998b",
+    "url": "https://static.rust-lang.org/dist/2026-04-01/rustc-nightly-src.tar.xz",
+    "sha256": "9de9d7a01a3bd2ec3581fec866453061036914f6df153d0b25d5fdc54a28f035",
+    "bytes": 240051588,
+    "archive_downloaded": true,
+    "archive_digest_verified": true,
+    "channel_manifest_url": "https://static.rust-lang.org/dist/2026-04-01/channel-rust-nightly.toml",
+    "channel_manifest_sha256": "3b6d7428c43813922ef77da6ec2ca0f75e2e0de227e2febdd714336ab88d7908",
+    "manifest_matches_official_sha256_sidecar": true,
+    "source_checksum_url": "https://static.rust-lang.org/dist/2026-04-01/rustc-nightly-src.tar.xz.sha256",
+    "source_matches_official_sha256_sidecar": true
+  },
+  "stage0": {
+    "archive_member": "rustc-nightly-src/src/stage0",
+    "sha256": "9aa08fe0e0935ef42449eb244f438c5697dbb076091f5168c004b115fdaf781d",
+    "matches_source_commit_file": true,
+    "channel": "beta",
+    "date": "2026-03-05",
+    "commit": "ad726b5063362ec9897ef3d67452fc5606ee70fa",
+    "channel_manifest_sha256": "18261f24c2dc26c5bfc6647e837c2e820a478f52d55aea7ff98eb24f43c750dd",
+    "channel_manifest_url": "https://static.rust-lang.org/dist/2026-03-05/channel-rust-beta.toml",
+    "manifest_matches_official_sha256_sidecar": true,
+    "targets": {
+      "x86_64-unknown-linux-gnu": {
+        "url": "https://static.rust-lang.org/dist/2026-03-05/rust-beta-x86_64-unknown-linux-gnu.tar.xz",
+        "published_sha256": "6ac3648729b590296c433607fe7d7f6cf7aff3ed459b4dd64188164beb528961",
+        "archive_downloaded": false,
+        "installed": false
+      },
+      "aarch64-unknown-linux-gnu": {
+        "url": "https://static.rust-lang.org/dist/2026-03-05/rust-beta-aarch64-unknown-linux-gnu.tar.xz",
+        "published_sha256": "3f995e93b1fbde48b3fe07c71ea8d77ee1e90367d8158f9f49390d4bc3dbd3fc",
+        "archive_downloaded": false,
+        "installed": false
+      },
+      "aarch64-apple-darwin": {
+        "url": "https://static.rust-lang.org/dist/2026-03-05/rust-beta-aarch64-apple-darwin.tar.xz",
+        "published_sha256": "c665bde9d7e1c6ad3edac04b794e5ce2b8480b28b49ca3d8f4e3a494e1c0d056",
+        "archive_downloaded": false,
+        "installed": false
+      },
+      "x86_64-apple-darwin": {
+        "url": "https://static.rust-lang.org/dist/2026-03-05/rust-beta-x86_64-apple-darwin.tar.xz",
+        "published_sha256": "6f9025bdce1af6874e0b442a7903074621a037d23dc77e79f9b75fba653115a9",
+        "archive_downloaded": false,
+        "installed": false
+      }
+    }
+  },
+  "signatures_verified": false,
+  "compiler_installed": false,
+  "native_builds_executed": false,
+  "upstream_submitted": false
+}

--- a/packaging/spack-overlay/solver-logs/dated-rust-single-nightly.log
+++ b/packaging/spack-overlay/solver-logs/dated-rust-single-nightly.log
@@ -1,3 +1,7 @@
+==> Compilers have been configured automatically from PATH inspection
+==> Using cached archive: /opt/homebrew/Cellar/spack/1.2.2/var/spack/cache/blobs/sha256/5f4b96c08a7868a6e95a64cd4829bd956fd8aeea42436c371371dae973c057e7
+==> Using cached archive: /opt/homebrew/Cellar/spack/1.2.2/var/spack/cache/blobs/sha256/8720111b230ced41bf77601ef3f54e085e3f53b080a24570992b71340ac5da49
+==> Installing "clingo-bootstrap@=spack~apps~docs+ipo+optimized+python build_system=cmake build_type=Release commit=2a025667090d71b2c9dce60fe924feb6bde8f667 generator=make platform=darwin os=bigsur target=aarch64" from a buildcache
  -   py-voiage@2.2.0 build_system=python_pip platform=darwin os=tahoe target=m1
  -       ^py-click@8.5.0 build_system=python_pip platform=darwin os=tahoe target=m1
  -           ^py-flit-core@3.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
@@ -36,10 +40,6 @@
  -       ^py-pip@26.1.2 build_system=generic platform=darwin os=tahoe target=m1
  -       ^py-polars@1.42.1 build_system=python_pip platform=darwin os=tahoe target=m1
  -           ^py-polars-runtime-32@1.42.1 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-maturin@1.13.1 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^py-setuptools-rust@1.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^rust@nightly-2026-04-01~dev~docs+src build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                   ^rust-bootstrap@beta-2026-03-05 build_system=generic platform=darwin os=tahoe target=m1
  -       ^py-pyarrow@25.0.0 build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -           ^arrow@25.0.0~brotli~bz2~compute+csv~cuda+dataset+filesystem~gandiva~glog~hdfs+ipc~ipo~jemalloc~lz4~orc+parquet+python+shared~snappy~tensorflow~zlib~zstd build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -               ^boost@1.90.0~atomic~charconv~chrono~clanglibcpp~container~context~contract~conversion~date_time~debug~exception~fiber+filesystem~graph~graph_parallel~icu~iostreams~json~locale~log~math~mpi~mqtt5+multithreaded~nowide~numpy~openmethod~pic~program_options~python~random~regex~serialization+shared~signals2~singlethreaded~stacktrace+system~taggedlayout~test~thread~timer~type_erasure~url~versionedlayout~wave build_system=generic cxxstd=11 patches:=a440f96 visibility=hidden platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
@@ -128,7 +128,7 @@
  -           ^zlib-ng@2.3.3+compat+new_strategies+opt+pic+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -           ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -       ^python-venv@1.0 build_system=generic platform=darwin os=tahoe target=m1
- -       ^rust@1.96.0~dev~docs+src build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
+ -       ^rust@nightly-2026-04-01~dev~docs+src build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -           ^curl@8.20.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -               ^nghttp2@1.67.1 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -           ^libgit2@1.9.1~curl~ipo+mmap+ssh build_system=cmake build_type=Release generator=make https=system platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
@@ -136,5 +136,5 @@
  -           ^libssh2@1.11.1+shared build_system=autotools crypto=openssl platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
  -           ^ninja@1.13.2+re2c build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
  -               ^re2c@4.4 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^rust-bootstrap@1.96.0 build_system=generic platform=darwin os=tahoe target=m1
+ -           ^rust-bootstrap@beta-2026-03-05 build_system=generic platform=darwin os=tahoe target=m1
 

--- a/packaging/spack-overlay/solver-logs/dated-rust-stable-edge-failed.log
+++ b/packaging/spack-overlay/solver-logs/dated-rust-stable-edge-failed.log
@@ -1,0 +1,200 @@
+==> Compilers have been configured automatically from PATH inspection
+==> Error: failed to concretize `py-voiage@2.2.0` for the following reasons:
+     1. Cannot satisfy 'rust@nightly-2026-04-01'
+     2. Cannot satisfy 'rust@nightly-2026-04-01' (version 1.96.0 does not match)
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     3. Cannot satisfy 'rust@1.88:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.88: when @1.12.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     4. Cannot satisfy 'rust@1.83:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.83: when @1.10.2: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     5. Cannot satisfy 'rust@1.74:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.74: when @1.7.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     6. Cannot satisfy 'rust@1.70:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.70: when @1.5.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     7. Cannot satisfy 'rust@1.67:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.67: when @1.4.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     8. Cannot satisfy 'rust@1.64:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.64: when @0.15.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     9. Cannot satisfy 'rust@1.62:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.62: when @0.14.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+    10. Cannot satisfy 'rust@1.59:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.59: when @0.13.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 

--- a/packaging/spack-overlay/solver-logs/dated-rust-stable-requirements-failed.log
+++ b/packaging/spack-overlay/solver-logs/dated-rust-stable-requirements-failed.log
@@ -1,0 +1,253 @@
+==> Compilers have been configured automatically from PATH inspection
+==> Error: failed to concretize `py-voiage@2.2.0` for the following reasons:
+     1. Cannot satisfy 'rust@nightly-2026-04-01'
+     2. Cannot satisfy 'rust@nightly-2026-04-01' (version 1.96.0 does not match)
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     3. Cannot satisfy 'rust@1.88:1' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because ^rust@1.88:1 is a requirement for package py-maturin 
+          required because py-libcst depends on rust 
+            required because py-pyarrow depends on py-libcst@1.8.6: when @25: 
+              required because py-voiage depends on py-pyarrow@25 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-maturin depends on rust@1.88: when @1.12.0: 
+            required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+              required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+                required because py-voiage depends on py-polars@1.42.1:1 
+            required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+              required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+                required because py-voiage depends on py-pydantic@2.13.4:2 
+            required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+            required because py-pydantic-core depends on py-maturin@1 
+            required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+              required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+                required because py-voiage depends on py-jsonschema@4.26:4 
+              required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+              required because py-referencing depends on py-rpds-py@0.7.0: 
+                required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+                required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                  required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+            required because py-voiage depends on py-maturin@1.9:1 
+          required because py-maturin depends on rust@1.83: when @1.10.2: 
+          required because py-maturin depends on rust@1.74: when @1.7.0: 
+          required because py-maturin depends on rust@1.70: when @1.5.0: 
+          required because py-maturin depends on rust@1.67: when @1.4.0: 
+          required because py-maturin depends on rust@1.64: when @0.15.0: 
+          required because py-maturin depends on rust@1.62: when @0.14.3: 
+          required because py-maturin depends on rust@1.59: when @0.13.3: 
+          required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-pydantic-core depends on rust@1.88: when @2.46.4: 
+          required because py-pydantic-core depends on rust@1.75: when @2.27: 
+          required because py-rpds-py depends on rust@1.60: 
+          required because py-rpds-py depends on rust@1.85: when @0.25: 
+          required because py-rpds-py depends on rust@1.76: when @0.19: 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+          required because py-setuptools-rust depends on rust 
+            required because py-libcst depends on py-setuptools-rust 
+            required because py-maturin depends on py-setuptools-rust@1.4: 
+            required because py-maturin depends on py-setuptools-rust@1.11: when @1.8.6: 
+          required because py-voiage depends on py-maturin@1.9:1 
+          required because py-voiage depends on rust@1.85: 
+          required because ^rust@1.88:1 is a requirement for package py-pydantic-core 
+     4. Cannot satisfy 'rust@1.88:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.88: when @1.12.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     5. Cannot satisfy 'rust@1.83:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.83: when @1.10.2: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     6. Cannot satisfy 'rust@1.74:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.74: when @1.7.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     7. Cannot satisfy 'rust@1.70:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.70: when @1.5.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     8. Cannot satisfy 'rust@1.67:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.67: when @1.4.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     9. Cannot satisfy 'rust@1.64:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.64: when @0.15.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+    10. Cannot satisfy 'rust@1.62:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.62: when @0.14.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+    11. Cannot satisfy 'rust@1.59:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.59: when @0.13.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 

--- a/packaging/spack-overlay/solver-logs/dated-rust-three-tools-failed.log
+++ b/packaging/spack-overlay/solver-logs/dated-rust-three-tools-failed.log
@@ -1,0 +1,199 @@
+==> Error: failed to concretize `py-voiage@2.2.0` for the following reasons:
+     1. Cannot satisfy 'rust@nightly-2026-04-01'
+     2. Cannot satisfy 'rust@nightly-2026-04-01' (version 1.96.0 does not match)
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     3. Cannot satisfy 'rust@1.88:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.88: when @1.12.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     4. Cannot satisfy 'rust@1.83:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.83: when @1.10.2: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     5. Cannot satisfy 'rust@1.74:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.74: when @1.7.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     6. Cannot satisfy 'rust@1.70:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.70: when @1.5.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     7. Cannot satisfy 'rust@1.67:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.67: when @1.4.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+     8. Cannot satisfy 'rust@1.64:' and 'rust@nightly-2026-04-01'
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+        required because py-maturin depends on rust@1.64: when @0.15.0: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+     9. Cannot satisfy 'rust@1.62:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.62: when @0.14.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 
+    10. Cannot satisfy 'rust@1.59:' and 'rust@nightly-2026-04-01'
+        required because py-maturin depends on rust@1.59: when @0.13.3: 
+          required because py-polars-runtime-32 depends on py-maturin@1.3.2: 
+            required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+              required because py-voiage depends on py-polars@1.42.1:1 
+                required because py-voiage@2.2.0 requested explicitly 
+          required because py-pydantic-core depends on py-maturin@1.10:1 when @2.46.4: 
+            required because py-pydantic depends on py-pydantic-core@2.46.4 when @2.13.4 
+              required because py-voiage depends on py-pydantic@2.13.4:2 
+          required because py-pydantic-core depends on py-maturin@1.9.4:1 when @2.41: 
+          required because py-pydantic-core depends on py-maturin@1 
+          required because py-rpds-py depends on py-maturin@1.9:1 when @0.25: 
+            required because py-jsonschema depends on py-rpds-py@0.25: when @4.26: 
+              required because py-voiage depends on py-jsonschema@4.26:4 
+            required because py-jsonschema depends on py-rpds-py@0.7.1: when @4.18: 
+            required because py-referencing depends on py-rpds-py@0.7.0: 
+              required because py-jsonschema depends on py-referencing@0.28.4: when @4.18: 
+              required because py-jsonschema-specifications depends on py-referencing@0.31.0: 
+                required because py-jsonschema depends on py-jsonschema-specifications@2023.03.6: when @4.18: 
+          required because py-voiage depends on py-maturin@1.9:1 
+        required because py-polars-runtime-32 depends on rust@nightly-2026-04-01 
+          required because py-polars depends on py-polars-runtime-32@1.42.1 when @1.42.1 
+            required because py-voiage depends on py-polars@1.42.1:1 
+              required because py-voiage@2.2.0 requested explicitly 

--- a/packaging/spack-overlay/solver-logs/voiage.json
+++ b/packaging/spack-overlay/solver-logs/voiage.json
@@ -78,7 +78,7 @@
           },
           {
             "name": "py-jsonschema",
-            "hash": "shc6wuoafsuuuu25egqyvfpqghue5hpq",
+            "hash": "d5ky3vzcnchmwm75xhc4z246kvx4n6kw",
             "parameters": {
               "deptypes": [
                 "run"
@@ -88,7 +88,7 @@
           },
           {
             "name": "py-maturin",
-            "hash": "w5q5lhho35tveeegzn35buhsussppitj",
+            "hash": "mrv7nppqbsx27key6hwqjcv3jurqttjo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -128,7 +128,7 @@
           },
           {
             "name": "py-polars",
-            "hash": "s6e5ilg3yvr6pveslvb6qocyqtlucx2y",
+            "hash": "px2m5unosihxtsx3y4tgzdqabjdpt6q5",
             "parameters": {
               "deptypes": [
                 "run"
@@ -138,7 +138,7 @@
           },
           {
             "name": "py-pyarrow",
-            "hash": "vz6pzc3btsueu3nptggeyuhnodwmfola",
+            "hash": "3sglgcgo7txirwcxtw7lahwnbmkokicx",
             "parameters": {
               "deptypes": [
                 "run"
@@ -148,7 +148,7 @@
           },
           {
             "name": "py-pydantic",
-            "hash": "znussdvf7c4nxdxw4gmdqc33toxhnjc3",
+            "hash": "q5str2xe24znedvvtszmyx3ufwlw4hs6",
             "parameters": {
               "deptypes": [
                 "run"
@@ -240,7 +240,7 @@
           },
           {
             "name": "rust",
-            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "hash": "f4ao3mncicrhc6eis6oeoeshiuqyfoim",
             "parameters": {
               "deptypes": [
                 "build"
@@ -252,7 +252,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "2tqjkmgjjzws7wakt57rre2rob4rj42y"
+        "hash": "gr2mzdndkrgkt3qdlxanww7ohuiyrvno"
       },
       {
         "name": "py-click",
@@ -4204,7 +4204,7 @@
           },
           {
             "name": "py-jsonschema-specifications",
-            "hash": "fsh6bdz2th5habaarrusxplaurw545yn",
+            "hash": "4kdgj2myghdmrtuk5jm3g4pnmw6a365y",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4225,7 +4225,7 @@
           },
           {
             "name": "py-referencing",
-            "hash": "uzodffdldcmg32sb22k3fje5uopewnu3",
+            "hash": "fdjrf26ehb3b5dklhx7dqiyiqehc2s4r",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4236,7 +4236,7 @@
           },
           {
             "name": "py-rpds-py",
-            "hash": "vdmugyilykjxywaevdwu6zlm3hl7wxad",
+            "hash": "4sdwsnyyjacplriq563fyy7w5b3hqmz4",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4281,7 +4281,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "shc6wuoafsuuuu25egqyvfpqghue5hpq"
+        "hash": "d5ky3vzcnchmwm75xhc4z246kvx4n6kw"
       },
       {
         "name": "py-attrs",
@@ -8406,7 +8406,7 @@
           },
           {
             "name": "py-referencing",
-            "hash": "uzodffdldcmg32sb22k3fje5uopewnu3",
+            "hash": "fdjrf26ehb3b5dklhx7dqiyiqehc2s4r",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8451,7 +8451,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "fsh6bdz2th5habaarrusxplaurw545yn"
+        "hash": "4kdgj2myghdmrtuk5jm3g4pnmw6a365y"
       },
       {
         "name": "py-referencing",
@@ -8558,7 +8558,7 @@
           },
           {
             "name": "py-rpds-py",
-            "hash": "vdmugyilykjxywaevdwu6zlm3hl7wxad",
+            "hash": "4sdwsnyyjacplriq563fyy7w5b3hqmz4",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8603,7 +8603,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "uzodffdldcmg32sb22k3fje5uopewnu3"
+        "hash": "fdjrf26ehb3b5dklhx7dqiyiqehc2s4r"
       },
       {
         "name": "py-rpds-py",
@@ -8691,7 +8691,7 @@
           },
           {
             "name": "py-maturin",
-            "hash": "w5q5lhho35tveeegzn35buhsussppitj",
+            "hash": "mrv7nppqbsx27key6hwqjcv3jurqttjo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8743,7 +8743,7 @@
           },
           {
             "name": "rust",
-            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "hash": "f4ao3mncicrhc6eis6oeoeshiuqyfoim",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8755,7 +8755,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vdmugyilykjxywaevdwu6zlm3hl7wxad"
+        "hash": "4sdwsnyyjacplriq563fyy7w5b3hqmz4"
       },
       {
         "name": "py-maturin",
@@ -8874,7 +8874,7 @@
           },
           {
             "name": "py-setuptools-rust",
-            "hash": "opzw6zedjgujv7psznyxu4qnwcc2ivr5",
+            "hash": "gibleffgofjw2li7ugkkhf3jbkd2er5u",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8916,7 +8916,7 @@
           },
           {
             "name": "rust",
-            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "hash": "f4ao3mncicrhc6eis6oeoeshiuqyfoim",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8929,7 +8929,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "w5q5lhho35tveeegzn35buhsussppitj"
+        "hash": "mrv7nppqbsx27key6hwqjcv3jurqttjo"
       },
       {
         "name": "py-setuptools-rust",
@@ -9069,7 +9069,7 @@
           },
           {
             "name": "rust",
-            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "hash": "f4ao3mncicrhc6eis6oeoeshiuqyfoim",
             "parameters": {
               "deptypes": [
                 "run"
@@ -9081,7 +9081,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "opzw6zedjgujv7psznyxu4qnwcc2ivr5"
+        "hash": "gibleffgofjw2li7ugkkhf3jbkd2er5u"
       },
       {
         "name": "py-semantic-version",
@@ -9266,7 +9266,7 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "4qsgzc55lbwz73ouxyqg3xv63o4d7r53aw7ze5el2lanqmvxninq====",
+        "package_hash": "rnw4nqee5gf2d2vzzo6qg2e7it2hjsvna4vfxor4stiesr2iijaq====",
         "dependencies": [
           {
             "name": "apple-clang",
@@ -9404,7 +9404,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr"
+        "hash": "f4ao3mncicrhc6eis6oeoeshiuqyfoim"
       },
       {
         "name": "cmake",
@@ -12249,7 +12249,7 @@
           },
           {
             "name": "py-polars-runtime-32",
-            "hash": "pvtn5r76witgg2737sw3vkxqkkzvgyrr",
+            "hash": "kuvhv4joppi43v67kqbjzlczr7dhuxvm",
             "parameters": {
               "deptypes": [
                 "run"
@@ -12303,7 +12303,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "s6e5ilg3yvr6pveslvb6qocyqtlucx2y"
+        "hash": "px2m5unosihxtsx3y4tgzdqabjdpt6q5"
       },
       {
         "name": "py-polars-runtime-32",
@@ -12369,7 +12369,7 @@
         "dependencies": [
           {
             "name": "py-maturin",
-            "hash": "s2kz5pxqqceanow3wxzdrnshh2gytekx",
+            "hash": "xwa5crmfuv2l66k6jwwe3miyv7y4lcdw",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12421,7 +12421,7 @@
           },
           {
             "name": "rust",
-            "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah",
+            "hash": "jpn5zh6b2gofxqplt4esfn6ickvw2lt4",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12433,7 +12433,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "pvtn5r76witgg2737sw3vkxqkkzvgyrr"
+        "hash": "kuvhv4joppi43v67kqbjzlczr7dhuxvm"
       },
       {
         "name": "py-maturin",
@@ -12552,7 +12552,7 @@
           },
           {
             "name": "py-setuptools-rust",
-            "hash": "xywhal6te4gn7yul4ygpoghzs5sya5ol",
+            "hash": "h3fgbogm4aap4im3nqc4fwlnhxprhinq",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12594,7 +12594,7 @@
           },
           {
             "name": "rust",
-            "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah",
+            "hash": "jpn5zh6b2gofxqplt4esfn6ickvw2lt4",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12607,7 +12607,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "s2kz5pxqqceanow3wxzdrnshh2gytekx"
+        "hash": "xwa5crmfuv2l66k6jwwe3miyv7y4lcdw"
       },
       {
         "name": "py-setuptools-rust",
@@ -12747,7 +12747,7 @@
           },
           {
             "name": "rust",
-            "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah",
+            "hash": "jpn5zh6b2gofxqplt4esfn6ickvw2lt4",
             "parameters": {
               "deptypes": [
                 "run"
@@ -12759,7 +12759,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "xywhal6te4gn7yul4ygpoghzs5sya5ol"
+        "hash": "h3fgbogm4aap4im3nqc4fwlnhxprhinq"
       },
       {
         "name": "rust",
@@ -12824,7 +12824,7 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "veb7renk23dd7hpy3z4o2lwjwd7bnt2c4t2yozlynspgx4wnqicq====",
+        "package_hash": "dzga7f232id4y6hyjryprylj7rrc35txsrgaliorfbd74useplhq====",
         "dependencies": [
           {
             "name": "apple-clang",
@@ -12962,7 +12962,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah"
+        "hash": "jpn5zh6b2gofxqplt4esfn6ickvw2lt4"
       },
       {
         "name": "rust-bootstrap",
@@ -13175,7 +13175,7 @@
           },
           {
             "name": "py-libcst",
-            "hash": "kx33j7rmul6cc246vwtflso623e3ncnh",
+            "hash": "kzxzaiyckda7ceey3qv5i364mjippl2t",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13270,7 +13270,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vz6pzc3btsueu3nptggeyuhnodwmfola"
+        "hash": "3sglgcgo7txirwcxtw7lahwnbmkokicx"
       },
       {
         "name": "arrow",
@@ -14794,7 +14794,7 @@
           },
           {
             "name": "py-setuptools-rust",
-            "hash": "opzw6zedjgujv7psznyxu4qnwcc2ivr5",
+            "hash": "gibleffgofjw2li7ugkkhf3jbkd2er5u",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14846,7 +14846,7 @@
           },
           {
             "name": "rust",
-            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "hash": "f4ao3mncicrhc6eis6oeoeshiuqyfoim",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14858,7 +14858,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "kx33j7rmul6cc246vwtflso623e3ncnh"
+        "hash": "kzxzaiyckda7ceey3qv5i364mjippl2t"
       },
       {
         "name": "py-pyyaml",
@@ -15430,7 +15430,7 @@
           },
           {
             "name": "py-pydantic-core",
-            "hash": "xv4nvtihaprzsu4thuimhlorjc2sqhzd",
+            "hash": "zdthkkej674lsempaqbhiie6ciowulej",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15497,7 +15497,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "znussdvf7c4nxdxw4gmdqc33toxhnjc3"
+        "hash": "q5str2xe24znedvvtszmyx3ufwlw4hs6"
       },
       {
         "name": "py-annotated-types",
@@ -15683,7 +15683,7 @@
         "dependencies": [
           {
             "name": "py-maturin",
-            "hash": "w5q5lhho35tveeegzn35buhsussppitj",
+            "hash": "mrv7nppqbsx27key6hwqjcv3jurqttjo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15746,7 +15746,7 @@
           },
           {
             "name": "rust",
-            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "hash": "f4ao3mncicrhc6eis6oeoeshiuqyfoim",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15758,7 +15758,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "xv4nvtihaprzsu4thuimhlorjc2sqhzd"
+        "hash": "zdthkkej674lsempaqbhiie6ciowulej"
       },
       {
         "name": "py-typing-extensions",

--- a/packaging/spack-overlay/solver-logs/voiage.json
+++ b/packaging/spack-overlay/solver-logs/voiage.json
@@ -1,0 +1,19022 @@
+{
+  "spec": {
+    "_meta": {
+      "version": 5
+    },
+    "nodes": [
+      {
+        "name": "py-voiage",
+        "version": "2.2.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "4mmo3qsap34iszicalekdiihly67dgnr63a3wu43s76eyxoi4saa====",
+        "dependencies": [
+          {
+            "name": "py-click",
+            "hash": "j7meirhqyfrwdkz5i6yjt5zlgva7fghq",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-jsonschema",
+            "hash": "shc6wuoafsuuuu25egqyvfpqghue5hpq",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-maturin",
+            "hash": "w5q5lhho35tveeegzn35buhsussppitj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pandas",
+            "hash": "ucw2it4b2pfltaz2wmyh522d6rkc2c2n",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-polars",
+            "hash": "s6e5ilg3yvr6pveslvb6qocyqtlucx2y",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pyarrow",
+            "hash": "vz6pzc3btsueu3nptggeyuhnodwmfola",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pydantic",
+            "hash": "znussdvf7c4nxdxw4gmdqc33toxhnjc3",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-scikit-learn",
+            "hash": "sowk6gpb7s75p62bcert2z2qspyrtclq",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-scipy",
+            "hash": "h3kxp56o42mlwo5g3irvrviu7brys4zr",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-typer",
+            "hash": "3rmv4fpa5njcfe4qh23admc3yo5pazyg",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-typing-extensions",
+            "hash": "istyqwnwt2tufln6abuchhhotpfhmjrx",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-xarray",
+            "hash": "6bsikoooqbvda2dpvbrbjoj5xuzh4h4s",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "2tqjkmgjjzws7wakt57rre2rob4rj42y"
+      },
+      {
+        "name": "py-click",
+        "version": "8.5.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "bwtr2om4wbz7cq5462ofzrg2kyqcxz5m4gydnzvel5oggefkaf7q====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "j7meirhqyfrwdkz5i6yjt5zlgva7fghq"
+      },
+      {
+        "name": "py-flit-core",
+        "version": "3.12.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "pt5cnwzlrqkodwjzr2kuisw7p3cn5jnvyi3d3nudkcprtcuxnlrq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5"
+      },
+      {
+        "name": "py-pip",
+        "version": "26.1.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "uov4bvgqzkskrwqdp4xt237uyxiantgyr6a3zjewthko442bs2vq====",
+        "dependencies": [
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew"
+      },
+      {
+        "name": "python",
+        "version": "3.14.5",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "bz2": true,
+          "ctypes": true,
+          "dbm": true,
+          "debug": false,
+          "freethreading": false,
+          "libxml2": true,
+          "lzma": true,
+          "optimizations": false,
+          "pic": true,
+          "pyexpat": true,
+          "pythoncmd": true,
+          "readline": true,
+          "shared": true,
+          "sqlite3": true,
+          "ssl": true,
+          "static": false,
+          "tests": false,
+          "tkinter": false,
+          "uuid": true,
+          "zlib": true,
+          "zstd": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "joslfmmiib2wt4n5v6vv6hfj6k35en625uilkqkmtej5dm5vqdna====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "apple-libuuid",
+            "hash": "gjtqvhfo3t7damoje5eh3iws2gfsswjt",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "uuid"
+              ]
+            }
+          },
+          {
+            "name": "bzip2",
+            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "expat",
+            "hash": "x5ovcbk323jbsyjvrn76wrb56xx5js52",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gdbm",
+            "hash": "t3wvm22tgiwgkwoxb7zfxafltfjwt5oa",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gettext",
+            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libffi",
+            "hash": "oyefbrren2rgkizhkwfk5rgjmmcfxutc",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "readline",
+            "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "sqlite",
+            "hash": "xj623b2avuv36wjimofsygpxbmhrv4sl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "xz",
+            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          },
+          {
+            "name": "zstd",
+            "hash": "e6anxsyrvvfaxhsxbkg56amkhsk6c5nv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "x6td2havcli6acz4o52xc46nguqrodg2"
+      },
+      {
+        "name": "apple-clang",
+        "version": "21.0.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "bundle",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "external": {
+          "path": "/usr",
+          "module": null,
+          "extra_attributes": {
+            "compilers": {
+              "c": "/usr/bin/clang",
+              "cxx": "/usr/bin/clang++"
+            }
+          }
+        },
+        "package_hash": "wi7ij62tcqvlrtl7ilc5f65hwxccv5jdxx67uxydxm2c5tzywr7a====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b"
+      },
+      {
+        "name": "apple-libuuid",
+        "version": "1353.100.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "bundle",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "external": {
+          "path": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+          "module": null,
+          "extra_attributes": {}
+        },
+        "package_hash": "4pdb7oo3tfp7b6ulthbraqtadpzwdfti6ot7b2asi7hetjfibwxq====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "gjtqvhfo3t7damoje5eh3iws2gfsswjt"
+      },
+      {
+        "name": "bzip2",
+        "version": "1.0.8",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "debug": false,
+          "pic": false,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "23pafj3kmpyregjxpmso3hf2q5op467msdhghyksoj2sv75ixqga====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "f66e7vo7zkss445atltrjo7npnxaymup"
+      },
+      {
+        "name": "compiler-wrapper",
+        "version": "1.1.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "krswqw733edchvgy6sdrysilrhnacucktrtqngbnbtcymxtsnkaa====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "2eppidz73j5cixagdntn6caaysmx5bpx"
+      },
+      {
+        "name": "diffutils",
+        "version": "3.12",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "gwdibkyu5ed7w73ge5rpiboowwfww4lk6wa7epmipesccj7jo6ia====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libiconv",
+            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "iconv"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv"
+      },
+      {
+        "name": "gmake",
+        "version": "4.4.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "guile": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "t7cpl3gi3q6vihjpyqrvviu4rlsgcfjvv4mt4rcq3wie2i7jr6sq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea"
+      },
+      {
+        "name": "gnuconfig",
+        "version": "2025-07-10",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "g6zjj36dyki3z5v5vnjiqp5knhvogsphfmr5ocjr7fqzcnrwe3la====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "cxt42mygaqmcy56nfni4afyojpabaeto"
+      },
+      {
+        "name": "libiconv",
+        "version": "1.18",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "libs": [
+            "shared",
+            "static"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ewtsucjkci2hquwbnguwdkediavggpdgzm4vi5rwwunj4pon32rq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4"
+      },
+      {
+        "name": "expat",
+        "version": "2.8.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "libbsd": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "chz3qcllcofiy3njufwfu2zm6npgq6a5lsrsbw3jhdbsyoceazgq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "x5ovcbk323jbsyjvrn76wrb56xx5js52"
+      },
+      {
+        "name": "gdbm",
+        "version": "1.26",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "5ua7ahogxot5dxzyurihdriblxzuavehguaupbd6ixrtciqfekbq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "readline",
+            "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "t3wvm22tgiwgkwoxb7zfxafltfjwt5oa"
+      },
+      {
+        "name": "readline",
+        "version": "8.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "patches": [
+            "21f0a03106dbe697337cd25c70eb0edbaa2bdb6d595b45f83285cdd35bac84de",
+            "72dee13601ce38f6746eb15239999a7c56f8e1ff5eb1ec8153a1f213e4acdb29",
+            "e27364396ba9f6debf7cbaaf1a669e2b2854241ae07f7eca74ca8a8ba0c97472"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "21f0a03106dbe697337cd25c70eb0edbaa2bdb6d595b45f83285cdd35bac84de",
+          "e27364396ba9f6debf7cbaaf1a669e2b2854241ae07f7eca74ca8a8ba0c97472",
+          "72dee13601ce38f6746eb15239999a7c56f8e1ff5eb1ec8153a1f213e4acdb29"
+        ],
+        "package_hash": "6jqbqmx6gmbvcqzadr5pu7srx5pjspimgerocfu5qzijur6d6nxa====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen"
+      },
+      {
+        "name": "ncurses",
+        "version": "6.6",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "abi": "none",
+          "build_system": "autotools",
+          "patches": [
+            "7a351bc4953a4ab70dabdbea31c8db0c03d40ce505335f3b6687180dde24c535"
+          ],
+          "symlinks": false,
+          "termlib": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "7a351bc4953a4ab70dabdbea31c8db0c03d40ce505335f3b6687180dde24c535"
+        ],
+        "package_hash": "ezbmun4s3mducpc653hq5scim7iwi7fcpwkmsk6ljgkyosipmviq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r"
+      },
+      {
+        "name": "pkgconf",
+        "version": "2.5.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "o6vd55gzw74grnmg4yrt3smyrtsshssqjvxsqbchcjimkv2nkysa====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc"
+      },
+      {
+        "name": "gettext",
+        "version": "1.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "bzip2": true,
+          "curses": true,
+          "git": true,
+          "libunistring": false,
+          "libxml2": true,
+          "pic": true,
+          "shared": true,
+          "tar": true,
+          "xz": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ovlnai7b6g5wmztjbdlh44etm2otg4x7pr23rxinhlvnwljpouoq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "bzip2",
+            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libiconv",
+            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "iconv"
+              ]
+            }
+          },
+          {
+            "name": "libxml2",
+            "hash": "gpg4o6qwia66675izq7pq2tj7qbfk4mz",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "tar",
+            "hash": "n7jq5maroxawr5zwk5dzl46uo72mp7d2",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "xz",
+            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq"
+      },
+      {
+        "name": "libxml2",
+        "version": "2.15.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "pic": true,
+          "python": false,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "mlipmbzp7ge4oowcba2wlftdnyojw7qogswkczoxyvpl5cnnn3ua====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libiconv",
+            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "iconv"
+              ]
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "xz",
+            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "gpg4o6qwia66675izq7pq2tj7qbfk4mz"
+      },
+      {
+        "name": "xz",
+        "version": "5.8.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "libs": [
+            "shared",
+            "static"
+          ],
+          "pic": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "2p4c67wy2rdvwyfvjctbvgx4b2ezbzinzfp3ab4cbmyhdgsynjaq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b"
+      },
+      {
+        "name": "zlib-ng",
+        "version": "2.3.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "compat": true,
+          "new_strategies": true,
+          "opt": true,
+          "pic": true,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "bnbx7ezlmmjgjyubhncgeel7lpbjrj6l4aeuhyewdeyz56l7tqsq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr"
+      },
+      {
+        "name": "tar",
+        "version": "1.35",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "zip": "pigz",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "6ehejdbvmcwxgv5nwhsx7vwwyitb4lspgxi5cr3qv7m4m3ibavoq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "bzip2",
+            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libiconv",
+            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "iconv"
+              ]
+            }
+          },
+          {
+            "name": "pigz",
+            "hash": "m7cgtntes44ljcaanyefoaexeokll3xa",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "xz",
+            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zstd",
+            "hash": "e6anxsyrvvfaxhsxbkg56amkhsk6c5nv",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "n7jq5maroxawr5zwk5dzl46uo72mp7d2"
+      },
+      {
+        "name": "pigz",
+        "version": "2.8",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "makefile",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "wwjevhnbqmfhhepjfnbstlv3wqwwelfovcncjxtvamqxrbwhw7zq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "m7cgtntes44ljcaanyefoaexeokll3xa"
+      },
+      {
+        "name": "zstd",
+        "version": "1.5.7",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "makefile",
+          "compression": [
+            "none"
+          ],
+          "libs": [
+            "shared",
+            "static"
+          ],
+          "programs": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "wboc256qmgsrykonxftejdfurvumzlypglynd5a4gyqedm2fyhvq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "e6anxsyrvvfaxhsxbkg56amkhsk6c5nv"
+      },
+      {
+        "name": "libffi",
+        "version": "3.5.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "5etpcowfvrexvad7mlwrtyifh7s7jxjoumi7nqcbrunwr2eljzda====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "oyefbrren2rgkizhkwfk5rgjmmcfxutc"
+      },
+      {
+        "name": "openssl",
+        "version": "3.6.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "certs": "mozilla",
+          "docs": false,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "uma22ggryy2n4gaojca6cehkcvscq6dusx7n25ixuofsdfstio5a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "ca-certificates-mozilla",
+            "hash": "q4sjoyzux5b2b5foq3zuqrhexam7fbtp",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl",
+            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl"
+      },
+      {
+        "name": "ca-certificates-mozilla",
+        "version": "2026-03-19",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "lke3kzjefo4dmuiohzoe2xscjxkupvajh7lzpucca5yb3rdwmwra====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "q4sjoyzux5b2b5foq3zuqrhexam7fbtp"
+      },
+      {
+        "name": "perl",
+        "version": "5.42.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cpanm": true,
+          "opcode": true,
+          "open": true,
+          "shared": true,
+          "threads": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "2khvmuuco4dztminmufybx22ii3w2lg76my26stxowiuin45ulqq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "berkeley-db",
+            "hash": "yf6glkiuqhbalt6drpfv7ypuqaby7dlq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "bzip2",
+            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gdbm",
+            "hash": "t3wvm22tgiwgkwoxb7zfxafltfjwt5oa",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "less",
+            "hash": "s2blqq7wpn52jpbyha2mxoswgc6ynxyt",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml"
+      },
+      {
+        "name": "berkeley-db",
+        "version": "18.1.40",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cxx": true,
+          "docs": false,
+          "patches": [
+            "26090f418891757af46ac3b89a9f43d6eb5989f7a3dce3d1cfc99fba547203b3",
+            "b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522"
+          ],
+          "stl": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522",
+          "26090f418891757af46ac3b89a9f43d6eb5989f7a3dce3d1cfc99fba547203b3"
+        ],
+        "package_hash": "hjvyfptdgfnbf5l2nqfjylteroet5spd43lse4scnbhm5yge2x2q====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "yf6glkiuqhbalt6drpfv7ypuqaby7dlq"
+      },
+      {
+        "name": "less",
+        "version": "692",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "vk4i7xorbhfmkhljk6j732vldgdoaltvrgkte63vulk6a67rdfha====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "s2blqq7wpn52jpbyha2mxoswgc6ynxyt"
+      },
+      {
+        "name": "sqlite",
+        "version": "3.53.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "column_metadata": true,
+          "fts": true,
+          "rtree": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "kbznjezipzenc57giiwxqcdo3ljzpt4q3que6lzaydizky2nhw6q====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "readline",
+            "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "xj623b2avuv36wjimofsygpxbmhrv4sl"
+      },
+      {
+        "name": "python-venv",
+        "version": "1.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "kdta7ilemit6mnm7boqnwnpvez3gb2nkgxostojzosh72kufwydq====",
+        "dependencies": [
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "insqdinizfotrnfthoft6ybsevaijmfv"
+      },
+      {
+        "name": "py-wheel",
+        "version": "0.45.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "7ssc7yg2a464b2rurfpb3wx2fmls6y2a4yalc373x2erhxobx4jq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "loosups3b4reuwyrli5pniucc4gkavdi"
+      },
+      {
+        "name": "py-jsonschema",
+        "version": "4.26.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "format-nongpl": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "2cgizt24kzf4adhf3zriyiu37fee7llvoetznitkytoh67zedozq====",
+        "dependencies": [
+          {
+            "name": "py-attrs",
+            "hash": "j4rpsdlzhot3ytgrslxtiij2vqayt6g6",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatch-fancy-pypi-readme",
+            "hash": "qf6pdf4o3nhmjhw4m6ypja2zoug3k4tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatch-vcs",
+            "hash": "xoshwunag6zciaynwz7silccrdxd4mj2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-jsonschema-specifications",
+            "hash": "fsh6bdz2th5habaarrusxplaurw545yn",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-referencing",
+            "hash": "uzodffdldcmg32sb22k3fje5uopewnu3",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-rpds-py",
+            "hash": "vdmugyilykjxywaevdwu6zlm3hl7wxad",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "shc6wuoafsuuuu25egqyvfpqghue5hpq"
+      },
+      {
+        "name": "py-attrs",
+        "version": "26.1.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "xnad4n3wxskwlybbnnebvwg45ulgmfbhahm45tola6pszrxm6qsq====",
+        "dependencies": [
+          {
+            "name": "py-hatch-fancy-pypi-readme",
+            "hash": "qf6pdf4o3nhmjhw4m6ypja2zoug3k4tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatch-vcs",
+            "hash": "xoshwunag6zciaynwz7silccrdxd4mj2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "j4rpsdlzhot3ytgrslxtiij2vqayt6g6"
+      },
+      {
+        "name": "py-hatch-fancy-pypi-readme",
+        "version": "25.1.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "7h2gpsjs7hligoiwr7dum55xbyucnnhbyu3gwhgz55ksquu4ijva====",
+        "dependencies": [
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qf6pdf4o3nhmjhw4m6ypja2zoug3k4tn"
+      },
+      {
+        "name": "py-hatchling",
+        "version": "1.29.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ljpqr54iebz6o7kdo6vn4mvtn3rchfzppceh66bygr2lml4nd5ta====",
+        "dependencies": [
+          {
+            "name": "py-packaging",
+            "hash": "u5q6yh2ym3emguofwk4kggboeri5re7t",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pathspec",
+            "hash": "55ltqwujvjqtblrpscd5v3d4r33hdd64",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pluggy",
+            "hash": "dy47onebj7syo25evwp2inzy5sbhfbp3",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-trove-classifiers",
+            "hash": "e3gmi6td4ebt6vrbhflnmtb7w4cl6x3s",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d"
+      },
+      {
+        "name": "py-packaging",
+        "version": "26.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "rrlzcdd5ptjkofi6qn7j2s6bvehbptfkndpxhzyjv5z4v37rtgaa====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "u5q6yh2ym3emguofwk4kggboeri5re7t"
+      },
+      {
+        "name": "py-pathspec",
+        "version": "1.1.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "kuqzdao7sqzgtqw3irg47frfydyikc7v6pxywkkrso3r7cp6fb4q====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "55ltqwujvjqtblrpscd5v3d4r33hdd64"
+      },
+      {
+        "name": "py-pluggy",
+        "version": "1.6.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "2iegqsoh3ty4i7wxp2danwg6mswtuevow37cptfj4os7u7rijida====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "dy47onebj7syo25evwp2inzy5sbhfbp3"
+      },
+      {
+        "name": "py-setuptools",
+        "version": "82.0.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "txzwesbaojo2pwm7mov7h6sftcsgdt5oxdgiontetkcxudegnmnq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47"
+      },
+      {
+        "name": "py-setuptools-scm",
+        "version": "9.2.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "toml": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "tc2nb4r3au3u4vwkrltebytaqvvhcuzte3luyg3m2n2sfsmdib7a====",
+        "dependencies": [
+          {
+            "name": "git",
+            "hash": "r5futqh3p4p6xts65fcgah3fuofadyua",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-packaging",
+            "hash": "u5q6yh2ym3emguofwk4kggboeri5re7t",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57"
+      },
+      {
+        "name": "git",
+        "version": "2.53.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "man": true,
+          "nls": true,
+          "patches": [
+            "67fa97142eed2ab2b0e9385b233254adb4bdf4dd42addf966d6ece3fd2a3c294"
+          ],
+          "perl": true,
+          "subtree": true,
+          "tcltk": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "67fa97142eed2ab2b0e9385b233254adb4bdf4dd42addf966d6ece3fd2a3c294"
+        ],
+        "package_hash": "d3a7zn4hyuq6rxymfwtrimrcmm7qf5xve54yzogpszaqqkigjglq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "autoconf",
+            "hash": "au4r5fsjtce5km4q225ptgxfxjn6sipb",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "automake",
+            "hash": "zs7f52fc7sy24pd42kqers24sihuwfrg",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "z42lcw4nq6bqsbbjteufvqyqc3rwto6q",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "expat",
+            "hash": "x5ovcbk323jbsyjvrn76wrb56xx5js52",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gettext",
+            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libiconv",
+            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "iconv"
+              ]
+            }
+          },
+          {
+            "name": "libidn2",
+            "hash": "eswkdrox2poeulrcspercshtt7tpuaeu",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libtool",
+            "hash": "jblwy45tdxcxi6iyhmaligxt4eumrp6c",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "m4",
+            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssh",
+            "hash": "nw7otd4tfcg6uwloxgmnv626op3yfqrs",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pcre2",
+            "hash": "gsjqvgexcuipyofmrfzbiavtbcm2ruiw",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl",
+            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "r5futqh3p4p6xts65fcgah3fuofadyua"
+      },
+      {
+        "name": "autoconf",
+        "version": "2.72",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "os7r3cxrf3hkkkcgvuzcpshodek7hylxdsq4qa425ykps33d2bcq====",
+        "dependencies": [
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "m4",
+            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl",
+            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "au4r5fsjtce5km4q225ptgxfxjn6sipb"
+      },
+      {
+        "name": "m4",
+        "version": "1.4.21",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "sigsegv": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "uqxut5tqgyjrkdkhgopowjvbus5tb5zzuu2i3uo6odle67f3r26a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libsigsegv",
+            "hash": "6bxbmkak7ep5pr7ows6pf546vanhzvss",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt"
+      },
+      {
+        "name": "libsigsegv",
+        "version": "2.15",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "owum656m6rpybyktdfeeksuvu7p2g4l6rxs2qys5h7sgvvtuxmza====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "6bxbmkak7ep5pr7ows6pf546vanhzvss"
+      },
+      {
+        "name": "automake",
+        "version": "1.18.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ah4rkjdzqkmhyh6erbzj5cebrxeoqxt4k4peteswpmrz5wc23s7q====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "autoconf",
+            "hash": "au4r5fsjtce5km4q225ptgxfxjn6sipb",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl",
+            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "zs7f52fc7sy24pd42kqers24sihuwfrg"
+      },
+      {
+        "name": "curl",
+        "version": "8.20.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "gssapi": false,
+          "ldap": false,
+          "libidn2": false,
+          "librtmp": false,
+          "libs": [
+            "shared",
+            "static"
+          ],
+          "libssh": false,
+          "libssh2": false,
+          "nghttp2": true,
+          "tls": [
+            "openssl"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "6k4rb6udvmamovquozk4o7c4bufszbxgfofxaegdkrrvntpjkclq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "nghttp2",
+            "hash": "i26u5jl77znledpx35oedfwz7pjr64py",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "z42lcw4nq6bqsbbjteufvqyqc3rwto6q"
+      },
+      {
+        "name": "nghttp2",
+        "version": "1.67.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "s57echxnxs2pa26gyxrozc3jj6d65y3beqpwam4gbco4t5gx6vka====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "i26u5jl77znledpx35oedfwz7pjr64py"
+      },
+      {
+        "name": "libidn2",
+        "version": "2.3.8",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "u6kovvtfxzi5gkpasfioxx3bn25e3iqj7im2bw2pbn3hkjgianwq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libunistring",
+            "hash": "saaz5bpluyk5o33l6b4apr4r4fa43pof",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "eswkdrox2poeulrcspercshtt7tpuaeu"
+      },
+      {
+        "name": "libunistring",
+        "version": "1.4.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "2rtlfhrr6s27nalw3s5pruedvgasc52y37il4ky3kembhczeb4rq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libiconv",
+            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "iconv"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "saaz5bpluyk5o33l6b4apr4r4fa43pof"
+      },
+      {
+        "name": "libtool",
+        "version": "2.5.4",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "uxekz42i6wgztwghuk46bozo3qjsusrxlfz5a77z3ioctuv23llq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "file",
+            "hash": "qogtknbfwex7nfglwbqaldvayorjuidv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "findutils",
+            "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "m4",
+            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "jblwy45tdxcxi6iyhmaligxt4eumrp6c"
+      },
+      {
+        "name": "file",
+        "version": "5.46",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "static": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "tm46egn4rph3tva6ltwaaimsijp42b3dyoajagiy2tecnjlh57iq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "bzip2",
+            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "xz",
+            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          },
+          {
+            "name": "zstd",
+            "hash": "e6anxsyrvvfaxhsxbkg56amkhsk6c5nv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qogtknbfwex7nfglwbqaldvayorjuidv"
+      },
+      {
+        "name": "findutils",
+        "version": "4.10.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "patches": [
+            "440b9543365b4692a2e6e0b5674809659846658d34d1dfc542c4397c8d668b92"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "440b9543365b4692a2e6e0b5674809659846658d34d1dfc542c4397c8d668b92"
+        ],
+        "package_hash": "7qjqvag5fjhfmbwxf3kraqy4as7b5tn7n3rjo332y3gwm3hxpuva====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gettext",
+            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a"
+      },
+      {
+        "name": "openssh",
+        "version": "10.3p1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "gssapi": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "vubmk4bqo4fzt42dufcet7iswhgx5mwu4mga7ttnccgdpma3ixna====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "krb5",
+            "hash": "mmtsyi7733y6swplzsraw3aqyrs3kqs2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libedit",
+            "hash": "cw4uwioti3csrypvhqojgb5dzqrwq7ls",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libxcrypt",
+            "hash": "vborjfjuvpdfmyyrnuql62iwu6ta6isr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "nw7otd4tfcg6uwloxgmnv626op3yfqrs"
+      },
+      {
+        "name": "krb5",
+        "version": "1.22.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "7rukoxvyvs7di3sybsvagldghiytf5huks2wlhj2zoukguntcpfq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "bison",
+            "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "findutils",
+            "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gettext",
+            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libedit",
+            "hash": "cw4uwioti3csrypvhqojgb5dzqrwq7ls",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl",
+            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "mmtsyi7733y6swplzsraw3aqyrs3kqs2"
+      },
+      {
+        "name": "bison",
+        "version": "3.8.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "color": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ayxhzq5gsdhdjn7xpy57gduvlldm6uegtnqici4mlqzqtdmkf2dq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "m4",
+            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd"
+      },
+      {
+        "name": "libedit",
+        "version": "3.1-20251016",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "iw5rblyn2culfszupb56jwzbrq5jdvlt5ikqdxx4okojhoouitoa====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "cw4uwioti3csrypvhqojgb5dzqrwq7ls"
+      },
+      {
+        "name": "libxcrypt",
+        "version": "4.5.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "obsolete_api": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "4emt2ct7ithxrxyp4cqvcehq6zptruurmedx6xrxsncjezriaxuq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl",
+            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "vborjfjuvpdfmyyrnuql62iwu6ta6isr"
+      },
+      {
+        "name": "pcre2",
+        "version": "10.44",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "jit": false,
+          "multibyte": true,
+          "pic": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "vkl6pgpob4o2hiqvsk7t6alf7emlsxbi2bo7x3rbr2soxsfxfoba====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "gsjqvgexcuipyofmrfzbiavtbcm2ruiw"
+      },
+      {
+        "name": "py-trove-classifiers",
+        "version": "2026.6.1.19",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "nh7wphaku5bnidwgg6ue6a3tc5khsplheecz5a5qosshouhlt7zq====",
+        "dependencies": [
+          {
+            "name": "py-calver",
+            "hash": "re4riyhcnm55qphrp43ckeojkxxesknp",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "e3gmi6td4ebt6vrbhflnmtb7w4cl6x3s"
+      },
+      {
+        "name": "py-calver",
+        "version": "2025.10.20",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "rikeqkwuph7xs6mw6mkoaqixc22oful6sqrwmn7pezpj5jxxufaa====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "re4riyhcnm55qphrp43ckeojkxxesknp"
+      },
+      {
+        "name": "py-hatch-vcs",
+        "version": "0.5.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "6ymlmuhefs2f4sz7w3qjnfj57ixlhtj6jrh3tewwrukxy4pzsila====",
+        "dependencies": [
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "xoshwunag6zciaynwz7silccrdxd4mj2"
+      },
+      {
+        "name": "py-jsonschema-specifications",
+        "version": "2025.9.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "bc2nmjfrpvt5b6hvys2gocwaikmzu2bmi5l5ybbwt4bcvvv4kfpq====",
+        "dependencies": [
+          {
+            "name": "py-hatch-vcs",
+            "hash": "xoshwunag6zciaynwz7silccrdxd4mj2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-referencing",
+            "hash": "uzodffdldcmg32sb22k3fje5uopewnu3",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "fsh6bdz2th5habaarrusxplaurw545yn"
+      },
+      {
+        "name": "py-referencing",
+        "version": "0.37.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ldwblxs5br3k6zud3l6fkyhegknhgeezfdeitrkc36lbztwriu2a====",
+        "dependencies": [
+          {
+            "name": "py-attrs",
+            "hash": "j4rpsdlzhot3ytgrslxtiij2vqayt6g6",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatch-vcs",
+            "hash": "xoshwunag6zciaynwz7silccrdxd4mj2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-rpds-py",
+            "hash": "vdmugyilykjxywaevdwu6zlm3hl7wxad",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "uzodffdldcmg32sb22k3fje5uopewnu3"
+      },
+      {
+        "name": "py-rpds-py",
+        "version": "0.27.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "bqgxorthiwycgl6y5knahc2acgooxkhov57atck6qnnyz4ospruq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-maturin",
+            "hash": "w5q5lhho35tveeegzn35buhsussppitj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "vdmugyilykjxywaevdwu6zlm3hl7wxad"
+      },
+      {
+        "name": "py-maturin",
+        "version": "1.13.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "sfustejwrbotcfkwymfave253tadgndn4wgggpmsrjg72sommt6a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "bzip2",
+            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-rust",
+            "hash": "opzw6zedjgujv7psznyxu4qnwcc2ivr5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "w5q5lhho35tveeegzn35buhsussppitj"
+      },
+      {
+        "name": "py-setuptools-rust",
+        "version": "1.12.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "goe65ecstszgzrbh4nyvwnkan3ieddavftmcgqyvjjtzg3wqpwgq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-semantic-version",
+            "hash": "fu6gsmwrnzgyzugh6q3zomr22kjnkgu7",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "opzw6zedjgujv7psznyxu4qnwcc2ivr5"
+      },
+      {
+        "name": "py-semantic-version",
+        "version": "2.10.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "lg4fww42z7geuoiv7jd4xgz4o7ed2jmbtkqskqq2hiixafcebsqa====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "fu6gsmwrnzgyzugh6q3zomr22kjnkgu7"
+      },
+      {
+        "name": "rust",
+        "version": "1.96.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "generic",
+          "dev": false,
+          "docs": false,
+          "src": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "4qsgzc55lbwz73ouxyqg3xv63o4d7r53aw7ze5el2lanqmvxninq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "z42lcw4nq6bqsbbjteufvqyqc3rwto6q",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libgit2",
+            "hash": "qn3p6zkthvi3p2etue4blrdt3aetrlev",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libssh2",
+            "hash": "qeixktacxr3g6wz6h34lgmhszb6u2cbz",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ninja",
+            "hash": "e426cv65l4537wctm672pk4on66n3kva",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust-bootstrap",
+            "hash": "vhtpwofuvrhfza6am5jaoy54jk3noymg",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr"
+      },
+      {
+        "name": "cmake",
+        "version": "3.31.11",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "build_type": "Release",
+          "doc": false,
+          "ncurses": true,
+          "ownlibs": true,
+          "qtgui": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "6tgtyzgohykswmnmkm3m4w3lbzttl7ccfgq67lj2nabjnz5egmba====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "z42lcw4nq6bqsbbjteufvqyqc3rwto6q",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "blnqchrxbgphjeye6tdenbekubwqiznr"
+      },
+      {
+        "name": "libgit2",
+        "version": "1.9.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "curl": false,
+          "generator": "make",
+          "https": "system",
+          "ipo": false,
+          "mmap": true,
+          "ssh": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "qe6kqfcxiwmycu2fdivxeukrkajz4jaqrod5hh3dti7wita5mp7a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libssh2",
+            "hash": "qeixktacxr3g6wz6h34lgmhszb6u2cbz",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pcre",
+            "hash": "efugbhodng7s237m2a7n4hacpdnvqi3o",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qn3p6zkthvi3p2etue4blrdt3aetrlev"
+      },
+      {
+        "name": "libssh2",
+        "version": "1.11.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "crypto": "openssl",
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "yqmxcercvmdj4wydnrynaevdofw2i67gzwllz67ck2lkhg3mld3q====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "xz",
+            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qeixktacxr3g6wz6h34lgmhszb6u2cbz"
+      },
+      {
+        "name": "pcre",
+        "version": "8.45",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "jit": false,
+          "multibyte": true,
+          "pic": true,
+          "shared": true,
+          "static": true,
+          "utf": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "i2pvfsribcb567g6ztpkc2kqlcl43dw4vksvp3e4qher5xizdo7a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "efugbhodng7s237m2a7n4hacpdnvqi3o"
+      },
+      {
+        "name": "ninja",
+        "version": "1.13.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "re2c": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "uuvqgx4th7p23zkj3upav45jkieybnujaxafz6gfydixqhnfdmaq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "re2c",
+            "hash": "pnrrfayrvskcqajiplffnrp75w6qew3f",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "e426cv65l4537wctm672pk4on66n3kva"
+      },
+      {
+        "name": "re2c",
+        "version": "4.4",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "3vca5kfxu5fr6kdiweop3q65yeephppguqoe6vslrzditlmpuhnq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "pnrrfayrvskcqajiplffnrp75w6qew3f"
+      },
+      {
+        "name": "rust-bootstrap",
+        "version": "1.96.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "6bfkyesjskvxihyx7vyn5uefvctc6ofjgot6s7t7u5ingahnj7ga====",
+        "dependencies": [
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "vhtpwofuvrhfza6am5jaoy54jk3noymg"
+      },
+      {
+        "name": "py-numpy",
+        "version": "2.4.6",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "patches": [
+            "873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604"
+        ],
+        "package_hash": "3fe65gvuu3yl54uyjpzk6s3uogaqbdsoxoyx5ig5ujmcl3wmkika====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openblas",
+            "hash": "j42osoa4cbllwvtz2vndhz5gzvjfven3",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "blas",
+                "lapack"
+              ]
+            }
+          },
+          {
+            "name": "py-cython",
+            "hash": "5abmpkicqy6jsfjyjis5q7lh3dw4vbrj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-meson-python",
+            "hash": "mnrfwjsfji2e66232ypw4cicn4nqv2tz",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "5qbayddo243sliixvhlpxwrqg45frgsk"
+      },
+      {
+        "name": "openblas",
+        "version": "0.3.33",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "bignuma": false,
+          "build_system": "makefile",
+          "consistent_fpcsr": false,
+          "dynamic_dispatch": true,
+          "fortran": true,
+          "ilp64": false,
+          "locking": true,
+          "patches": [
+            "723ddc1553b6d27ff89d96985f7732695935c0d4d8df766987702689bdb750ac"
+          ],
+          "pic": true,
+          "shared": true,
+          "static": false,
+          "symbol_suffix": "none",
+          "threads": "none",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "723ddc1553b6d27ff89d96985f7732695935c0d4d8df766987702689bdb750ac"
+        ],
+        "package_hash": "zvlaojkxhj2rfwudx3ihy5mueaoxos4ku3wfldcrzhmei3kr2xuq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "fortran"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "fortran-rt",
+                "libgfortran"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "j42osoa4cbllwvtz2vndhz5gzvjfven3"
+      },
+      {
+        "name": "gcc",
+        "version": "16.2.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "binutils": true,
+          "bootstrap": true,
+          "build_system": "autotools",
+          "build_type": "RelWithDebInfo",
+          "graphite": false,
+          "languages": [
+            "c",
+            "c++",
+            "fortran"
+          ],
+          "libsanitizer": true,
+          "mold": false,
+          "nvptx": false,
+          "piclibs": false,
+          "profiled": false,
+          "strip": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "external": {
+          "path": "/opt/homebrew",
+          "module": null,
+          "extra_attributes": {
+            "compilers": {
+              "c": "/opt/homebrew/bin/gcc-16",
+              "cxx": "/opt/homebrew/bin/g++-16",
+              "fortran": "/opt/homebrew/bin/gfortran"
+            }
+          }
+        },
+        "package_hash": "bkqs3w2bph67itgvyruqwlgihn7eo55246dicgcd5dqk7bu7vo5q====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4"
+      },
+      {
+        "name": "gcc-runtime",
+        "version": "16.2.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "4wopkmadudswpydg45u4k2mzsyzwvmcmwre2cb735c7kd43qwpdq====",
+        "dependencies": [
+          {
+            "name": "gcc",
+            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs"
+      },
+      {
+        "name": "py-cython",
+        "version": "3.2.4",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "koz2ghpmuag6hky4ujh62m3wxou4nyp42m3qcnbh7oy3sdyabqwq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "5abmpkicqy6jsfjyjis5q7lh3dw4vbrj"
+      },
+      {
+        "name": "py-meson-python",
+        "version": "0.19.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "z3jzjklz4nbf4yc7dl5borlhbzusdcrqbrjtnzzz7ijo5xcuetbq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "meson",
+            "hash": "j52zmh7klthnjj2rrujzzmhftzhuw4c7",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ninja",
+            "hash": "e426cv65l4537wctm672pk4on66n3kva",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-packaging",
+            "hash": "u5q6yh2ym3emguofwk4kggboeri5re7t",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pyproject-metadata",
+            "hash": "ph6zvt6o4z2uvvlgjurba54excfmjm6o",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "mnrfwjsfji2e66232ypw4cicn4nqv2tz"
+      },
+      {
+        "name": "meson",
+        "version": "1.11.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "patches": [
+            "0f0b1bd854856c5f0926723437c9cd0507836bb93b45bdb434f5d3f618cc78dc"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "0f0b1bd854856c5f0926723437c9cd0507836bb93b45bdb434f5d3f618cc78dc"
+        ],
+        "package_hash": "ulpg4jgxomfqcjb6ohem424wd22ydmsow7j2nilpc6j6jp4up7qq====",
+        "dependencies": [
+          {
+            "name": "ninja",
+            "hash": "e426cv65l4537wctm672pk4on66n3kva",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "j52zmh7klthnjj2rrujzzmhftzhuw4c7"
+      },
+      {
+        "name": "py-pyproject-metadata",
+        "version": "0.11.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "jyqvrtmgejtm7iv3qvvi6s36avivre76e7ihupa7p4m35leazi5q====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-packaging",
+            "hash": "u5q6yh2ym3emguofwk4kggboeri5re7t",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ph6zvt6o4z2uvvlgjurba54excfmjm6o"
+      },
+      {
+        "name": "py-pandas",
+        "version": "2.3.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "excel": false,
+          "parquet": false,
+          "performance": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "e2nih5pki6laww4kr6wsvvu4dlxdyt3gikvmcpognkkfsdhtvqzq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "meson",
+            "hash": "j52zmh7klthnjj2rrujzzmhftzhuw4c7",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-cython",
+            "hash": "5abmpkicqy6jsfjyjis5q7lh3dw4vbrj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-meson-python",
+            "hash": "mnrfwjsfji2e66232ypw4cicn4nqv2tz",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-python-dateutil",
+            "hash": "dr5ycrzo3w5zgdjzleexvmkd23npsznx",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pytz",
+            "hash": "doszh7t67ufhhmaiiaxike5gzohx6cqa",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-tzdata",
+            "hash": "5wx3ry2lv4udhc266ghl6y4peqvr5nfh",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-versioneer",
+            "hash": "qnyhr2x5soshthhfr4kcrv4oiker7mgq",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ucw2it4b2pfltaz2wmyh522d6rkc2c2n"
+      },
+      {
+        "name": "py-python-dateutil",
+        "version": "2.9.0.post0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ykjzsnrjwac4mqqy2sczqtiybxm2txra6ohg7bydkq2xgjy5mica====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-six",
+            "hash": "p2p657lh73rto2mqwvtpvre2rlusqopf",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "dr5ycrzo3w5zgdjzleexvmkd23npsznx"
+      },
+      {
+        "name": "py-six",
+        "version": "1.17.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "eiknuz6vwcgwr4a3sdnq2zx757oh24v44la5ibof7umofb4x57zq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "p2p657lh73rto2mqwvtpvre2rlusqopf"
+      },
+      {
+        "name": "py-pytz",
+        "version": "2025.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "oqawsk4au7cy7gt3srxq2hkyr6ap3hztwlqojpc7xu2ckyolyknq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "doszh7t67ufhhmaiiaxike5gzohx6cqa"
+      },
+      {
+        "name": "py-tzdata",
+        "version": "2026.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ptkqk36rvgsotgzlguszvwtx62rkvmv4rc76zda3v2oandhuhl6q====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "5wx3ry2lv4udhc266ghl6y4peqvr5nfh"
+      },
+      {
+        "name": "py-versioneer",
+        "version": "0.29",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "toml": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "rvjah2t6kjo5fbgdf4l3e2zz2f44ap5eae6dfiub3d5e2bx4ykoa====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qnyhr2x5soshthhfr4kcrv4oiker7mgq"
+      },
+      {
+        "name": "py-polars",
+        "version": "1.42.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "3uwkolc24l2z2zyr4jkqqkgxgfmnuxgdxec5mxoocgct5plfmjxa====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-polars-runtime-32",
+            "hash": "pvtn5r76witgg2737sw3vkxqkkzvgyrr",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "s6e5ilg3yvr6pveslvb6qocyqtlucx2y"
+      },
+      {
+        "name": "py-polars-runtime-32",
+        "version": "1.42.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "vzz5cet4t2lw6xuo65tnbjreos5tsvbaysocbgkfpbjtjscgatka====",
+        "dependencies": [
+          {
+            "name": "py-maturin",
+            "hash": "s2kz5pxqqceanow3wxzdrnshh2gytekx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "pvtn5r76witgg2737sw3vkxqkkzvgyrr"
+      },
+      {
+        "name": "py-maturin",
+        "version": "1.13.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "sfustejwrbotcfkwymfave253tadgndn4wgggpmsrjg72sommt6a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "bzip2",
+            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-rust",
+            "hash": "xywhal6te4gn7yul4ygpoghzs5sya5ol",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "s2kz5pxqqceanow3wxzdrnshh2gytekx"
+      },
+      {
+        "name": "py-setuptools-rust",
+        "version": "1.12.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "goe65ecstszgzrbh4nyvwnkan3ieddavftmcgqyvjjtzg3wqpwgq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-semantic-version",
+            "hash": "fu6gsmwrnzgyzugh6q3zomr22kjnkgu7",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "xywhal6te4gn7yul4ygpoghzs5sya5ol"
+      },
+      {
+        "name": "rust",
+        "version": "nightly-2026-04-01",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "generic",
+          "dev": false,
+          "docs": false,
+          "src": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "veb7renk23dd7hpy3z4o2lwjwd7bnt2c4t2yozlynspgx4wnqicq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "z42lcw4nq6bqsbbjteufvqyqc3rwto6q",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libgit2",
+            "hash": "qn3p6zkthvi3p2etue4blrdt3aetrlev",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libssh2",
+            "hash": "qeixktacxr3g6wz6h34lgmhszb6u2cbz",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ninja",
+            "hash": "e426cv65l4537wctm672pk4on66n3kva",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust-bootstrap",
+            "hash": "mu32udyy3tm6gcqs74yzmjknpqjcs56x",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qrpwv56uqcw7ky6vzqkwznyf544xvzah"
+      },
+      {
+        "name": "rust-bootstrap",
+        "version": "beta-2026-03-05",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "t3dbqijksusikqqsjcj2n6kkayo3jurcakcuxuqp5dac6nt5c55q====",
+        "dependencies": [
+          {
+            "name": "zlib-ng",
+            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "mu32udyy3tm6gcqs74yzmjknpqjcs56x"
+      },
+      {
+        "name": "py-pyarrow",
+        "version": "25.0.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "3ern2kx66yb2xctnbashrfwlum4alp52ljp23uspetw4xw23ygva====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "arrow",
+            "hash": "6ndxlwzdrbhr4bnghwhhzdnwa7rjjjzg",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "py-cython",
+            "hash": "5abmpkicqy6jsfjyjis5q7lh3dw4vbrj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-libcst",
+            "hash": "kx33j7rmul6cc246vwtflso623e3ncnh",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-scikit-build-core",
+            "hash": "ll6n7bbrgitctm72ntizxd66qiz5gzl5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "vz6pzc3btsueu3nptggeyuhnodwmfola"
+      },
+      {
+        "name": "arrow",
+        "version": "25.0.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "brotli": false,
+          "build_system": "cmake",
+          "build_type": "Release",
+          "bz2": false,
+          "compute": false,
+          "csv": true,
+          "cuda": false,
+          "dataset": true,
+          "filesystem": true,
+          "gandiva": false,
+          "generator": "make",
+          "glog": false,
+          "hdfs": false,
+          "ipc": true,
+          "ipo": false,
+          "jemalloc": false,
+          "lz4": false,
+          "orc": false,
+          "parquet": true,
+          "python": true,
+          "shared": true,
+          "snappy": false,
+          "tensorflow": false,
+          "zlib": false,
+          "zstd": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "56yobbv2clb5pto4ugxxpkhqn4kdurmggkd5p4swyutjthdksv4q====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "boost",
+            "hash": "uon24phcff3qud4aummzeqh7c2acu3uy",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "flatbuffers",
+            "hash": "erxo2bygk5eeprhcmij5gp6bc233edkw",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ninja",
+            "hash": "e426cv65l4537wctm672pk4on66n3kva",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "xbhg2swzezhpqb4lfqafqy5bi7flvlyl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rapidjson",
+            "hash": "topfebfgodbijgo4cfcnzbmd7iboezm7",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "re2",
+            "hash": "gvvy7aassumbxvmknukncaqnkj7oc5z2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "thrift",
+            "hash": "qxykzbdgucrp7mq3qmiatuuqlbnfbtqt",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "utf8proc",
+            "hash": "7euilxwxzqi7ue4lwgnh4mk3gokqcr25",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "xsimd",
+            "hash": "3rlrcl4nran2zz5x7bh2jz5shn4as44j",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "6ndxlwzdrbhr4bnghwhhzdnwa7rjjjzg"
+      },
+      {
+        "name": "boost",
+        "version": "1.90.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "atomic": false,
+          "build_system": "generic",
+          "charconv": false,
+          "chrono": false,
+          "clanglibcpp": false,
+          "container": false,
+          "context": false,
+          "contract": false,
+          "conversion": false,
+          "cxxstd": "11",
+          "date_time": false,
+          "debug": false,
+          "exception": false,
+          "fiber": false,
+          "filesystem": true,
+          "graph": false,
+          "graph_parallel": false,
+          "icu": false,
+          "iostreams": false,
+          "json": false,
+          "locale": false,
+          "log": false,
+          "math": false,
+          "mpi": false,
+          "mqtt5": false,
+          "multithreaded": true,
+          "nowide": false,
+          "numpy": false,
+          "openmethod": false,
+          "patches": [
+            "a440f9696d3bbb77e7eab1516c004730f622e59c71d39960b472026ef92f88e8"
+          ],
+          "pic": false,
+          "program_options": false,
+          "python": false,
+          "random": false,
+          "regex": false,
+          "serialization": false,
+          "shared": true,
+          "signals2": false,
+          "singlethreaded": false,
+          "stacktrace": false,
+          "system": true,
+          "taggedlayout": false,
+          "test": false,
+          "thread": false,
+          "timer": false,
+          "type_erasure": false,
+          "url": false,
+          "versionedlayout": false,
+          "visibility": "hidden",
+          "wave": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "a440f9696d3bbb77e7eab1516c004730f622e59c71d39960b472026ef92f88e8"
+        ],
+        "package_hash": "7jl2bofdxsthd2xq45mgtrkxurxu3swharjgcaexcr4scv2nugpq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "uon24phcff3qud4aummzeqh7c2acu3uy"
+      },
+      {
+        "name": "flatbuffers",
+        "version": "24.12.23",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "generator": "make",
+          "ipo": false,
+          "python": false,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ctythqsy3mi6yrgqm6byg5gqkmxkcpdzyrcfktqyrhf6rgepwmgq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "erxo2bygk5eeprhcmij5gp6bc233edkw"
+      },
+      {
+        "name": "rapidjson",
+        "version": "1.2.0-2024-08-16",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "commit": "7c73dd7de7c4f14379b781418c6e947ad464c818",
+          "doc": false,
+          "generator": "make",
+          "ipo": false,
+          "patches": [
+            "ee123c71ce5c44a627b087240d4e06839ff154e063c0c2b84c83a927efd8a269"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "ee123c71ce5c44a627b087240d4e06839ff154e063c0c2b84c83a927efd8a269"
+        ],
+        "package_hash": "zozhtfchvaondgprh4fv7gv4uchzdei2zwnv7dj7wco4ha4dz57a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "topfebfgodbijgo4cfcnzbmd7iboezm7"
+      },
+      {
+        "name": "re2",
+        "version": "2024-07-02",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "generator": "make",
+          "icu": false,
+          "ipo": false,
+          "pic": true,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "o3q3b3k4x7cnf5b4dccyaqzj4fzsqh5a2gxuokk73cfl233brccq====",
+        "dependencies": [
+          {
+            "name": "abseil-cpp",
+            "hash": "4ugimtuh3owsaeqlpzlugmfrnlicco4v",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "gvvy7aassumbxvmknukncaqnkj7oc5z2"
+      },
+      {
+        "name": "abseil-cpp",
+        "version": "20260107.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "cxxstd": "17",
+          "generator": "make",
+          "ipo": false,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ce4brhfex5prp35z7nujdbnh7cptrgm7nwpbe7kdrbk7gdzg73ba====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "4ugimtuh3owsaeqlpzlugmfrnlicco4v"
+      },
+      {
+        "name": "thrift",
+        "version": "0.22.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "c_glib": false,
+          "cpp": true,
+          "generator": "make",
+          "ipo": false,
+          "java": false,
+          "javascript": false,
+          "libevent": false,
+          "nodejs": false,
+          "openssl": false,
+          "python": false,
+          "qt5": false,
+          "shared": true,
+          "zlib": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "4af7izpvsx66ic5eytsvn6zkgtdtdl2kjerdea3h6qhhh56skpoa====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "bison",
+            "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "boost",
+            "hash": "uon24phcff3qud4aummzeqh7c2acu3uy",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "flex",
+            "hash": "cwazdijqx6zawlet4m27jkx7ni4ueytl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "qxykzbdgucrp7mq3qmiatuuqlbnfbtqt"
+      },
+      {
+        "name": "flex",
+        "version": "2.6.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "lex": true,
+          "nls": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "m2uhgcztia4wregbekbmg73yh5yvc4p2a5gkm56ii4wogndm3ktq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "bison",
+            "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "findutils",
+            "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "m4",
+            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "cwazdijqx6zawlet4m27jkx7ni4ueytl"
+      },
+      {
+        "name": "utf8proc",
+        "version": "2.10.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "generator": "make",
+          "ipo": false,
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "opscjeckm5ke333o2kxbi7uzdprg4533jjwpc5h2oa6ux2e7sefq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "7euilxwxzqi7ue4lwgnh4mk3gokqcr25"
+      },
+      {
+        "name": "xsimd",
+        "version": "13.2.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "generator": "make",
+          "ipo": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "v2pybpnchpm4gaduuyheqzmr7zxsda3nkno3ma3d5dwkuhpqjaga====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "3rlrcl4nran2zz5x7bh2jz5shn4as44j"
+      },
+      {
+        "name": "py-libcst",
+        "version": "1.8.6",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "i52gfacefxkclah3dsy63n6yb3fqhl7gyktp3wkjasnzi6pyyipq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pyyaml",
+            "hash": "la2un3wf5vfogltjter5jdwmajimqypz",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-rust",
+            "hash": "opzw6zedjgujv7psznyxu4qnwcc2ivr5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "kx33j7rmul6cc246vwtflso623e3ncnh"
+      },
+      {
+        "name": "py-pyyaml",
+        "version": "6.0.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "libyaml": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "xrdpicj2oiy2flltjatydctcbytuqv434g4t7rri3fsyqjj2k2dq====",
+        "dependencies": [
+          {
+            "name": "libyaml",
+            "hash": "lbgbqsxe36pdvoqm7gqpmd33rxw76wup",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-cython",
+            "hash": "5abmpkicqy6jsfjyjis5q7lh3dw4vbrj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "la2un3wf5vfogltjter5jdwmajimqypz"
+      },
+      {
+        "name": "libyaml",
+        "version": "0.2.5",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "uerjalcebiknyntippb2di6vu4hkis3fs7g46s6q5qob4k5y4esq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "lbgbqsxe36pdvoqm7gqpmd33rxw76wup"
+      },
+      {
+        "name": "py-scikit-build-core",
+        "version": "0.12.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "pyproject": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "cda3jjlilax52jp46oxyecxil4zky75cjybqav6sedy7yo6kqtka====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "fortran"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "fortran-rt",
+                "libgfortran"
+              ]
+            }
+          },
+          {
+            "name": "py-hatch-vcs",
+            "hash": "xoshwunag6zciaynwz7silccrdxd4mj2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-packaging",
+            "hash": "u5q6yh2ym3emguofwk4kggboeri5re7t",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pathspec",
+            "hash": "55ltqwujvjqtblrpscd5v3d4r33hdd64",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ll6n7bbrgitctm72ntizxd66qiz5gzl5"
+      },
+      {
+        "name": "py-pydantic",
+        "version": "2.13.4",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "dotenv": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "6csnervg7idrxcb2576numsou6x57tsvoprcfrjakdc65cbmcmwa====",
+        "dependencies": [
+          {
+            "name": "py-annotated-types",
+            "hash": "ojpkg6m3klqrtlafm2a3lswinluzxefd",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatch-fancy-pypi-readme",
+            "hash": "qf6pdf4o3nhmjhw4m6ypja2zoug3k4tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pydantic-core",
+            "hash": "xv4nvtihaprzsu4thuimhlorjc2sqhzd",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-typing-extensions",
+            "hash": "istyqwnwt2tufln6abuchhhotpfhmjrx",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-typing-inspection",
+            "hash": "oortf6ou6hfcc6lvn3h3cqpludgq6oci",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "znussdvf7c4nxdxw4gmdqc33toxhnjc3"
+      },
+      {
+        "name": "py-annotated-types",
+        "version": "0.7.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "jyknifdbhokanxc3322l75si5ldrl3nbzythneyk4ib7434vxc6a====",
+        "dependencies": [
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ojpkg6m3klqrtlafm2a3lswinluzxefd"
+      },
+      {
+        "name": "py-pydantic-core",
+        "version": "2.46.4",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "bcve2vnev5sr24qlbvrxquuy63dpwuy46qz64vktnhi7b3bvxfeq====",
+        "dependencies": [
+          {
+            "name": "py-maturin",
+            "hash": "w5q5lhho35tveeegzn35buhsussppitj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-typing-extensions",
+            "hash": "istyqwnwt2tufln6abuchhhotpfhmjrx",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "rust",
+            "hash": "emsmxzgmgnxtlixz3whmccwe2mqlekpr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "xv4nvtihaprzsu4thuimhlorjc2sqhzd"
+      },
+      {
+        "name": "py-typing-extensions",
+        "version": "4.16.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "5e2qqray5tpprokxq3yvqpen2yr5yx5hm2jvwbews6xikzgxz36a====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "istyqwnwt2tufln6abuchhhotpfhmjrx"
+      },
+      {
+        "name": "py-typing-inspection",
+        "version": "0.4.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "kwidpruujuejwttcj3wg3jwqqqskmezqotep2ee436qhmi6iexia====",
+        "dependencies": [
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-typing-extensions",
+            "hash": "istyqwnwt2tufln6abuchhhotpfhmjrx",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "oortf6ou6hfcc6lvn3h3cqpludgq6oci"
+      },
+      {
+        "name": "py-scikit-learn",
+        "version": "1.9.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "s4z3eb2w7hnfmpbbolazdsqdsttygf2c2ctuia57zow3f3wrzaba====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "llvm-openmp",
+            "hash": "klpyxk5mbgpl6u32blthz57sjwoh626m",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-cython",
+            "hash": "5abmpkicqy6jsfjyjis5q7lh3dw4vbrj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-joblib",
+            "hash": "u5et5q4djmowsrdaz7nu5ft5gqitgq2w",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-meson-python",
+            "hash": "mnrfwjsfji2e66232ypw4cicn4nqv2tz",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-narwhals",
+            "hash": "lp6oqgxvm7a7eldtxx4xigoegkzqp3zo",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-scipy",
+            "hash": "h3kxp56o42mlwo5g3irvrviu7brys4zr",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-threadpoolctl",
+            "hash": "s2fxlhs7i6eylh62iw26kijlcfalfb7c",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "sowk6gpb7s75p62bcert2z2qspyrtclq"
+      },
+      {
+        "name": "llvm-openmp",
+        "version": "20.1.8",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "fortran": false,
+          "generator": "make",
+          "ipo": false,
+          "multicompat": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "bvxhxpeb6l4vwegdl634ihu6hgftlvs4txfeefu6wxurxrvrxe5a====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "klpyxk5mbgpl6u32blthz57sjwoh626m"
+      },
+      {
+        "name": "py-joblib",
+        "version": "1.5.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "akatyiyii74zp3zz4dijpkcapoqncb6frb3g3kzxava3bgcexhta====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "u5et5q4djmowsrdaz7nu5ft5gqitgq2w"
+      },
+      {
+        "name": "py-narwhals",
+        "version": "2.19.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ljegzx5kddk3cohxrchx6i6x57xn66dsiqxy2wflxp2a47erbpmq====",
+        "dependencies": [
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "lp6oqgxvm7a7eldtxx4xigoegkzqp3zo"
+      },
+      {
+        "name": "py-scipy",
+        "version": "1.16.3",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "or65iya3rb2cnjcjgd5pcy2laial7b5heopbr7hboqozzp62lyaa====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "fortran"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "fortran-rt",
+                "libgfortran"
+              ]
+            }
+          },
+          {
+            "name": "meson",
+            "hash": "j52zmh7klthnjj2rrujzzmhftzhuw4c7",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openblas",
+            "hash": "j42osoa4cbllwvtz2vndhz5gzvjfven3",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "blas",
+                "lapack"
+              ]
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "py-cython",
+            "hash": "5abmpkicqy6jsfjyjis5q7lh3dw4vbrj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-meson-python",
+            "hash": "mnrfwjsfji2e66232ypw4cicn4nqv2tz",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pybind11",
+            "hash": "zc6ypqj7r7seyfyeyvgu7duqgrcwynum",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pythran",
+            "hash": "uqhmbbcxswmztywhtwjixvqpkftjtsai",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "h3kxp56o42mlwo5g3irvrviu7brys4zr"
+      },
+      {
+        "name": "py-pybind11",
+        "version": "3.0.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "generator": "ninja",
+          "ipo": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "tbwsv5n4ytuke5f4jhwpfufum3oxr6rrfaiorctpgu2irazefl2q====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "blnqchrxbgphjeye6tdenbekubwqiznr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ninja",
+            "hash": "e426cv65l4537wctm672pk4on66n3kva",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-scikit-build-core",
+            "hash": "ll6n7bbrgitctm72ntizxd66qiz5gzl5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "zc6ypqj7r7seyfyeyvgu7duqgrcwynum"
+      },
+      {
+        "name": "py-pythran",
+        "version": "0.18.1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "zi5hc2k66cd7krsbt4c34ec5jbc53plfamt4kwfd5kje5a7fjsza====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "llvm-openmp",
+            "hash": "klpyxk5mbgpl6u32blthz57sjwoh626m",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-beniget",
+            "hash": "6kxslanrzqr24zdr6irez3w2zgn772if",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-gast",
+            "hash": "ie3sxlmrkuhh2lkfpnqsdr5affm4e5pb",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-ply",
+            "hash": "hcxfgebfkhd3ey7xy75otgbcmkcz4lxe",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "uqhmbbcxswmztywhtwjixvqpkftjtsai"
+      },
+      {
+        "name": "py-beniget",
+        "version": "0.4.2.post1",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "nmiod4vsw7kzt5leqcnpa4i7ob2m7te72b6c4pst7omz6e3cfydq====",
+        "dependencies": [
+          {
+            "name": "py-gast",
+            "hash": "ie3sxlmrkuhh2lkfpnqsdr5affm4e5pb",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "6kxslanrzqr24zdr6irez3w2zgn772if"
+      },
+      {
+        "name": "py-gast",
+        "version": "0.6.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "fiu4hgarbutcor2yfava4yjpv3ye3dmbxs7h2udpyceh7spmxnha====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ie3sxlmrkuhh2lkfpnqsdr5affm4e5pb"
+      },
+      {
+        "name": "py-ply",
+        "version": "3.11",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "j2g4senjqvtekuxuhd47vfssbyrk7aho2bxmhebmakokcedfqpsa====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "hcxfgebfkhd3ey7xy75otgbcmkcz4lxe"
+      },
+      {
+        "name": "py-threadpoolctl",
+        "version": "3.6.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "joyzsv2m5spoyyo4amx526bc3bczfgilbrmfc42l4g2w4dccbz6q====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "s2fxlhs7i6eylh62iw26kijlcfalfb7c"
+      },
+      {
+        "name": "py-typer",
+        "version": "0.27.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "dy4ghvc7neqouuncw464nfgsex3wyhrmmrje4dqi77tvmivjff4a====",
+        "dependencies": [
+          {
+            "name": "py-annotated-doc",
+            "hash": "tweegyrml64qbtqslolfcq2rdy3aeqmi",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pdm-backend",
+            "hash": "no362ciybniqrzfea4ud6owymgi3jvzu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-rich",
+            "hash": "go4tjnyi7lt6c5uwjwz3gmk5vmmyihyp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-shellingham",
+            "hash": "h65xduvcff6stmfgakstvytd7dcr7ba6",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-typing-extensions",
+            "hash": "istyqwnwt2tufln6abuchhhotpfhmjrx",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "3rmv4fpa5njcfe4qh23admc3yo5pazyg"
+      },
+      {
+        "name": "py-annotated-doc",
+        "version": "0.0.5",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "voiage_hpc_overlay",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "fy4sts5kbtbjm6xt4fu7lgk6yatbc6bbgyj6nxngszwu22ib55fa====",
+        "dependencies": [
+          {
+            "name": "py-pdm-backend",
+            "hash": "no362ciybniqrzfea4ud6owymgi3jvzu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "tweegyrml64qbtqslolfcq2rdy3aeqmi"
+      },
+      {
+        "name": "py-pdm-backend",
+        "version": "2.4.7",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "dmcwv5mjmzqqxul7nfcxea7upcplkfpsxurr6ivipmx5oihs63ua====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "no362ciybniqrzfea4ud6owymgi3jvzu"
+      },
+      {
+        "name": "py-rich",
+        "version": "15.0.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ycy2o74nn3ttbmdnkyiromaaav6xtnko7mimhmibvmlh4mnmrvza====",
+        "dependencies": [
+          {
+            "name": "py-markdown-it-py",
+            "hash": "26tsir2h5o7s56tzui7mpnbt24gi22io",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-poetry-core",
+            "hash": "djutus4o5onbxybl5yv2cyo3o7svybl2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pygments",
+            "hash": "ylpnsx3rixfsrnhlmsnshmce2cn7hggn",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "go4tjnyi7lt6c5uwjwz3gmk5vmmyihyp"
+      },
+      {
+        "name": "py-markdown-it-py",
+        "version": "4.0.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "linkify": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "jz3xym3igpoiuu3t7przswd4buecixu7rcwiqhda3vhiezzo3h5a====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-mdurl",
+            "hash": "hc5io6yyzuyzywoqewjpzjhbyo6xvfme",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "26tsir2h5o7s56tzui7mpnbt24gi22io"
+      },
+      {
+        "name": "py-mdurl",
+        "version": "0.1.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "sat65c2wqlgamn46cclxqj47emiqt7aet27lffdtrnfl3p5fpqwa====",
+        "dependencies": [
+          {
+            "name": "py-flit-core",
+            "hash": "sx4akdu4u4p5yf67vizqp4xe243nyoi5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "hc5io6yyzuyzywoqewjpzjhbyo6xvfme"
+      },
+      {
+        "name": "py-poetry-core",
+        "version": "2.3.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "nc6kx3licn7aaboirrrnr233kbyf6kpdsibrlsjw5b7arnfcxvxq====",
+        "dependencies": [
+          {
+            "name": "apple-clang",
+            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "djutus4o5onbxybl5yv2cyo3o7svybl2"
+      },
+      {
+        "name": "py-pygments",
+        "version": "2.19.2",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "7s7t7k3733jbhqgjlxzcdp5xcalek2sbcwwbawsg4trtcjymnxmq====",
+        "dependencies": [
+          {
+            "name": "py-hatchling",
+            "hash": "pfga2wnwa2ah6may6zcow76p5u4sx75d",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ylpnsx3rixfsrnhlmsnshmce2cn7hggn"
+      },
+      {
+        "name": "py-shellingham",
+        "version": "1.5.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "cmlh637tyqg65b57xfmmxwmgtce236dcpleqtjthtycideimuwbq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "h65xduvcff6stmfgakstvytd7dcr7ba6"
+      },
+      {
+        "name": "py-xarray",
+        "version": "2024.7.0",
+        "arch": {
+          "platform": "darwin",
+          "platform_os": "tahoe",
+          "target": {
+            "name": "m1",
+            "vendor": "Apple",
+            "features": [
+              "aes",
+              "asimd",
+              "asimddp",
+              "asimdfhm",
+              "asimdhp",
+              "asimdrdm",
+              "atomics",
+              "cpuid",
+              "crc32",
+              "dcpodp",
+              "dcpop",
+              "dit",
+              "evtstrm",
+              "fcma",
+              "flagm",
+              "flagm2",
+              "fp",
+              "fphp",
+              "frint",
+              "ilrcpc",
+              "jscvt",
+              "lrcpc",
+              "paca",
+              "pacg",
+              "pmull",
+              "sb",
+              "sha1",
+              "sha2",
+              "sha3",
+              "sha512",
+              "ssbs",
+              "uscat"
+            ],
+            "generation": 0,
+            "parents": [
+              "armv8.4a"
+            ],
+            "cpupart": "0x022"
+          }
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "io": false,
+          "parallel": false,
+          "viz": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "7cs5yf47fja7gjtovftftakbdw3mrsku75vdu57kpukohmtlwzlq====",
+        "dependencies": [
+          {
+            "name": "py-numpy",
+            "hash": "5qbayddo243sliixvhlpxwrqg45frgsk",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-packaging",
+            "hash": "u5q6yh2ym3emguofwk4kggboeri5re7t",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pandas",
+            "hash": "ucw2it4b2pfltaz2wmyh522d6rkc2c2n",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "iba7t37oeolxtkecoasaq7qzhrrkqsew",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "hc56y5kv2mtr6zymb7a2wvy7wg2gie47",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "6v4bjdl342hh3p2uqxhkaf6xkm6skp57",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "loosups3b4reuwyrli5pniucc4gkavdi",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "x6td2havcli6acz4o52xc46nguqrodg2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "insqdinizfotrnfthoft6ybsevaijmfv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "6bsikoooqbvda2dpvbrbjoj5xuzh4h4s"
+      }
+    ]
+  }
+}

--- a/packaging/spack-overlay/solver-receipt.json
+++ b/packaging/spack-overlay/solver-receipt.json
@@ -1,9 +1,9 @@
 {
   "schema": "voiage.spack-overlay-solver.v1",
-  "recorded_at": "2026-08-31T15:39:23.487595+00:00",
+  "recorded_at": "2026-08-31T16:18:52.105595+00:00",
   "catalogue_commit": "d4f7c711a6a42f1c4d551c8fd10fce9a11340a81",
   "host": "macOS arm64",
-  "manifest_sha256": "300ad4cc5aa3294be9897f1ca50c38bbe8aa51b1d2f18d4e44ae10f85054498a",
+  "manifest_sha256": "0c1be98e5df3e661782bc901fd5dd404af8db0901ee98b9a70ed379c5f72b78a",
   "results": [
     {
       "spec": "py-typer@0.27.2",
@@ -40,7 +40,7 @@
   "prior_failure_evidence": "history/pre-dated-rust-69873911/solver-receipt.json",
   "concrete_dag": {
     "path": "solver-logs/voiage.json",
-    "sha256": "08b3516df1c77b174bb4251290575aa9bdd47522509210f96d3efabdf5ca5b02",
+    "sha256": "66db4f2a406dc0d610e5d754ee59b9ee44b9b36a4612f1e6eb874f8b631d73c4",
     "nodes": 139,
     "duplicated_build_tools": {
       "py-maturin": 2,

--- a/tests/test_hpc_dated_rust.py
+++ b/tests/test_hpc_dated_rust.py
@@ -1,0 +1,220 @@
+"""Check dated compiler provenance and executable recipe configuration paths."""
+
+import ast
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1] / "packaging/spack-overlay"
+
+
+def _method(package: str, method: str, namespace: dict[str, Any]) -> Any:
+    """Execute the actual recipe method without installing Spack in test lanes."""
+    tree = ast.parse((ROOT / "packages" / package / "package.py").read_text())
+    node = next(
+        child
+        for parent in tree.body
+        if isinstance(parent, ast.ClassDef)
+        for child in parent.body
+        if isinstance(child, ast.FunctionDef) and child.name == method
+    )
+    module = ast.Module(body=[node], type_ignores=[])
+    methods: dict[str, Any] = {}
+    exec(compile(module, f"{package}/package.py", "exec"), namespace, methods)  # noqa: S102 - executes checked-in recipe code
+    return methods[method]
+
+
+def test_dated_source_and_stage0_are_bound_to_official_metadata() -> None:
+    audit = json.loads((ROOT / "rust-source-audit.json").read_text())
+    compiler = audit["compiler"]
+    stage0 = audit["stage0"]
+    assert compiler["archive_digest_verified"]
+    assert compiler["archive_downloaded"]
+    assert compiler["bytes"] > 0
+    assert compiler["sha256"] in (ROOT / "packages/rust/package.py").read_text()
+    assert compiler["manifest_matches_official_sha256_sidecar"]
+    assert stage0["matches_source_commit_file"]
+    assert stage0["manifest_matches_official_sha256_sidecar"]
+    assert stage0["channel"] == "beta"
+    assert stage0["date"] == "2026-03-05"
+    for target, entry in stage0["targets"].items():
+        assert (
+            entry["published_sha256"]
+            in (ROOT / "packages/rust-bootstrap/package.py").read_text()
+        )
+        assert f"/2026-03-05/rust-beta-{target}.tar.xz" in entry["url"]
+        assert not entry["installed"]
+    assert not audit["compiler_installed"]
+    assert not audit["native_builds_executed"]
+
+
+def test_dated_urls_do_not_fall_through_generic_version_parser() -> None:
+    rust_url = _method("rust", "url_for_version", {})
+    assert rust_url(None, "nightly-2026-04-01") == (
+        "https://static.rust-lang.org/dist/2026-04-01/rustc-nightly-src.tar.xz"
+    )
+    bootstrap_url = _method("rust-bootstrap", "url_for_version", {})
+    for os_name, os_suffix in [
+        ("darwin", "apple-darwin"),
+        ("linux", "unknown-linux-gnu"),
+    ]:
+        for arch in ["x86_64", "aarch64"]:
+            package = SimpleNamespace(
+                os=os_name, target=arch, rust_os={os_name: os_suffix}
+            )
+            assert bootstrap_url(package, "beta-2026-03-05") == (
+                "https://static.rust-lang.org/dist/2026-03-05/"
+                f"rust-beta-{arch}-{os_suffix}.tar.xz"
+            )
+
+
+def test_dated_configure_uses_nightly_channel_and_explicit_bootstrap() -> None:
+    calls: list[tuple[str, ...]] = []
+    configure = _method(
+        "rust", "configure", {"configure": lambda *args: calls.append(args)}
+    )
+
+    class Spec:
+        def __init__(self, nightly: bool) -> None:
+            self.nightly = nightly
+
+        def satisfies(self, condition: str) -> bool:
+            return self.nightly and condition == "@=nightly-2026-04-01"
+
+        def __getitem__(self, name: str) -> Any:
+            assert name == "rust-bootstrap"
+            return SimpleNamespace(
+                prefix=SimpleNamespace(
+                    bin=SimpleNamespace(
+                        cargo="/bootstrap/bin/cargo", rustc="/bootstrap/bin/rustc"
+                    )
+                )
+            )
+
+    for nightly in [True, False]:
+        spec = Spec(nightly)
+        configure(SimpleNamespace(spec=spec), spec, "/candidate")
+        flags = calls[-1]
+        expected = "nightly" if nightly else "stable"
+        assert f"--release-channel={expected}" in flags
+        assert "build.cargo=/bootstrap/bin/cargo" in flags
+        assert "build.rustc=/bootstrap/bin/rustc" in flags
+        assert "llvm.download-ci-llvm=false" in flags
+        assert "build.vendor=true" in flags
+        assert ("rust.download-rustc=false" in flags) is nightly
+
+
+def test_bootstrap_install_passes_distinct_arguments() -> None:
+    calls: list[tuple[str, ...]] = []
+    install = _method(
+        "rust-bootstrap",
+        "install",
+        {"Executable": lambda _: lambda *args: calls.append(args)},
+    )
+    install(None, None, "/prefix with spaces")
+    assert calls == [("--prefix=/prefix with spaces", "--without=rust-docs")]
+
+
+def test_polars_build_uses_its_direct_dated_rust_prefix() -> None:
+    values: dict[str, str] = {}
+    method = _method(
+        "py-polars-runtime-32",
+        "setup_build_environment",
+        {"EnvironmentModifications": Any},
+    )
+    rust = SimpleNamespace(
+        prefix=SimpleNamespace(
+            bin=SimpleNamespace(rustc="/dated/bin/rustc", cargo="/dated/bin/cargo")
+        )
+    )
+    method(
+        SimpleNamespace(spec={"rust": rust}), SimpleNamespace(set=values.__setitem__)
+    )
+    assert values == {"RUSTC": "/dated/bin/rustc", "CARGO": "/dated/bin/cargo"}
+    assert "RUSTC_BOOTSTRAP" not in values
+
+
+def test_concrete_graph_keeps_only_the_four_build_tools_separate() -> None:
+    receipt = json.loads((ROOT / "solver-receipt.json").read_text())
+    artifact = receipt["concrete_dag"]
+    path = ROOT / artifact["path"]
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == artifact["sha256"]
+    nodes = json.loads(path.read_text())["spec"]["nodes"]
+    by_hash = {node["hash"]: node for node in nodes}
+    counts = Counter(node["name"] for node in nodes)
+    assert {name: count for name, count in counts.items() if count > 1} == {
+        "rust": 2,
+        "rust-bootstrap": 2,
+        "py-maturin": 2,
+        "py-setuptools-rust": 2,
+    }
+    for node in nodes:
+        if node["name"] in {"py-maturin", "py-setuptools-rust"}:
+            continue
+        for edge in node.get("dependencies", []):
+            if edge["name"] == "rust":
+                assert edge["parameters"]["deptypes"] == ["build"]
+                expected = (
+                    "nightly-2026-04-01"
+                    if node["name"] == "py-polars-runtime-32"
+                    else "1.96.0"
+                )
+                assert by_hash[edge["hash"]]["version"] == expected
+    for name, compiler in [
+        ("py-polars-runtime-32", "nightly-2026-04-01"),
+        ("py-pydantic-core", "1.96.0"),
+    ]:
+        node = next(node for node in nodes if node["name"] == name)
+        edges = {edge["name"]: edge for edge in node["dependencies"]}
+        assert by_hash[edges["rust"]["hash"]]["version"] == compiler
+        assert edges["rust"]["parameters"]["deptypes"] == ["build"]
+        maturin = by_hash[edges["py-maturin"]["hash"]]
+        edges = {edge["name"]: edge for edge in maturin["dependencies"]}
+        assert by_hash[edges["rust"]["hash"]]["version"] == compiler
+        assert edges["rust"]["parameters"]["deptypes"] == ["build", "run"]
+        plugin = by_hash[edges["py-setuptools-rust"]["hash"]]
+        edge = next(edge for edge in plugin["dependencies"] if edge["name"] == "rust")
+        assert by_hash[edge["hash"]]["version"] == compiler
+        assert edge["parameters"]["deptypes"] == ["run"]
+
+
+def test_solver_configuration_and_audits_are_manifest_bound() -> None:
+    manifest = json.loads((ROOT / "manifest.json").read_text())
+    for name in [
+        "concretizer.yaml",
+        "rust-source-audit.json",
+        "rust-backend-source-audit.json",
+    ]:
+        assert (
+            manifest["support_sha256"][name]
+            == hashlib.sha256((ROOT / name).read_bytes()).hexdigest()
+        )
+    config = (ROOT / "concretizer.yaml").read_text()
+    assert "unify: true" in config
+    assert "strategy: minimal" in config
+    assert "unify: false" not in config
+    duplicate_limits = {
+        line.split(":", 1)[0].strip(): int(line.split(":", 1)[1])
+        for line in config.split("max_dupes:\n", 1)[1].splitlines()
+        if line.strip()
+    }
+    assert duplicate_limits == {
+        "rust": 2,
+        "rust-bootstrap": 2,
+        "py-maturin": 2,
+        "py-setuptools-rust": 2,
+    }
+
+
+def test_intermediate_solver_failures_remain_inspectable() -> None:
+    diagnostics = json.loads((ROOT / "dated-rust-diagnostics.json").read_text())
+    assert [entry["exit_code"] for entry in diagnostics["attempts"]] == [0, 1, 1, 1]
+    for entry in diagnostics["attempts"]:
+        path = (ROOT / entry["path"]).resolve()
+        assert path.is_relative_to((ROOT / "solver-logs").resolve())
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == entry["sha256"]
+        if entry["exit_code"]:
+            assert "Error: failed to concretize" in path.read_text()

--- a/tests/test_hpc_spack_overlay.py
+++ b/tests/test_hpc_spack_overlay.py
@@ -62,9 +62,18 @@ def test_overlay_versions_match_verified_source_digests() -> None:
         source = entry.get("sources", [entry])[0]
         assert source.get("download_hash_verified", source.get("hash_verified"))
         recipe = ROOT / "packages" / f"py-{entry['name']}" / "package.py"
-        assert (
-            f'"{entry["version"]}", sha256="{source["sha256"]}"' in recipe.read_text()
-        )
+        versions = {
+            node.args[0].value: keyword.value.value
+            for node in ast.walk(ast.parse(recipe.read_text()))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "version"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            for keyword in node.keywords
+            if keyword.arg == "sha256" and isinstance(keyword.value, ast.Constant)
+        }
+        assert versions[entry["version"]] == source["sha256"]
     arrow = json.loads((ROOT / "arrow-source-audit.json").read_text())
     assert arrow["sha256"] in (ROOT / "packages/arrow/package.py").read_text()
     assert arrow["sha512_verified_against"].endswith(".sha512")
@@ -73,7 +82,7 @@ def test_overlay_versions_match_verified_source_digests() -> None:
 
 def test_native_dependency_requirements_are_not_downgraded() -> None:
     core = (ROOT / "packages/py-pydantic-core/package.py").read_text()
-    assert 'depends_on("rust@1.88:"' in core
+    assert 'depends_on("rust@1.88:1"' in core
     assert 'depends_on("py-maturin@1.10:1"' in core
     runtime = (ROOT / "packages/py-polars-runtime-32/package.py").read_text()
     assert 'depends_on("rust@nightly-2026-04-01"' in runtime


### PR DESCRIPTION
## Why

The pinned Spack catalogue could not resolve Voiage's complete dependency graph: Polars requires Rust nightly 2026-04-01 while other Rust extensions and their build backends need a stable compiler. The earlier overlay retained this failure explicitly.

## Changes

- Add source-verified dated Rust and its exact stage0 bootstrap metadata, preserving upstream recipe copyright and dependency types.
- Keep unified concretization with minimal duplication bounded to two instances each of Rust, rust-bootstrap, Maturin and setuptools-rust. Bind Polars to its direct dated compiler and preserve stable Rust for the other extensions.
- Retain the successful 139-node whole-Voiage DAG, all four solver logs, checksum manifests, rejected intermediate attempts and the previous overlay evidence.
- Add behavioral recipe tests and documentation that separates solver success from native build readiness.

Related to #1025. This does not close the native HPC build or upstream distribution requirements.

## Validation and scope

The reviewed pre-transplant tree `83e3262da9d5cfbfc95d550063863c622fce7ea8` on base `698739117b280416958cb5c1e1f8b2d624b3c182` passed all 15 tox environments; coverage was 95.11% with 4,675 tests passing and 15 skipped. An independent agent checked the source hashes, compiler/backend edges, bounded duplicates and evidence bindings. Consumer Python and production documentation dependency audits passed; these are not an audit of a built native Spack graph.

After the initial parent transplant, the two CodeQL recipe findings were repaired (class-method parameter spelling and an explanatory certificate fallback comment). All four specs were concretized again; the 139-node DAG is unchanged except propagated package hashes. The repaired commits were then rebased onto `790727317e6f154f54fdb1d037d7143752dc7d0b`. Fresh 20 focused tests and ingestion-conformance, lint, Vale and harness checks passed again on this final base. These checks are recorded separately from the pre-transplant full matrix.

Actual concretization passed on native macOS arm64 with the pinned catalogue. The compiler source archive was downloaded and SHA-256 verified. Bootstrap binary checksums were checked against official dated manifests, but bootstrap binaries were not downloaded or installed. No Rust compiler or native HPC package build, Linux/foss validation, module-load validation or upstream submission was performed. No `RUSTC_BOOTSTRAP`, global `unify: false`, guessed external compiler or weakened minimum release requirement is introduced.

Authored changes pass whitespace checks. Retained verbatim solver logs are deliberately excluded from whitespace normalization so their recorded hashes remain valid.
