### PR TITLE
Bound the residual NLTK manuscript-tool advisory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+- Enforce NLTK 3.10.3 as the manuscript-tool security floor and record the
+  bounded, currently unpatched model-persistence advisory without claiming the
+  isolated readability environment is globally vulnerability-free.
+
 - Inherit builtin Spack licence metadata in the Python, Expat and OpenSSL security overlays so SBOM generation does not reject successful source installations.
 
 - Prepare an isolated Arrow/PyArrow 25.0.1 EasyBuild 2024a provider with

--- a/conductor/tracks/remaining_backlog_delivery_20260831/nltk-residual-advisory-20260902.json
+++ b/conductor/tracks/remaining_backlog_delivery_20260831/nltk-residual-advisory-20260902.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "voiage.nltk-residual-advisory.v1",
+  "recorded_at": "2026-09-02",
+  "advisory": "GHSA-8mgp-746c-j5xp",
+  "cve": "CVE-2026-81726",
+  "upstream_advisory": "https://github.com/nltk/nltk/security/advisories/GHSA-8mgp-746c-j5xp",
+  "affected_versions": "<=3.10.3",
+  "patched_release": null,
+  "selected_version": "3.10.3",
+  "selection_basis": "The latest stable release fixes the advisories addressed by PR #1073; no stable release patches this residual advisory.",
+  "scope": [
+    "scripts/audit_arxiv_readability.py",
+    "scripts/audit_joss_readability.py"
+  ],
+  "scope_description": "Isolated review-only Textstat readability calculation with a fixed NLTK_DATA directory and the cmudict corpus.",
+  "affected_model_persistence_calls": [
+    "TransitionParser.train",
+    "TransitionParser.parse",
+    "AveragedPerceptron.save",
+    "AveragedPerceptron.load",
+    "PerceptronTagger.save_to_json",
+    "save_maxent_params"
+  ],
+  "affected_api_identifiers": [
+    "TransitionParser",
+    "AveragedPerceptron",
+    "PerceptronTagger",
+    "save_maxent_params"
+  ],
+  "callsite_audit": "The two readability scripts do not call the affected model persistence APIs and do not accept model import or export paths.",
+  "disposition": "bounded_not_reachable_in_declared_scope",
+  "limitations": "Callsite absence is bounded repository evidence, not a claim that NLTK 3.10.3 is vulnerability-free or that every transitive NLTK path is safe.",
+  "monitoring": "Retain the exact 3.10.3 pins and review upstream stable releases and security advisories before changing the isolated environments.",
+  "upgrade_rule": "Update both exact pins together to the first stable patched release, then refresh this disposition and its callsite audit."
+}

--- a/tests/test_arxiv_readiness.py
+++ b/tests/test_arxiv_readiness.py
@@ -1,4 +1,6 @@
+import ast
 import importlib.util
+import json
 from pathlib import Path
 import re
 import tarfile
@@ -41,6 +43,14 @@ def test_arxiv_template_tools_are_pinned_and_registered() -> None:
     root = Path.cwd()
     requirements = (root / "requirements-arxiv.txt").read_text()
     modules = (root / ".gitmodules").read_text()
+    disposition = json.loads(
+        (
+            root
+            / "conductor/tracks/remaining_backlog_delivery_20260831"
+            / "nltk-residual-advisory-20260902.json"
+        ).read_text()
+    )
+    selected_version = Version(disposition["selected_version"])
 
     assert "arxiv-collector==" in requirements
     assert "arxiv-latex-cleaner==" in requirements
@@ -53,12 +63,77 @@ def test_arxiv_template_tools_are_pinned_and_registered() -> None:
         pin = re.fullmatch(r"nltk==(3\.10\.\d+)", nltk_lines[0])
         assert pin is not None
         version = Version(pin[1])
-        assert Version("3.10.0") <= version < Version("3.11")
+        assert version == selected_version
         nltk_versions.append(version)
     assert nltk_versions[0] == nltk_versions[1]
     assert "pyphen==0.17.2" in requirements
     assert "edithatogo/sourceright.git" in modules
     assert "edithatogo/authentext.git" in modules
+
+
+def test_readability_nltk_residual_advisory_is_bounded() -> None:
+    root = Path.cwd()
+    disposition = json.loads(
+        (
+            root
+            / "conductor/tracks/remaining_backlog_delivery_20260831"
+            / "nltk-residual-advisory-20260902.json"
+        ).read_text()
+    )
+
+    assert disposition["advisory"] == "GHSA-8mgp-746c-j5xp"
+    assert disposition["affected_versions"] == "<=3.10.3"
+    assert disposition["patched_release"] is None
+    assert disposition["selected_version"] == "3.10.3"
+    assert disposition["scope"] == [
+        "scripts/audit_arxiv_readability.py",
+        "scripts/audit_joss_readability.py",
+    ]
+
+    expected_affected_calls = {
+        "TransitionParser.train",
+        "TransitionParser.parse",
+        "AveragedPerceptron.save",
+        "AveragedPerceptron.load",
+        "PerceptronTagger.save_to_json",
+        "save_maxent_params",
+    }
+    expected_affected_identifiers = {
+        "TransitionParser",
+        "AveragedPerceptron",
+        "PerceptronTagger",
+        "save_maxent_params",
+    }
+    assert set(disposition["affected_model_persistence_calls"]) == (
+        expected_affected_calls
+    )
+    assert set(disposition["affected_api_identifiers"]) == (
+        expected_affected_identifiers
+    )
+
+    observed_calls: set[str] = set()
+    for filename in disposition["scope"]:
+        source = (root / filename).read_text()
+        for identifier in expected_affected_identifiers:
+            assert identifier not in source
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            parts: list[str] = []
+            target = node.func
+            while isinstance(target, ast.Attribute):
+                parts.append(target.attr)
+                target = target.value
+            if isinstance(target, ast.Name):
+                parts.append(target.id)
+            if parts:
+                observed_calls.add(".".join(reversed(parts)))
+    assert expected_affected_calls.isdisjoint(observed_calls)
+    assert disposition["upgrade_rule"] == (
+        "Update both exact pins together to the first stable patched release, "
+        "then refresh this disposition and its callsite audit."
+    )
 
 
 def test_manuscript_uses_citation_order_and_cross_referenced_end_matter() -> None:

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
     delivery and Codecov controls (#656), measured opt-in testing (#1028), HPC
     recipes (#1025), remaining issue evidence, protected PR merges and verified
     cleanup. Keep unsatisfied human and external outcomes open.
+    *   [x] Enforce the NLTK 3.10.3 manuscript-tool security floor and retain a
+        bounded disposition for the unpatched model-persistence advisory.
 
 *   [~] Deliver the hardened v2.2.0 release through
     `conductor/tracks/v2_2_release_and_venue_submissions_20260830/` (#1037).


### PR DESCRIPTION
NLTK 3.10.3 fixes the advisories that triggered the automated dependency update, but GHSA-8mgp-746c-j5xp still affects the latest stable release and has no patched release. The isolated manuscript readability tools do not call the affected model persistence APIs, yet the repository previously allowed older vulnerable 3.10.x pins and did not retain this bounded disposition.

This PR raises the tested security floor to NLTK 3.10.3 while preserving synchronized exact pins, records the residual advisory and no-patch status, and adds an AST-based regression that verifies the two readability scripts do not reference the affected persistence APIs. It also records the first-stable-patch upgrade rule without claiming NLTK 3.10.3 is globally vulnerability-free.

Validation:
- `tox -p 3` (all 15 environments passed)
- strict dependency frontier passed; unrelated `uv.lock` upgrade churn was restored
- focused arXiv/JOSS readiness tests passed
