### PR TITLE
Scale estimation variance property tolerance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@
 
 ## Unreleased
 
+- Make the estimation-variance property bound scale-aware so valid
+  floating-point decompositions at large magnitudes do not fail spuriously.
+
 - Bind the current voiageR source distribution and three-platform native smoke
   evidence to the reviewed full manual check, while preserving its two NOTEs
   and keeping CRAN and rOpenSci actions external.

--- a/tests/test_estimation_variance_properties.py
+++ b/tests/test_estimation_variance_properties.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from statistics import fmean, pvariance
 
-from hypothesis import given, settings
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 import pytest
 
@@ -34,13 +34,18 @@ def _discrete_decomposition(
     split=st.integers(min_value=1, max_value=8),
 )
 @settings(max_examples=80, deadline=None)
+@example(
+    values=[699051.4296875, 0.0, 699051.4296875, 0.0, 699051.43359375],
+    split=2,
+)
 def test_discrete_evppi_var_obeys_total_variance(
     values: list[float], split: int
 ) -> None:
     groups = [index % split for index in range(len(values))]
     prior, expected_within, between = _discrete_decomposition(values, groups)
     assert prior == pytest.approx(expected_within + between, rel=1.0e-12, abs=1.0e-8)
-    assert 0.0 <= between <= prior + 1.0e-6
+    tolerance = max(1.0, abs(prior)) * 1.0e-12
+    assert 0.0 <= between <= prior + tolerance
 
 
 @given(

--- a/todo.md
+++ b/todo.md
@@ -474,6 +474,8 @@ destination registry and publication decisions remain separate external gates.
         promotion, release and parent closure.
 
 *   [x] Implement estimation-focused variance-reduction VOI.
+    *   [x] Use a scale-aware tolerance for the floating-point total-variance
+        bound and retain the discovered large-magnitude counterexample.
     *   Conductor track: `estimation_focused_variance_voi_20260727`.
     *   Planned contract: v1.2.0; MoSCoW: Must; canonical requirements M14/M17.
     *   GitHub issue: #619, native sub-issue of #318 under programme #313.


### PR DESCRIPTION
A retained Hypothesis counterexample exposed an absolute-tolerance defect in the total-variance property test: variances near 1.17e11 can differ by normal floating-point rounding beyond the fixed 1e-6 allowance even though the decomposition passes its scale-aware equality check.

This change applies the same relative tolerance principle to the upper-bound assertion and pins the discovered large-magnitude example as a permanent regression case. Runtime behavior is unchanged.

Validation:
- focused estimation variance property tests passed
- Ruff check and format passed
- full tox: 14 environments passed; docs initially failed because the fresh worktree had uninitialized pinned submodules
- pinned submodules initialized, then the docs environment passed
- coverage environment passed
