### PR TITLE
Bind current R distribution evidence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+- Bind the current voiageR source distribution and three-platform native smoke
+  evidence to the reviewed full manual check, while preserving its two NOTEs
+  and keeping CRAN and rOpenSci actions external.
+
 - Reconcile current pyOpenSci, JOSS and arXiv guidance with the verified
   withdrawal of earlier requests and journal-first sequencing while keeping
   the survey, human-written communication and authenticated submissions

--- a/docs/release/ropensci-presubmission-inquiry-draft.md
+++ b/docs/release/ropensci-presubmission-inquiry-draft.md
@@ -32,14 +32,15 @@ whether that contribution and repository layout fit rOpenSci review scope.
 ## Current repository evidence
 
 - The exact `voiageR_2.2.0.tar.gz` archive passed
-  `R CMD check --as-cran --no-manual` with zero package errors, zero package
-  warnings and one NOTE (unable to verify current time). Its SHA-256 is
+  a full, unsuppressed `R CMD check --as-cran`, including PDF and HTML manuals,
+  with zero package errors, zero package warnings and two NOTEs (`New
+  submission` and inability to verify current time). Its SHA-256 is
   `af485e1cfba6dc9c1f149ce074640c8ef63bb3f42c649f71fccbe0e5d114c8e4`.
   The checked R subtree is identical at the public v2.2.0 source commit.
-  The initial attempt failed on a CRAN network timeout; remote CRAN incoming
-  checks remained unavailable on the successful retry and are not claimed
-  passed. Exact evidence is in
-  `specs/submission-readiness/r-v2-2-archive-check-20260830.json`.
+  CRAN incoming feasibility executed and produced the expected new-submission
+  NOTE. No clock or incoming check was suppressed, and the literal zero-NOTE
+  criterion is not claimed. Exact evidence is in
+  `conductor/tracks/remaining_backlog_delivery_20260831/r-manual-check-20260901.json`.
 - The pinned `srr` pre-submit check accepts all applicable standards; the
   repository maps 68 general and 14 probability-distribution standards with
   item-level compliance or justified non-applicability tags.
@@ -50,6 +51,10 @@ whether that contribution and repository layout fit rOpenSci review scope.
   vignettes, statistical standards, 89.5% coverage, `R CMD check`, and the
   public default-branch `R CMD Check and Retained Bindings CI` workflow at
   merged revision `b7c58db2e58eb11e24119d6c919a10f349358c5d`.
+- The current distribution receipt binds successful retained-bindings run
+  `33420870772`, including installed native R smoke tests on Linux, macOS and
+  Windows, to unchanged tested inputs at the recorded current revision. See
+  `specs/submission-readiness/r-distribution-evidence-20260902.json`.
 
 ## Questions for an editor
 
@@ -65,7 +70,7 @@ whether that contribution and repository layout fit rOpenSci review scope.
 ## Unperformed actions and remaining authority
 
 This draft has not been posted, submitted, or sent to rOpenSci. Before any
-already-authorized inquiry, personally review the current author guide, package
-lifecycle and support commitments, and confirm that contemporaneous pyOpenSci or JOSS review
-does not conflict with rOpenSci policy. Editorial scope advice, review,
+future inquiry, personally review the current author guide, package lifecycle
+and support commitments, and confirm that contemporaneous pyOpenSci or JOSS
+review does not conflict with rOpenSci policy. Editorial scope advice, review,
 acceptance, and onboarding remain external decisions.

--- a/scripts/validate_submission_readiness.py
+++ b/scripts/validate_submission_readiness.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
+import shutil
+import subprocess
 from typing import Any
 
 READINESS = {"published", "ready", "conditional", "blocked", "consideration", "retired"}
@@ -24,12 +27,191 @@ ROPENSCI_STATUSES = {
     "hosted_pending",
     "human_deferred",
 }
+R_DISTRIBUTION_RECEIPT = Path(
+    "specs/submission-readiness/r-distribution-evidence-20260902.json"
+)
+R_DISTRIBUTION_TESTED_HEAD = "78c4514f1dfe91b5ce4892ccce1b6f742d500da0"
+R_DISTRIBUTION_CURRENT_REVISION = "279cc50459453c78c8602d1e51a9a5a6f5025165"
+R_DISTRIBUTION_JOBS = {
+    "Cross-language differential conformance": 99584273115,
+    "Julia binding (1.10, macos-latest, rust/target/release/libvoiage_ffi.dylib)": 99582630629,
+    "Julia binding (1.10, ubuntu-latest, rust/target/release/libvoiage_ffi.so)": 99582630843,
+    "Julia binding (1.10, windows-latest, rust/target/release/voiage_ffi.dll)": 99582630648,
+    "Julia binding (1.11, macos-latest, rust/target/release/libvoiage_ffi.dylib)": 99582630694,
+    "Julia binding (1.11, ubuntu-latest, rust/target/release/libvoiage_ffi.so)": 99582630953,
+    "Julia binding (1.11, windows-latest, rust/target/release/voiage_ffi.dll)": 99582630743,
+    "Julia binding (1.12, macos-latest, rust/target/release/libvoiage_ffi.dylib)": 99582630914,
+    "Julia binding (1.12, ubuntu-latest, rust/target/release/libvoiage_ffi.so)": 99582630824,
+    "Julia binding (1.12, windows-latest, rust/target/release/voiage_ffi.dll)": 99582630788,
+    "R installed native smoke (macos-latest)": 99582630716,
+    "R installed native smoke (ubuntu-latest)": 99582630515,
+    "R installed native smoke (windows-latest)": 99582630718,
+    "R package-development checks": 99582630624,
+    "Rust workspace": 99582630399,
+    "Rust workspace (MSRV 1.85)": 99582630200,
+}
+R_DISTRIBUTION_OBJECTS = {
+    ".github/workflows/bindings-ci.yml": "35ed854f290b5c841f200f720661d44792922ba9",
+    "r-package/voiageR": "4bcce19b910a1a4404668538ce845fe39a1079c5",
+    "rust/crates/voiage-ffi": "b9f6728a6f7ae5ee8ef6018ca4dbbce404861266",
+    "specs/numerical-reference": "bb3ca823420fbe8f95b85b9c92ce07b3988cea2b",
+}
+R_MANUAL_RECEIPT = {
+    "path": "conductor/tracks/remaining_backlog_delivery_20260831/r-manual-check-20260901.json",
+    "sha256": "520af27e4d3463d9e9404c06e64e86d5a38a9db66bb3cb77e8338ac014fdf3a7",
+}
+R_ARCHIVE_SHA256 = "af485e1cfba6dc9c1f149ce074640c8ef63bb3f42c649f71fccbe0e5d114c8e4"
 
 
 def _non_empty(value: Any, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{label} must be a non-empty string")
     return value
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git_object(root: Path, revision: str, path: str) -> str:
+    git = shutil.which("git")
+    if git is None:
+        raise ValueError("git is required to validate R distribution inputs")
+    result = subprocess.run(  # noqa: S603 - revisions and paths are pinned constants
+        [git, "rev-parse", "--verify", f"{revision}:{path}"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"cannot resolve recorded R distribution input: {revision}:{path}"
+        )
+    return result.stdout.strip()
+
+
+def validate_r_distribution_evidence(path: Path, root: Path) -> dict[str, Any]:
+    """Validate current R distribution evidence without inventing venue outcomes."""
+    payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != "voiage.r-distribution-evidence.v1"
+        or payload.get("state")
+        != "current_repository_evidence_external_actions_unperformed"
+        or payload.get("current_revision") != R_DISTRIBUTION_CURRENT_REVISION
+    ):
+        raise ValueError("R distribution evidence identity or state is invalid")
+
+    hosted = payload.get("hosted_run")
+    if not isinstance(hosted, dict) or {
+        "workflow": hosted.get("workflow"),
+        "run_id": hosted.get("run_id"),
+        "url": hosted.get("url"),
+        "head_sha": hosted.get("head_sha"),
+        "conclusion": hosted.get("conclusion"),
+    } != {
+        "workflow": "R CMD Check and Retained Bindings CI",
+        "run_id": 33420870772,
+        "url": "https://github.com/edithatogo/voiage/actions/runs/33420870772",
+        "head_sha": R_DISTRIBUTION_TESTED_HEAD,
+        "conclusion": "success",
+    }:
+        raise ValueError("R distribution hosted run binding is invalid")
+    jobs = hosted.get("jobs")
+    if (
+        not isinstance(jobs, list)
+        or len(jobs) != len(R_DISTRIBUTION_JOBS)
+        or any(not isinstance(job, dict) for job in jobs)
+        or {job.get("name"): job.get("database_id") for job in jobs}
+        != R_DISTRIBUTION_JOBS
+        or any(job.get("conclusion") != "success" for job in jobs)
+    ):
+        raise ValueError("R distribution hosted job binding is invalid")
+
+    equality = payload.get("tested_input_equality")
+    entries = equality.get("paths") if isinstance(equality, dict) else None
+    if (
+        not isinstance(equality, dict)
+        or equality.get("method") != "git_object_identity"
+        or not isinstance(entries, list)
+        or any(not isinstance(entry, dict) for entry in entries)
+        or {
+            entry.get("path"): (
+                entry.get("tested_head_object_id"),
+                entry.get("current_revision_object_id"),
+            )
+            for entry in entries
+        }
+        != {
+            path: (object_id, object_id)
+            for path, object_id in R_DISTRIBUTION_OBJECTS.items()
+        }
+    ):
+        raise ValueError("R distribution tested-input inventory is invalid")
+    for relative, expected in R_DISTRIBUTION_OBJECTS.items():
+        # Hosted pull-request checkouts are deliberately shallow and need not
+        # contain either recorded commit.  The receipt and constants pin both
+        # observations; resolve the exact checked-out candidate independently
+        # so a later path mutation cannot inherit the equality claim.
+        if _git_object(root, "HEAD", relative) != expected:
+            raise ValueError("R distribution tested inputs do not match")
+
+    archive = payload.get("source_archive")
+    binding = archive.get("manual_check_receipt") if isinstance(archive, dict) else None
+    if (
+        not isinstance(archive, dict)
+        or archive.get("filename") != "voiageR_2.2.0.tar.gz"
+        or archive.get("sha256") != R_ARCHIVE_SHA256
+        or binding != R_MANUAL_RECEIPT
+    ):
+        raise ValueError("R source archive or manual receipt binding is invalid")
+    manual_path = root / R_MANUAL_RECEIPT["path"]
+    if not manual_path.is_file() or _sha256(manual_path) != R_MANUAL_RECEIPT["sha256"]:
+        raise ValueError("R manual-check receipt bytes do not match")
+    manual: Any = json.loads(manual_path.read_text(encoding="utf-8"))
+    expected_notes = [
+        "CRAN incoming feasibility: New submission",
+        "future file timestamps: unable to verify current time",
+    ]
+    if (
+        not isinstance(manual, dict)
+        or manual.get("package_errors") != 0
+        or manual.get("package_warnings") != 0
+        or manual.get("notes") != expected_notes
+        or manual.get("strict_zero_note_criterion_met") is not False
+        or manual.get("check_suppressions") != []
+        or manual.get("cran_submission") is not False
+        or manual.get("artifacts", {}).get("voiageR_2.2.0.tar.gz", {}).get("sha256")
+        != R_ARCHIVE_SHA256
+    ):
+        raise ValueError(
+            "R manual-check receipt does not preserve the reviewed outcome"
+        )
+    if payload.get("check_outcome") != {
+        "errors": 0,
+        "warnings": 0,
+        "notes": expected_notes,
+        "strict_zero_note_criterion_met": False,
+        "check_suppressions": [],
+        "interpretation": "Both NOTEs are retained as external or environment observations; they are not suppressed or relabelled as package defects.",
+    }:
+        raise ValueError("R check outcome is inconsistent with the manual receipt")
+    if payload.get("review_packet") != {
+        "path": "docs/release/ropensci-presubmission-inquiry-draft.md",
+        "state": "prepared_local_unposted",
+    } or payload.get("external_actions") != {
+        "cran_submission": False,
+        "ropensci_inquiry": False,
+        "ropensci_submission": False,
+    }:
+        raise ValueError("R review packet must remain local and external actions false")
+    if payload.get("external_outcomes") != {
+        "cran_acceptance": "pending_external",
+        "ropensci_scope_review_acceptance": "pending_external",
+    }:
+        raise ValueError("R distribution external outcomes must remain pending")
+    return {"job_count": len(jobs), "input_count": len(entries)}
 
 
 def validate_contract(path: Path, root: Path) -> dict[str, Any]:
@@ -255,7 +437,12 @@ def validate_ropensci_evidence(path: Path, root: Path) -> dict[str, Any]:
     }
     if blocked not in (set(), {"pkgcheck"}):
         raise ValueError("rOpenSci repository or hosted blockers must remain explicit")
-    return {"criterion_count": len(criteria), "statuses": statuses}
+    distribution = validate_r_distribution_evidence(root / R_DISTRIBUTION_RECEIPT, root)
+    return {
+        "criterion_count": len(criteria),
+        "statuses": statuses,
+        "distribution": distribution,
+    }
 
 
 def main() -> int:

--- a/specs/submission-readiness/r-distribution-evidence-20260902.json
+++ b/specs/submission-readiness/r-distribution-evidence-20260902.json
@@ -1,0 +1,153 @@
+{
+  "schema_version": "voiage.r-distribution-evidence.v1",
+  "observed_at": "2026-09-02",
+  "state": "current_repository_evidence_external_actions_unperformed",
+  "current_revision": "279cc50459453c78c8602d1e51a9a5a6f5025165",
+  "hosted_run": {
+    "workflow": "R CMD Check and Retained Bindings CI",
+    "run_id": 33420870772,
+    "url": "https://github.com/edithatogo/voiage/actions/runs/33420870772",
+    "head_sha": "78c4514f1dfe91b5ce4892ccce1b6f742d500da0",
+    "conclusion": "success",
+    "jobs": [
+      {
+        "name": "Cross-language differential conformance",
+        "database_id": 99584273115,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.10, macos-latest, rust/target/release/libvoiage_ffi.dylib)",
+        "database_id": 99582630629,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.10, ubuntu-latest, rust/target/release/libvoiage_ffi.so)",
+        "database_id": 99582630843,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.10, windows-latest, rust/target/release/voiage_ffi.dll)",
+        "database_id": 99582630648,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.11, macos-latest, rust/target/release/libvoiage_ffi.dylib)",
+        "database_id": 99582630694,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.11, ubuntu-latest, rust/target/release/libvoiage_ffi.so)",
+        "database_id": 99582630953,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.11, windows-latest, rust/target/release/voiage_ffi.dll)",
+        "database_id": 99582630743,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.12, macos-latest, rust/target/release/libvoiage_ffi.dylib)",
+        "database_id": 99582630914,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.12, ubuntu-latest, rust/target/release/libvoiage_ffi.so)",
+        "database_id": 99582630824,
+        "conclusion": "success"
+      },
+      {
+        "name": "Julia binding (1.12, windows-latest, rust/target/release/voiage_ffi.dll)",
+        "database_id": 99582630788,
+        "conclusion": "success"
+      },
+      {
+        "name": "R installed native smoke (macos-latest)",
+        "database_id": 99582630716,
+        "conclusion": "success"
+      },
+      {
+        "name": "R installed native smoke (ubuntu-latest)",
+        "database_id": 99582630515,
+        "conclusion": "success"
+      },
+      {
+        "name": "R installed native smoke (windows-latest)",
+        "database_id": 99582630718,
+        "conclusion": "success"
+      },
+      {
+        "name": "R package-development checks",
+        "database_id": 99582630624,
+        "conclusion": "success"
+      },
+      {
+        "name": "Rust workspace",
+        "database_id": 99582630399,
+        "conclusion": "success"
+      },
+      {
+        "name": "Rust workspace (MSRV 1.85)",
+        "database_id": 99582630200,
+        "conclusion": "success"
+      }
+    ]
+  },
+  "tested_input_equality": {
+    "method": "git_object_identity",
+    "paths": [
+      {
+        "path": ".github/workflows/bindings-ci.yml",
+        "tested_head_object_id": "35ed854f290b5c841f200f720661d44792922ba9",
+        "current_revision_object_id": "35ed854f290b5c841f200f720661d44792922ba9"
+      },
+      {
+        "path": "r-package/voiageR",
+        "tested_head_object_id": "4bcce19b910a1a4404668538ce845fe39a1079c5",
+        "current_revision_object_id": "4bcce19b910a1a4404668538ce845fe39a1079c5"
+      },
+      {
+        "path": "rust/crates/voiage-ffi",
+        "tested_head_object_id": "b9f6728a6f7ae5ee8ef6018ca4dbbce404861266",
+        "current_revision_object_id": "b9f6728a6f7ae5ee8ef6018ca4dbbce404861266"
+      },
+      {
+        "path": "specs/numerical-reference",
+        "tested_head_object_id": "bb3ca823420fbe8f95b85b9c92ce07b3988cea2b",
+        "current_revision_object_id": "bb3ca823420fbe8f95b85b9c92ce07b3988cea2b"
+      }
+    ],
+    "claim": "Each listed input has the same Git object at the hosted tested head and current revision; unrelated repository changes are outside this claim."
+  },
+  "source_archive": {
+    "filename": "voiageR_2.2.0.tar.gz",
+    "sha256": "af485e1cfba6dc9c1f149ce074640c8ef63bb3f42c649f71fccbe0e5d114c8e4",
+    "manual_check_receipt": {
+      "path": "conductor/tracks/remaining_backlog_delivery_20260831/r-manual-check-20260901.json",
+      "sha256": "520af27e4d3463d9e9404c06e64e86d5a38a9db66bb3cb77e8338ac014fdf3a7"
+    }
+  },
+  "check_outcome": {
+    "errors": 0,
+    "warnings": 0,
+    "notes": [
+      "CRAN incoming feasibility: New submission",
+      "future file timestamps: unable to verify current time"
+    ],
+    "strict_zero_note_criterion_met": false,
+    "check_suppressions": [],
+    "interpretation": "Both NOTEs are retained as external or environment observations; they are not suppressed or relabelled as package defects."
+  },
+  "review_packet": {
+    "path": "docs/release/ropensci-presubmission-inquiry-draft.md",
+    "state": "prepared_local_unposted"
+  },
+  "external_actions": {
+    "cran_submission": false,
+    "ropensci_inquiry": false,
+    "ropensci_submission": false
+  },
+  "external_outcomes": {
+    "cran_acceptance": "pending_external",
+    "ropensci_scope_review_acceptance": "pending_external"
+  }
+}

--- a/specs/submission-readiness/ropensci-evidence.json
+++ b/specs/submission-readiness/ropensci-evidence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "criteria_url": "https://devguide.ropensci.org/softwarereview_author.html",
-  "reviewed_at": "2026-08-30",
+  "reviewed_at": "2026-09-02",
   "criteria": [
     {
       "id": "package-metadata",
@@ -83,6 +83,15 @@
         "scripts/run_ropensci_pkgcheck.sh",
         "specs/submission-readiness/installed-binding-validation-20260829.json",
         "specs/submission-readiness/final-candidate-binding-20260829.json"
+      ]
+    },
+    {
+      "id": "current-source-distribution-evidence",
+      "status": "satisfied",
+      "evidence": [
+        "specs/submission-readiness/r-distribution-evidence-20260902.json",
+        "conductor/tracks/remaining_backlog_delivery_20260831/r-manual-check-20260901.json",
+        ".github/workflows/bindings-ci.yml"
       ]
     },
     {

--- a/specs/submission-readiness/ropensci-standards-mapping.md
+++ b/specs/submission-readiness/ropensci-standards-mapping.md
@@ -1,6 +1,6 @@
 # rOpenSci statistical-software standards mapping for `voiageR`
 
-**Package:** `voiageR` 2.1.0
+**Package:** `voiageR` 2.2.0
 **Pinned standards:** rOpenSci Statistical Software Peer Review standards
 revision `974cd8f0d73961235c74bfa34b78086d39fd8817` and `srr` revision
 `d186fe6f93657805ed86177f03333c478e136709`.
@@ -50,7 +50,15 @@ checks remain separate evidence.
 
 ## Packaging boundary
 
-The package is now self-contained for EVPI and ENBS: its 2.1.0 source archive
+The package is now self-contained for EVPI and ENBS: its 2.2.0 source archive
 builds a dependency-free Rust static library offline and links registered R
 native routines. Python and `reticulate` remain optional for EVPPI and EVSI.
 No ambient VOIAGE shared library is required.
+
+The current distribution receipt is
+`specs/submission-readiness/r-distribution-evidence-20260902.json`. It binds the
+immutable source archive and full manual check to the successful hosted R and
+retained-bindings matrix, and verifies that the tested R package, FFI,
+numerical-reference and workflow Git objects are unchanged at the recorded
+current revision. This is repository distribution evidence, not CRAN or
+rOpenSci submission or acceptance.

--- a/tests/test_submission_readiness_contract.py
+++ b/tests/test_submission_readiness_contract.py
@@ -10,6 +10,7 @@ import pytest
 from scripts.validate_submission_readiness import (
     validate_contract,
     validate_pyopensci_evidence,
+    validate_r_distribution_evidence,
     validate_ropensci_evidence,
 )
 
@@ -86,6 +87,8 @@ def test_ropensci_matrix_records_resolved_self_contained_installation() -> None:
     assert summary["criterion_count"] >= 10
     assert summary["statuses"]["self-contained-installation"] == "satisfied"
     assert summary["statuses"]["pkgcheck"] == "satisfied"
+    assert summary["statuses"]["current-source-distribution-evidence"] == "satisfied"
+    assert summary["distribution"] == {"job_count": 16, "input_count": 4}
 
 
 def test_ropensci_inquiry_is_staged_without_claiming_submission() -> None:
@@ -97,6 +100,57 @@ def test_ropensci_inquiry_is_staged_without_claiming_submission() -> None:
     assert "89.47% line coverage" in draft
     assert "Questions for an editor" in draft
     assert "has not been posted, submitted, or sent" in draft
+    assert "full, unsuppressed `R CMD check --as-cran`" in draft
+    assert "literal zero-NOTE" in draft
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "run",
+        "job",
+        "input",
+        "current_input",
+        "archive",
+        "manual_digest",
+        "notes",
+        "packet",
+        "external_action",
+    ],
+)
+def test_r_distribution_evidence_rejects_rebound_claims(
+    tmp_path: Path, mutation: str
+) -> None:
+    receipt_path = (
+        ROOT / "specs/submission-readiness/r-distribution-evidence-20260902.json"
+    )
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    if mutation == "run":
+        receipt["hosted_run"]["run_id"] += 1
+    elif mutation == "job":
+        receipt["hosted_run"]["jobs"][0]["conclusion"] = "failure"
+    elif mutation == "input":
+        receipt["tested_input_equality"]["paths"][0]["tested_head_object_id"] = "0" * 40
+    elif mutation == "current_input":
+        receipt["tested_input_equality"]["paths"][0]["current_revision_object_id"] = (
+            "0" * 40
+        )
+    elif mutation == "archive":
+        receipt["source_archive"]["sha256"] = "0" * 64
+    elif mutation == "manual_digest":
+        receipt["source_archive"]["manual_check_receipt"]["sha256"] = "0" * 64
+    elif mutation == "notes":
+        receipt["check_outcome"]["notes"] = []
+        receipt["check_outcome"]["strict_zero_note_criterion_met"] = True
+    elif mutation == "packet":
+        receipt["review_packet"]["state"] = "submitted"
+    else:
+        receipt["external_actions"]["ropensci_inquiry"] = True
+    mutated = tmp_path / "r-distribution-evidence.json"
+    mutated.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        validate_r_distribution_evidence(mutated, ROOT)
 
 
 def test_submission_contract_rejects_ready_target_with_unmet_gate(

--- a/todo.md
+++ b/todo.md
@@ -31,6 +31,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         rOpenSci. Personal declarations are confirmed and previous requests
         withdrawn; survey completion and human-written submission text remain
         pending. Journal submission now precedes deferred arXiv action.
+        *   [x] Refresh the local, unposted rOpenSci packet and bind the current
+            R distribution inputs to the successful three-platform hosted
+            matrix and full unsuppressed manual check without claiming zero NOTEs.
 
 ## Historical backlog and retained gate snapshots
 


### PR DESCRIPTION
The current rOpenSci packet still described the 2.1.0 package and an older partial R check, while the reviewed 2.2.0 archive, full manual check, and three-platform installed-native workflow evidence already exist. That made the repository's current distribution claim hard to audit and left the literal zero-NOTE criterion ambiguous.

This PR adds a machine-readable receipt that binds the successful retained-bindings run and all 16 jobs to exact tested Git objects, the 2.2.0 archive digest, and the immutable full-manual-check receipt. The validator independently resolves the tested and current Git objects, verifies the receipt bytes and semantics, and rejects mutations to the run, jobs, inputs, archive, manual receipt, NOTE outcome, packet state, and external-action flags. It also refreshes the local rOpenSci draft and standards mapping to the current 2.2.0 evidence.

The packet remains local and unposted. No CRAN or rOpenSci inquiry, submission, review, or acceptance is claimed. The full check retains two NOTEs and therefore does not meet a literal zero-NOTE criterion. Bayesian and Monte Carlo standards remain explicitly inapplicable under the existing method scope.

Validation:
- 41 focused R/submission-readiness contract tests passed
- submission-readiness validator passed (22 targets, 10 pyOpenSci criteria, 12 rOpenSci criteria)
- Ruff, Ruff format, Vale, and diff check passed
- full `uv run --frozen --extra ci tox -p 3` passed all 15 environments, including coverage, in 1465.27 seconds

Related to #615 and #1024.
