### PR TITLE
Fix inherited Spack licence metadata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+- Inherit builtin Spack licence metadata in the Python, Expat and OpenSSL security overlays so SBOM generation does not reject successful source installations.
+
 - Prepare an isolated Arrow/PyArrow 25.0.1 EasyBuild 2024a provider with
   source-verified native and Python build dependencies and numerical smoke
   checks; native HPC installation remains pending.

--- a/packaging/spack-overlay/arrow-patch-source-audit.json
+++ b/packaging/spack-overlay/arrow-patch-source-audit.json
@@ -195,7 +195,7 @@
       {
         "requirement": "numpy>=1.25",
         "package": "py-numpy",
-        "version": "2.4.6",
+        "version": "2.3.5",
         "deptypes": [
           "build",
           "run"
@@ -252,5 +252,7 @@
     ]
   },
   "libcst_cargo_source_closure": "libcst-cargo-source-closure.json",
-  "qualified_dag_sha256": "567dcdb63d11e40b73ebb41717383b8b99fca604abd79dc809e273893d2c9651"
+  "qualified_dag_sha256": "b6228dfedc9e4ecfdf2c6fee96a46a291d5fe5dd1330448f256116de3fb18773",
+  "qualified_dag_recorded_at": "2026-09-01T12:17:15.826481+00:00",
+  "qualified_dag_host": "Ubuntu 24.04 Linux arm64"
 }

--- a/packaging/spack-overlay/builder-dispatch-audit.json
+++ b/packaging/spack-overlay/builder-dispatch-audit.json
@@ -117,9 +117,9 @@
     }
   },
   "recipe_sha256": {
-    "python": "69638efd8fcaf28c111012a6423c63b14517e9a6e6e0b5591694917abe231e6c",
-    "openssl": "2b4c407d4b504e4b506f30cb10f338625d38c70b5c1d76a77b3b7b9f5b1f79fb",
-    "expat": "361d23b4544538f8208e34d0e2bc17517d3504851a77ebfe317f7ba41cab4475"
+    "python": "43f95f1421296dd2cb4c3c5f9010adceaf6b706fa77ab86cb8bf29f723cefe1a",
+    "openssl": "0ff7bf35b466b138db4d2659c4e04fff29f99dfc1ca4c8ffb58375d3a5a1166a",
+    "expat": "1727f9f9a1d59940e8c4489bda00863dc654781dd69707153543a12e272195cb"
   },
   "native_build_executed": false
 }

--- a/packaging/spack-overlay/manifest.json
+++ b/packaging/spack-overlay/manifest.json
@@ -5,8 +5,8 @@
   "voiage_recipe_commit": "dec5a1b5996ea1c5eef55bd791cb1ce89c38968a",
   "recipe_sha256": {
     "packages/arrow/package.py": "5e5ba7caeb9cbd491ec4999a2531032b6fa8834698e18f4535fcb239f82ad10f",
-    "packages/expat/package.py": "361d23b4544538f8208e34d0e2bc17517d3504851a77ebfe317f7ba41cab4475",
-    "packages/openssl/package.py": "2b4c407d4b504e4b506f30cb10f338625d38c70b5c1d76a77b3b7b9f5b1f79fb",
+    "packages/expat/package.py": "1727f9f9a1d59940e8c4489bda00863dc654781dd69707153543a12e272195cb",
+    "packages/openssl/package.py": "0ff7bf35b466b138db4d2659c4e04fff29f99dfc1ca4c8ffb58375d3a5a1166a",
     "packages/py-annotated-doc/package.py": "5238e58c461846aca7b8f0d7879a41efa546eab7458d5c5396437756e58f10dc",
     "packages/py-click/package.py": "bdbe6166b9516b13c9f1e112a9560ab4ac79b86fb9cf3992ccba369d078fc3fa",
     "packages/py-libcst/package.py": "35feaf4b660af1cc4d7e91a886ae32147545f94609c5b165bce630082aee30bc",
@@ -20,7 +20,7 @@
     "packages/py-typer/package.py": "e13b10d527710d0ca77b12cc910f6db703f63a35cf18ea79e2be1eb51fc44d11",
     "packages/py-typing-extensions/package.py": "bc339c7bbb0f4eb478484269204bbccf4d755d03565ddb397552ed7006a1ed30",
     "packages/py-voiage/package.py": "ed0d76fad55f718854dd83520435d2e8c3d57fbdd084fb29e0ef4cf68d42eb90",
-    "packages/python/package.py": "69638efd8fcaf28c111012a6423c63b14517e9a6e6e0b5591694917abe231e6c",
+    "packages/python/package.py": "43f95f1421296dd2cb4c3c5f9010adceaf6b706fa77ab86cb8bf29f723cefe1a",
     "packages/rust/package.py": "c6379f7a29de431875d7adc2a94661e56fa69b96f3dfb791cbea085d05558fdc",
     "packages/rust-bootstrap/package.py": "9fa3514b619fcb45b0a4fc4107493e16397c336a13018ac9a08b79999a4ed02b",
     "packages/xsimd/package.py": "4941b94e05bcd36bd71a66b4fdd2bf44e3b9ff772d3fb3ab9e4b146573f41520"
@@ -36,8 +36,8 @@
     "rust-source-audit.json": "0e17803e2bd39637bfa4d122e4ddcf3a699742ae1dc2ab4281224e12007c1471",
     "rust-backend-source-audit.json": "0fbaea54166ab7389192f126225705c30865e2736bba76e0991c0e6de9472c23",
     "security-source-audit.json": "305b54b91f698df3180d45729c980593c2d29baf7b7999c4fcae93cdaca3c5e6",
-    "builder-dispatch-audit.json": "95f517e343537fce2d15fa35a092dfe7f94e9deb52f1cf2c5b3acb27f48095df",
-    "arrow-patch-source-audit.json": "5f1ad11e4b0d16172c9e05bdbda55d9018cb2c40e9317fc5843b1cf004b41f5b",
+    "builder-dispatch-audit.json": "7a2c381846030f5f59cfa737a741193c1d00199e83a8968dc4fd3dc1c7727674",
+    "arrow-patch-source-audit.json": "0d6d0cec187baf0802b6317010057ee8a1f30dc0a385849d6c01a9bdee35fb4f",
     "libcst-cargo-source-closure.json": "46c4843d3b04e48633b1d74e9b59d88480d12da71d64f15eb63a28fa5857da46"
   }
 }

--- a/packaging/spack-overlay/packages/expat/package.py
+++ b/packaging/spack-overlay/packages/expat/package.py
@@ -4,14 +4,13 @@
 
 """Preserve the pinned catalogue build with a security-maintained source."""
 
-from spack.package import depends_on, license, version  # noqa: A004 - Spack directive
+from spack.package import depends_on, version
 from spack_repo.builtin.packages.expat.package import Expat as BuiltinExpat
 
 
 class Expat(BuiltinExpat):
     """Security-maintained source with the pinned catalogue's build semantics."""
 
-    license("MIT")
     version(
         "2.8.3",
         sha256="b4cc2483927d5e90bf8c40b44a6b95b368b42a8a96e25883fce188b48a92b670",

--- a/packaging/spack-overlay/packages/openssl/package.py
+++ b/packaging/spack-overlay/packages/openssl/package.py
@@ -4,14 +4,13 @@
 
 """Preserve the pinned catalogue build with a security-maintained source."""
 
-from spack.package import depends_on, license, version  # noqa: A004 - Spack directive
+from spack.package import depends_on, version
 from spack_repo.builtin.packages.openssl.package import Openssl as BuiltinOpenssl
 
 
 class Openssl(BuiltinOpenssl):
     """Security-maintained source with the pinned catalogue's build semantics."""
 
-    license("Apache-2.0")
     version(
         "3.6.4",
         sha256="9bffaa1ad1e07b354c21bd3324ec02fa15579f45a7d0494b3e74bc449b7333ef",

--- a/packaging/spack-overlay/packages/python/package.py
+++ b/packaging/spack-overlay/packages/python/package.py
@@ -4,14 +4,13 @@
 
 """Preserve the pinned catalogue build with a security-maintained source."""
 
-from spack.package import depends_on, license, version  # noqa: A004 - Spack directive
+from spack.package import depends_on, version
 from spack_repo.builtin.packages.python.package import Python as BuiltinPython
 
 
 class Python(BuiltinPython):
     """Security-maintained source with the pinned catalogue's build semantics."""
 
-    license("0BSD")
     version(
         "3.12.14",
         sha256="6c6df908d2c3fd24e6d76869e92542abd0f33aec9dfc18df8875f89660286d43",

--- a/packaging/spack-overlay/solver-logs/voiage.json
+++ b/packaging/spack-overlay/solver-logs/voiage.json
@@ -8,51 +8,9 @@
         "name": "py-voiage",
         "version": "2.2.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -68,7 +26,7 @@
         "dependencies": [
           {
             "name": "py-click",
-            "hash": "4o7lsguwugqoz2inbaoi2wpncby6d6m2",
+            "hash": "bjce6qem6ikvsx6f5cuiqk73xkumryer",
             "parameters": {
               "deptypes": [
                 "run"
@@ -78,7 +36,7 @@
           },
           {
             "name": "py-jsonschema",
-            "hash": "h427vo7wvbexfrhah3vknw54jiywobkd",
+            "hash": "geangsp725ix6jeir5ovfwpuro4rtsvy",
             "parameters": {
               "deptypes": [
                 "run"
@@ -88,7 +46,7 @@
           },
           {
             "name": "py-maturin",
-            "hash": "sxu2d3246n5n6wku6ai2q7zoud2ivftd",
+            "hash": "6vy3zo7r2jffajh34j3s22rpqcadbmm4",
             "parameters": {
               "deptypes": [
                 "build"
@@ -98,7 +56,7 @@
           },
           {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "run"
@@ -108,7 +66,7 @@
           },
           {
             "name": "py-pandas",
-            "hash": "wpnad7cfczidplyxjfyzg5om2zpkektk",
+            "hash": "64wuz3wepx4neipupv5ggnakqmcfoi6d",
             "parameters": {
               "deptypes": [
                 "run"
@@ -118,7 +76,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -128,7 +86,7 @@
           },
           {
             "name": "py-polars",
-            "hash": "me3udu6uyndalsy6aygffbcggjthrarb",
+            "hash": "fmetxmmvon6ntltuozxxdrmjbdbw7vbf",
             "parameters": {
               "deptypes": [
                 "run"
@@ -138,7 +96,7 @@
           },
           {
             "name": "py-pyarrow",
-            "hash": "d2yw3fourt7yoxfsu7cdsw6sursl7lel",
+            "hash": "ay45xtgh4omyzsyq5ip432rwj2z2gvbf",
             "parameters": {
               "deptypes": [
                 "run"
@@ -148,7 +106,7 @@
           },
           {
             "name": "py-pydantic",
-            "hash": "r4y47icdvd6pkhenl3u2prxj4qyqe6rh",
+            "hash": "oovbhqkjowdp5yncp7vox4jtsolsmx52",
             "parameters": {
               "deptypes": [
                 "run"
@@ -158,7 +116,7 @@
           },
           {
             "name": "py-scikit-learn",
-            "hash": "lmrkdxw7hmdtkaynbbfgbthgpbzffszz",
+            "hash": "m2eevxtkij6wry644fvreikqa4lesya3",
             "parameters": {
               "deptypes": [
                 "run"
@@ -168,7 +126,7 @@
           },
           {
             "name": "py-scipy",
-            "hash": "ebzu5yeraelh2srtwjdd5phy5tobv6uj",
+            "hash": "z7bkk2rumd3dlau2te6zmgzfzmpghxdt",
             "parameters": {
               "deptypes": [
                 "run"
@@ -178,7 +136,7 @@
           },
           {
             "name": "py-typer",
-            "hash": "mnihnap6bexqulnfjlnsihu4znzns2oq",
+            "hash": "63kj4rps7dsuqlqahjcqro3pejpldkpz",
             "parameters": {
               "deptypes": [
                 "run"
@@ -188,7 +146,7 @@
           },
           {
             "name": "py-typing-extensions",
-            "hash": "3luhcd4nz3fgh3fxjegc6rcsdduysyjr",
+            "hash": "epvpeyyy4uiwc5fcjdttbd72ngbj4dt7",
             "parameters": {
               "deptypes": [
                 "run"
@@ -198,7 +156,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -208,7 +166,7 @@
           },
           {
             "name": "py-xarray",
-            "hash": "uwcwtsumrfeb2vlaedgeokq2vgqzkphn",
+            "hash": "54oiizdsxrc5exj7omo2hldg2lyeq6kd",
             "parameters": {
               "deptypes": [
                 "run"
@@ -218,7 +176,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -229,7 +187,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -240,7 +198,7 @@
           },
           {
             "name": "rust",
-            "hash": "4yx3pkx6tefwrwi2mnvvybmmgjplghwi",
+            "hash": "lomrlsgokiq43mxhvlf7hnyqc7m4gu6q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -252,57 +210,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "q4tvbq6qp43ofxr5alw4d5rwwfbs7avm"
+        "hash": "vvibzq7fjdekoxohxe3njglvyzppcw4t"
       },
       {
         "name": "py-click",
         "version": "8.5.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -318,7 +234,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -328,7 +244,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -338,7 +254,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -348,7 +264,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -359,7 +275,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -372,57 +288,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "4o7lsguwugqoz2inbaoi2wpncby6d6m2"
+        "hash": "bjce6qem6ikvsx6f5cuiqk73xkumryer"
       },
       {
         "name": "py-flit-core",
         "version": "3.12.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -438,7 +312,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -448,7 +322,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -458,7 +332,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -469,7 +343,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -482,57 +356,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji"
+        "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo"
       },
       {
         "name": "py-pip",
         "version": "26.1.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -548,7 +380,7 @@
         "dependencies": [
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -559,7 +391,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -572,57 +404,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3"
+        "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj"
       },
       {
         "name": "python",
         "version": "3.12.14",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -654,11 +444,43 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "6xuwnadlcdl73nre2us6oiesxuccj52qmtkhammvkvy3mnt2cuka====",
+        "package_hash": "eov6cin4wnxx7n5awjcssp4zqneauag3f6x2zopsnkcr6olotojq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "bzip2",
+            "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "expat",
+            "hash": "eslwzfruvoiypttp7xwtdhobmnubhqpy",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -670,45 +492,10 @@
             }
           },
           {
-            "name": "apple-libuuid",
-            "hash": "gjtqvhfo3t7damoje5eh3iws2gfsswjt",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build",
-                "link"
-              ],
-              "virtuals": [
-                "uuid"
-              ]
-            }
-          },
-          {
-            "name": "bzip2",
-            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
-            "parameters": {
-              "deptypes": [
-                "build",
-                "link"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "expat",
-            "hash": "p74tzbic6xuladqhvdq53pqnct7c77ju",
-            "parameters": {
-              "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
@@ -716,7 +503,7 @@
           },
           {
             "name": "gdbm",
-            "hash": "t3wvm22tgiwgkwoxb7zfxafltfjwt5oa",
+            "hash": "tmzarcsv7ukdfvdxwt2d3crshgdolfyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -727,7 +514,7 @@
           },
           {
             "name": "gettext",
-            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "hash": "elwfaifirlj7xa4qwdzygrxoeylrpy2a",
             "parameters": {
               "deptypes": [
                 "build",
@@ -737,8 +524,20 @@
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -748,7 +547,7 @@
           },
           {
             "name": "libffi",
-            "hash": "oyefbrren2rgkizhkwfk5rgjmmcfxutc",
+            "hash": "ppxhuaqezwtn42ir3lxmf5wznvkxdris",
             "parameters": {
               "deptypes": [
                 "build",
@@ -759,7 +558,7 @@
           },
           {
             "name": "libxcrypt",
-            "hash": "vborjfjuvpdfmyyrnuql62iwu6ta6isr",
+            "hash": "cdy63abqrphwhj5l3ovwskmeor6lymtv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -770,7 +569,7 @@
           },
           {
             "name": "ncurses",
-            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -781,7 +580,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -792,7 +591,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -804,7 +603,7 @@
           },
           {
             "name": "readline",
-            "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen",
+            "hash": "o7h6uthufnnhgugp45tcg2mnikrusl55",
             "parameters": {
               "deptypes": [
                 "build",
@@ -815,7 +614,7 @@
           },
           {
             "name": "sqlite",
-            "hash": "xj623b2avuv36wjimofsygpxbmhrv4sl",
+            "hash": "xdwrdvs7gskan5cvobpyfb65kl6lt4f7",
             "parameters": {
               "deptypes": [
                 "build",
@@ -825,8 +624,21 @@
             }
           },
           {
+            "name": "util-linux-uuid",
+            "hash": "tzcdlmuy7oux7uavrj5eyqn5hiw4e5b6",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "uuid"
+              ]
+            }
+          },
+          {
             "name": "xz",
-            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat",
             "parameters": {
               "deptypes": [
                 "build",
@@ -837,7 +649,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -852,120 +664,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc"
-      },
-      {
-        "name": "apple-clang",
-        "version": "21.0.0",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": "aarch64"
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "build_system": "bundle",
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "external": {
-          "path": "/usr",
-          "module": null,
-          "extra_attributes": {
-            "compilers": {
-              "c": "/usr/bin/clang",
-              "cxx": "/usr/bin/clang++"
-            }
-          }
-        },
-        "package_hash": "wi7ij62tcqvlrtl7ilc5f65hwxccv5jdxx67uxydxm2c5tzywr7a====",
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b"
-      },
-      {
-        "name": "apple-libuuid",
-        "version": "1353.100.2",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": "aarch64"
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "build_system": "bundle",
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "external": {
-          "path": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
-          "module": null,
-          "extra_attributes": {}
-        },
-        "package_hash": "4pdb7oo3tfp7b6ulthbraqtadpzwdfti6ot7b2asi7hetjfibwxq====",
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "gjtqvhfo3t7damoje5eh3iws2gfsswjt"
+        "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp"
       },
       {
         "name": "bzip2",
         "version": "1.0.8",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -983,8 +690,28 @@
         "package_hash": "23pafj3kmpyregjxpmso3hf2q5op467msdhghyksoj2sv75ixqga====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -995,28 +722,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "diffutils",
-            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1028,57 +757,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "f66e7vo7zkss445atltrjo7npnxaymup"
+        "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj"
       },
       {
         "name": "compiler-wrapper",
         "version": "1.1.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1094,57 +781,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "2eppidz73j5cixagdntn6caaysmx5bpx"
+        "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey"
       },
       {
         "name": "diffutils",
         "version": "3.12",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1159,8 +804,18 @@
         "package_hash": "gwdibkyu5ed7w73ge5rpiboowwfww4lk6wa7epmipesccj7jo6ia====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1171,18 +826,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1192,7 +859,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1202,7 +869,7 @@
           },
           {
             "name": "libiconv",
-            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "hash": "gn3ajcmluy2ttffe57xqv2cbwqsv7nqa",
             "parameters": {
               "deptypes": [
                 "build",
@@ -1217,57 +884,142 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv"
+        "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu"
+      },
+      {
+        "name": "gcc",
+        "version": "13.3.0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "binutils": true,
+          "bootstrap": true,
+          "build_system": "autotools",
+          "build_type": "RelWithDebInfo",
+          "graphite": false,
+          "languages": [
+            "c",
+            "c++",
+            "fortran"
+          ],
+          "libsanitizer": true,
+          "mold": false,
+          "nvptx": false,
+          "piclibs": false,
+          "profiled": false,
+          "strip": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "external": {
+          "path": "/usr",
+          "module": null,
+          "extra_attributes": {
+            "compilers": {
+              "c": "/usr/bin/gcc",
+              "cxx": "/usr/bin/g++",
+              "fortran": "/usr/bin/gfortran"
+            }
+          }
+        },
+        "package_hash": "x377fg3krfj43nsz5lhk3ekj5k2wmhiaof654s67xnolgibkzg2q====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx"
+      },
+      {
+        "name": "gcc-runtime",
+        "version": "13.3.0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "generic",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "4wopkmadudswpydg45u4k2mzsyzwvmcmwre2cb735c7kd43qwpdq====",
+        "dependencies": [
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon"
+      },
+      {
+        "name": "glibc",
+        "version": "2.39",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "external": {
+          "path": "/usr",
+          "module": null,
+          "extra_attributes": {}
+        },
+        "package_hash": "uykmboa2sw2jkcgvgh6ywrvd7l2m6puhzhzdljklfme6w6agh6ia====",
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr"
       },
       {
         "name": "gmake",
         "version": "4.4.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1283,8 +1035,18 @@
         "package_hash": "t7cpl3gi3q6vihjpyqrvviu4rlsgcfjvv4mt4rcq3wie2i7jr6sq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1295,70 +1057,40 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
             }
           }
         ],
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea"
+        "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox"
       },
       {
         "name": "gnuconfig",
         "version": "2025-07-10",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1374,57 +1106,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "cxt42mygaqmcy56nfni4afyojpabaeto"
+        "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe"
       },
       {
         "name": "libiconv",
         "version": "1.18",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1443,8 +1133,18 @@
         "package_hash": "ewtsucjkci2hquwbnguwdkediavggpdgzm4vi5rwwunj4pon32rq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1455,18 +1155,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1476,7 +1188,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1488,62 +1200,20 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4"
+        "hash": "gn3ajcmluy2ttffe57xqv2cbwqsv7nqa"
       },
       {
         "name": "expat",
         "version": "2.8.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
           "build_system": "autotools",
-          "libbsd": false,
+          "libbsd": true,
           "cflags": [],
           "cppflags": [],
           "cxxflags": [],
@@ -1551,11 +1221,21 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "a45tc5mwzieca767qv665qyht64ludsubrbke6wdqspfvanpnhtq====",
+        "package_hash": "dkqeaxoag7jb3c7h3igvbcorwgmthifeavv5q5gklqjwaf2ll6wa====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1567,18 +1247,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1588,7 +1280,209 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libbsd",
+            "hash": "2ce66nc6sb5n5rpwkjkg5xxzdjk2vpup",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "eslwzfruvoiypttp7xwtdhobmnubhqpy"
+      },
+      {
+        "name": "libbsd",
+        "version": "0.12.2",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "5gnibbsprzzfd3vetrot37bmbo6kjh2n7nndbptn5pom566ykmja====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libmd",
+            "hash": "wrzuvebw36nrgiammipfngqedcej2zcl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "2ce66nc6sb5n5rpwkjkg5xxzdjk2vpup"
+      },
+      {
+        "name": "libmd",
+        "version": "1.1.0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "aweljvbus3jawtrwv6aknn77pvvebijyyudnh4srxk57iexhvhmq====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1600,57 +1494,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "p74tzbic6xuladqhvdq53pqnct7c77ju"
+        "hash": "wrzuvebw36nrgiammipfngqedcej2zcl"
       },
       {
         "name": "gdbm",
         "version": "1.26",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1665,8 +1517,18 @@
         "package_hash": "5ua7ahogxot5dxzyurihdriblxzuavehguaupbd6ixrtciqfekbq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1677,18 +1539,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1698,7 +1572,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1708,7 +1582,7 @@
           },
           {
             "name": "readline",
-            "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen",
+            "hash": "o7h6uthufnnhgugp45tcg2mnikrusl55",
             "parameters": {
               "deptypes": [
                 "build",
@@ -1721,57 +1595,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "t3wvm22tgiwgkwoxb7zfxafltfjwt5oa"
+        "hash": "tmzarcsv7ukdfvdxwt2d3crshgdolfyq"
       },
       {
         "name": "readline",
         "version": "8.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1796,8 +1628,18 @@
         "package_hash": "6jqbqmx6gmbvcqzadr5pu7srx5pjspimgerocfu5qzijur6d6nxa====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1808,18 +1650,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1829,7 +1683,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1839,7 +1693,7 @@
           },
           {
             "name": "ncurses",
-            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -1852,57 +1706,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen"
+        "hash": "o7h6uthufnnhgugp45tcg2mnikrusl55"
       },
       {
         "name": "ncurses",
         "version": "6.6",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -1926,8 +1738,18 @@
         "package_hash": "ezbmun4s3mducpc653hq5scim7iwi7fcpwkmsk6ljgkyosipmviq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1939,18 +1761,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1960,7 +1794,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1970,7 +1804,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -1984,57 +1818,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r"
+        "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl"
       },
       {
         "name": "pkgconf",
         "version": "2.5.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -2049,8 +1841,18 @@
         "package_hash": "o6vd55gzw74grnmg4yrt3smyrtsshssqjvxsqbchcjimkv2nkysa====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2061,18 +1863,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2082,7 +1896,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2094,57 +1908,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc"
+        "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn"
       },
       {
         "name": "gettext",
         "version": "1.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -2168,8 +1940,29 @@
         "package_hash": "ovlnai7b6g5wmztjbdlh44etm2otg4x7pr23rxinhlvnwljpouoq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "bzip2",
+            "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2181,29 +1974,30 @@
             }
           },
           {
-            "name": "bzip2",
-            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2213,7 +2007,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2223,7 +2017,7 @@
           },
           {
             "name": "libiconv",
-            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "hash": "gn3ajcmluy2ttffe57xqv2cbwqsv7nqa",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2236,7 +2030,7 @@
           },
           {
             "name": "libxml2",
-            "hash": "gpg4o6qwia66675izq7pq2tj7qbfk4mz",
+            "hash": "r4ottk74ltukg6bnmjnvccs4uuoeqbko",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2247,7 +2041,7 @@
           },
           {
             "name": "ncurses",
-            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2258,7 +2052,7 @@
           },
           {
             "name": "tar",
-            "hash": "n7jq5maroxawr5zwk5dzl46uo72mp7d2",
+            "hash": "q6x7pmr6sfhgibxpav24xfiry7ubqjfv",
             "parameters": {
               "deptypes": [
                 "run"
@@ -2268,7 +2062,7 @@
           },
           {
             "name": "xz",
-            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2282,57 +2076,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq"
+        "hash": "elwfaifirlj7xa4qwdzygrxoeylrpy2a"
       },
       {
         "name": "libxml2",
         "version": "2.15.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -2350,8 +2102,18 @@
         "package_hash": "mlipmbzp7ge4oowcba2wlftdnyojw7qogswkczoxyvpl5cnnn3ua====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2362,18 +2124,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2383,7 +2157,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2393,7 +2167,7 @@
           },
           {
             "name": "libiconv",
-            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "hash": "gn3ajcmluy2ttffe57xqv2cbwqsv7nqa",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2406,7 +2180,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2418,7 +2192,7 @@
           },
           {
             "name": "xz",
-            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2429,7 +2203,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2444,57 +2218,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "gpg4o6qwia66675izq7pq2tj7qbfk4mz"
+        "hash": "r4ottk74ltukg6bnmjnvccs4uuoeqbko"
       },
       {
         "name": "xz",
         "version": "5.8.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -2514,8 +2246,18 @@
         "package_hash": "2p4c67wy2rdvwyfvjctbvgx4b2ezbzinzfp3ab4cbmyhdgsynjaq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2526,18 +2268,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2547,7 +2301,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2559,57 +2313,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b"
+        "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat"
       },
       {
         "name": "zlib-ng",
         "version": "2.3.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -2629,8 +2341,18 @@
         "package_hash": "bnbx7ezlmmjgjyubhncgeel7lpbjrj6l4aeuhyewdeyz56l7tqsq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2642,18 +2364,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2663,7 +2397,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2675,57 +2409,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr"
+        "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec"
       },
       {
         "name": "tar",
         "version": "1.35",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -2741,8 +2433,28 @@
         "package_hash": "6ehejdbvmcwxgv5nwhsx7vwwyitb4lspgxi5cr3qv7m4m3ibavoq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "bzip2",
+            "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2753,28 +2465,30 @@
             }
           },
           {
-            "name": "bzip2",
-            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "run"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2784,7 +2498,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2794,7 +2508,7 @@
           },
           {
             "name": "libiconv",
-            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "hash": "gn3ajcmluy2ttffe57xqv2cbwqsv7nqa",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2807,7 +2521,7 @@
           },
           {
             "name": "pigz",
-            "hash": "m7cgtntes44ljcaanyefoaexeokll3xa",
+            "hash": "j4qw35m7chylc45fzcdt2piqn4luywzc",
             "parameters": {
               "deptypes": [
                 "run"
@@ -2817,7 +2531,7 @@
           },
           {
             "name": "xz",
-            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat",
             "parameters": {
               "deptypes": [
                 "run"
@@ -2827,7 +2541,7 @@
           },
           {
             "name": "zstd",
-            "hash": "e6anxsyrvvfaxhsxbkg56amkhsk6c5nv",
+            "hash": "x3x5ccth36mjzyuup2uvtahusav5632a",
             "parameters": {
               "deptypes": [
                 "run"
@@ -2839,57 +2553,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "n7jq5maroxawr5zwk5dzl46uo72mp7d2"
+        "hash": "q6x7pmr6sfhgibxpav24xfiry7ubqjfv"
       },
       {
         "name": "pigz",
         "version": "2.8",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -2904,8 +2576,18 @@
         "package_hash": "wwjevhnbqmfhhepjfnbstlv3wqwwelfovcncjxtvamqxrbwhw7zq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2916,18 +2598,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -2937,7 +2631,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -2952,57 +2646,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "m7cgtntes44ljcaanyefoaexeokll3xa"
+        "hash": "j4qw35m7chylc45fzcdt2piqn4luywzc"
       },
       {
         "name": "zstd",
         "version": "1.5.7",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3025,8 +2677,18 @@
         "package_hash": "wboc256qmgsrykonxftejdfurvumzlypglynd5a4gyqedm2fyhvq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3038,18 +2700,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3061,57 +2735,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "e6anxsyrvvfaxhsxbkg56amkhsk6c5nv"
+        "hash": "x3x5ccth36mjzyuup2uvtahusav5632a"
       },
       {
         "name": "libffi",
         "version": "3.5.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3126,8 +2758,18 @@
         "package_hash": "5etpcowfvrexvad7mlwrtyifh7s7jxjoumi7nqcbrunwr2eljzda====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3139,18 +2781,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3160,7 +2814,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3172,57 +2826,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "oyefbrren2rgkizhkwfk5rgjmmcfxutc"
+        "hash": "ppxhuaqezwtn42ir3lxmf5wznvkxdris"
       },
       {
         "name": "libxcrypt",
         "version": "4.5.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3238,8 +2850,18 @@
         "package_hash": "4emt2ct7ithxrxyp4cqvcehq6zptruurmedx6xrxsncjezriaxuq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3250,18 +2872,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3271,7 +2905,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3281,7 +2915,7 @@
           },
           {
             "name": "perl",
-            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3293,57 +2927,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vborjfjuvpdfmyyrnuql62iwu6ta6isr"
+        "hash": "cdy63abqrphwhj5l3ovwskmeor6lymtv"
       },
       {
         "name": "perl",
         "version": "5.42.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3363,20 +2955,8 @@
         "package_hash": "2khvmuuco4dztminmufybx22ii3w2lg76my26stxowiuin45ulqq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c"
-              ]
-            }
-          },
-          {
             "name": "berkeley-db",
-            "hash": "yf6glkiuqhbalt6drpfv7ypuqaby7dlq",
+            "hash": "yeedwhrsfsbux24orn6wh7p4czwqj2in",
             "parameters": {
               "deptypes": [
                 "build",
@@ -3387,7 +2967,7 @@
           },
           {
             "name": "bzip2",
-            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj",
             "parameters": {
               "deptypes": [
                 "build",
@@ -3398,7 +2978,7 @@
           },
           {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3407,8 +2987,30 @@
             }
           },
           {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
             "name": "gdbm",
-            "hash": "t3wvm22tgiwgkwoxb7zfxafltfjwt5oa",
+            "hash": "tmzarcsv7ukdfvdxwt2d3crshgdolfyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -3418,8 +3020,20 @@
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3429,7 +3043,7 @@
           },
           {
             "name": "less",
-            "hash": "s2blqq7wpn52jpbyha2mxoswgc6ynxyt",
+            "hash": "4txatlqyhzgmyhvb42n7bj3f5rrqurof",
             "parameters": {
               "deptypes": [
                 "run"
@@ -3439,7 +3053,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -3454,57 +3068,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml"
+        "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy"
       },
       {
         "name": "berkeley-db",
         "version": "18.1.40",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3530,8 +3102,18 @@
         "package_hash": "hjvyfptdgfnbf5l2nqfjylteroet5spd43lse4scnbhm5yge2x2q====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3543,18 +3125,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3564,7 +3158,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3576,57 +3170,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "yf6glkiuqhbalt6drpfv7ypuqaby7dlq"
+        "hash": "yeedwhrsfsbux24orn6wh7p4czwqj2in"
       },
       {
         "name": "less",
         "version": "692",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3641,8 +3193,18 @@
         "package_hash": "vk4i7xorbhfmkhljk6j732vldgdoaltvrgkte63vulk6a67rdfha====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3653,18 +3215,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3674,7 +3248,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3684,7 +3258,7 @@
           },
           {
             "name": "ncurses",
-            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -3697,57 +3271,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "s2blqq7wpn52jpbyha2mxoswgc6ynxyt"
+        "hash": "4txatlqyhzgmyhvb42n7bj3f5rrqurof"
       },
       {
         "name": "openssl",
         "version": "3.6.4",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -3762,11 +3294,31 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "hw5re46qadw5rw3regh5c4nrhranhffldmukgmfcmf2wekkdrwhq====",
+        "package_hash": "7ugicr6gmcx6ysn6mzffe4r66kucipfepjrb3dmriwe3xy3xqkcq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "ca-certificates-mozilla",
+            "hash": "d7ca4nc4hchxu6hyfiffpz5tzz72vncb",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3778,28 +3330,30 @@
             }
           },
           {
-            "name": "ca-certificates-mozilla",
-            "hash": "q4sjoyzux5b2b5foq3zuqrhexam7fbtp",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3809,7 +3363,7 @@
           },
           {
             "name": "perl",
-            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3819,7 +3373,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -3834,57 +3388,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv"
+        "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c"
       },
       {
         "name": "ca-certificates-mozilla",
         "version": "2026-03-19",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3900,57 +3412,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "q4sjoyzux5b2b5foq3zuqrhexam7fbtp"
+        "hash": "d7ca4nc4hchxu6hyfiffpz5tzz72vncb"
       },
       {
         "name": "sqlite",
         "version": "3.53.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -3968,8 +3438,18 @@
         "package_hash": "kbznjezipzenc57giiwxqcdo3ljzpt4q3que6lzaydizky2nhw6q====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -3980,18 +3460,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4001,7 +3493,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4011,7 +3503,7 @@
           },
           {
             "name": "readline",
-            "hash": "vphp43fwghkrxxog2uvyyg5rqico2pen",
+            "hash": "o7h6uthufnnhgugp45tcg2mnikrusl55",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4022,7 +3514,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4037,57 +3529,117 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "xj623b2avuv36wjimofsygpxbmhrv4sl"
+        "hash": "xdwrdvs7gskan5cvobpyfb65kl6lt4f7"
+      },
+      {
+        "name": "util-linux-uuid",
+        "version": "2.41",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "vll4vw56n6xfqajbwvyduhkespr6jcsjcmc3epu24dvsir6vjuha====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "tzcdlmuy7oux7uavrj5eyqn5hiw4e5b6"
       },
       {
         "name": "python-venv",
         "version": "1.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -4103,7 +3655,7 @@
         "dependencies": [
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4116,57 +3668,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf"
+        "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq"
       },
       {
         "name": "py-wheel",
         "version": "0.45.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -4182,7 +3692,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4192,7 +3702,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4203,7 +3713,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4216,57 +3726,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a"
+        "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an"
       },
       {
         "name": "py-jsonschema",
         "version": "4.26.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -4283,7 +3751,7 @@
         "dependencies": [
           {
             "name": "py-attrs",
-            "hash": "x4aiwy3xjwdqstflaxsjmnkkkcdwoexo",
+            "hash": "y5wsvbklhrk6npbjsecna6sxqnjvks42",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4294,7 +3762,7 @@
           },
           {
             "name": "py-hatch-fancy-pypi-readme",
-            "hash": "i44ajczlub7e4ll2iwtelv72xoia4vqn",
+            "hash": "572isdqnn7w7myq36c4nmuczw7hg3xha",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4304,7 +3772,7 @@
           },
           {
             "name": "py-hatch-vcs",
-            "hash": "rqud6mszhna3e4ah6w2l6unhiczlf3ly",
+            "hash": "rchuzf3y2c2h6udbmfwfybiu3tfal25q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4314,7 +3782,7 @@
           },
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4324,7 +3792,7 @@
           },
           {
             "name": "py-jsonschema-specifications",
-            "hash": "7nr4och6tcnfxd44zw7lednzit3m43wr",
+            "hash": "2fb62ussiswrbpc5gpvpfu2ycmzyxzbh",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4335,7 +3803,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4345,7 +3813,7 @@
           },
           {
             "name": "py-referencing",
-            "hash": "e6az6rhpxtrj45nqe2g6nsmm2y7asw5n",
+            "hash": "5iqi6qcix4ilyhfrsofou5ccqbfpyw7z",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4356,7 +3824,7 @@
           },
           {
             "name": "py-rpds-py",
-            "hash": "5bkjtty4gc64p2sr3y6iudbalwyhypkp",
+            "hash": "g3qr4sgsdy2frfqrpyjuscgqbmuy7o3s",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4367,7 +3835,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4377,7 +3845,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4388,7 +3856,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4401,57 +3869,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "h427vo7wvbexfrhah3vknw54jiywobkd"
+        "hash": "geangsp725ix6jeir5ovfwpuro4rtsvy"
       },
       {
         "name": "py-attrs",
         "version": "26.1.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -4467,7 +3893,7 @@
         "dependencies": [
           {
             "name": "py-hatch-fancy-pypi-readme",
-            "hash": "i44ajczlub7e4ll2iwtelv72xoia4vqn",
+            "hash": "572isdqnn7w7myq36c4nmuczw7hg3xha",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4477,7 +3903,7 @@
           },
           {
             "name": "py-hatch-vcs",
-            "hash": "rqud6mszhna3e4ah6w2l6unhiczlf3ly",
+            "hash": "rchuzf3y2c2h6udbmfwfybiu3tfal25q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4487,7 +3913,7 @@
           },
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4497,7 +3923,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4507,7 +3933,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4517,7 +3943,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4528,7 +3954,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4541,57 +3967,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "x4aiwy3xjwdqstflaxsjmnkkkcdwoexo"
+        "hash": "y5wsvbklhrk6npbjsecna6sxqnjvks42"
       },
       {
         "name": "py-hatch-fancy-pypi-readme",
         "version": "25.1.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -4607,7 +3991,7 @@
         "dependencies": [
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4618,7 +4002,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4628,7 +4012,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4638,7 +4022,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4649,7 +4033,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4662,57 +4046,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "i44ajczlub7e4ll2iwtelv72xoia4vqn"
+        "hash": "572isdqnn7w7myq36c4nmuczw7hg3xha"
       },
       {
         "name": "py-hatchling",
         "version": "1.29.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -4728,7 +4070,7 @@
         "dependencies": [
           {
             "name": "py-packaging",
-            "hash": "5ffho2mv3pdpg2lup4526gedy6jhdzuq",
+            "hash": "da5km5iuzzq4ydcecig2m3rrs4wldedw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4739,7 +4081,7 @@
           },
           {
             "name": "py-pathspec",
-            "hash": "lgjjqknhp4gb2hgx5iuumngt4ctmjaac",
+            "hash": "cwji4bzk43dez6vgaswp7ualjbmmgwlq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4750,7 +4092,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4760,7 +4102,7 @@
           },
           {
             "name": "py-pluggy",
-            "hash": "svsudxlq7qscgins62247sleyn2vbq3o",
+            "hash": "dbkc7r22uxkcwhphcc5iif6deleaprdd",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4771,7 +4113,7 @@
           },
           {
             "name": "py-trove-classifiers",
-            "hash": "d46yao5wykmwyoql4pkrdbiptjmhv72o",
+            "hash": "5kkbk5tiu34zgdbwlw6alddfdu6ttfj2",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4782,7 +4124,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4792,7 +4134,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4803,7 +4145,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4816,57 +4158,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae"
+        "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz"
       },
       {
         "name": "py-packaging",
         "version": "26.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -4882,7 +4182,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4892,7 +4192,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4902,7 +4202,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -4912,7 +4212,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4923,7 +4223,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -4936,57 +4236,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "5ffho2mv3pdpg2lup4526gedy6jhdzuq"
+        "hash": "da5km5iuzzq4ydcecig2m3rrs4wldedw"
       },
       {
         "name": "py-pathspec",
         "version": "1.1.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -5002,7 +4260,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5012,7 +4270,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5022,7 +4280,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5032,7 +4290,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5043,7 +4301,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5056,57 +4314,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "lgjjqknhp4gb2hgx5iuumngt4ctmjaac"
+        "hash": "cwji4bzk43dez6vgaswp7ualjbmmgwlq"
       },
       {
         "name": "py-pluggy",
         "version": "1.6.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -5122,7 +4338,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5132,7 +4348,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5142,7 +4358,7 @@
           },
           {
             "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5152,7 +4368,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5162,7 +4378,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5173,7 +4389,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5186,57 +4402,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "svsudxlq7qscgins62247sleyn2vbq3o"
+        "hash": "dbkc7r22uxkcwhphcc5iif6deleaprdd"
       },
       {
         "name": "py-setuptools",
         "version": "82.0.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -5252,7 +4426,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5262,7 +4436,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5273,7 +4447,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5286,57 +4460,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6"
+        "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl"
       },
       {
         "name": "py-setuptools-scm",
         "version": "9.2.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -5353,7 +4485,7 @@
         "dependencies": [
           {
             "name": "git",
-            "hash": "b6ga3no4ozuoaq2yxye6bdk22hqlo54f",
+            "hash": "l22shvbj7xhqyleroktatdxsw32zwixh",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5364,7 +4496,7 @@
           },
           {
             "name": "py-packaging",
-            "hash": "5ffho2mv3pdpg2lup4526gedy6jhdzuq",
+            "hash": "da5km5iuzzq4ydcecig2m3rrs4wldedw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5375,7 +4507,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5385,7 +4517,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5396,7 +4528,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5406,7 +4538,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5417,7 +4549,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5430,66 +4562,21 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "425jqbogutgkehsadbos5akiyjfbttcz"
+        "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai"
       },
       {
         "name": "git",
         "version": "2.53.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
           "build_system": "autotools",
           "man": true,
           "nls": true,
-          "patches": [
-            "67fa97142eed2ab2b0e9385b233254adb4bdf4dd42addf966d6ece3fd2a3c294"
-          ],
           "perl": true,
           "subtree": true,
           "tcltk": false,
@@ -5500,26 +4587,11 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "patches": [
-          "67fa97142eed2ab2b0e9385b233254adb4bdf4dd42addf966d6ece3fd2a3c294"
-        ],
-        "package_hash": "d3a7zn4hyuq6rxymfwtrimrcmm7qf5xve54yzogpszaqqkigjglq====",
+        "package_hash": "3nj7eut73fimuf3taykerqugty7lodh63horouqpyb7afqr2ibcq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c"
-              ]
-            }
-          },
-          {
             "name": "autoconf",
-            "hash": "au4r5fsjtce5km4q225ptgxfxjn6sipb",
+            "hash": "nqlngw4hecyfr6jxmzcg4bgjd5rvaygo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5529,7 +4601,7 @@
           },
           {
             "name": "automake",
-            "hash": "zs7f52fc7sy24pd42kqers24sihuwfrg",
+            "hash": "zoscbzww2pwvftjwagbdbmr5mtodhsvh",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5539,7 +4611,7 @@
           },
           {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5549,7 +4621,7 @@
           },
           {
             "name": "curl",
-            "hash": "ptydlgoe7volqmy2e6wsvnfiwjfnkn5t",
+            "hash": "l7l4celxf7j5ex4bvd327purjwiti5y2",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5560,7 +4632,7 @@
           },
           {
             "name": "diffutils",
-            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5570,10 +4642,32 @@
           },
           {
             "name": "expat",
-            "hash": "p74tzbic6xuladqhvdq53pqnct7c77ju",
+            "hash": "eslwzfruvoiypttp7xwtdhobmnubhqpy",
             "parameters": {
               "deptypes": [
                 "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
                 "link"
               ],
               "virtuals": []
@@ -5581,7 +4675,7 @@
           },
           {
             "name": "gettext",
-            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "hash": "elwfaifirlj7xa4qwdzygrxoeylrpy2a",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5591,8 +4685,20 @@
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5602,7 +4708,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5612,7 +4718,7 @@
           },
           {
             "name": "libiconv",
-            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "hash": "gn3ajcmluy2ttffe57xqv2cbwqsv7nqa",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5625,7 +4731,7 @@
           },
           {
             "name": "libidn2",
-            "hash": "eswkdrox2poeulrcspercshtt7tpuaeu",
+            "hash": "xnpzw6ouhyuazatjafnfxotziipnyqao",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5636,7 +4742,7 @@
           },
           {
             "name": "libtool",
-            "hash": "jblwy45tdxcxi6iyhmaligxt4eumrp6c",
+            "hash": "vqz2wpjwstnnv5c62sfq2avmlafs4qea",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5646,7 +4752,7 @@
           },
           {
             "name": "m4",
-            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "hash": "4voacumvytiugnmop25vvsnun7chknqw",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5656,7 +4762,7 @@
           },
           {
             "name": "openssh",
-            "hash": "3g5776ottss2gzwn2g6i3exrhndnb2lt",
+            "hash": "ijvsnra5mj7kod5jst3lxcbfz572zb7m",
             "parameters": {
               "deptypes": [
                 "run"
@@ -5666,7 +4772,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5677,7 +4783,7 @@
           },
           {
             "name": "pcre2",
-            "hash": "gsjqvgexcuipyofmrfzbiavtbcm2ruiw",
+            "hash": "piyl67baxvpfkwzpbgw42xutn3hm6jao",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5688,7 +4794,7 @@
           },
           {
             "name": "perl",
-            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5699,7 +4805,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5714,57 +4820,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "b6ga3no4ozuoaq2yxye6bdk22hqlo54f"
+        "hash": "l22shvbj7xhqyleroktatdxsw32zwixh"
       },
       {
         "name": "autoconf",
         "version": "2.72",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -5780,7 +4844,7 @@
         "dependencies": [
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5790,7 +4854,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5800,7 +4864,7 @@
           },
           {
             "name": "m4",
-            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "hash": "4voacumvytiugnmop25vvsnun7chknqw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5811,7 +4875,7 @@
           },
           {
             "name": "perl",
-            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5824,57 +4888,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "au4r5fsjtce5km4q225ptgxfxjn6sipb"
+        "hash": "nqlngw4hecyfr6jxmzcg4bgjd5rvaygo"
       },
       {
         "name": "m4",
         "version": "1.4.21",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -5890,8 +4912,28 @@
         "package_hash": "uqxut5tqgyjrkdkhgopowjvbus5tb5zzuu2i3uo6odle67f3r26a====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5903,28 +4945,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "diffutils",
-            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5934,7 +4978,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -5944,7 +4988,7 @@
           },
           {
             "name": "libsigsegv",
-            "hash": "6bxbmkak7ep5pr7ows6pf546vanhzvss",
+            "hash": "qs7qbi6u4hb3b7o5ccsahrzawndgsnoq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -5957,57 +5001,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt"
+        "hash": "4voacumvytiugnmop25vvsnun7chknqw"
       },
       {
         "name": "libsigsegv",
         "version": "2.15",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6022,8 +5024,18 @@
         "package_hash": "owum656m6rpybyktdfeeksuvu7p2g4l6rxs2qys5h7sgvvtuxmza====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6034,18 +5046,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6055,7 +5079,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6067,57 +5091,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "6bxbmkak7ep5pr7ows6pf546vanhzvss"
+        "hash": "qs7qbi6u4hb3b7o5ccsahrzawndgsnoq"
       },
       {
         "name": "automake",
         "version": "1.18.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6132,8 +5114,28 @@
         "package_hash": "ah4rkjdzqkmhyh6erbzj5cebrxeoqxt4k4peteswpmrz5wc23s7q====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "autoconf",
+            "hash": "nqlngw4hecyfr6jxmzcg4bgjd5rvaygo",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6144,28 +5146,30 @@
             }
           },
           {
-            "name": "autoconf",
-            "hash": "au4r5fsjtce5km4q225ptgxfxjn6sipb",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6175,7 +5179,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6185,7 +5189,7 @@
           },
           {
             "name": "perl",
-            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6198,57 +5202,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "zs7f52fc7sy24pd42kqers24sihuwfrg"
+        "hash": "zoscbzww2pwvftjwagbdbmr5mtodhsvh"
       },
       {
         "name": "curl",
         "version": "8.20.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6277,8 +5239,18 @@
         "package_hash": "6k4rb6udvmamovquozk4o7c4bufszbxgfofxaegdkrrvntpjkclq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6290,18 +5262,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6311,7 +5295,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6321,7 +5305,7 @@
           },
           {
             "name": "nghttp2",
-            "hash": "i26u5jl77znledpx35oedfwz7pjr64py",
+            "hash": "qyd2sdmx67di7tybne6wcn4aiz32tjqz",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6332,7 +5316,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6343,7 +5327,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6355,7 +5339,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6370,57 +5354,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "ptydlgoe7volqmy2e6wsvnfiwjfnkn5t"
+        "hash": "l7l4celxf7j5ex4bvd327purjwiti5y2"
       },
       {
         "name": "nghttp2",
         "version": "1.67.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6435,8 +5377,28 @@
         "package_hash": "s57echxnxs2pa26gyxrozc3jj6d65y3beqpwam4gbco4t5gx6vka====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6448,28 +5410,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "diffutils",
-            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6479,7 +5443,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6489,7 +5453,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6503,57 +5467,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "i26u5jl77znledpx35oedfwz7pjr64py"
+        "hash": "qyd2sdmx67di7tybne6wcn4aiz32tjqz"
       },
       {
         "name": "libidn2",
         "version": "2.3.8",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6568,8 +5490,18 @@
         "package_hash": "u6kovvtfxzi5gkpasfioxx3bn25e3iqj7im2bw2pbn3hkjgianwq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6580,18 +5512,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6601,7 +5545,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6611,7 +5555,7 @@
           },
           {
             "name": "libunistring",
-            "hash": "saaz5bpluyk5o33l6b4apr4r4fa43pof",
+            "hash": "764fugs7eogfzkrkfjtk43qzrvjhsjef",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6624,57 +5568,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "eswkdrox2poeulrcspercshtt7tpuaeu"
+        "hash": "xnpzw6ouhyuazatjafnfxotziipnyqao"
       },
       {
         "name": "libunistring",
         "version": "1.4.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6689,8 +5591,18 @@
         "package_hash": "2rtlfhrr6s27nalw3s5pruedvgasc52y37il4ky3kembhczeb4rq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6701,18 +5613,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6722,7 +5646,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6732,7 +5656,7 @@
           },
           {
             "name": "libiconv",
-            "hash": "b5wefmz6fecl3ndz4gqlvc5acmuvuzn4",
+            "hash": "gn3ajcmluy2ttffe57xqv2cbwqsv7nqa",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6747,57 +5671,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "saaz5bpluyk5o33l6b4apr4r4fa43pof"
+        "hash": "764fugs7eogfzkrkfjtk43qzrvjhsjef"
       },
       {
         "name": "libtool",
         "version": "2.5.4",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6812,20 +5694,8 @@
         "package_hash": "uxekz42i6wgztwghuk46bozo3qjsusrxlfz5a77z3ioctuv23llq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c"
-              ]
-            }
-          },
-          {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6835,7 +5705,7 @@
           },
           {
             "name": "file",
-            "hash": "qogtknbfwex7nfglwbqaldvayorjuidv",
+            "hash": "lclivoh43ufpzvvfhskptpogilger54k",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6846,7 +5716,7 @@
           },
           {
             "name": "findutils",
-            "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a",
+            "hash": "ijownbucjh3jpsrhgvsvmxbe6l2ij6bk",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6856,8 +5726,42 @@
             }
           },
           {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6867,7 +5771,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6877,7 +5781,7 @@
           },
           {
             "name": "m4",
-            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "hash": "4voacumvytiugnmop25vvsnun7chknqw",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6889,57 +5793,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "jblwy45tdxcxi6iyhmaligxt4eumrp6c"
+        "hash": "vqz2wpjwstnnv5c62sfq2avmlafs4qea"
       },
       {
         "name": "file",
         "version": "5.46",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -6955,20 +5817,8 @@
         "package_hash": "tm46egn4rph3tva6ltwaaimsijp42b3dyoajagiy2tecnjlh57iq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c"
-              ]
-            }
-          },
-          {
             "name": "bzip2",
-            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj",
             "parameters": {
               "deptypes": [
                 "build",
@@ -6979,7 +5829,7 @@
           },
           {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6988,8 +5838,42 @@
             }
           },
           {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -6999,7 +5883,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7009,7 +5893,7 @@
           },
           {
             "name": "xz",
-            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7020,7 +5904,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7033,7 +5917,7 @@
           },
           {
             "name": "zstd",
-            "hash": "e6anxsyrvvfaxhsxbkg56amkhsk6c5nv",
+            "hash": "x3x5ccth36mjzyuup2uvtahusav5632a",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7046,57 +5930,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "qogtknbfwex7nfglwbqaldvayorjuidv"
+        "hash": "lclivoh43ufpzvvfhskptpogilger54k"
       },
       {
         "name": "findutils",
         "version": "4.10.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -7117,8 +5959,18 @@
         "package_hash": "7qjqvag5fjhfmbwxf3kraqy4as7b5tn7n3rjo332y3gwm3hxpuva====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7129,18 +5981,18 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
             "name": "gettext",
-            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "hash": "elwfaifirlj7xa4qwdzygrxoeylrpy2a",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7149,8 +6001,20 @@
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7160,7 +6024,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7172,57 +6036,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a"
+        "hash": "ijownbucjh3jpsrhgvsvmxbe6l2ij6bk"
       },
       {
         "name": "openssh",
         "version": "10.3p1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -7238,8 +6060,18 @@
         "package_hash": "vubmk4bqo4fzt42dufcet7iswhgx5mwu4mga7ttnccgdpma3ixna====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7251,18 +6083,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7272,7 +6116,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7282,7 +6126,7 @@
           },
           {
             "name": "krb5",
-            "hash": "hwa7m6bhxdcrnjhsyxnk2ywatx2pqslk",
+            "hash": "r7jmevkvedpeaxjvatoy7pe6gkzdmfml",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7293,7 +6137,7 @@
           },
           {
             "name": "libedit",
-            "hash": "cw4uwioti3csrypvhqojgb5dzqrwq7ls",
+            "hash": "rsoavq2xkqr2c5u5eodxq5ea65ui4b2m",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7304,7 +6148,7 @@
           },
           {
             "name": "libxcrypt",
-            "hash": "vborjfjuvpdfmyyrnuql62iwu6ta6isr",
+            "hash": "cdy63abqrphwhj5l3ovwskmeor6lymtv",
             "parameters": {
               "deptypes": [
                 "link"
@@ -7314,7 +6158,7 @@
           },
           {
             "name": "ncurses",
-            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7325,7 +6169,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7336,7 +6180,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7351,57 +6195,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "3g5776ottss2gzwn2g6i3exrhndnb2lt"
+        "hash": "ijvsnra5mj7kod5jst3lxcbfz572zb7m"
       },
       {
         "name": "krb5",
         "version": "1.22.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -7417,8 +6219,48 @@
         "package_hash": "7rukoxvyvs7di3sybsvagldghiytf5huks2wlhj2zoukguntcpfq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "bison",
+            "hash": "djmloovh4xxpvhv2ocysskcxmbi3zol2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "findutils",
+            "hash": "ijownbucjh3jpsrhgvsvmxbe6l2ij6bk",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7430,48 +6272,18 @@
             }
           },
           {
-            "name": "bison",
-            "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "diffutils",
-            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "findutils",
-            "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a",
-            "parameters": {
-              "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
             "name": "gettext",
-            "hash": "zgaxf6iyuu5iolkksxu4vr5sqvxq5fyq",
+            "hash": "elwfaifirlj7xa4qwdzygrxoeylrpy2a",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7481,8 +6293,20 @@
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7492,7 +6316,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7502,7 +6326,7 @@
           },
           {
             "name": "libedit",
-            "hash": "cw4uwioti3csrypvhqojgb5dzqrwq7ls",
+            "hash": "rsoavq2xkqr2c5u5eodxq5ea65ui4b2m",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7513,7 +6337,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7524,7 +6348,7 @@
           },
           {
             "name": "perl",
-            "hash": "gv3gz6yu45gcjqq7xfxelyqq2uvxgwml",
+            "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7534,7 +6358,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7548,57 +6372,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "hwa7m6bhxdcrnjhsyxnk2ywatx2pqslk"
+        "hash": "r7jmevkvedpeaxjvatoy7pe6gkzdmfml"
       },
       {
         "name": "bison",
         "version": "3.8.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -7614,8 +6396,28 @@
         "package_hash": "ayxhzq5gsdhdjn7xpy57gduvlldm6uegtnqici4mlqzqtdmkf2dq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7627,28 +6429,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "diffutils",
-            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7658,7 +6462,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7668,7 +6472,7 @@
           },
           {
             "name": "m4",
-            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "hash": "4voacumvytiugnmop25vvsnun7chknqw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7681,57 +6485,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd"
+        "hash": "djmloovh4xxpvhv2ocysskcxmbi3zol2"
       },
       {
         "name": "libedit",
         "version": "3.1-20251016",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -7746,8 +6508,18 @@
         "package_hash": "iw5rblyn2culfszupb56jwzbrq5jdvlt5ikqdxx4okojhoouitoa====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7758,18 +6530,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7779,7 +6563,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7789,7 +6573,7 @@
           },
           {
             "name": "ncurses",
-            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -7800,7 +6584,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7814,57 +6598,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "cw4uwioti3csrypvhqojgb5dzqrwq7ls"
+        "hash": "rsoavq2xkqr2c5u5eodxq5ea65ui4b2m"
       },
       {
         "name": "pcre2",
         "version": "10.44",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -7882,8 +6624,18 @@
         "package_hash": "vkl6pgpob4o2hiqvsk7t6alf7emlsxbi2bo7x3rbr2soxsfxfoba====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7894,18 +6646,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7915,7 +6679,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -7927,57 +6691,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "gsjqvgexcuipyofmrfzbiavtbcm2ruiw"
+        "hash": "piyl67baxvpfkwzpbgw42xutn3hm6jao"
       },
       {
         "name": "py-trove-classifiers",
         "version": "2026.6.1.19",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -7993,7 +6715,7 @@
         "dependencies": [
           {
             "name": "py-calver",
-            "hash": "hbqdwf4qtqubwng4mzzba7vb3dpyobj5",
+            "hash": "vzt356z7kqrg2bwa5xg4hhmanroxdzym",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8003,7 +6725,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8013,7 +6735,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8023,7 +6745,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8033,7 +6755,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8044,7 +6766,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8057,57 +6779,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "d46yao5wykmwyoql4pkrdbiptjmhv72o"
+        "hash": "5kkbk5tiu34zgdbwlw6alddfdu6ttfj2"
       },
       {
         "name": "py-calver",
         "version": "2025.10.20",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -8123,7 +6803,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8133,7 +6813,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8143,7 +6823,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8153,7 +6833,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8164,7 +6844,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8177,57 +6857,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "hbqdwf4qtqubwng4mzzba7vb3dpyobj5"
+        "hash": "vzt356z7kqrg2bwa5xg4hhmanroxdzym"
       },
       {
         "name": "py-hatch-vcs",
         "version": "0.5.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -8243,7 +6881,7 @@
         "dependencies": [
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8254,7 +6892,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8264,7 +6902,7 @@
           },
           {
             "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8275,7 +6913,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8285,7 +6923,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8296,7 +6934,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8309,57 +6947,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "rqud6mszhna3e4ah6w2l6unhiczlf3ly"
+        "hash": "rchuzf3y2c2h6udbmfwfybiu3tfal25q"
       },
       {
         "name": "py-jsonschema-specifications",
         "version": "2025.9.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -8375,7 +6971,7 @@
         "dependencies": [
           {
             "name": "py-hatch-vcs",
-            "hash": "rqud6mszhna3e4ah6w2l6unhiczlf3ly",
+            "hash": "rchuzf3y2c2h6udbmfwfybiu3tfal25q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8385,7 +6981,7 @@
           },
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8395,7 +6991,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8405,7 +7001,7 @@
           },
           {
             "name": "py-referencing",
-            "hash": "e6az6rhpxtrj45nqe2g6nsmm2y7asw5n",
+            "hash": "5iqi6qcix4ilyhfrsofou5ccqbfpyw7z",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8416,7 +7012,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8426,7 +7022,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8437,7 +7033,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8450,57 +7046,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "7nr4och6tcnfxd44zw7lednzit3m43wr"
+        "hash": "2fb62ussiswrbpc5gpvpfu2ycmzyxzbh"
       },
       {
         "name": "py-referencing",
         "version": "0.37.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -8516,7 +7070,7 @@
         "dependencies": [
           {
             "name": "py-attrs",
-            "hash": "x4aiwy3xjwdqstflaxsjmnkkkcdwoexo",
+            "hash": "y5wsvbklhrk6npbjsecna6sxqnjvks42",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8527,7 +7081,7 @@
           },
           {
             "name": "py-hatch-vcs",
-            "hash": "rqud6mszhna3e4ah6w2l6unhiczlf3ly",
+            "hash": "rchuzf3y2c2h6udbmfwfybiu3tfal25q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8537,7 +7091,7 @@
           },
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8547,7 +7101,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8557,7 +7111,7 @@
           },
           {
             "name": "py-rpds-py",
-            "hash": "5bkjtty4gc64p2sr3y6iudbalwyhypkp",
+            "hash": "g3qr4sgsdy2frfqrpyjuscgqbmuy7o3s",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8568,7 +7122,7 @@
           },
           {
             "name": "py-typing-extensions",
-            "hash": "3luhcd4nz3fgh3fxjegc6rcsdduysyjr",
+            "hash": "epvpeyyy4uiwc5fcjdttbd72ngbj4dt7",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8579,7 +7133,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8589,7 +7143,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8600,7 +7154,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8613,57 +7167,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "e6az6rhpxtrj45nqe2g6nsmm2y7asw5n"
+        "hash": "5iqi6qcix4ilyhfrsofou5ccqbfpyw7z"
       },
       {
         "name": "py-rpds-py",
         "version": "0.27.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -8678,8 +7190,18 @@
         "package_hash": "bqgxorthiwycgl6y5knahc2acgooxkhov57atck6qnnyz4ospruq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8690,18 +7212,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-maturin",
-            "hash": "sxu2d3246n5n6wku6ai2q7zoud2ivftd",
+            "hash": "6vy3zo7r2jffajh34j3s22rpqcadbmm4",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8711,7 +7245,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8721,7 +7255,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8731,7 +7265,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8742,7 +7276,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8753,7 +7287,7 @@
           },
           {
             "name": "rust",
-            "hash": "4yx3pkx6tefwrwi2mnvvybmmgjplghwi",
+            "hash": "lomrlsgokiq43mxhvlf7hnyqc7m4gu6q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8765,57 +7299,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "5bkjtty4gc64p2sr3y6iudbalwyhypkp"
+        "hash": "g3qr4sgsdy2frfqrpyjuscgqbmuy7o3s"
       },
       {
         "name": "py-maturin",
         "version": "1.13.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -8830,20 +7322,8 @@
         "package_hash": "sfustejwrbotcfkwymfave253tadgndn4wgggpmsrjg72sommt6a====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c"
-              ]
-            }
-          },
-          {
             "name": "bzip2",
-            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8854,7 +7334,7 @@
           },
           {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8863,8 +7343,42 @@
             }
           },
           {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8874,7 +7388,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8884,7 +7398,7 @@
           },
           {
             "name": "py-setuptools-rust",
-            "hash": "qkhrocik7ue3zrtehffdoqsvszseozxi",
+            "hash": "nqoqwrc3ybxnggifu2dyvlxdh6vxmkqz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8894,7 +7408,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -8904,7 +7418,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8915,7 +7429,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8926,7 +7440,7 @@
           },
           {
             "name": "rust",
-            "hash": "4yx3pkx6tefwrwi2mnvvybmmgjplghwi",
+            "hash": "lomrlsgokiq43mxhvlf7hnyqc7m4gu6q",
             "parameters": {
               "deptypes": [
                 "build",
@@ -8939,57 +7453,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "sxu2d3246n5n6wku6ai2q7zoud2ivftd"
+        "hash": "6vy3zo7r2jffajh34j3s22rpqcadbmm4"
       },
       {
         "name": "py-setuptools-rust",
         "version": "1.12.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -9005,7 +7477,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9015,7 +7487,7 @@
           },
           {
             "name": "py-semantic-version",
-            "hash": "rtrbfrvddsb64tv54qzyktpah5qkfi57",
+            "hash": "hwvacg56gsdoispcrfxk53jyj3eepu6b",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9026,7 +7498,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9037,7 +7509,7 @@
           },
           {
             "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9047,7 +7519,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9057,7 +7529,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9068,7 +7540,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9079,7 +7551,7 @@
           },
           {
             "name": "rust",
-            "hash": "4yx3pkx6tefwrwi2mnvvybmmgjplghwi",
+            "hash": "lomrlsgokiq43mxhvlf7hnyqc7m4gu6q",
             "parameters": {
               "deptypes": [
                 "run"
@@ -9091,57 +7563,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "qkhrocik7ue3zrtehffdoqsvszseozxi"
+        "hash": "nqoqwrc3ybxnggifu2dyvlxdh6vxmkqz"
       },
       {
         "name": "py-semantic-version",
         "version": "2.10.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -9157,7 +7587,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9167,7 +7597,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9177,7 +7607,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9187,7 +7617,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9198,7 +7628,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9211,57 +7641,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "rtrbfrvddsb64tv54qzyktpah5qkfi57"
+        "hash": "hwvacg56gsdoispcrfxk53jyj3eepu6b"
       },
       {
         "name": "rust",
         "version": "1.96.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -9279,8 +7667,39 @@
         "package_hash": "rnw4nqee5gf2d2vzzo6qg2e7it2hjsvna4vfxor4stiesr2iijaq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "l7l4celxf7j5ex4bvd327purjwiti5y2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9292,39 +7711,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "curl",
-            "hash": "ptydlgoe7volqmy2e6wsvnfiwjfnkn5t",
-            "parameters": {
-              "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "libgit2",
-            "hash": "nicc5wvvv4h7oh225ypwqcevxjsodrbo",
+            "hash": "jogx2muhf7ivi2qnavlltl2twlbghzkv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9335,7 +7745,7 @@
           },
           {
             "name": "libssh2",
-            "hash": "m4sg62e67uyenbob3yzhijkrudoumxrs",
+            "hash": "lz2k3zstbcjxnkhevfdkazunn2rdmt72",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9346,7 +7756,7 @@
           },
           {
             "name": "ninja",
-            "hash": "wrrgzxi7br3krs3wylftkrtztc4rqh73",
+            "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9356,7 +7766,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9367,7 +7777,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9379,7 +7789,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9389,7 +7799,7 @@
           },
           {
             "name": "rust-bootstrap",
-            "hash": "vhtpwofuvrhfza6am5jaoy54jk3noymg",
+            "hash": "vkeghiprr6b4w6wa733dnyhlke5yfyzd",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9399,7 +7809,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9414,57 +7824,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "4yx3pkx6tefwrwi2mnvvybmmgjplghwi"
+        "hash": "lomrlsgokiq43mxhvlf7hnyqc7m4gu6q"
       },
       {
         "name": "cmake",
         "version": "3.31.11",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -9484,8 +7852,29 @@
         "package_hash": "6tgtyzgohykswmnmkm3m4w3lbzttl7ccfgq67lj2nabjnz5egmba====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "l7l4celxf7j5ex4bvd327purjwiti5y2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9497,29 +7886,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "curl",
-            "hash": "ptydlgoe7volqmy2e6wsvnfiwjfnkn5t",
-            "parameters": {
-              "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9530,7 +7920,7 @@
           },
           {
             "name": "ncurses",
-            "hash": "n6cymhqok3by3fwktcalltyzkck4ew5r",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9541,7 +7931,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9556,57 +7946,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd"
+        "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv"
       },
       {
         "name": "libgit2",
         "version": "1.9.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -9628,8 +7976,28 @@
         "package_hash": "qe6kqfcxiwmycu2fdivxeukrkajz4jaqrod5hh3dti7wita5mp7a====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9640,28 +8008,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9671,7 +8041,18 @@
           },
           {
             "name": "libssh2",
-            "hash": "m4sg62e67uyenbob3yzhijkrudoumxrs",
+            "hash": "lz2k3zstbcjxnkhevfdkazunn2rdmt72",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "openssl",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9682,7 +8063,7 @@
           },
           {
             "name": "pcre",
-            "hash": "efugbhodng7s237m2a7n4hacpdnvqi3o",
+            "hash": "sojx5tu2g7w64i52p3sgsnwtwjf4wfpt",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9693,7 +8074,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9707,57 +8088,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "nicc5wvvv4h7oh225ypwqcevxjsodrbo"
+        "hash": "jogx2muhf7ivi2qnavlltl2twlbghzkv"
       },
       {
         "name": "libssh2",
         "version": "1.11.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -9774,8 +8113,18 @@
         "package_hash": "yqmxcercvmdj4wydnrynaevdofw2i67gzwllz67ck2lkhg3mld3q====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9786,18 +8135,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9807,7 +8168,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9817,7 +8178,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9828,7 +8189,7 @@
           },
           {
             "name": "xz",
-            "hash": "sd6advhsbk5bffgo4pa35ohnio7iwe2b",
+            "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9839,7 +8200,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -9854,57 +8215,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "m4sg62e67uyenbob3yzhijkrudoumxrs"
+        "hash": "lz2k3zstbcjxnkhevfdkazunn2rdmt72"
       },
       {
         "name": "pcre",
         "version": "8.45",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -9925,8 +8244,18 @@
         "package_hash": "i2pvfsribcb567g6ztpkc2kqlcl43dw4vksvp3e4qher5xizdo7a====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9938,18 +8267,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9959,7 +8300,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -9971,57 +8312,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "efugbhodng7s237m2a7n4hacpdnvqi3o"
+        "hash": "sojx5tu2g7w64i52p3sgsnwtwjf4wfpt"
       },
       {
         "name": "ninja",
         "version": "1.13.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -10037,8 +8336,18 @@
         "package_hash": "uuvqgx4th7p23zkj3upav45jkieybnujaxafz6gfydixqhnfdmaq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10050,18 +8359,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10071,7 +8392,7 @@
           },
           {
             "name": "re2c",
-            "hash": "nobhlmmne52mvwcutcyudwomiiyc34s4",
+            "hash": "7kbvfifg5dw6jo5rzgcvci2cdma6usjl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10083,57 +8404,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "wrrgzxi7br3krs3wylftkrtztc4rqh73"
+        "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv"
       },
       {
         "name": "re2c",
         "version": "4.4",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -10148,8 +8427,18 @@
         "package_hash": "3vca5kfxu5fr6kdiweop3q65yeephppguqoe6vslrzditlmpuhnq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10161,18 +8450,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10182,7 +8483,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10192,7 +8493,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10204,57 +8505,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "nobhlmmne52mvwcutcyudwomiiyc34s4"
+        "hash": "7kbvfifg5dw6jo5rzgcvci2cdma6usjl"
       },
       {
         "name": "rust-bootstrap",
         "version": "1.96.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -10266,11 +8525,21 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "6bfkyesjskvxihyx7vyn5uefvctc6ofjgot6s7t7u5ingahnj7ga====",
+        "package_hash": "35lzugyfxbznnwsamps4f3y4zly3hkzklpbglmjjhw7k5nqoejqq====",
         "dependencies": [
           {
+            "name": "patchelf",
+            "hash": "tkcpp45cyecm35pdahlxukkoo7ggiekc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10285,57 +8554,106 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vhtpwofuvrhfza6am5jaoy54jk3noymg"
+        "hash": "vkeghiprr6b4w6wa733dnyhlke5yfyzd"
+      },
+      {
+        "name": "patchelf",
+        "version": "0.17.2",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "nm25gytnhmovyk27jn6ogdbch5apxjgaz5pci3zkcrw475ufouoa====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "tkcpp45cyecm35pdahlxukkoo7ggiekc"
       },
       {
         "name": "py-typing-extensions",
         "version": "4.16.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -10351,7 +8669,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10361,7 +8679,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10371,7 +8689,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10381,7 +8699,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10392,7 +8710,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10405,57 +8723,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "3luhcd4nz3fgh3fxjegc6rcsdduysyjr"
+        "hash": "epvpeyyy4uiwc5fcjdttbd72ngbj4dt7"
       },
       {
         "name": "py-numpy",
-        "version": "2.4.6",
+        "version": "2.3.5",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -10473,11 +8749,21 @@
         "patches": [
           "873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604"
         ],
-        "package_hash": "3fe65gvuu3yl54uyjpzk6s3uogaqbdsoxoyx5ig5ujmcl3wmkika====",
+        "package_hash": "n7otoms2z4xe2ho2ka2ctoxnvcaak44bbrvkqdariyzlr7h2hipq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10489,18 +8775,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "openblas",
-            "hash": "j42osoa4cbllwvtz2vndhz5gzvjfven3",
+            "hash": "vsc3fncjotiaam7jrrf7yzggcrub2kdb",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10514,7 +8812,7 @@
           },
           {
             "name": "py-cython",
-            "hash": "6koytqdfzgrojtnt65dfhag6nltjqxsd",
+            "hash": "uc54gih6oozlx2fgfsh7dq4xfmspjf7r",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10524,7 +8822,7 @@
           },
           {
             "name": "py-meson-python",
-            "hash": "6ronsvddetpkvmki5b3kalxj5mkqdhf4",
+            "hash": "4b65qsgmyek35im5y6rgt5uvx6uwip6e",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10534,7 +8832,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10544,7 +8842,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10554,7 +8852,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10566,7 +8864,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10579,57 +8877,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "2o7rggazig7spilocm3aammlabuf5ozp"
+        "hash": "33gxp7pzmutq7em6epbeozdznjjepenv"
       },
       {
         "name": "openblas",
         "version": "0.3.33",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -10661,21 +8917,8 @@
         "package_hash": "zvlaojkxhj2rfwudx3ihy5mueaoxos4ku3wfldcrzhmei3kr2xuq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c",
-                "cxx"
-              ]
-            }
-          },
-          {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10685,19 +8928,21 @@
           },
           {
             "name": "gcc",
-            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
               ],
               "virtuals": [
+                "c",
+                "cxx",
                 "fortran"
               ]
             }
           },
           {
             "name": "gcc-runtime",
-            "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
                 "link"
@@ -10709,136 +8954,20 @@
             }
           },
           {
-            "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
-          }
-        ],
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "j42osoa4cbllwvtz2vndhz5gzvjfven3"
-      },
-      {
-        "name": "gcc",
-        "version": "16.2.0",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": "aarch64"
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "binutils": true,
-          "bootstrap": true,
-          "build_system": "autotools",
-          "build_type": "RelWithDebInfo",
-          "graphite": false,
-          "languages": [
-            "c",
-            "c++",
-            "fortran"
-          ],
-          "libsanitizer": true,
-          "mold": false,
-          "nvptx": false,
-          "piclibs": false,
-          "profiled": false,
-          "strip": false,
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "external": {
-          "path": "/opt/homebrew",
-          "module": null,
-          "extra_attributes": {
-            "compilers": {
-              "c": "/opt/homebrew/bin/gcc-16",
-              "cxx": "/opt/homebrew/bin/g++-16",
-              "fortran": "/opt/homebrew/bin/gfortran"
-            }
-          }
-        },
-        "package_hash": "bkqs3w2bph67itgvyruqwlgihn7eo55246dicgcd5dqk7bu7vo5q====",
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4"
-      },
-      {
-        "name": "gcc-runtime",
-        "version": "16.2.0",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "build_system": "generic",
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "package_hash": "4wopkmadudswpydg45u4k2mzsyzwvmcmwre2cb735c7kd43qwpdq====",
-        "dependencies": [
+          },
           {
-            "name": "gcc",
-            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10850,57 +8979,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs"
+        "hash": "vsc3fncjotiaam7jrrf7yzggcrub2kdb"
       },
       {
         "name": "py-cython",
         "version": "3.2.4",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -10915,8 +9002,18 @@
         "package_hash": "koz2ghpmuag6hky4ujh62m3wxou4nyp42m3qcnbh7oy3sdyabqwq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10928,18 +9025,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10949,7 +9058,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10960,7 +9069,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -10970,7 +9079,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10982,7 +9091,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -10995,57 +9104,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "6koytqdfzgrojtnt65dfhag6nltjqxsd"
+        "hash": "uc54gih6oozlx2fgfsh7dq4xfmspjf7r"
       },
       {
         "name": "py-meson-python",
         "version": "0.19.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -11060,8 +9127,18 @@
         "package_hash": "z3jzjklz4nbf4yc7dl5borlhbzusdcrqbrjtnzzz7ijo5xcuetbq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11072,18 +9149,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "meson",
-            "hash": "jqulumt5e6asiyiaaechgpyrjdmqv7i4",
+            "hash": "z2vjusc5e4ejfetpc67i6rvc2r34losl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11094,7 +9183,7 @@
           },
           {
             "name": "ninja",
-            "hash": "wrrgzxi7br3krs3wylftkrtztc4rqh73",
+            "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11105,7 +9194,7 @@
           },
           {
             "name": "py-packaging",
-            "hash": "5ffho2mv3pdpg2lup4526gedy6jhdzuq",
+            "hash": "da5km5iuzzq4ydcecig2m3rrs4wldedw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11116,7 +9205,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11126,7 +9215,7 @@
           },
           {
             "name": "py-pyproject-metadata",
-            "hash": "xlxoexha7wze4cwfmmmack5zrdutsq3w",
+            "hash": "c76l7bnft2ymy6elumlztkgzuvodaxbo",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11137,7 +9226,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11147,7 +9236,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11158,7 +9247,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11171,57 +9260,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "6ronsvddetpkvmki5b3kalxj5mkqdhf4"
+        "hash": "4b65qsgmyek35im5y6rgt5uvx6uwip6e"
       },
       {
         "name": "meson",
         "version": "1.11.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -11243,7 +9290,7 @@
         "dependencies": [
           {
             "name": "ninja",
-            "hash": "wrrgzxi7br3krs3wylftkrtztc4rqh73",
+            "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv",
             "parameters": {
               "deptypes": [
                 "run"
@@ -11253,7 +9300,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11263,7 +9310,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11274,7 +9321,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11284,7 +9331,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11295,7 +9342,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11308,57 +9355,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "jqulumt5e6asiyiaaechgpyrjdmqv7i4"
+        "hash": "z2vjusc5e4ejfetpc67i6rvc2r34losl"
       },
       {
         "name": "py-pyproject-metadata",
         "version": "0.11.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -11374,7 +9379,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11384,7 +9389,7 @@
           },
           {
             "name": "py-packaging",
-            "hash": "5ffho2mv3pdpg2lup4526gedy6jhdzuq",
+            "hash": "da5km5iuzzq4ydcecig2m3rrs4wldedw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11395,7 +9400,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11405,7 +9410,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11415,7 +9420,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11426,7 +9431,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11439,64 +9444,22 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "xlxoexha7wze4cwfmmmack5zrdutsq3w"
+        "hash": "c76l7bnft2ymy6elumlztkgzuvodaxbo"
       },
       {
         "name": "py-pandas",
         "version": "2.3.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
           "build_system": "python_pip",
           "excel": false,
           "parquet": false,
-          "performance": false,
+          "performance": true,
           "cflags": [],
           "cppflags": [],
           "cxxflags": [],
@@ -11507,8 +9470,18 @@
         "package_hash": "e2nih5pki6laww4kr6wsvvu4dlxdyt3gikvmcpognkkfsdhtvqzq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11520,8 +9493,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "meson",
+            "hash": "z2vjusc5e4ejfetpc67i6rvc2r34losl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11530,18 +9525,18 @@
             }
           },
           {
-            "name": "meson",
-            "hash": "jqulumt5e6asiyiaaechgpyrjdmqv7i4",
+            "name": "py-bottleneck",
+            "hash": "o64acyorztcieexyktzpr2cnaq2omivc",
             "parameters": {
               "deptypes": [
-                "build"
+                "run"
               ],
               "virtuals": []
             }
           },
           {
             "name": "py-cython",
-            "hash": "6koytqdfzgrojtnt65dfhag6nltjqxsd",
+            "hash": "uc54gih6oozlx2fgfsh7dq4xfmspjf7r",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11551,7 +9546,7 @@
           },
           {
             "name": "py-meson-python",
-            "hash": "6ronsvddetpkvmki5b3kalxj5mkqdhf4",
+            "hash": "4b65qsgmyek35im5y6rgt5uvx6uwip6e",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11560,8 +9555,28 @@
             }
           },
           {
+            "name": "py-numba",
+            "hash": "fve6ta4x4p537m5gxoznxsf4x3amitbe",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numexpr",
+            "hash": "oolt2wfpvpz2lhntnbbxxq4fwjer66ft",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11572,7 +9587,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11582,7 +9597,7 @@
           },
           {
             "name": "py-python-dateutil",
-            "hash": "adw4yrr2becnjggvcjihqko75nmsydok",
+            "hash": "wwfnvfg32vx7iaundudzksec4kglqlml",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11593,7 +9608,7 @@
           },
           {
             "name": "py-pytz",
-            "hash": "kw7d6ysuvl6vv7kbulk4xlrybzoyo6mu",
+            "hash": "7cfyq2qkw6y4ogzi66tf5ip5faswvxtp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11604,7 +9619,7 @@
           },
           {
             "name": "py-tzdata",
-            "hash": "zccxziktthugs5j3isb4nma4flo5hmbe",
+            "hash": "funfskjxsztptkp3ns2dd5cpuni2x7sz",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11615,7 +9630,7 @@
           },
           {
             "name": "py-versioneer",
-            "hash": "6lvy6unlrlafworbpybqd4qhf7a27jsx",
+            "hash": "5xl5izk2xuyuyvtwn6sl56ue5ehfk7k5",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11625,7 +9640,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11635,7 +9650,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11646,7 +9661,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11659,57 +9674,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "wpnad7cfczidplyxjfyzg5om2zpkektk"
+        "hash": "64wuz3wepx4neipupv5ggnakqmcfoi6d"
       },
       {
-        "name": "py-python-dateutil",
-        "version": "2.9.0.post0",
+        "name": "py-bottleneck",
+        "version": "1.6.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -11721,11 +9694,11 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "ykjzsnrjwac4mqqy2sczqtiybxm2txra6ohg7bydkq2xgjy5mica====",
+        "package_hash": "tg2q6qgjmqmvnc7ems3245xgupsrb4kat7sxdi4rzazbhuzjo5xq====",
         "dependencies": [
           {
-            "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11734,28 +9707,42 @@
             }
           },
           {
-            "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
-            "name": "py-six",
-            "hash": "pqlur4uwuyzl57ry4jjbkra33zjpz2ac",
+            "name": "py-numpy",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11765,8 +9752,38 @@
             }
           },
           {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-versioneer",
+            "hash": "5xl5izk2xuyuyvtwn6sl56ue5ehfk7k5",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -11776,7 +9793,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11787,7 +9804,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -11800,417 +9817,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "adw4yrr2becnjggvcjihqko75nmsydok"
-      },
-      {
-        "name": "py-six",
-        "version": "1.17.0",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "build_system": "python_pip",
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "package_hash": "eiknuz6vwcgwr4a3sdnq2zx757oh24v44la5ibof7umofb4x57zq====",
-        "dependencies": [
-          {
-            "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
-            "parameters": {
-              "deptypes": [
-                "build",
-                "run"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
-            "parameters": {
-              "deptypes": [
-                "build",
-                "run"
-              ],
-              "virtuals": []
-            }
-          }
-        ],
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "pqlur4uwuyzl57ry4jjbkra33zjpz2ac"
-      },
-      {
-        "name": "py-pytz",
-        "version": "2025.2",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "build_system": "python_pip",
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "package_hash": "oqawsk4au7cy7gt3srxq2hkyr6ap3hztwlqojpc7xu2ckyolyknq====",
-        "dependencies": [
-          {
-            "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
-            "parameters": {
-              "deptypes": [
-                "build",
-                "run"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
-            "parameters": {
-              "deptypes": [
-                "build",
-                "run"
-              ],
-              "virtuals": []
-            }
-          }
-        ],
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "kw7d6ysuvl6vv7kbulk4xlrybzoyo6mu"
-      },
-      {
-        "name": "py-tzdata",
-        "version": "2026.1",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "build_system": "python_pip",
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "package_hash": "ptkqk36rvgsotgzlguszvwtx62rkvmv4rc76zda3v2oandhuhl6q====",
-        "dependencies": [
-          {
-            "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
-            "parameters": {
-              "deptypes": [
-                "build",
-                "run"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
-            "parameters": {
-              "deptypes": [
-                "build",
-                "run"
-              ],
-              "virtuals": []
-            }
-          }
-        ],
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "zccxziktthugs5j3isb4nma4flo5hmbe"
+        "hash": "o64acyorztcieexyktzpr2cnaq2omivc"
       },
       {
         "name": "py-versioneer",
         "version": "0.29",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -12226,8 +9841,18 @@
         "package_hash": "rvjah2t6kjo5fbgdf4l3e2zz2f44ap5eae6dfiub3d5e2bx4ykoa====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12238,18 +9863,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12259,7 +9896,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12269,7 +9906,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12279,7 +9916,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12290,7 +9927,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12303,57 +9940,1944 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "6lvy6unlrlafworbpybqd4qhf7a27jsx"
+        "hash": "5xl5izk2xuyuyvtwn6sl56ue5ehfk7k5"
+      },
+      {
+        "name": "py-numba",
+        "version": "0.65.1",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "tbb": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "4hg2qyout2in26jl33cdak2hh4xwnzw35qfr37uy4kshurienoba====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "py-llvmlite",
+            "hash": "dpkiak223y4ktomr4bpodvxvlblvzjzv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "fve6ta4x4p537m5gxoznxsf4x3amitbe"
+      },
+      {
+        "name": "py-llvmlite",
+        "version": "0.47.0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "qdhmx7rmwoehh6x4gdlpaxmyqtwmagzj5a72zbqtghyqimyiujpa====",
+        "dependencies": [
+          {
+            "name": "binutils",
+            "hash": "vx7u2frnhes4pr2vqnmcne3wknig6m33",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "llvm",
+            "hash": "owu6o3eolqxhz4fhrdlunyn4itd542qz",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "dpkiak223y4ktomr4bpodvxvlblvzjzv"
+      },
+      {
+        "name": "binutils",
+        "version": "2.46.1",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "compress_debug_sections": "zlib",
+          "debuginfod": false,
+          "gas": false,
+          "gprofng": false,
+          "headers": false,
+          "interwork": false,
+          "ld": false,
+          "libiberty": false,
+          "libs": [
+            "shared",
+            "static"
+          ],
+          "lto": false,
+          "nls": false,
+          "pgo": false,
+          "plugins": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "jqaqf47kxmp57rnxofjmjpqpz26xa7heffb36crzkno5fbg5k65a====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          },
+          {
+            "name": "zstd",
+            "hash": "x3x5ccth36mjzyuup2uvtahusav5632a",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "vx7u2frnhes4pr2vqnmcne3wknig6m33"
+      },
+      {
+        "name": "llvm",
+        "version": "20.1.8",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "cmake",
+          "build_type": "Release",
+          "clang": true,
+          "compiler-rt": "runtime",
+          "cuda": false,
+          "flang": false,
+          "generator": "ninja",
+          "gold": false,
+          "ipo": false,
+          "libcxx": "runtime",
+          "libomptarget": true,
+          "libomptarget_debug": false,
+          "libunwind": "runtime",
+          "link_llvm_dylib": false,
+          "lld": true,
+          "lldb": true,
+          "llvm_dylib": true,
+          "lua": true,
+          "mlir": false,
+          "offload": true,
+          "openmp": "runtime",
+          "polly": true,
+          "python": false,
+          "shlib_symbol_version": "none",
+          "split_dwarf": false,
+          "targets": [
+            "aarch64",
+            "amdgpu",
+            "nvptx",
+            "x86"
+          ],
+          "utils": false,
+          "version_suffix": "none",
+          "z3": false,
+          "zstd": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "vj6hc3rnhn7ib2kpi57fsis7z3la2hmshv5ymyfb332mdixji2ja====",
+        "dependencies": [
+          {
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "hwloc",
+            "hash": "7rvs5czzbw3kct2knlxi3gmkqbum5ojv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libedit",
+            "hash": "rsoavq2xkqr2c5u5eodxq5ea65ui4b2m",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libffi",
+            "hash": "ppxhuaqezwtn42ir3lxmf5wznvkxdris",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libxml2",
+            "hash": "r4ottk74ltukg6bnmjnvccs4uuoeqbko",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "lua",
+            "hash": "v5db4lrji4e4qrkoisa7ynaz5irpkrq2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ninja",
+            "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl-data-dumper",
+            "hash": "octgjez2nwun7tkntpdjem3tqinpzoqp",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "swig",
+            "hash": "6qjtbm6wt5xjel5vk3pzli2ubjxn5a2w",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "xz",
+            "hash": "rdnnstyuaq34m4gdut64m5mote2h6dat",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "owu6o3eolqxhz4fhrdlunyn4itd542qz"
+      },
+      {
+        "name": "hwloc",
+        "version": "2.13.0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cairo": false,
+          "cuda": false,
+          "gl": false,
+          "level_zero": false,
+          "libs": [
+            "shared",
+            "static"
+          ],
+          "libudev": false,
+          "libxml2": true,
+          "nvml": false,
+          "opencl": false,
+          "patches": [
+            "b4db98b39733435273e57b8229ee834ce50d2785641d1587d8039598752b1a3d"
+          ],
+          "pci": true,
+          "rocm": false,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "b4db98b39733435273e57b8229ee834ce50d2785641d1587d8039598752b1a3d"
+        ],
+        "package_hash": "czx4w5nspkuop6ame4ahhczllwb3wejsb7qd65p3dmhuqivs7raa====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libpciaccess",
+            "hash": "gpsjk7hhd7ezx6ac2jkli5j7we4mwz5e",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "libxml2",
+            "hash": "r4ottk74ltukg6bnmjnvccs4uuoeqbko",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "7rvs5czzbw3kct2knlxi3gmkqbum5ojv"
+      },
+      {
+        "name": "libpciaccess",
+        "version": "0.17",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "gimtp7pj65ztup3wjhpbnubyg6gcrpmwhbyouysxdlsfwevm7m5a====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "util-macros",
+            "hash": "sgcupaq7wr36pu2wpdsdr6h4i2qsjd6n",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "gpsjk7hhd7ezx6ac2jkli5j7we4mwz5e"
+      },
+      {
+        "name": "util-macros",
+        "version": "1.20.2",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "g4o57nb2ihedexsi5hnb46wyf4tdipsl6qfx3ntw64yem3l3oysq====",
+        "dependencies": [
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "sgcupaq7wr36pu2wpdsdr6h4i2qsjd6n"
+      },
+      {
+        "name": "lua",
+        "version": "5.3.6",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "makefile",
+          "fetcher": "curl",
+          "shared": true,
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "i3u4re2d6fftju3wohvbxir6kkgyxwoxcq2okijjsier5bp5ixxq====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "l7l4celxf7j5ex4bvd327purjwiti5y2",
+            "parameters": {
+              "deptypes": [
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "ncurses",
+            "hash": "2j5s45djkl7pcol2thec6vlfwxolzvnl",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "readline",
+            "hash": "o7h6uthufnnhgugp45tcg2mnikrusl55",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "unzip",
+            "hash": "3z6myz5yrhjjfkmgpsdchnjizuckry3u",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "v5db4lrji4e4qrkoisa7ynaz5irpkrq2"
+      },
+      {
+        "name": "unzip",
+        "version": "6.0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "makefile",
+          "patches": [
+            "179330daaf395b631025d23ec666c227707caa8859a872cc39d3ea0e2a645e97",
+            "24582ff3dcd926d1a46caf8506f76999d2525dd66e36f50b25dca50799695f12",
+            "251d5755ffb1e9701434c545fcda0fbfc2a16372f9d807fd07606b1364a1b55b",
+            "337131428f491b7030f96ee5b8ef3d8f5963730d1619b2754c624f4616d79adb",
+            "44599c80ea507c1fcfb8fb58b4c9d8d18f3157de453c1e0469a703322deb042a",
+            "47e9deff12845e71de98cd19506a51c21d756a61bb67c0b17e77b84bdbe9fb84",
+            "4e5a081aa8d0ad9aa5ceeda9eaeefbb6a7e7666d6b7a5b81cb0a61a3ff99a942",
+            "59c0983b53801d3080684bc616d3570ccacfe471f3a8c442916b87f2f3bfa334",
+            "64f64985270e026c01d2c19c6b66c218cf5bcfc7cf3d4a44e601fad41975ec73",
+            "74bc961e8013a4058687a3730590a709b7889203beb74a4a8369ba0301bef0e2",
+            "7d8e5c77ad99f9bf56d4cbf224b5635367feb44f81745dec84b44365f8f5eb16",
+            "81ca46cfd3cf732de8cf78c57790ed7d5c73a5e8d41943b8f6313cede6004f3e",
+            "881d2ed0755926f8ca1a0393b0ae0b5fe6d69ec784d6d5bfa1db06742246d0ea",
+            "aced0f27191a67f9b8b3fdc5995938a64fd87cea64a0bbba2106e06137ef91c2",
+            "b6f64d7b57e74ceaa794dd13a6937f063ec915343f3d5d88b0f81c919e7bf171",
+            "b7a14c33db93d1e5b4fc6ce113b4b99ff7a81ed56f46c87e001f22ec085e0273",
+            "c9a863e570bdaf2637c43bf1bba3d97808a1b0504d85418f6a8550ac286788f2",
+            "ee9e26018190a515572b66a26118916843aa1002131a86b5c52769dc663b7acb",
+            "f6f62365acad3ab3b5f4b2982e418168a8fa29420868c7571a6c59cc475dd167",
+            "f88b9d4119a1e256f3335a2d2c142dd95d13d7c5f9e5ecd4371e547249f3557c",
+            "fde8f9d6dbc5e9dc59f4497de8e4e313fd74318eaf5f33421acd74442fd10706"
+          ],
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "patches": [
+          "f6f62365acad3ab3b5f4b2982e418168a8fa29420868c7571a6c59cc475dd167",
+          "881d2ed0755926f8ca1a0393b0ae0b5fe6d69ec784d6d5bfa1db06742246d0ea",
+          "74bc961e8013a4058687a3730590a709b7889203beb74a4a8369ba0301bef0e2",
+          "fde8f9d6dbc5e9dc59f4497de8e4e313fd74318eaf5f33421acd74442fd10706",
+          "64f64985270e026c01d2c19c6b66c218cf5bcfc7cf3d4a44e601fad41975ec73",
+          "c9a863e570bdaf2637c43bf1bba3d97808a1b0504d85418f6a8550ac286788f2",
+          "337131428f491b7030f96ee5b8ef3d8f5963730d1619b2754c624f4616d79adb",
+          "b7a14c33db93d1e5b4fc6ce113b4b99ff7a81ed56f46c87e001f22ec085e0273",
+          "251d5755ffb1e9701434c545fcda0fbfc2a16372f9d807fd07606b1364a1b55b",
+          "b6f64d7b57e74ceaa794dd13a6937f063ec915343f3d5d88b0f81c919e7bf171",
+          "7d8e5c77ad99f9bf56d4cbf224b5635367feb44f81745dec84b44365f8f5eb16",
+          "aced0f27191a67f9b8b3fdc5995938a64fd87cea64a0bbba2106e06137ef91c2",
+          "47e9deff12845e71de98cd19506a51c21d756a61bb67c0b17e77b84bdbe9fb84",
+          "24582ff3dcd926d1a46caf8506f76999d2525dd66e36f50b25dca50799695f12",
+          "f88b9d4119a1e256f3335a2d2c142dd95d13d7c5f9e5ecd4371e547249f3557c",
+          "ee9e26018190a515572b66a26118916843aa1002131a86b5c52769dc663b7acb",
+          "179330daaf395b631025d23ec666c227707caa8859a872cc39d3ea0e2a645e97",
+          "44599c80ea507c1fcfb8fb58b4c9d8d18f3157de453c1e0469a703322deb042a",
+          "81ca46cfd3cf732de8cf78c57790ed7d5c73a5e8d41943b8f6313cede6004f3e",
+          "59c0983b53801d3080684bc616d3570ccacfe471f3a8c442916b87f2f3bfa334",
+          "4e5a081aa8d0ad9aa5ceeda9eaeefbb6a7e7666d6b7a5b81cb0a61a3ff99a942"
+        ],
+        "package_hash": "jll2spid4jxi53uk2savzamnpu2lkpp3lmvnu2iryb5md56q7dra====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "3z6myz5yrhjjfkmgpsdchnjizuckry3u"
+      },
+      {
+        "name": "perl-data-dumper",
+        "version": "2.173",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "perl",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "b7mb2qnooigmh5un3poom74fxvk7v6nqddgnh5s5hu2xqnrrra5a====",
+        "dependencies": [
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "perl",
+            "hash": "hvgkbkquqiphtesb2goyz45wpgkxxpyy",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "octgjez2nwun7tkntpdjem3tqinpzoqp"
+      },
+      {
+        "name": "swig",
+        "version": "4.4.1",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "autotools",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "m36ygg3l4zbob6ed65xcylavbmrm3ndjwctb43adxaum4orwo2ra====",
+        "dependencies": [
+          {
+            "name": "automake",
+            "hash": "zoscbzww2pwvftjwagbdbmr5mtodhsvh",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "gmake",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gnuconfig",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pcre2",
+            "hash": "piyl67baxvpfkwzpbgw42xutn3hm6jao",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "pkgconf",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "pkgconfig"
+              ]
+            }
+          },
+          {
+            "name": "zlib-ng",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": [
+                "zlib-api"
+              ]
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "6qjtbm6wt5xjel5vk3pzli2ubjxn5a2w"
+      },
+      {
+        "name": "py-numexpr",
+        "version": "2.14.1",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "cghc3mw2w5jziq7fjrsnnl5pugnxtuinkv25vmbwfevaaxbpxvta====",
+        "dependencies": [
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c",
+                "cxx"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
+            "name": "py-numpy",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "oolt2wfpvpz2lhntnbbxxq4fwjer66ft"
+      },
+      {
+        "name": "py-python-dateutil",
+        "version": "2.9.0.post0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ykjzsnrjwac4mqqy2sczqtiybxm2txra6ohg7bydkq2xgjy5mica====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools-scm",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-six",
+            "hash": "kakxncsqwzyymv2sainqrmmaomm6yci7",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "wwfnvfg32vx7iaundudzksec4kglqlml"
+      },
+      {
+        "name": "py-six",
+        "version": "1.17.0",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "eiknuz6vwcgwr4a3sdnq2zx757oh24v44la5ibof7umofb4x57zq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "kakxncsqwzyymv2sainqrmmaomm6yci7"
+      },
+      {
+        "name": "py-pytz",
+        "version": "2025.2",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "oqawsk4au7cy7gt3srxq2hkyr6ap3hztwlqojpc7xu2ckyolyknq====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "7cfyq2qkw6y4ogzi66tf5ip5faswvxtp"
+      },
+      {
+        "name": "py-tzdata",
+        "version": "2026.1",
+        "arch": {
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
+        },
+        "namespace": "builtin",
+        "parameters": {
+          "build_system": "python_pip",
+          "cflags": [],
+          "cppflags": [],
+          "cxxflags": [],
+          "fflags": [],
+          "ldflags": [],
+          "ldlibs": []
+        },
+        "package_hash": "ptkqk36rvgsotgzlguszvwtx62rkvmv4rc76zda3v2oandhuhl6q====",
+        "dependencies": [
+          {
+            "name": "py-pip",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-setuptools",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "py-wheel",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "python-venv",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "run"
+              ],
+              "virtuals": []
+            }
+          }
+        ],
+        "annotations": {
+          "original_specfile_version": 5
+        },
+        "hash": "funfskjxsztptkp3ns2dd5cpuni2x7sz"
       },
       {
         "name": "py-polars",
         "version": "1.42.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -12369,7 +11893,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12379,7 +11903,7 @@
           },
           {
             "name": "py-polars-runtime-32",
-            "hash": "uby7hpbggdr7oprfa6zmdyil6pmln3mq",
+            "hash": "fdvwytpbhjzpiy7pdbmddhcxhoulstbv",
             "parameters": {
               "deptypes": [
                 "run"
@@ -12389,7 +11913,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12399,7 +11923,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12409,7 +11933,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12420,7 +11944,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12433,57 +11957,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "me3udu6uyndalsy6aygffbcggjthrarb"
+        "hash": "fmetxmmvon6ntltuozxxdrmjbdbw7vbf"
       },
       {
         "name": "py-polars-runtime-32",
         "version": "1.42.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -12499,7 +11981,7 @@
         "dependencies": [
           {
             "name": "py-maturin",
-            "hash": "ajv3x4a7httn2amzarm5knjfdokv2dbp",
+            "hash": "nq4gwf3fcyso4n2sifnyxlqq5mxfkzqt",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12509,7 +11991,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12519,7 +12001,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12529,7 +12011,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12540,7 +12022,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12551,7 +12033,7 @@
           },
           {
             "name": "rust",
-            "hash": "5u3ce7u7ov4ahivr55kbkvy2p6rz4p4f",
+            "hash": "aykeeprqpothgqkqomry6jzgb2xrqckr",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12563,57 +12045,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "uby7hpbggdr7oprfa6zmdyil6pmln3mq"
+        "hash": "fdvwytpbhjzpiy7pdbmddhcxhoulstbv"
       },
       {
         "name": "py-maturin",
         "version": "1.13.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -12628,20 +12068,8 @@
         "package_hash": "sfustejwrbotcfkwymfave253tadgndn4wgggpmsrjg72sommt6a====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c"
-              ]
-            }
-          },
-          {
             "name": "bzip2",
-            "hash": "f66e7vo7zkss445atltrjo7npnxaymup",
+            "hash": "hyxuywa5hajihfzpbwvduwp5453ficnj",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12652,7 +12080,7 @@
           },
           {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12661,8 +12089,42 @@
             }
           },
           {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": [
+                "c"
+              ]
+            }
+          },
+          {
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12672,7 +12134,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12682,7 +12144,7 @@
           },
           {
             "name": "py-setuptools-rust",
-            "hash": "lcm4p542twghwoisfht2va4qznjea5xx",
+            "hash": "unyxmveu4tou7ekfkup4nvhcceijuxut",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12692,7 +12154,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12702,7 +12164,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12713,7 +12175,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12724,7 +12186,7 @@
           },
           {
             "name": "rust",
-            "hash": "5u3ce7u7ov4ahivr55kbkvy2p6rz4p4f",
+            "hash": "aykeeprqpothgqkqomry6jzgb2xrqckr",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12737,57 +12199,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "ajv3x4a7httn2amzarm5knjfdokv2dbp"
+        "hash": "nq4gwf3fcyso4n2sifnyxlqq5mxfkzqt"
       },
       {
         "name": "py-setuptools-rust",
         "version": "1.12.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -12803,7 +12223,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12813,7 +12233,7 @@
           },
           {
             "name": "py-semantic-version",
-            "hash": "rtrbfrvddsb64tv54qzyktpah5qkfi57",
+            "hash": "hwvacg56gsdoispcrfxk53jyj3eepu6b",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12824,7 +12244,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12835,7 +12255,7 @@
           },
           {
             "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12845,7 +12265,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12855,7 +12275,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12866,7 +12286,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -12877,7 +12297,7 @@
           },
           {
             "name": "rust",
-            "hash": "5u3ce7u7ov4ahivr55kbkvy2p6rz4p4f",
+            "hash": "aykeeprqpothgqkqomry6jzgb2xrqckr",
             "parameters": {
               "deptypes": [
                 "run"
@@ -12889,57 +12309,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "lcm4p542twghwoisfht2va4qznjea5xx"
+        "hash": "unyxmveu4tou7ekfkup4nvhcceijuxut"
       },
       {
         "name": "rust",
         "version": "nightly-2026-04-01",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -12957,8 +12335,39 @@
         "package_hash": "dzga7f232id4y6hyjryprylj7rrc35txsrgaliorfbd74useplhq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "curl",
+            "hash": "l7l4celxf7j5ex4bvd327purjwiti5y2",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -12970,39 +12379,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "curl",
-            "hash": "ptydlgoe7volqmy2e6wsvnfiwjfnkn5t",
-            "parameters": {
-              "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "libgit2",
-            "hash": "nicc5wvvv4h7oh225ypwqcevxjsodrbo",
+            "hash": "jogx2muhf7ivi2qnavlltl2twlbghzkv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13013,7 +12413,7 @@
           },
           {
             "name": "libssh2",
-            "hash": "m4sg62e67uyenbob3yzhijkrudoumxrs",
+            "hash": "lz2k3zstbcjxnkhevfdkazunn2rdmt72",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13024,7 +12424,7 @@
           },
           {
             "name": "ninja",
-            "hash": "wrrgzxi7br3krs3wylftkrtztc4rqh73",
+            "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13034,7 +12434,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13045,7 +12445,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13057,7 +12457,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13067,7 +12467,7 @@
           },
           {
             "name": "rust-bootstrap",
-            "hash": "mu32udyy3tm6gcqs74yzmjknpqjcs56x",
+            "hash": "j2i5mlz2ogifwat4kgiohyzpvf554hkd",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13077,7 +12477,7 @@
           },
           {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13092,57 +12492,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "5u3ce7u7ov4ahivr55kbkvy2p6rz4p4f"
+        "hash": "aykeeprqpothgqkqomry6jzgb2xrqckr"
       },
       {
         "name": "rust-bootstrap",
         "version": "beta-2026-03-05",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -13154,11 +12512,21 @@
           "ldflags": [],
           "ldlibs": []
         },
-        "package_hash": "t3dbqijksusikqqsjcj2n6kkayo3jurcakcuxuqp5dac6nt5c55q====",
+        "package_hash": "y5erxhjdnjmdj2t53kjp5bwhhq2ttiipzkqrg2s2tultozoqhu2a====",
         "dependencies": [
           {
+            "name": "patchelf",
+            "hash": "tkcpp45cyecm35pdahlxukkoo7ggiekc",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
             "name": "zlib-ng",
-            "hash": "kts2gmgky4jbqy2sibj54akvyur2emqr",
+            "hash": "oanblfvyw6t3qc7pwzd6uztojuxqfvec",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13173,57 +12541,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "mu32udyy3tm6gcqs74yzmjknpqjcs56x"
+        "hash": "j2i5mlz2ogifwat4kgiohyzpvf554hkd"
       },
       {
         "name": "py-pyarrow",
         "version": "25.0.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -13238,8 +12564,39 @@
         "package_hash": "rjtuymoqfsgezuo7bmqa3tldujeribxgsal56sqgnifl2knpjyua====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "arrow",
+            "hash": "xv54gvngolfhpbpuygcodzcynej3eff6",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13251,39 +12608,30 @@
             }
           },
           {
-            "name": "arrow",
-            "hash": "ke5rivljigcr7hc4haou6bbbpon4q2eb",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13295,7 +12643,7 @@
           },
           {
             "name": "py-cython",
-            "hash": "6koytqdfzgrojtnt65dfhag6nltjqxsd",
+            "hash": "uc54gih6oozlx2fgfsh7dq4xfmspjf7r",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13305,7 +12653,7 @@
           },
           {
             "name": "py-libcst",
-            "hash": "yxmg4ixjbeunalqqbxqgu7rmew7dx347",
+            "hash": "o7viwsevli5mu6xvyfmhykd4sy6nwhrk",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13315,7 +12663,7 @@
           },
           {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13326,7 +12674,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13336,7 +12684,7 @@
           },
           {
             "name": "py-scikit-build-core",
-            "hash": "s6yryivls2kvrua42xycytoilpqrblmj",
+            "hash": "v4jnytlsivvizeql5rjbl5jmlnt7slgz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13346,7 +12694,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13356,7 +12704,7 @@
           },
           {
             "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13366,7 +12714,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13376,7 +12724,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13387,7 +12735,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13400,57 +12748,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "d2yw3fourt7yoxfsu7cdsw6sursl7lel"
+        "hash": "ay45xtgh4omyzsyq5ip432rwj2z2gvbf"
       },
       {
         "name": "arrow",
         "version": "25.0.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -13489,8 +12795,50 @@
         "package_hash": "bej5tiplbqydf2dag4rvxxtnz3znqu4bkbq53ly2l5cukbrt4yqq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "boost",
+            "hash": "veo2gonsvhhcqqqxrl6bs6poh6brqa2i",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "flatbuffers",
+            "hash": "iqrwhgvih5fdylzzbhd6m3ldhimtaitf",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13502,50 +12850,30 @@
             }
           },
           {
-            "name": "boost",
-            "hash": "uon24phcff3qud4aummzeqh7c2acu3uy",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "flatbuffers",
-            "hash": "cn7v2xep5gqwlcvg6dengilctcihdhmk",
-            "parameters": {
-              "deptypes": [
-                "build",
                 "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13555,7 +12883,7 @@
           },
           {
             "name": "ninja",
-            "hash": "wrrgzxi7br3krs3wylftkrtztc4rqh73",
+            "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13565,7 +12893,7 @@
           },
           {
             "name": "openssl",
-            "hash": "safjyytgnje6giqmesie5dg6o6bq2vlv",
+            "hash": "3i64b6wx35q5j2mlv6t4dfspvmigob6c",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13576,7 +12904,7 @@
           },
           {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13587,7 +12915,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13598,7 +12926,7 @@
           },
           {
             "name": "rapidjson",
-            "hash": "v7gqqoj5eyhdgzhp6zeg3w7doeuhxcq3",
+            "hash": "w2p2pc7bxj2ljmplpoe3l736pusfihzi",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13609,7 +12937,7 @@
           },
           {
             "name": "re2",
-            "hash": "iyzpu6qxgmnjiifso35oncxqaiphxjyr",
+            "hash": "ax6eciznvaaakttkffbwufsqu32zblqb",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13620,7 +12948,7 @@
           },
           {
             "name": "thrift",
-            "hash": "izwnvvnxdstedslnmthsdvsqb3m4ahwe",
+            "hash": "ll3qducxcb3ionyeki6lg7cbkq6vtqo6",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13631,7 +12959,7 @@
           },
           {
             "name": "utf8proc",
-            "hash": "vvmaimyirj3yqhoww75ejuhlgcbsy4mn",
+            "hash": "i5oi63av7a7adp5hfwyn44hfidbwo3w2",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13642,7 +12970,7 @@
           },
           {
             "name": "xsimd",
-            "hash": "pqstsy3bpksf45hzok3d6xu7mli2tx6w",
+            "hash": "awt5xl45yy676sengqi5snlkmpuovu6f",
             "parameters": {
               "deptypes": [
                 "build",
@@ -13655,57 +12983,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "ke5rivljigcr7hc4haou6bbbpon4q2eb"
+        "hash": "xv54gvngolfhpbpuygcodzcynej3eff6"
       },
       {
         "name": "boost",
         "version": "1.90.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -13774,8 +13060,18 @@
         "package_hash": "7jl2bofdxsthd2xq45mgtrkxurxu3swharjgcaexcr4scv2nugpq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13787,70 +13083,40 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
+            }
+          },
+          {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
             }
           }
         ],
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "uon24phcff3qud4aummzeqh7c2acu3uy"
+        "hash": "veo2gonsvhhcqqqxrl6bs6poh6brqa2i"
       },
       {
         "name": "flatbuffers",
         "version": "24.12.23",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -13870,8 +13136,28 @@
         "package_hash": "ctythqsy3mi6yrgqm6byg5gqkmxkcpdzyrcfktqyrhf6rgepwmgq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13882,28 +13168,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -13915,57 +13203,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "cn7v2xep5gqwlcvg6dengilctcihdhmk"
+        "hash": "iqrwhgvih5fdylzzbhd6m3ldhimtaitf"
       },
       {
         "name": "rapidjson",
         "version": "1.2.0-2024-08-16",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -13991,8 +13237,28 @@
         "package_hash": "zozhtfchvaondgprh4fv7gv4uchzdei2zwnv7dj7wco4ha4dz57a====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14003,28 +13269,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14036,57 +13304,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "v7gqqoj5eyhdgzhp6zeg3w7doeuhxcq3"
+        "hash": "w2p2pc7bxj2ljmplpoe3l736pusfihzi"
       },
       {
         "name": "re2",
         "version": "2024-07-02",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -14108,7 +13334,7 @@
         "dependencies": [
           {
             "name": "abseil-cpp",
-            "hash": "axwxjub3stwrjj57vnruqp2bjfv5xj7x",
+            "hash": "mfpahfezmupawbhgwjze2z66bhpz7zje",
             "parameters": {
               "deptypes": [
                 "build",
@@ -14118,8 +13344,28 @@
             }
           },
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14130,28 +13376,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14163,57 +13411,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "iyzpu6qxgmnjiifso35oncxqaiphxjyr"
+        "hash": "ax6eciznvaaakttkffbwufsqu32zblqb"
       },
       {
         "name": "abseil-cpp",
         "version": "20260107.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -14233,8 +13439,28 @@
         "package_hash": "ce4brhfex5prp35z7nujdbnh7cptrgm7nwpbe7kdrbk7gdzg73ba====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14245,28 +13471,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14278,57 +13506,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "axwxjub3stwrjj57vnruqp2bjfv5xj7x"
+        "hash": "mfpahfezmupawbhgwjze2z66bhpz7zje"
       },
       {
         "name": "thrift",
         "version": "0.22.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -14357,8 +13543,59 @@
         "package_hash": "4af7izpvsx66ic5eytsvn6zkgtdtdl2kjerdea3h6qhhh56skpoa====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "bison",
+            "hash": "djmloovh4xxpvhv2ocysskcxmbi3zol2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "boost",
+            "hash": "veo2gonsvhhcqqqxrl6bs6poh6brqa2i",
+            "parameters": {
+              "deptypes": [
+                "build",
+                "link"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "flex",
+            "hash": "mbq7h4vme6xmvhpzehoqkrhvvnqyvmbr",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14370,59 +13607,30 @@
             }
           },
           {
-            "name": "bison",
-            "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "boost",
-            "hash": "uon24phcff3qud4aummzeqh7c2acu3uy",
-            "parameters": {
-              "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "flex",
-            "hash": "cwazdijqx6zawlet4m27jkx7ni4ueytl",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14432,7 +13640,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14446,57 +13654,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "izwnvvnxdstedslnmthsdvsqb3m4ahwe"
+        "hash": "ll3qducxcb3ionyeki6lg7cbkq6vtqo6"
       },
       {
         "name": "flex",
         "version": "2.6.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -14513,8 +13679,48 @@
         "package_hash": "m2uhgcztia4wregbekbmg73yh5yvc4p2a5gkm56ii4wogndm3ktq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "bison",
+            "hash": "djmloovh4xxpvhv2ocysskcxmbi3zol2",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "diffutils",
+            "hash": "qacpnaxax3im2jq2csgmw3ootncrnyuu",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "findutils",
+            "hash": "ijownbucjh3jpsrhgvsvmxbe6l2ij6bk",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14526,48 +13732,30 @@
             }
           },
           {
-            "name": "bison",
-            "hash": "65v2ji2nkmymbi26mpoffwiagenskmrd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "diffutils",
-            "hash": "7ig2s6kfxqqvlprsn7vp3gdzh2ckuzzv",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "findutils",
-            "hash": "vmabkgu4dvo2u4hzvknt3gquapyyit6a",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14577,7 +13765,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14587,7 +13775,7 @@
           },
           {
             "name": "m4",
-            "hash": "cufpq5wqh3w7udla7gc2shpnvzzcg7mt",
+            "hash": "4voacumvytiugnmop25vvsnun7chknqw",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14599,57 +13787,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "cwazdijqx6zawlet4m27jkx7ni4ueytl"
+        "hash": "mbq7h4vme6xmvhpzehoqkrhvvnqyvmbr"
       },
       {
         "name": "utf8proc",
         "version": "2.10.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -14668,8 +13814,28 @@
         "package_hash": "opscjeckm5ke333o2kxbi7uzdprg4533jjwpc5h2oa6ux2e7sefq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14680,28 +13846,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14713,57 +13881,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vvmaimyirj3yqhoww75ejuhlgcbsy4mn"
+        "hash": "i5oi63av7a7adp5hfwyn44hfidbwo3w2"
       },
       {
         "name": "xsimd",
         "version": "14.2.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -14781,8 +13907,28 @@
         "package_hash": "nrd6buke5gk3j2dkxbnzb5a5cs3o4ebwykk3kvz3jzckkvtlhs7a====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14794,28 +13940,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14827,57 +13975,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "pqstsy3bpksf45hzok3d6xu7mli2tx6w"
+        "hash": "awt5xl45yy676sengqi5snlkmpuovu6f"
       },
       {
         "name": "py-libcst",
         "version": "1.8.6",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -14893,7 +13999,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14903,7 +14009,7 @@
           },
           {
             "name": "py-pyyaml",
-            "hash": "jjztkx74hjwukxflivt4igqzr6c6k7as",
+            "hash": "ucfgyguczlcd2v377megzoyzch5q5rys",
             "parameters": {
               "deptypes": [
                 "build",
@@ -14914,7 +14020,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14924,7 +14030,7 @@
           },
           {
             "name": "py-setuptools-rust",
-            "hash": "qkhrocik7ue3zrtehffdoqsvszseozxi",
+            "hash": "nqoqwrc3ybxnggifu2dyvlxdh6vxmkqz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14934,7 +14040,7 @@
           },
           {
             "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14944,7 +14050,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14954,7 +14060,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -14965,7 +14071,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -14976,7 +14082,7 @@
           },
           {
             "name": "rust",
-            "hash": "4yx3pkx6tefwrwi2mnvvybmmgjplghwi",
+            "hash": "lomrlsgokiq43mxhvlf7hnyqc7m4gu6q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -14988,57 +14094,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "yxmg4ixjbeunalqqbxqgu7rmew7dx347"
+        "hash": "o7viwsevli5mu6xvyfmhykd4sy6nwhrk"
       },
       {
         "name": "py-pyyaml",
         "version": "6.0.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -15055,7 +14119,7 @@
         "dependencies": [
           {
             "name": "libyaml",
-            "hash": "lbgbqsxe36pdvoqm7gqpmd33rxw76wup",
+            "hash": "dqhd7c6ivgo7cefwaqbrluqq2krsg6ww",
             "parameters": {
               "deptypes": [
                 "link"
@@ -15065,7 +14129,7 @@
           },
           {
             "name": "py-cython",
-            "hash": "6koytqdfzgrojtnt65dfhag6nltjqxsd",
+            "hash": "uc54gih6oozlx2fgfsh7dq4xfmspjf7r",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15075,7 +14139,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15085,7 +14149,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15095,7 +14159,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15105,7 +14169,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15117,7 +14181,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15130,57 +14194,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "jjztkx74hjwukxflivt4igqzr6c6k7as"
+        "hash": "ucfgyguczlcd2v377megzoyzch5q5rys"
       },
       {
         "name": "libyaml",
         "version": "0.2.5",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -15195,8 +14217,18 @@
         "package_hash": "uerjalcebiknyntippb2di6vu4hkis3fs7g46s6q5qob4k5y4esq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15207,18 +14239,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
+            "hash": "6wopwqfeduhghg5ovcxbslfsk3fliaox",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15228,7 +14272,7 @@
           },
           {
             "name": "gnuconfig",
-            "hash": "cxt42mygaqmcy56nfni4afyojpabaeto",
+            "hash": "jvnxyfro7ym7bn5xetymolkmwaw4vnbe",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15240,57 +14284,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "lbgbqsxe36pdvoqm7gqpmd33rxw76wup"
+        "hash": "dqhd7c6ivgo7cefwaqbrluqq2krsg6ww"
       },
       {
         "name": "py-scikit-build-core",
         "version": "0.12.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -15306,21 +14308,8 @@
         "package_hash": "cda3jjlilax52jp46oxyecxil4zky75cjybqav6sedy7yo6kqtka====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c",
-                "cxx"
-              ]
-            }
-          },
-          {
             "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15331,7 +14320,7 @@
           },
           {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15341,19 +14330,21 @@
           },
           {
             "name": "gcc",
-            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
               ],
               "virtuals": [
+                "c",
+                "cxx",
                 "fortran"
               ]
             }
           },
           {
             "name": "gcc-runtime",
-            "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
                 "link"
@@ -15365,8 +14356,20 @@
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-hatch-vcs",
-            "hash": "rqud6mszhna3e4ah6w2l6unhiczlf3ly",
+            "hash": "rchuzf3y2c2h6udbmfwfybiu3tfal25q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15376,7 +14379,7 @@
           },
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15386,7 +14389,7 @@
           },
           {
             "name": "py-packaging",
-            "hash": "5ffho2mv3pdpg2lup4526gedy6jhdzuq",
+            "hash": "da5km5iuzzq4ydcecig2m3rrs4wldedw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15397,7 +14400,7 @@
           },
           {
             "name": "py-pathspec",
-            "hash": "lgjjqknhp4gb2hgx5iuumngt4ctmjaac",
+            "hash": "cwji4bzk43dez6vgaswp7ualjbmmgwlq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15408,7 +14411,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15418,7 +14421,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15428,7 +14431,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15439,7 +14442,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15452,57 +14455,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "s6yryivls2kvrua42xycytoilpqrblmj"
+        "hash": "v4jnytlsivvizeql5rjbl5jmlnt7slgz"
       },
       {
         "name": "py-pydantic",
         "version": "2.13.4",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -15519,7 +14480,7 @@
         "dependencies": [
           {
             "name": "py-annotated-types",
-            "hash": "arwa4d25lyqrlizjzv2eustbpcwsc6f4",
+            "hash": "kvbqxetauz4ihqm7lzgircoj46u2j3kg",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15530,7 +14491,7 @@
           },
           {
             "name": "py-hatch-fancy-pypi-readme",
-            "hash": "i44ajczlub7e4ll2iwtelv72xoia4vqn",
+            "hash": "572isdqnn7w7myq36c4nmuczw7hg3xha",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15540,7 +14501,7 @@
           },
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15550,7 +14511,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15560,7 +14521,7 @@
           },
           {
             "name": "py-pydantic-core",
-            "hash": "gbr6z2h7t6x3wvvtycn5phln3yphwsv4",
+            "hash": "pivvaqsq3sy5va2dehxnfzbl7evciinw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15571,7 +14532,7 @@
           },
           {
             "name": "py-typing-extensions",
-            "hash": "3luhcd4nz3fgh3fxjegc6rcsdduysyjr",
+            "hash": "epvpeyyy4uiwc5fcjdttbd72ngbj4dt7",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15582,7 +14543,7 @@
           },
           {
             "name": "py-typing-inspection",
-            "hash": "xi5kmc65yuhc4j6cwbkhp7fytip7sppy",
+            "hash": "bt36nkpyqlvyn24tk7pswdoocek7pyd3",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15593,7 +14554,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15603,7 +14564,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15614,7 +14575,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15627,57 +14588,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "r4y47icdvd6pkhenl3u2prxj4qyqe6rh"
+        "hash": "oovbhqkjowdp5yncp7vox4jtsolsmx52"
       },
       {
         "name": "py-annotated-types",
         "version": "0.7.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -15693,7 +14612,7 @@
         "dependencies": [
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15703,7 +14622,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15713,7 +14632,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15723,7 +14642,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15734,7 +14653,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15747,57 +14666,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "arwa4d25lyqrlizjzv2eustbpcwsc6f4"
+        "hash": "kvbqxetauz4ihqm7lzgircoj46u2j3kg"
       },
       {
         "name": "py-pydantic-core",
         "version": "2.46.4",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -15813,7 +14690,7 @@
         "dependencies": [
           {
             "name": "py-maturin",
-            "hash": "sxu2d3246n5n6wku6ai2q7zoud2ivftd",
+            "hash": "6vy3zo7r2jffajh34j3s22rpqcadbmm4",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15823,7 +14700,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15833,7 +14710,7 @@
           },
           {
             "name": "py-typing-extensions",
-            "hash": "3luhcd4nz3fgh3fxjegc6rcsdduysyjr",
+            "hash": "epvpeyyy4uiwc5fcjdttbd72ngbj4dt7",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15844,7 +14721,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15854,7 +14731,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15865,7 +14742,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15876,7 +14753,7 @@
           },
           {
             "name": "rust",
-            "hash": "4yx3pkx6tefwrwi2mnvvybmmgjplghwi",
+            "hash": "lomrlsgokiq43mxhvlf7hnyqc7m4gu6q",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15888,57 +14765,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "gbr6z2h7t6x3wvvtycn5phln3yphwsv4"
+        "hash": "pivvaqsq3sy5va2dehxnfzbl7evciinw"
       },
       {
         "name": "py-typing-inspection",
         "version": "0.4.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -15954,7 +14789,7 @@
         "dependencies": [
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15964,7 +14799,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15974,7 +14809,7 @@
           },
           {
             "name": "py-typing-extensions",
-            "hash": "3luhcd4nz3fgh3fxjegc6rcsdduysyjr",
+            "hash": "epvpeyyy4uiwc5fcjdttbd72ngbj4dt7",
             "parameters": {
               "deptypes": [
                 "build",
@@ -15985,7 +14820,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -15995,7 +14830,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16006,7 +14841,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16019,57 +14854,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "xi5kmc65yuhc4j6cwbkhp7fytip7sppy"
+        "hash": "bt36nkpyqlvyn24tk7pswdoocek7pyd3"
       },
       {
         "name": "py-scikit-learn",
         "version": "1.9.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -16084,8 +14877,18 @@
         "package_hash": "s4z3eb2w7hnfmpbbolazdsqdsttygf2c2ctuia57zow3f3wrzaba====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16097,29 +14900,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "llvm-openmp",
-            "hash": "ze2h6rabh2o6mbk6u5jsfqp22x7bx73i",
-            "parameters": {
-              "deptypes": [
-                "build",
                 "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-cython",
-            "hash": "6koytqdfzgrojtnt65dfhag6nltjqxsd",
+            "hash": "uc54gih6oozlx2fgfsh7dq4xfmspjf7r",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16129,7 +14933,7 @@
           },
           {
             "name": "py-joblib",
-            "hash": "vxzyfb5ntuu6hbwzrv5ww33wdhgprfmj",
+            "hash": "dgdyuwyu4apjeizfaeec2jixivdbsdzc",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16140,7 +14944,7 @@
           },
           {
             "name": "py-meson-python",
-            "hash": "6ronsvddetpkvmki5b3kalxj5mkqdhf4",
+            "hash": "4b65qsgmyek35im5y6rgt5uvx6uwip6e",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16150,7 +14954,7 @@
           },
           {
             "name": "py-narwhals",
-            "hash": "suvmpqlw43aw3gbti5ddi3aumngvqxf7",
+            "hash": "em7mimmcmte37b3bnb5stfzo5izbyrys",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16161,7 +14965,7 @@
           },
           {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16173,7 +14977,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16183,7 +14987,7 @@
           },
           {
             "name": "py-scipy",
-            "hash": "ebzu5yeraelh2srtwjdd5phy5tobv6uj",
+            "hash": "z7bkk2rumd3dlau2te6zmgzfzmpghxdt",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16194,7 +14998,7 @@
           },
           {
             "name": "py-threadpoolctl",
-            "hash": "ig6efoyweq2uyzn3l657ey4av43zzrtu",
+            "hash": "w5c64evtu5o3h5vqqe6h7qa6akehiu2j",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16205,7 +15009,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16215,7 +15019,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16227,7 +15031,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16240,173 +15044,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "lmrkdxw7hmdtkaynbbfgbthgpbzffszz"
-      },
-      {
-        "name": "llvm-openmp",
-        "version": "20.1.8",
-        "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
-        },
-        "namespace": "builtin",
-        "parameters": {
-          "build_system": "cmake",
-          "build_type": "Release",
-          "fortran": false,
-          "generator": "make",
-          "ipo": false,
-          "multicompat": true,
-          "cflags": [],
-          "cppflags": [],
-          "cxxflags": [],
-          "fflags": [],
-          "ldflags": [],
-          "ldlibs": []
-        },
-        "package_hash": "bvxhxpeb6l4vwegdl634ihu6hgftlvs4txfeefu6wxurxrvrxe5a====",
-        "dependencies": [
-          {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c",
-                "cxx"
-              ]
-            }
-          },
-          {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          },
-          {
-            "name": "gmake",
-            "hash": "x7otsagrpvgf4ff7enuaokuyqp7mzfea",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": []
-            }
-          }
-        ],
-        "annotations": {
-          "original_specfile_version": 5
-        },
-        "hash": "ze2h6rabh2o6mbk6u5jsfqp22x7bx73i"
+        "hash": "m2eevxtkij6wry644fvreikqa4lesya3"
       },
       {
         "name": "py-joblib",
         "version": "1.5.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -16422,7 +15068,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16432,7 +15078,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16442,7 +15088,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16452,7 +15098,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16463,7 +15109,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16476,57 +15122,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "vxzyfb5ntuu6hbwzrv5ww33wdhgprfmj"
+        "hash": "dgdyuwyu4apjeizfaeec2jixivdbsdzc"
       },
       {
         "name": "py-narwhals",
         "version": "2.19.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -16542,7 +15146,7 @@
         "dependencies": [
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16552,7 +15156,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16562,7 +15166,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16572,7 +15176,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16583,7 +15187,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16596,57 +15200,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "suvmpqlw43aw3gbti5ddi3aumngvqxf7"
+        "hash": "em7mimmcmte37b3bnb5stfzo5izbyrys"
       },
       {
         "name": "py-scipy",
         "version": "1.16.3",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -16661,21 +15223,8 @@
         "package_hash": "or65iya3rb2cnjcjgd5pcy2laial7b5heopbr7hboqozzp62lyaa====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
-            "parameters": {
-              "deptypes": [
-                "build"
-              ],
-              "virtuals": [
-                "c",
-                "cxx"
-              ]
-            }
-          },
-          {
             "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16685,19 +15234,21 @@
           },
           {
             "name": "gcc",
-            "hash": "qyel5zk4z2gubafvqtprdjjcxynfhyt4",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
               ],
               "virtuals": [
+                "c",
+                "cxx",
                 "fortran"
               ]
             }
           },
           {
             "name": "gcc-runtime",
-            "hash": "inc5xi4ayqdshxcrtbaol46e4vezkdhs",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
                 "link"
@@ -16709,8 +15260,20 @@
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "meson",
-            "hash": "jqulumt5e6asiyiaaechgpyrjdmqv7i4",
+            "hash": "z2vjusc5e4ejfetpc67i6rvc2r34losl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16720,7 +15283,7 @@
           },
           {
             "name": "openblas",
-            "hash": "j42osoa4cbllwvtz2vndhz5gzvjfven3",
+            "hash": "vsc3fncjotiaam7jrrf7yzggcrub2kdb",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16734,7 +15297,7 @@
           },
           {
             "name": "pkgconf",
-            "hash": "ehygpyzbjxnrzkgadusqgoq5fzr3hrqc",
+            "hash": "iklut3kgdv6tjbn53fs6wvvlaozla5tn",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16746,7 +15309,7 @@
           },
           {
             "name": "py-cython",
-            "hash": "6koytqdfzgrojtnt65dfhag6nltjqxsd",
+            "hash": "uc54gih6oozlx2fgfsh7dq4xfmspjf7r",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16756,7 +15319,7 @@
           },
           {
             "name": "py-meson-python",
-            "hash": "6ronsvddetpkvmki5b3kalxj5mkqdhf4",
+            "hash": "4b65qsgmyek35im5y6rgt5uvx6uwip6e",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16766,7 +15329,7 @@
           },
           {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16778,7 +15341,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16788,7 +15351,7 @@
           },
           {
             "name": "py-pybind11",
-            "hash": "udn2pnhkknpuozgej235gardi6p6srsk",
+            "hash": "5uvpjfxuevqvpvfk623i57q3n4gtmgwm",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16799,7 +15362,7 @@
           },
           {
             "name": "py-pythran",
-            "hash": "6ztt7izdinl5tt2zmuxvstdoccbib3aq",
+            "hash": "aaktj5pey2uddgtdv6uuh4hprdr6cbn6",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16809,7 +15372,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16819,7 +15382,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16831,7 +15394,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16844,57 +15407,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "ebzu5yeraelh2srtwjdd5phy5tobv6uj"
+        "hash": "z7bkk2rumd3dlau2te6zmgzfzmpghxdt"
       },
       {
         "name": "py-pybind11",
         "version": "3.0.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -16912,8 +15433,28 @@
         "package_hash": "tbwsv5n4ytuke5f4jhwpfufum3oxr6rrfaiorctpgu2irazefl2q====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "cmake",
+            "hash": "4guzcdi4owq4cylbhco5oeo4hvkdoatv",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16924,28 +15465,30 @@
             }
           },
           {
-            "name": "cmake",
-            "hash": "vxkpk2lor7lusiubaaa2q7ywhvajirnd",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "ninja",
-            "hash": "wrrgzxi7br3krs3wylftkrtztc4rqh73",
+            "hash": "bwxfmzwp7wmdvl4xfhjl4xgfj4ikzbsv",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16955,7 +15498,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16965,7 +15508,7 @@
           },
           {
             "name": "py-scikit-build-core",
-            "hash": "s6yryivls2kvrua42xycytoilpqrblmj",
+            "hash": "v4jnytlsivvizeql5rjbl5jmlnt7slgz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16975,7 +15518,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -16985,7 +15528,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -16996,7 +15539,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17009,57 +15552,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "udn2pnhkknpuozgej235gardi6p6srsk"
+        "hash": "5uvpjfxuevqvpvfk623i57q3n4gtmgwm"
       },
       {
         "name": "py-pythran",
         "version": "0.18.1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -17074,8 +15575,18 @@
         "package_hash": "zi5hc2k66cd7krsbt4c34ec5jbc53plfamt4kwfd5kje5a7fjsza====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17086,29 +15597,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
-            "name": "llvm-openmp",
-            "hash": "ze2h6rabh2o6mbk6u5jsfqp22x7bx73i",
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
             "parameters": {
               "deptypes": [
-                "build",
-                "run"
+                "link"
               ],
-              "virtuals": []
+              "virtuals": [
+                "libc"
+              ]
             }
           },
           {
             "name": "py-beniget",
-            "hash": "24x4jkjgb7ek7wxdshq3gaxqmesqbuve",
+            "hash": "mauiikd6srfvnh6xienvbsa7dhyfbgw6",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17119,7 +15631,7 @@
           },
           {
             "name": "py-gast",
-            "hash": "zucbs4qq5davmwjwuqpf5ep6opitd3j5",
+            "hash": "6ire5upf6qvx2nahvndoyrosy3racgm5",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17130,7 +15642,7 @@
           },
           {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17141,7 +15653,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17151,7 +15663,7 @@
           },
           {
             "name": "py-ply",
-            "hash": "zj2iepk66ybrj4nqmr3w6wkzot4umajk",
+            "hash": "sx5db4vnuipte3gfpvxeumkylhwlvcmv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17162,7 +15674,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17173,7 +15685,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17183,7 +15695,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17194,7 +15706,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17207,57 +15719,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "6ztt7izdinl5tt2zmuxvstdoccbib3aq"
+        "hash": "aaktj5pey2uddgtdv6uuh4hprdr6cbn6"
       },
       {
         "name": "py-beniget",
         "version": "0.4.2.post1",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -17273,7 +15743,7 @@
         "dependencies": [
           {
             "name": "py-gast",
-            "hash": "zucbs4qq5davmwjwuqpf5ep6opitd3j5",
+            "hash": "6ire5upf6qvx2nahvndoyrosy3racgm5",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17284,7 +15754,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17294,7 +15764,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17304,7 +15774,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17314,7 +15784,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17325,7 +15795,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17338,57 +15808,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "24x4jkjgb7ek7wxdshq3gaxqmesqbuve"
+        "hash": "mauiikd6srfvnh6xienvbsa7dhyfbgw6"
       },
       {
         "name": "py-gast",
         "version": "0.6.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -17404,7 +15832,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17414,7 +15842,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17424,7 +15852,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17434,7 +15862,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17445,7 +15873,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17458,57 +15886,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "zucbs4qq5davmwjwuqpf5ep6opitd3j5"
+        "hash": "6ire5upf6qvx2nahvndoyrosy3racgm5"
       },
       {
         "name": "py-ply",
         "version": "3.11",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -17524,7 +15910,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17534,7 +15920,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17544,7 +15930,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17554,7 +15940,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17565,7 +15951,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17578,57 +15964,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "zj2iepk66ybrj4nqmr3w6wkzot4umajk"
+        "hash": "sx5db4vnuipte3gfpvxeumkylhwlvcmv"
       },
       {
         "name": "py-threadpoolctl",
         "version": "3.6.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -17644,7 +15988,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17654,7 +15998,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17664,7 +16008,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17674,7 +16018,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17685,7 +16029,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17698,57 +16042,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "ig6efoyweq2uyzn3l657ey4av43zzrtu"
+        "hash": "w5c64evtu5o3h5vqqe6h7qa6akehiu2j"
       },
       {
         "name": "py-typer",
         "version": "0.27.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -17764,7 +16066,7 @@
         "dependencies": [
           {
             "name": "py-annotated-doc",
-            "hash": "dxogg5g6xxix4ivxrjrdr2zbz7gmnfh3",
+            "hash": "jka7zekwldofz6tcccijkwkkxekgddyh",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17775,7 +16077,7 @@
           },
           {
             "name": "py-pdm-backend",
-            "hash": "es2ei2c3y5ygklkw2yxuicmpgblug24s",
+            "hash": "ippc4zphn7dr6z2xkkrdc7ohrvwdc36s",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17785,7 +16087,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17795,7 +16097,7 @@
           },
           {
             "name": "py-rich",
-            "hash": "m7fa7z5mq27plyss2x5bphtzafmqtvhx",
+            "hash": "mlzjl2fpmcxcid4sg5s2o3n5xzdfzamj",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17806,7 +16108,7 @@
           },
           {
             "name": "py-shellingham",
-            "hash": "ksq4komfn35laadjcvos4g42s5ruek7j",
+            "hash": "ttpldvag67w7avhrgmzbspayjljvlbzo",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17817,7 +16119,7 @@
           },
           {
             "name": "py-typing-extensions",
-            "hash": "3luhcd4nz3fgh3fxjegc6rcsdduysyjr",
+            "hash": "epvpeyyy4uiwc5fcjdttbd72ngbj4dt7",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17828,7 +16130,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17838,7 +16140,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17849,7 +16151,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17862,57 +16164,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "mnihnap6bexqulnfjlnsihu4znzns2oq"
+        "hash": "63kj4rps7dsuqlqahjcqro3pejpldkpz"
       },
       {
         "name": "py-annotated-doc",
         "version": "0.0.5",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "voiage_hpc_overlay",
         "parameters": {
@@ -17928,7 +16188,7 @@
         "dependencies": [
           {
             "name": "py-pdm-backend",
-            "hash": "es2ei2c3y5ygklkw2yxuicmpgblug24s",
+            "hash": "ippc4zphn7dr6z2xkkrdc7ohrvwdc36s",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17938,7 +16198,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17948,7 +16208,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -17958,7 +16218,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17969,7 +16229,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -17982,57 +16242,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "dxogg5g6xxix4ivxrjrdr2zbz7gmnfh3"
+        "hash": "jka7zekwldofz6tcccijkwkkxekgddyh"
       },
       {
         "name": "py-pdm-backend",
         "version": "2.4.7",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18048,7 +16266,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18058,7 +16276,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18068,7 +16286,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18079,7 +16297,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18092,57 +16310,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "es2ei2c3y5ygklkw2yxuicmpgblug24s"
+        "hash": "ippc4zphn7dr6z2xkkrdc7ohrvwdc36s"
       },
       {
         "name": "py-rich",
         "version": "15.0.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18158,7 +16334,7 @@
         "dependencies": [
           {
             "name": "py-markdown-it-py",
-            "hash": "uohy2jfpq7mbssn5eemk5okzzcvt7ye2",
+            "hash": "btormmsrqzdjveinrzou7mcpabbwlx5t",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18169,7 +16345,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18179,7 +16355,7 @@
           },
           {
             "name": "py-poetry-core",
-            "hash": "4e3dzwchyg7tiwynog7nbdxq4ugd2ccg",
+            "hash": "dulpwvphy37igifpbfgkp4npl5qnj2we",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18189,7 +16365,7 @@
           },
           {
             "name": "py-pygments",
-            "hash": "5qsxblsysmk2imm34d2dpfxrtdoeooqe",
+            "hash": "wk7lsy3cih5eobvumaydmyxkxil5pnd5",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18200,7 +16376,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18210,7 +16386,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18221,7 +16397,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18234,57 +16410,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "m7fa7z5mq27plyss2x5bphtzafmqtvhx"
+        "hash": "mlzjl2fpmcxcid4sg5s2o3n5xzdfzamj"
       },
       {
         "name": "py-markdown-it-py",
         "version": "4.0.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18301,7 +16435,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18311,7 +16445,7 @@
           },
           {
             "name": "py-mdurl",
-            "hash": "2ppdvsde6lsfwuxliuowvgibhpykfgfz",
+            "hash": "e5r2rshsr32lt77ukdfvo3kwifgrwf6w",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18322,7 +16456,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18332,7 +16466,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18342,7 +16476,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18353,7 +16487,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18366,57 +16500,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "uohy2jfpq7mbssn5eemk5okzzcvt7ye2"
+        "hash": "btormmsrqzdjveinrzou7mcpabbwlx5t"
       },
       {
         "name": "py-mdurl",
         "version": "0.1.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18432,7 +16524,7 @@
         "dependencies": [
           {
             "name": "py-flit-core",
-            "hash": "rjzzb7jt2vn2te7kuaerhwwo4nglsnji",
+            "hash": "kvy26ffnjxaoqti4cbrfxgyanuj6bloo",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18442,7 +16534,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18452,7 +16544,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18462,7 +16554,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18473,7 +16565,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18486,57 +16578,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "2ppdvsde6lsfwuxliuowvgibhpykfgfz"
+        "hash": "e5r2rshsr32lt77ukdfvo3kwifgrwf6w"
       },
       {
         "name": "py-poetry-core",
         "version": "2.3.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18551,8 +16601,18 @@
         "package_hash": "nc6kx3licn7aaboirrrnr233kbyf6kpdsibrlsjw5b7arnfcxvxq====",
         "dependencies": [
           {
-            "name": "apple-clang",
-            "hash": "ti7wjieqs6tajzpk3dehf3u5jnuqk37b",
+            "name": "compiler-wrapper",
+            "hash": "6zpo3h7bsaqb4grhowmfvg66phciokey",
+            "parameters": {
+              "deptypes": [
+                "build"
+              ],
+              "virtuals": []
+            }
+          },
+          {
+            "name": "gcc",
+            "hash": "ecodgxi6uy67gzfhttxwhz6zbqclwjdx",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18563,18 +16623,30 @@
             }
           },
           {
-            "name": "compiler-wrapper",
-            "hash": "2eppidz73j5cixagdntn6caaysmx5bpx",
+            "name": "gcc-runtime",
+            "hash": "usx5bqskcrguwrtrxcgie3pkj3alimon",
             "parameters": {
               "deptypes": [
-                "build"
+                "link"
               ],
               "virtuals": []
             }
           },
           {
+            "name": "glibc",
+            "hash": "wqjtbsviuku7636hcyn654wbxpxra6gr",
+            "parameters": {
+              "deptypes": [
+                "link"
+              ],
+              "virtuals": [
+                "libc"
+              ]
+            }
+          },
+          {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18584,7 +16656,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18594,7 +16666,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18605,7 +16677,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18618,57 +16690,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "4e3dzwchyg7tiwynog7nbdxq4ugd2ccg"
+        "hash": "dulpwvphy37igifpbfgkp4npl5qnj2we"
       },
       {
         "name": "py-pygments",
         "version": "2.19.2",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18684,7 +16714,7 @@
         "dependencies": [
           {
             "name": "py-hatchling",
-            "hash": "2zvgxhgzk6f5w2gybpcp3tq77yxyn6ae",
+            "hash": "k5pvxgr3f7zstfpzh2qsuurumwche7fz",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18694,7 +16724,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18704,7 +16734,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18714,7 +16744,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18725,7 +16755,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18738,57 +16768,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "5qsxblsysmk2imm34d2dpfxrtdoeooqe"
+        "hash": "wk7lsy3cih5eobvumaydmyxkxil5pnd5"
       },
       {
         "name": "py-shellingham",
         "version": "1.5.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18804,7 +16792,7 @@
         "dependencies": [
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18814,7 +16802,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18824,7 +16812,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18834,7 +16822,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18845,7 +16833,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18858,57 +16846,15 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "ksq4komfn35laadjcvos4g42s5ruek7j"
+        "hash": "ttpldvag67w7avhrgmzbspayjljvlbzo"
       },
       {
         "name": "py-xarray",
         "version": "2024.7.0",
         "arch": {
-          "platform": "darwin",
-          "platform_os": "tahoe",
-          "target": {
-            "name": "m1",
-            "vendor": "Apple",
-            "features": [
-              "aes",
-              "asimd",
-              "asimddp",
-              "asimdfhm",
-              "asimdhp",
-              "asimdrdm",
-              "atomics",
-              "cpuid",
-              "crc32",
-              "dcpodp",
-              "dcpop",
-              "dit",
-              "evtstrm",
-              "fcma",
-              "flagm",
-              "flagm2",
-              "fp",
-              "fphp",
-              "frint",
-              "ilrcpc",
-              "jscvt",
-              "lrcpc",
-              "paca",
-              "pacg",
-              "pmull",
-              "sb",
-              "sha1",
-              "sha2",
-              "sha3",
-              "sha512",
-              "ssbs",
-              "uscat"
-            ],
-            "generation": 0,
-            "parents": [
-              "armv8.4a"
-            ],
-            "cpupart": "0x022"
-          }
+          "platform": "linux",
+          "platform_os": "ubuntu24.04",
+          "target": "aarch64"
         },
         "namespace": "builtin",
         "parameters": {
@@ -18927,7 +16873,7 @@
         "dependencies": [
           {
             "name": "py-numpy",
-            "hash": "2o7rggazig7spilocm3aammlabuf5ozp",
+            "hash": "33gxp7pzmutq7em6epbeozdznjjepenv",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18938,7 +16884,7 @@
           },
           {
             "name": "py-packaging",
-            "hash": "5ffho2mv3pdpg2lup4526gedy6jhdzuq",
+            "hash": "da5km5iuzzq4ydcecig2m3rrs4wldedw",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18949,7 +16895,7 @@
           },
           {
             "name": "py-pandas",
-            "hash": "wpnad7cfczidplyxjfyzg5om2zpkektk",
+            "hash": "64wuz3wepx4neipupv5ggnakqmcfoi6d",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18960,7 +16906,7 @@
           },
           {
             "name": "py-pip",
-            "hash": "xjmf2iplbipudfwl73skhrf3zdm4qyq3",
+            "hash": "p7sa4zgtff6kxgdexi2q4eb5qkmbbfoj",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18970,7 +16916,7 @@
           },
           {
             "name": "py-setuptools",
-            "hash": "xjz2tqzewreafpaj6gej7nd4hdg4ntx6",
+            "hash": "z7sxj3ppejkbkk3qkgjkovxemzt7lisl",
             "parameters": {
               "deptypes": [
                 "build",
@@ -18981,7 +16927,7 @@
           },
           {
             "name": "py-setuptools-scm",
-            "hash": "425jqbogutgkehsadbos5akiyjfbttcz",
+            "hash": "gjah56lzvzmbp5k6ijycjl53vwv3vuai",
             "parameters": {
               "deptypes": [
                 "build"
@@ -18991,7 +16937,7 @@
           },
           {
             "name": "py-wheel",
-            "hash": "3nieis7c4tgao7dnno22c3t6cn44ee2a",
+            "hash": "zvxubiic62sgzqwqsmuo6ur3cp25i3an",
             "parameters": {
               "deptypes": [
                 "build"
@@ -19001,7 +16947,7 @@
           },
           {
             "name": "python",
-            "hash": "awojznyi6hdtfwdw2gri4zujvzbqc6vc",
+            "hash": "ts7ng5d5ljxakiuwky3ka3usrcjzocfp",
             "parameters": {
               "deptypes": [
                 "build",
@@ -19012,7 +16958,7 @@
           },
           {
             "name": "python-venv",
-            "hash": "4ykihp67cmltun2si27mkgrz3jqgnkwf",
+            "hash": "giwqedlcygocqzbowhtqvrbs4hiocuyq",
             "parameters": {
               "deptypes": [
                 "build",
@@ -19025,7 +16971,7 @@
         "annotations": {
           "original_specfile_version": 5
         },
-        "hash": "uwcwtsumrfeb2vlaedgeokq2vgqzkphn"
+        "hash": "54oiizdsxrc5exj7omo2hldg2lyeq6kd"
       }
     ]
   }

--- a/packaging/spack-overlay/solver-logs/voiage.log
+++ b/packaging/spack-overlay/solver-logs/voiage.log
@@ -1,140 +1,155 @@
- -   py-voiage@2.2.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-click@8.5.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-flit-core@3.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-jsonschema@4.26.0~format-nongpl build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-attrs@26.1.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-hatch-fancy-pypi-readme@25.1.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-hatch-vcs@0.5.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-hatchling@1.29.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-pathspec@1.1.1 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-pluggy@1.6.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-trove-classifiers@2026.6.1.19 build_system=python_pip platform=darwin os=tahoe target=m1
- -                   ^py-calver@2025.10.20 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-jsonschema-specifications@2025.9.1 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-referencing@0.37.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-rpds-py@0.27.1 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -       ^py-maturin@1.13.1 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
-[e]          ^apple-clang@21.0.0 build_system=bundle platform=darwin os=tahoe target=aarch64
- -           ^bzip2@1.0.8~debug~pic+shared build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^diffutils@3.12 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^compiler-wrapper@1.1.0 build_system=generic platform=darwin os=tahoe target=m1
- -           ^py-setuptools@82.0.1 build_system=generic platform=darwin os=tahoe target=m1
- -           ^py-setuptools-rust@1.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-semantic-version@2.10.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-numpy@2.4.6 build_system=python_pip patches:=873745d platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^openblas@0.3.33~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared~static build_system=makefile patches:=723ddc1 symbol_suffix=none threads=none platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0 %fortran=gcc@16.2.0
- -           ^py-cython@3.2.4 build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^py-meson-python@0.19.0 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^py-pyproject-metadata@0.11.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-pandas@2.3.3~excel~parquet~performance build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^meson@1.11.1 build_system=python_pip patches:=0f0b1bd platform=darwin os=tahoe target=m1
- -           ^py-python-dateutil@2.9.0.post0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-six@1.17.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-pytz@2025.2 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-tzdata@2026.1 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-versioneer@0.29+toml build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -       ^py-pip@26.1.2 build_system=generic platform=darwin os=tahoe target=m1
- -       ^py-polars@1.42.1 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-polars-runtime-32@1.42.1 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-maturin@1.13.1 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^py-setuptools-rust@1.12.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^rust@nightly-2026-04-01~dev~docs+src build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                   ^rust-bootstrap@beta-2026-03-05 build_system=generic platform=darwin os=tahoe target=m1
- -       ^py-pyarrow@25.0.1 build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^arrow@25.0.1~brotli~bz2~compute+csv~cuda+dataset+filesystem~gandiva~glog~hdfs+ipc~ipo~jemalloc~lz4~orc+parquet+python+shared~snappy~tensorflow~zlib~zstd build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -               ^boost@1.90.0~atomic~charconv~chrono~clanglibcpp~container~context~contract~conversion~date_time~debug~exception~fiber+filesystem~graph~graph_parallel~icu~iostreams~json~locale~log~math~mpi~mqtt5+multithreaded~nowide~numpy~openmethod~pic~program_options~python~random~regex~serialization+shared~signals2~singlethreaded~stacktrace+system~taggedlayout~test~thread~timer~type_erasure~url~versionedlayout~wave build_system=generic cxxstd=11 patches:=a440f96 visibility=hidden platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -               ^flatbuffers@24.12.23~ipo~python+shared build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
- -               ^rapidjson@1.2.0-2024-08-16~doc~ipo build_system=cmake build_type=Release commit=7c73dd7de7c4f14379b781418c6e947ad464c818 generator=make patches:=ee123c7 platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
- -               ^re2@2024-07-02~icu~ipo+pic+shared build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
- -                   ^abseil-cpp@20260107.1~ipo+shared build_system=cmake build_type=Release cxxstd=17 generator=make platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
- -               ^thrift@0.22.0~c_glib+cpp~ipo~java~javascript~libevent~nodejs~openssl~python~qt5+shared~zlib build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                   ^bison@3.8.2~color build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                   ^flex@2.6.3+lex~nls build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                       ^findutils@4.10.0 build_system=autotools patches:=440b954 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^utf8proc@2.10.0~ipo+shared build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^xsimd@14.2.0~ipo build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^cmake@3.31.11~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^pkgconf@2.5.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^gnuconfig@2025-07-10 build_system=generic platform=darwin os=tahoe target=m1
- -           ^py-libcst@1.8.6 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-pyyaml@6.0.3+libyaml build_system=python_pip platform=darwin os=tahoe target=m1
- -                   ^libyaml@0.2.5 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^py-scikit-build-core@0.12.2~pyproject build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0 %fortran=gcc@16.2.0
- -           ^py-setuptools-scm@9.2.2+toml build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^git@2.53.0+man+nls+perl+subtree~tcltk build_system=autotools patches:=67fa971 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^autoconf@2.72 build_system=autotools platform=darwin os=tahoe target=m1
- -                   ^automake@1.18.1 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^libidn2@2.3.8 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                       ^libunistring@1.4.2 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^libtool@2.5.4 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                       ^file@5.46+static build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^m4@1.4.21+sigsegv build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                       ^libsigsegv@2.15 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^openssh@10.3p1+gssapi build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                       ^krb5@1.22.2+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                       ^libedit@3.1-20251016 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^pcre2@10.44~jit+multibyte+pic build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -       ^py-pydantic@2.13.4~dotenv build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-annotated-types@0.7.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-pydantic-core@2.46.4 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-typing-inspection@0.4.2 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-scikit-learn@1.9.0 build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^llvm-openmp@20.1.8~fortran~ipo+multicompat build_system=cmake build_type=Release generator=make platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^py-joblib@1.5.3 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-narwhals@2.19.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-threadpoolctl@3.6.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-scipy@1.16.3 build_system=python_pip platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0 %fortran=gcc@16.2.0
-[e]          ^gcc@16.2.0+binutils+bootstrap~graphite+libsanitizer~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=darwin os=tahoe target=aarch64
- -           ^gcc-runtime@16.2.0 build_system=generic platform=darwin os=tahoe target=m1
- -           ^py-pybind11@3.0.2+ipo build_system=cmake build_type=Release generator=ninja platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
- -           ^py-pythran@0.18.1 build_system=python_pip platform=darwin os=tahoe target=m1 %cxx=apple-clang@21.0.0
- -               ^py-beniget@0.4.2.post1 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-gast@0.6.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-ply@3.11 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-typer@0.27.2 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-annotated-doc@0.0.5 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-pdm-backend@2.4.7 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-rich@15.0.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-markdown-it-py@4.0.0~linkify build_system=python_pip platform=darwin os=tahoe target=m1
- -                   ^py-mdurl@0.1.2 build_system=python_pip platform=darwin os=tahoe target=m1
- -               ^py-poetry-core@2.3.2 build_system=python_pip platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^py-pygments@2.19.2 build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-shellingham@1.5.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-typing-extensions@4.16.0 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^py-wheel@0.45.1 build_system=generic platform=darwin os=tahoe target=m1
- -       ^py-xarray@2024.7.0~io~parallel~viz build_system=python_pip platform=darwin os=tahoe target=m1
- -           ^py-packaging@26.2 build_system=python_pip platform=darwin os=tahoe target=m1
- -       ^python@3.12.14+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~static~tests~tkinter+uuid+zlib build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
-[e]          ^apple-libuuid@1353.100.2 build_system=bundle platform=darwin os=tahoe target=aarch64
- -           ^expat@2.8.3~libbsd build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^gdbm@1.26 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^gettext@1.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -               ^libiconv@1.18 build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^libxml2@2.15.3+pic~python+shared build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^tar@1.35 build_system=autotools zip=pigz platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^pigz@2.8 build_system=makefile platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^gmake@4.4.1~guile build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^libffi@3.5.2 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^libxcrypt@4.5.2~obsolete_api build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -                   ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -                   ^less@692 build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^ncurses@6.6~symlinks+termlib abi=none build_system=autotools patches:=7a351bc platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^openssl@3.6.4~docs+shared build_system=generic certs=mozilla platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -               ^ca-certificates-mozilla@2026-03-19 build_system=generic platform=darwin os=tahoe target=m1
- -           ^readline@8.3 build_system=autotools patches:=21f0a03,72dee13,e273643 platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^sqlite@3.53.1+column_metadata+fts+rtree build_system=autotools platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^xz@5.8.3~pic build_system=autotools libs:=shared,static platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^zlib-ng@2.3.3+compat+new_strategies+opt+pic+shared build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -       ^python-venv@1.0 build_system=generic platform=darwin os=tahoe target=m1
- -       ^rust@1.96.0~dev~docs+src build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^curl@8.20.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -               ^nghttp2@1.67.1 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^libgit2@1.9.1~curl~ipo+mmap+ssh build_system=cmake build_type=Release generator=make https=system platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -               ^pcre@8.45~jit+multibyte+pic+shared+static+utf build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^libssh2@1.11.1+shared build_system=autotools crypto=openssl platform=darwin os=tahoe target=m1 %c=apple-clang@21.0.0
- -           ^ninja@1.13.2+re2c build_system=generic platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -               ^re2c@4.4 build_system=autotools platform=darwin os=tahoe target=m1 %c,cxx=apple-clang@21.0.0
- -           ^rust-bootstrap@1.96.0 build_system=generic platform=darwin os=tahoe target=m1
+ -   py-voiage@2.2.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-click@8.5.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-flit-core@3.12.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-jsonschema@4.26.0~format-nongpl build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-attrs@26.1.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-hatch-fancy-pypi-readme@25.1.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-hatch-vcs@0.5.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-hatchling@1.29.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-pathspec@1.1.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-pluggy@1.6.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-trove-classifiers@2026.6.1.19 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -                   ^py-calver@2025.10.20 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-jsonschema-specifications@2025.9.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-referencing@0.37.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-rpds-py@0.27.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -       ^py-maturin@1.13.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^bzip2@1.0.8~debug~pic+shared build_system=generic platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^diffutils@3.12 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^compiler-wrapper@1.1.0 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+[e]          ^gcc@13.3.0+binutils+bootstrap~graphite+libsanitizer~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=ubuntu24.04 target=aarch64
+ -           ^gcc-runtime@13.3.0 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+[e]          ^glibc@2.39 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-setuptools@82.0.1 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-setuptools-rust@1.12.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-semantic-version@2.10.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-numpy@2.3.5 build_system=python_pip patches:=873745d platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^openblas@0.3.33~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared~static build_system=makefile patches:=723ddc1 symbol_suffix=none threads=none platform=linux os=ubuntu24.04 target=aarch64 %c,cxx,fortran=gcc@13.3.0
+ -           ^py-cython@3.2.4 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^py-meson-python@0.19.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^py-pyproject-metadata@0.11.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-pandas@2.3.3~excel~parquet+performance build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^meson@1.11.1 build_system=python_pip patches:=0f0b1bd platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-bottleneck@1.6.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^py-numba@0.65.1~tbb build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^py-llvmlite@0.47.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                   ^binutils@2.46.1~debuginfod~gas~gprofng~headers~interwork~ld~libiberty~lto~nls~pgo+plugins build_system=autotools compress_debug_sections=zlib libs:=shared,static platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                   ^llvm@20.1.8+clang~cuda~flang~gold~ipo+libomptarget~libomptarget_debug~link_llvm_dylib+lld+lldb+llvm_dylib+lua~mlir+offload+polly~python~split_dwarf~utils~z3~zstd build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime shlib_symbol_version=none targets:=aarch64,amdgpu,nvptx,x86 version_suffix=none platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                       ^hwloc@2.13.0~cairo~cuda~gl~level_zero~libudev+libxml2~nvml~opencl+pci~rocm build_system=autotools libs:=shared,static patches:=b4db98b platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                           ^libpciaccess@0.17 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                               ^util-macros@1.20.2 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64
+ -                       ^libedit@3.1-20251016 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                       ^lua@5.3.6+shared build_system=makefile fetcher=curl platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                           ^unzip@6.0 build_system=makefile patches:=179330d,24582ff,251d575,3371314,44599c8,47e9def,4e5a081,59c0983,64f6498,74bc961,7d8e5c7,81ca46c,881d2ed,aced0f2,b6f64d7,b7a14c3,c9a863e,ee9e260,f6f6236,f88b9d4,fde8f9d platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                       ^perl-data-dumper@2.173 build_system=perl platform=linux os=ubuntu24.04 target=aarch64
+ -                       ^swig@4.4.1 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^py-numexpr@2.14.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^py-python-dateutil@2.9.0.post0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-six@1.17.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-pytz@2025.2 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-tzdata@2026.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-versioneer@0.29+toml build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -       ^py-pip@26.1.2 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-polars@1.42.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-polars-runtime-32@1.42.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-maturin@1.13.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^py-setuptools-rust@1.12.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^rust@nightly-2026-04-01~dev~docs+src build_system=generic platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                   ^rust-bootstrap@beta-2026-03-05 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-pyarrow@25.0.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^arrow@25.0.1~brotli~bz2~compute+csv~cuda+dataset+filesystem~gandiva~glog~hdfs+ipc~ipo~jemalloc~lz4~orc+parquet+python+shared~snappy~tensorflow~zlib~zstd build_system=cmake build_type=Release generator=make platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^boost@1.90.0~atomic~charconv~chrono~clanglibcpp~container~context~contract~conversion~date_time~debug~exception~fiber+filesystem~graph~graph_parallel~icu~iostreams~json~locale~log~math~mpi~mqtt5+multithreaded~nowide~numpy~openmethod~pic~program_options~python~random~regex~serialization+shared~signals2~singlethreaded~stacktrace+system~taggedlayout~test~thread~timer~type_erasure~url~versionedlayout~wave build_system=generic cxxstd=11 patches:=a440f96 visibility=hidden platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^flatbuffers@24.12.23~ipo~python+shared build_system=cmake build_type=Release generator=make platform=linux os=ubuntu24.04 target=aarch64 %cxx=gcc@13.3.0
+ -               ^rapidjson@1.2.0-2024-08-16~doc~ipo build_system=cmake build_type=Release commit=7c73dd7de7c4f14379b781418c6e947ad464c818 generator=make patches:=ee123c7 platform=linux os=ubuntu24.04 target=aarch64 %cxx=gcc@13.3.0
+ -               ^re2@2024-07-02~icu~ipo+pic+shared build_system=cmake build_type=Release generator=make platform=linux os=ubuntu24.04 target=aarch64 %cxx=gcc@13.3.0
+ -                   ^abseil-cpp@20260107.1~ipo+shared build_system=cmake build_type=Release cxxstd=17 generator=make platform=linux os=ubuntu24.04 target=aarch64 %cxx=gcc@13.3.0
+ -               ^thrift@0.22.0~c_glib+cpp~ipo~java~javascript~libevent~nodejs~openssl~python~qt5+shared~zlib build_system=cmake build_type=Release generator=make platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                   ^bison@3.8.2~color build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                   ^flex@2.6.3+lex~nls build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                       ^findutils@4.10.0 build_system=autotools patches:=440b954 platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^utf8proc@2.10.0~ipo+shared build_system=cmake build_type=Release generator=make platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^xsimd@14.2.0~ipo build_system=cmake build_type=Release generator=make platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^cmake@3.31.11~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^pkgconf@2.5.1 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^gnuconfig@2025-07-10 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-libcst@1.8.6 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-pyyaml@6.0.3+libyaml build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -                   ^libyaml@0.2.5 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^py-scikit-build-core@0.12.2~pyproject build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx,fortran=gcc@13.3.0
+ -           ^py-setuptools-scm@9.2.2+toml build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^git@2.53.0+man+nls+perl+subtree~tcltk build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^autoconf@2.72 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64
+ -                   ^automake@1.18.1 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^libidn2@2.3.8 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                       ^libunistring@1.4.2 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^libtool@2.5.4 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                       ^file@5.46+static build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^m4@1.4.21+sigsegv build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                       ^libsigsegv@2.15 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^openssh@10.3p1+gssapi build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                       ^krb5@1.22.2+shared build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                   ^pcre2@10.44~jit+multibyte+pic build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -       ^py-pydantic@2.13.4~dotenv build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-annotated-types@0.7.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-pydantic-core@2.46.4 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-typing-inspection@0.4.2 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-scikit-learn@1.9.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^py-joblib@1.5.3 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-narwhals@2.19.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-threadpoolctl@3.6.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-scipy@1.16.3 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c,cxx,fortran=gcc@13.3.0
+ -           ^py-pybind11@3.0.2+ipo build_system=cmake build_type=Release generator=ninja platform=linux os=ubuntu24.04 target=aarch64 %cxx=gcc@13.3.0
+ -           ^py-pythran@0.18.1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %cxx=gcc@13.3.0
+ -               ^py-beniget@0.4.2.post1 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-gast@0.6.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-ply@3.11 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-typer@0.27.2 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-annotated-doc@0.0.5 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-pdm-backend@2.4.7 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-rich@15.0.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-markdown-it-py@4.0.0~linkify build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -                   ^py-mdurl@0.1.2 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -               ^py-poetry-core@2.3.2 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^py-pygments@2.19.2 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-shellingham@1.5.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-typing-extensions@4.16.0 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-wheel@0.45.1 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -       ^py-xarray@2024.7.0~io~parallel~viz build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -           ^py-packaging@26.2 build_system=python_pip platform=linux os=ubuntu24.04 target=aarch64
+ -       ^python@3.12.14+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~static~tests~tkinter+uuid+zlib build_system=generic platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^expat@2.8.3+libbsd build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^libbsd@0.12.2 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^libmd@1.1.0 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^gdbm@1.26 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^gettext@1.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^libiconv@1.18 build_system=autotools libs:=shared,static platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^libxml2@2.15.3+pic~python+shared build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^tar@1.35 build_system=autotools zip=pigz platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^pigz@2.8 build_system=makefile platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^gmake@4.4.1~guile build_system=generic platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^libffi@3.5.2 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^libxcrypt@4.5.2~obsolete_api build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -                   ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -                   ^less@692 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^ncurses@6.6~symlinks+termlib abi=none build_system=autotools patches:=7a351bc platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^openssl@3.6.4~docs+shared build_system=generic certs=mozilla platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^ca-certificates-mozilla@2026-03-19 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -           ^readline@8.3 build_system=autotools patches:=21f0a03,72dee13,e273643 platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^sqlite@3.53.1+column_metadata+fts+rtree build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^util-linux-uuid@2.41 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^xz@5.8.3~pic build_system=autotools libs:=shared,static platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^zlib-ng@2.3.3+compat+new_strategies+opt+pic+shared build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -       ^python-venv@1.0 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -       ^rust@1.96.0~dev~docs+src build_system=generic platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^curl@8.20.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^nghttp2@1.67.1 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^libgit2@1.9.1~curl~ipo+mmap+ssh build_system=cmake build_type=Release generator=make https=system platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -               ^pcre@8.45~jit+multibyte+pic+shared+static+utf build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^libssh2@1.11.1+shared build_system=autotools crypto=openssl platform=linux os=ubuntu24.04 target=aarch64 %c=gcc@13.3.0
+ -           ^ninja@1.13.2+re2c build_system=generic platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -               ^re2c@4.4 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
+ -           ^rust-bootstrap@1.96.0 build_system=generic platform=linux os=ubuntu24.04 target=aarch64
+ -               ^patchelf@0.17.2 build_system=autotools platform=linux os=ubuntu24.04 target=aarch64 %c,cxx=gcc@13.3.0
 

--- a/packaging/spack-overlay/solver-receipt.json
+++ b/packaging/spack-overlay/solver-receipt.json
@@ -1,26 +1,27 @@
 {
   "schema": "voiage.spack-overlay-solver.v1",
-  "recorded_at": "2026-08-31T18:55:22.894965+00:00",
+  "recorded_at": "2026-09-01T12:16:53.606226+00:00",
   "catalogue_commit": "d4f7c711a6a42f1c4d551c8fd10fce9a11340a81",
-  "host": "macOS arm64",
-  "manifest_sha256": "34c3c0bd2168741e70fdb497979afe5fc3cbe44bc85a69fa3a8104690fb43e1c",
+  "host": "Ubuntu 24.04 Linux arm64",
+  "manifest_sha256": "1bf10eccbaeaba9f9649f80bd2c9ba7c9c1dbf1343dcfbbb427d983d10d5fee3",
   "results": [
     {
       "spec": "py-voiage@2.2.0",
       "exit_code": 0,
       "status": "concretized",
       "log_path": "solver-logs/voiage.log",
-      "log_sha256": "fbe930c5c402afec7cd91f3bafc76563063a5dcbcc247d2c9f821e26e40bbaf2"
+      "log_sha256": "2bd269a80937fce70852b28e930ad55313d29b27144208f33ef38e23c2c0113f"
     }
   ],
   "builds_executed": false,
   "module_load_executed": false,
   "spack_version": "1.2.2",
+  "spack_commit": "3e19345b6e12f5ff1b874f4059622fc6a1fd804a",
   "prior_failure_evidence": "history/pre-arrow-patch-38b573b5/solver-receipt.json",
   "concrete_dag": {
     "path": "solver-logs/voiage.json",
-    "sha256": "567dcdb63d11e40b73ebb41717383b8b99fca604abd79dc809e273893d2c9651",
-    "nodes": 139,
+    "sha256": "b6228dfedc9e4ecfdf2c6fee96a46a291d5fe5dd1330448f256116de3fb18773",
+    "nodes": 154,
     "duplicated_build_tools": {
       "py-maturin": 2,
       "py-setuptools-rust": 2,
@@ -39,5 +40,5 @@
       "xsimd": "14.2.0"
     }
   },
-  "root_constraints": "py-voiage@2.2.0 ^python@3.12.14 ^py-pyarrow@25.0.1"
+  "root_constraints": "py-voiage@2.2.0 ^python@3.12.14%gcc@13.3.0 ^py-pyarrow@25.0.1"
 }

--- a/tests/test_hpc_spack_overlay.py
+++ b/tests/test_hpc_spack_overlay.py
@@ -105,9 +105,13 @@ def test_spack_directives_are_explicit_including_license() -> None:
             for alias in node.names
         }
         assert "*" not in names
-        # Python also defines a builtin named license; it is not Spack's directive.
-        assert "license" in names
         assert "depends_on" in names
+        if recipe.parent.name in {"python", "expat", "openssl"}:
+            # These thin security overlays inherit unconditional license metadata.
+            assert "license" not in names
+        else:
+            # Python also defines a builtin named license; this is Spack's directive.
+            assert "license" in names
 
 
 def test_upstream_notices_remain_with_derived_recipes() -> None:

--- a/tests/test_spack_security_floor.py
+++ b/tests/test_spack_security_floor.py
@@ -62,7 +62,11 @@ def test_security_overlays_preserve_catalogue_methods_and_variants() -> None:
         calls = [
             node.value for node in classes[0].body if isinstance(node.value, ast.Call)
         ]
-        assert {node.func.id for node in calls} <= {"license", "version", "depends_on"}
+        assert {node.func.id for node in calls} <= {"version", "depends_on"}
+        # The builtin recipes already declare an unconditional license. Repeating
+        # it in a subclass makes Spack's SBOM hook reject the installed package
+        # with OverlappingLicenseError.
+        assert all(node.func.id != "license" for node in calls)
 
 
 def test_optional_parser_and_tls_floors_do_not_force_variants() -> None:


### PR DESCRIPTION
The native Linux Spack qualification reached successful Expat installation, then failed while generating installed-package metadata because the security overlay repeated the builtin recipe's unconditional licence. The same latent failure affected the Python and OpenSSL security overlays.

This change lets all three thin security overlays inherit their builtin licence metadata. It retains the pinned security versions and dependency floors, updates the derived overlay receipts, and adds regression assertions that these subclasses do not redeclare unconditional licences.

Validation:

- `tox -p 3` (all 15 environments passed)
- focused HPC overlay tests: 24 passed
- pinned Spack runtime loaded each updated overlay with one inherited licence entry
- `git diff --check`

The change removes the SBOM `OverlappingLicenseError` encountered by the native Linux source-install receipt without weakening any security floor.
