### PR TITLE
Reconcile venue submission status

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@
 
 ## Unreleased
 
+- Reconcile current pyOpenSci, JOSS and arXiv guidance with the verified
+  withdrawal of earlier requests and journal-first sequencing while keeping
+  the survey, human-written communication and authenticated submissions
+  external.
+
 - Enforce NLTK 3.10.3 as the manuscript-tool security floor and record the
   bounded, currently unpatched model-persistence advisory without claiming the
   isolated readability environment is globally vulnerability-free.

--- a/conductor/tracks/v2_2_release_and_venue_submissions_20260830/index.md
+++ b/conductor/tracks/v2_2_release_and_venue_submissions_20260830/index.md
@@ -20,6 +20,7 @@
 - [Post-merge venue-packet receipt](./venue-packet-merge-receipt-20260831.json)
 - [Archived gate continuity review](./archive-gate-continuity-review-20260831.md)
 - [Remaining venue human-action checklist](./venue-human-action-checklist-20260831.md)
+- [Current checklist supersession](./venue-human-action-checklist-supersession-20260902.md)
 - [Reconciliation validation and review](./status-reconciliation-validation-20260831.json)
 - [Maintainer venue decision](./maintainer-venue-decision-20260831.json)
 - [Previous-request withdrawal receipt](./pyopensci-withdrawal-receipt-20260831.json)

--- a/conductor/tracks/v2_2_release_and_venue_submissions_20260830/spec.md
+++ b/conductor/tracks/v2_2_release_and_venue_submissions_20260830/spec.md
@@ -54,11 +54,12 @@ not allow the agent to invent personal attestations or venue outcomes.
    r-universe, review, acceptance, or indexing outcomes prematurely.
 10. Keep repository readiness, release publication, submission creation, review,
     acceptance, DOI assignment, and indexing as distinct states.
-11. Resolve the pyOpenSci one-review-per-contact requirement against existing
-    submissions before posting. Do not infer that an on-hold issue is exempt,
-    close another package's issue, or invent a replacement maintainer. Avoid
-    concurrent review at different venues unless the editors explicitly allow
-    it, and obtain human review of venue communications.
+11. Preserve the resolution of the pyOpenSci one-review-per-contact requirement
+    against existing submissions. The later maintainer decision and withdrawal
+    receipt verify that requests #271 and #272 were closed as not planned;
+    preserve that evidence without treating closure as editorial approval.
+    Avoid concurrent review at different venues unless the editors explicitly
+    allow it, and obtain human review of venue communications.
 12. Complete all currently known repository-owned release and venue-packet
     repairs before the first venue submission. Preparing JOSS and rOpenSci
     materials does not start their reviews or bypass later eligibility gates.
@@ -91,8 +92,9 @@ not allow the agent to invent personal attestations or venue outcomes.
 ## External gates
 
 - Maintainer-only venue attestations and survey answers.
-- pyOpenSci contact-capacity clarification for open issues #271 and #272;
-  no concurrent venue review or inferred editorial exception.
+- Private pre-review survey, human-written submission body, and authenticated
+  pyOpenSci submission. Requests #271 and #272 are verified withdrawn and
+  closed; no editorial scope or capacity approval is inferred from closure.
 - GitHub environment protections and trusted-publishing authorization.
 - pyOpenSci scope screening, review, acceptance, and partner referral.
 - JOSS editorial screening, review, acceptance, and DOI publication.

--- a/conductor/tracks/v2_2_release_and_venue_submissions_20260830/venue-human-action-checklist-supersession-20260902.md
+++ b/conductor/tracks/v2_2_release_and_venue_submissions_20260830/venue-human-action-checklist-supersession-20260902.md
@@ -1,0 +1,20 @@
+# Venue human-action checklist supersession
+
+The dated `venue-human-action-checklist-20260831.md` is an immutable factual
+snapshot of observations made between 04:38 and 04:40 UTC on 31 August 2026.
+Its historical rows are preserved byte for byte and are not current action
+guidance.
+
+Later on 31 August, `maintainer-venue-decision-20260831.json` recorded the
+personal declarations and journal-first sequence, while
+`pyopensci-withdrawal-receipt-20260831.json` verified that requests #271 and
+#272 were withdrawn and closed as not planned. Current work follows
+`venue-next-actions-20260831.md`: complete the private pre-review survey, supply
+a human-written submission body, and perform the authenticated pyOpenSci
+submission. The confirmed commitment to write later review communication
+personally remains separate. ArXiv is deferred until an actual journal
+submission and later author action.
+
+The historical checklist must not trigger repeated declarations, a new
+contact-capacity request, or an arXiv-before-JOSS prerequisite. Withdrawal is
+not editorial scope or capacity approval.

--- a/docs/release/pyopensci-readiness.md
+++ b/docs/release/pyopensci-readiness.md
@@ -10,7 +10,7 @@ acceptance, or publication claim.
 The selected sequence is:
 
 1. prepare and refresh the pyOpenSci evidence package;
-2. complete all repairs, personal declarations and contact-capacity checks
+2. complete the private pre-review survey and human-written submission text
    before the already-authorized, human-led pyOpenSci submission;
 3. complete pyOpenSci review and record its external acceptance evidence; and
 4. only then, once JOSS eligibility and author prerequisites are evidenced,
@@ -71,5 +71,10 @@ provenance are documented in the README, methods documentation, and paper.
 Refresh the official guide and the evidence matrix immediately before any
 author-led inquiry. Historical AI-review confirmations do not certify the
 current packet. The unposted draft includes explicit current human-review,
-development-history, AI-scope and communication checks; existing submissions
-#271 and #272 still require contact-capacity clarification.
+development-history, AI-scope and communication checks. Previous requests #271
+and #272 were withdrawn and verified closed on 31 August 2026. The remaining
+immediate human gates are the private pre-review survey, a human-written
+submission body, and authenticated pyOpenSci submission. The maintainer's
+commitment to write later review communication personally is separately
+confirmed. Withdrawal of those requests resolves the observed contact overlap;
+it does not establish editorial scope or capacity approval.

--- a/scripts/validate_pyopensci_submission_staging.py
+++ b/scripts/validate_pyopensci_submission_staging.py
@@ -12,6 +12,10 @@ from typing import Any
 
 STAGING_PATH = Path("specs/submission-readiness/pyopensci-submission-staging.json")
 EXPECTED_CANDIDATE_VERSION = "2.2.0"
+EXPECTED_WITHDRAWAL_BINDING = {
+    "path": "conductor/tracks/v2_2_release_and_venue_submissions_20260830/pyopensci-withdrawal-receipt-20260831.json",
+    "sha256": "a0ee21b74f330b155e67148d3be5d74e38e6a5861761cc66987f60044f0e0e41",
+}
 EXPECTED_EXTERNAL_OUTCOMES = {
     "pyopensci_review": "not_started",
     "pyopensci_acceptance": "pending_external",
@@ -341,6 +345,39 @@ def validate_staging_packet(
         findings,
         require_all_files=require_all_files,
     )
+    withdrawal_binding = staging.get("withdrawal_receipt")
+    if withdrawal_binding != EXPECTED_WITHDRAWAL_BINDING:
+        findings.append(
+            "withdrawal receipt binding must match the reviewed path and SHA-256"
+        )
+    _, withdrawal = _validate_bound_file(
+        resolved_root,
+        withdrawal_binding,
+        "withdrawal receipt",
+        findings,
+        require_all_files=require_all_files,
+    )
+
+    issues = withdrawal.get("issues") if isinstance(withdrawal, dict) else None
+    if (
+        withdrawal is None
+        or withdrawal.get("schema_version") != "1.0"
+        or withdrawal.get("editorial_approval_inferred") is not False
+        or not isinstance(issues, list)
+        or len(issues) != 2
+        or {item.get("number") for item in issues if isinstance(item, dict)}
+        != {271, 272}
+        or any(
+            not isinstance(item, dict)
+            or item.get("action_status") != "verified"
+            or item.get("after_state") != "closed"
+            or item.get("after_state_reason") != "not_planned"
+            for item in issues
+        )
+    ):
+        findings.append(
+            "withdrawal receipt must verify requests 271 and 272 closed as not planned without editorial approval"
+        )
 
     if template is not None:
         if template.get("schema_version") != (
@@ -417,6 +454,12 @@ def validate_staging_packet(
             "blocked_pending_refresh_and_external_evidence"
         ):
             findings.append("JOSS handoff must remain blocked")
+        elif joss_handoff.get("permanent_arxiv_identifier") != (
+            "deferred_until_after_journal_submission_not_pre_joss_gate"
+        ):
+            findings.append(
+                "JOSS handoff must preserve the journal-first arXiv deferral"
+            )
 
     if draft_path is not None:
         draft = draft_path.read_text(encoding="utf-8")

--- a/specs/submission-readiness/pyopensci-submission-candidate.json
+++ b/specs/submission-readiness/pyopensci-submission-candidate.json
@@ -67,7 +67,7 @@
     "developer_research_use_release": "2.0.0",
     "non_author_engagement": "pending_issue_471",
     "doi_bearing_archive": "pending",
-    "permanent_arxiv_identifier": "pending",
+    "permanent_arxiv_identifier": "deferred_until_after_journal_submission_not_pre_joss_gate",
     "joss_submission": "not_started",
     "automated_replay_release": "2.2.0",
     "research_use_boundary": "Historical human-use record preserved; the v2.2.0 automated replay is not additional human use or independent adoption."

--- a/specs/submission-readiness/pyopensci-submission-staging.json
+++ b/specs/submission-readiness/pyopensci-submission-staging.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "voiage.pyopensci-submission-staging.v1",
   "prepared_at": "2026-08-29T00:22:00Z",
-  "updated_at": "2026-08-31T09:58:39.757960Z",
+  "updated_at": "2026-09-01T15:49:33Z",
   "state": "prepared_local_unposted",
   "draft": {
     "path": "docs/release/pyopensci-submission-draft.md",
@@ -15,7 +15,7 @@
   },
   "candidate": {
     "path": "specs/submission-readiness/pyopensci-submission-candidate.json",
-    "sha256": "fb55f3a9749f1a72eaec5c154c1a7173d8ab4e23e810b9c4d65d484a20a3404a"
+    "sha256": "781e404add7c49da10f2647f36d169c47cbaf557e6c411759f49b93c3346d462"
   },
   "candidate_version": "2.2.0",
   "candidate_confirmation": "confirmed_maintainer",
@@ -67,6 +67,10 @@
   "maintainer_confirmation": {
     "path": "conductor/tracks/v2_2_release_and_venue_submissions_20260830/maintainer-venue-decision-20260831.json",
     "sha256": "514f06a661b0a3a1de76b4bdda50efd6d21e633e40d1f64333d91d3c7bf8fb81"
+  },
+  "withdrawal_receipt": {
+    "path": "conductor/tracks/v2_2_release_and_venue_submissions_20260830/pyopensci-withdrawal-receipt-20260831.json",
+    "sha256": "a0ee21b74f330b155e67148d3be5d74e38e6a5861761cc66987f60044f0e0e41"
   },
   "action_gates": {
     "pre_review_survey": "pending",

--- a/specs/submission-readiness/targets.json
+++ b/specs/submission-readiness/targets.json
@@ -71,7 +71,7 @@
         {"id": "author-category-licence-upload", "status": "pending", "evidence": ["paper/readiness-manifest.json"]}
       ],
       "acceptance_evidence": ["Authenticated arXiv submission state", "Permanent announced arXiv identifier"],
-      "next_decision": "Author completes category, licence, source upload, metadata, and submission after final review."
+      "next_decision": "ArXiv is deferred until an actual journal submission exists and the author later reviews the category, licence, source package, metadata and authenticated submission."
     },
     {
       "id": "joss",
@@ -102,7 +102,7 @@
         {"id": "ai-affirmation", "status": "pending", "evidence": ["paper.md", "paper/joss-editorial-assurance.json", "AI_CONTRIBUTIONS.md", "specs/submission-readiness/pyopensci-submission-staging.json"]}
       ],
       "acceptance_evidence": ["pyOpenSci review issue", "pyOpenSci approval label and catalogue entry"],
-      "next_decision": "Complete all packet repairs and current human declarations, resolve contact-capacity eligibility for existing issues #271 and #272, and use human-written review communication. The pyOpenSci-first and subsequent eligible JOSS route is already authorized."
+      "next_decision": "Personal declarations are confirmed and previous requests #271 and #272 are withdrawn. Complete the private pre-review survey, supply a human-written submission body, and perform the authenticated pyOpenSci submission. The maintainer's separate commitment to write later review communication personally is confirmed. The subsequent eligible JOSS route is already authorized; arXiv remains deferred until an actual journal submission and later author action."
     },
     {
       "id": "ropensci",

--- a/tests/test_pyopensci_submission_staging.py
+++ b/tests/test_pyopensci_submission_staging.py
@@ -46,6 +46,9 @@ def _staged_packet(tmp_path: Path, draft: str) -> Path:
     confirmation = _load(STAGING).get("maintainer_confirmation")
     if confirmation:
         relative_files.append(Path(confirmation["path"]))
+    withdrawal = _load(STAGING).get("withdrawal_receipt")
+    if withdrawal:
+        relative_files.append(Path(withdrawal["path"]))
     for relative in relative_files:
         destination = staged_root / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -120,6 +123,131 @@ def test_candidate_is_bound_to_verified_publication() -> None:
     assert candidate["joss_handoff"]["state"] == (
         "blocked_pending_refresh_and_external_evidence"
     )
+    assert candidate["joss_handoff"]["permanent_arxiv_identifier"] == (
+        "deferred_until_after_journal_submission_not_pre_joss_gate"
+    )
+
+
+def test_current_venue_projections_follow_withdrawal_and_journal_first_order() -> None:
+    """Current guidance supersedes, without rewriting, the dated gate snapshot."""
+    targets = _load(ROOT / "specs" / "submission-readiness" / "targets.json")
+    by_id = {target["id"]: target for target in targets["targets"]}
+    pyopensci_decision = by_id["pyopensci"]["next_decision"]
+    arxiv_decision = by_id["arxiv"]["next_decision"]
+
+    assert "requests #271 and #272 are withdrawn" in pyopensci_decision
+    assert "private pre-review survey" in pyopensci_decision
+    assert "human-written submission body" in pyopensci_decision
+    assert "write later review communication personally is confirmed" in (
+        pyopensci_decision
+    )
+    assert "authenticated pyOpenSci submission" in pyopensci_decision
+    assert "resolve contact-capacity eligibility" not in pyopensci_decision
+    assert "deferred until an actual journal submission" in arxiv_decision
+
+    readiness = (ROOT / "docs" / "release" / "pyopensci-readiness.md").read_text(
+        encoding="utf-8"
+    )
+    assert "withdrawn and verified closed on 31 August 2026" in readiness
+    assert "still require contact-capacity clarification" not in readiness
+
+    historical_checklist = (
+        ROOT
+        / "conductor/tracks/v2_2_release_and_venue_submissions_20260830"
+        / "venue-human-action-checklist-20260831.md"
+    )
+    assert hashlib.sha256(historical_checklist.read_bytes()).hexdigest() == (
+        "47db7c5550defa0ee226481105677833618046078647289f24c3d9bb7489f425"
+    )
+    assert "Open; labels `presubmission`" in historical_checklist.read_text(
+        encoding="utf-8"
+    )
+
+    supersession = (
+        ROOT
+        / "conductor/tracks/v2_2_release_and_venue_submissions_20260830"
+        / "venue-human-action-checklist-supersession-20260902.md"
+    ).read_text(encoding="utf-8")
+    assert "immutable" in supersession
+    assert "factual snapshot" in supersession.replace("\n", " ")
+    assert "not current action guidance" in supersession.replace("\n", " ")
+    assert "must not trigger repeated declarations" in supersession
+
+    active_spec = (
+        ROOT / "conductor/tracks/v2_2_release_and_venue_submissions_20260830/spec.md"
+    ).read_text(encoding="utf-8")
+    assert "requests #271 and #272 were closed as not planned" in active_spec
+    assert "contact-capacity clarification for open issues #271 and #272" not in (
+        active_spec
+    )
+
+
+def test_validator_rejects_rebound_arxiv_before_joss_gate(tmp_path: Path) -> None:
+    """Rebinding the candidate hash cannot restore the superseded arXiv gate."""
+    staged_root = _staged_packet(tmp_path, DRAFT.read_text(encoding="utf-8"))
+    candidate_path = staged_root / CANDIDATE.relative_to(ROOT)
+    candidate = _load(candidate_path)
+    candidate["joss_handoff"]["permanent_arxiv_identifier"] = "pending"
+    candidate_path.write_text(json.dumps(candidate), encoding="utf-8")
+    staging_path = staged_root / STAGING.relative_to(ROOT)
+    staging = _load(staging_path)
+    staging["candidate"]["sha256"] = hashlib.sha256(
+        candidate_path.read_bytes()
+    ).hexdigest()
+    staging_path.write_text(json.dumps(staging), encoding="utf-8")
+
+    findings = validate_staging_packet(staged_root)
+
+    assert "JOSS handoff must preserve the journal-first arXiv deferral" in findings
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing_binding",
+        "missing_file",
+        "path",
+        "digest",
+        "state",
+        "reason",
+        "approval",
+    ],
+)
+def test_validator_rejects_invalid_withdrawal_evidence(
+    tmp_path: Path, mutation: str
+) -> None:
+    """Withdrawal claims require immutable, semantically valid issue evidence."""
+    staged_root = _staged_packet(tmp_path, DRAFT.read_text(encoding="utf-8"))
+    staging_path = staged_root / STAGING.relative_to(ROOT)
+    staging = _load(staging_path)
+    binding = staging["withdrawal_receipt"]
+    receipt_path = staged_root / binding["path"]
+
+    if mutation == "missing_binding":
+        del staging["withdrawal_receipt"]
+    elif mutation == "missing_file":
+        receipt_path.unlink()
+    elif mutation == "path":
+        copied = receipt_path.with_name("copied-withdrawal-receipt.json")
+        shutil.copyfile(receipt_path, copied)
+        binding["path"] = str(copied.relative_to(staged_root))
+    elif mutation == "digest":
+        binding["sha256"] = "0" * 64
+    else:
+        receipt = _load(receipt_path)
+        if mutation == "state":
+            receipt["issues"][0]["after_state"] = "open"
+        elif mutation == "reason":
+            receipt["issues"][1]["after_state_reason"] = "completed"
+        else:
+            receipt["editorial_approval_inferred"] = True
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+        binding["sha256"] = hashlib.sha256(receipt_path.read_bytes()).hexdigest()
+    staging_path.write_text(json.dumps(staging), encoding="utf-8")
+
+    findings = validate_staging_packet(staged_root)
+
+    assert any(finding.startswith("withdrawal receipt") for finding in findings)
 
 
 def test_staging_manifest_records_version_without_external_action() -> None:

--- a/todo.md
+++ b/todo.md
@@ -690,9 +690,12 @@ as recorded in the active task above; earlier route decisions below are historic
 
 *   [x] Reconcile post-merge release/venue evidence and the historical backlog
     under R13f (PR #1052; `a6d748cc`). Full local tox passed all 15 environments
-    with 4,601 tests passed and 95.11 percent coverage. Current declarations
-    and contact-capacity eligibility remain R14 gates; hosted checks and merge
-    of the reconciliation PR are separate from this local completion.
+    with 4,601 tests passed and 95.11 percent coverage. At that checkpoint,
+    declarations and contact-capacity eligibility remained R14 gates; hosted
+    checks and merge of the reconciliation PR were separate from local completion.
+    *   [x] Reconcile current venue projections with the verified withdrawal of
+        requests #271 and #272 and defer arXiv until journal submission, without
+        changing the unposted packet state or external human-action gates.
 
 *   [x] Complete and archive the pyOpenSci-first/JOSS-fast-track repository-
     readiness track.


### PR DESCRIPTION
Previous pyOpenSci requests were withdrawn, while current readiness documents still described contact-capacity clarification and an arXiv identifier as pre-JOSS work. That stale state could send the maintainer back through superseded gates or invert the confirmed journal-first sequence.

This change records the verified withdrawals in current projections, marks the dated checklist as superseded without rewriting its historical observations, and defers arXiv until an actual journal submission and later author action. It keeps the pyOpenSci packet `prepared_local_unposted`, retains every external-action flag as false, and adds validation that prevents the stale arXiv prerequisite from returning.

Validation:
- 70 focused tests passed
- pyOpenSci staging validator passed
- submission-readiness validator passed
- Ruff check and format passed
- Vale passed with zero errors or warnings
- `git diff --check` passed
