### PR TITLE
fix(hpc): integrate EasyBuild Arrow provider

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+- Integrate the checksum-bound Arrow and PyArrow 25.0.1 EasyBuild 2024a provider overlay into the parent provider contract while retaining native build and full-stack qualification as pending gates.
+
 - Add a checksum-bound Polars 1.42.1 EasyBuild 2024a provider with an exact dated-nightly Rust compiler boundary while retaining native build, full-stack and upstream gates.
 
 - Make the estimation-variance property bound scale-aware so valid

--- a/packaging/easybuild-overlay/README.md
+++ b/packaging/easybuild-overlay/README.md
@@ -97,8 +97,11 @@ is historical; use `evidence/scientific-robot-python31214.log` for this candidat
 
 ## Remaining work
 
-Backport Arrow/PyArrow with its complete native and source-build dependencies.
-The adjacent `easybuild-2024a-polars-overlay` resolves Polars and its dated-nightly
+The adjacent `easybuild-2024a-arrow-overlay` resolves Arrow and PyArrow 25.0.1
+with their checksum-bound native and source-build provider graph. Its manifest is
+bound from `providers.json`, together with the consumer's exact `Arrow/25.0.1`
+module dependency; native compilation and installed-module qualification remain
+pending. The adjacent `easybuild-2024a-polars-overlay` resolves Polars and its dated-nightly
 Rust source boundary; native build and installed-module qualification remain pending.
 The adjacent `easybuild-2024a-rust-overlay` supplies source-bound
 Pydantic and JSON Schema providers, including the required newer rpds-py. Preserve

--- a/packaging/easybuild-overlay/manifest.json
+++ b/packaging/easybuild-overlay/manifest.json
@@ -40,7 +40,7 @@
     "LICENSE.easybuild-easyblocks": "8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643",
     "LICENSE.easybuild-framework": "8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643",
     "NOTICE": "28ff3751aef534dcb220c3d88e63bf1d3b9535019ef0b89d947d5973110e54e9",
-    "README.md": "63028c7c729752aba4628d7d0e8029801b594966ec762a4d55686d1b127f6558",
+    "README.md": "b769001f501110f1ebca221a17931a6d584081838fb77eb8cb02e8da0427000c",
     "catalogue-reference/BLIS-1.0-GCC-13.3.0.eb": "90b21b6f7ff4da454fa8ceeceed86efc4d3df14db213aa242b6df24e96b9e10a",
     "catalogue-reference/FlexiBLAS-3.4.4-GCC-13.3.0.eb": "89c1026a52327d6edf33effb43af28fcdda9cf186f18c3263c3c1487ad591170",
     "catalogue-reference/ICU-75.1-GCCcore-13.3.0.eb": "89655466a3964d531eb3c36f524d697dda3aaa121edb4242bda730d0372866d2",
@@ -61,7 +61,7 @@
     "evidence/support-source-smoke.json": "c47184212972d63403a926c4ac3bb8708e05e2746e63c0db22fd1bc2cb56883c",
     "evidence/support-source-smoke.log": "213a3411b7432caaf73bd8f837551eb64e9b8d15891ff38ae5d3923a5106b454",
     "history/manifest-0b43545c.json": "5c16a76588db712e1e6c044cc86b83a3c3842fb7dbdbadfc56042be13f163174",
-    "providers.json": "868d40cd2d18be5e227189a6bd02c15ad477b3463b3f04c9a9179df1d88a5d79",
+    "providers.json": "5ba158176be8230f20c2bc4562633ccb0d1cf946d89c9f112bc0cf6592248615",
     "scientific-consumer-sources.json": "a11019c4b655cfc990ddbb0393eb967874986f75dd02c85b452cc05988de400e",
     "source-manifest-python31214.json": "a7a7b146f18c07628785dc7969be41e259eae0ef05fb8f794a972030d3bcebbe",
     "source-manifest.json": "bfee658562db323e1af1c371017de5542121812254c52d7212e90ee4fc8596de"

--- a/packaging/easybuild-overlay/providers.json
+++ b/packaging/easybuild-overlay/providers.json
@@ -329,9 +329,7 @@
       ]
     }
   },
-  "deferred_voiage_dependencies": [
-    "pyarrow"
-  ],
+  "deferred_voiage_dependencies": [],
   "foss_2023a_prepared": false,
   "whole_voiage_graph_resolved": false,
   "build_only_provider_overrides": {
@@ -346,6 +344,19 @@
   "external_provider_overlays": {
     "pydantic": "packaging/easybuild-2024a-rust-overlay",
     "jsonschema": "packaging/easybuild-2024a-rust-overlay",
-    "polars": "packaging/easybuild-2024a-polars-overlay"
+    "polars": "packaging/easybuild-2024a-polars-overlay",
+    "pyarrow": "packaging/easybuild-2024a-arrow-overlay"
+  },
+  "external_provider_evidence": {
+    "pyarrow": {
+      "version": "25.0.1",
+      "manifest": "packaging/easybuild-2024a-arrow-overlay/manifest.json",
+      "manifest_sha256": "de736380795902122bd0a25a1f05c7d07589f5e5b874bb2b539e9a20d5db7a66",
+      "native_build_executed": false,
+      "full_voiage_ready": false,
+      "consumer_recipe": "packaging/easybuild/voiage-2.2.0-foss-2024a.eb",
+      "consumer_recipe_sha256": "372e30dee9f40874514ac09c89c61d9cf3677f80edabda0cebb49955540b365f",
+      "consumer_dependency": "Arrow/25.0.1"
+    }
   }
 }

--- a/packaging/easybuild/voiage-2.2.0-foss-2024a.eb
+++ b/packaging/easybuild/voiage-2.2.0-foss-2024a.eb
@@ -28,7 +28,7 @@ dependencies = [
     ('pandas', '2.3.3'),
     ('xarray', '2024.11.0'),
     ('scikit-learn', '1.7.2'),
-    ('PyArrow', '25.0.0'),
+    ('Arrow', '25.0.1'),
     ('Polars', '1.42.1'),
     ('pydantic', '2.13.4'),
     ('jsonschema', '4.26.0'),

--- a/tests/test_easybuild_overlay.py
+++ b/tests/test_easybuild_overlay.py
@@ -208,11 +208,12 @@ def test_robot_and_source_smoke_are_distinct_from_native_build_evidence() -> Non
     providers = json.loads((ROOT / "providers.json").read_text())
     assert providers["foss_2023a_prepared"] is False
     assert providers["whole_voiage_graph_resolved"] is False
-    assert set(providers["deferred_voiage_dependencies"]) == {"pyarrow"}
+    assert providers["deferred_voiage_dependencies"] == []
     assert providers["external_provider_overlays"] == {
         "pydantic": "packaging/easybuild-2024a-rust-overlay",
         "jsonschema": "packaging/easybuild-2024a-rust-overlay",
         "polars": "packaging/easybuild-2024a-polars-overlay",
+        "pyarrow": "packaging/easybuild-2024a-arrow-overlay",
     }
 
 
@@ -323,3 +324,87 @@ def test_ctypes_refresh_changes_context_only_and_security_sources_are_bound() ->
         "a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8",
         openssl["sha256"],
     )
+
+
+def _validate_pyarrow_provider_integration(providers: dict[str, object]) -> None:
+    assert providers["deferred_voiage_dependencies"] == []
+    assert "pyarrow" not in providers["providers"]
+    overlays = providers["external_provider_overlays"]
+    evidence = providers["external_provider_evidence"]
+    assert isinstance(overlays, dict)
+    assert isinstance(evidence, dict)
+    assert overlays["pyarrow"] == "packaging/easybuild-2024a-arrow-overlay"
+    assert evidence == {
+        "pyarrow": {
+            "version": "25.0.1",
+            "manifest": "packaging/easybuild-2024a-arrow-overlay/manifest.json",
+            "manifest_sha256": "de736380795902122bd0a25a1f05c7d07589f5e5b874bb2b539e9a20d5db7a66",
+            "native_build_executed": False,
+            "full_voiage_ready": False,
+            "consumer_recipe": "packaging/easybuild/voiage-2.2.0-foss-2024a.eb",
+            "consumer_recipe_sha256": "372e30dee9f40874514ac09c89c61d9cf3677f80edabda0cebb49955540b365f",
+            "consumer_dependency": "Arrow/25.0.1",
+        }
+    }
+    binding = evidence["pyarrow"]
+    assert isinstance(binding, dict)
+    manifest_path = ROOT.parents[1] / binding["manifest"]
+    assert (
+        hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        == binding["manifest_sha256"]
+    )
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["arrow_version"] == binding["version"]
+    assert manifest["native_arrow_build_executed"] is False
+    assert manifest["full_voiage_ready"] is False
+    consumer_path = ROOT.parents[1] / binding["consumer_recipe"]
+    assert (
+        hashlib.sha256(consumer_path.read_bytes()).hexdigest()
+        == binding["consumer_recipe_sha256"]
+    )
+    consumer = _recipe(consumer_path)
+    assert ("Arrow", "25.0.1") in consumer["dependencies"]
+    assert not any(name == "PyArrow" for name, *_ in consumer["dependencies"])
+    assert binding["consumer_dependency"] == "Arrow/25.0.1"
+
+
+def test_pyarrow_external_provider_is_bound_and_fail_closed() -> None:
+    providers = json.loads((ROOT / "providers.json").read_text())
+    _validate_pyarrow_provider_integration(providers)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "deferred",
+        "path",
+        "digest",
+        "native",
+        "full",
+        "version",
+        "consumer_digest",
+        "consumer_dependency",
+    ],
+)
+def test_pyarrow_external_provider_rejects_mutated_evidence(mutation: str) -> None:
+    providers = json.loads((ROOT / "providers.json").read_text())
+    mutated = copy.deepcopy(providers)
+    binding = mutated["external_provider_evidence"]["pyarrow"]
+    if mutation == "deferred":
+        mutated["deferred_voiage_dependencies"] = ["pyarrow"]
+    elif mutation == "path":
+        mutated["external_provider_overlays"]["pyarrow"] = "packaging/missing"
+    elif mutation == "digest":
+        binding["manifest_sha256"] = "0" * 64
+    elif mutation == "native":
+        binding["native_build_executed"] = True
+    elif mutation == "full":
+        binding["full_voiage_ready"] = True
+    elif mutation == "consumer_digest":
+        binding["consumer_recipe_sha256"] = "0" * 64
+    elif mutation == "consumer_dependency":
+        binding["consumer_dependency"] = "PyArrow/25.0.0"
+    else:
+        binding["version"] = "25.0.0"
+    with pytest.raises((AssertionError, FileNotFoundError)):
+        _validate_pyarrow_provider_integration(mutated)

--- a/tests/test_hpc_packaging.py
+++ b/tests/test_hpc_packaging.py
@@ -43,10 +43,19 @@ def test_easyconfig_runtime_pins_satisfy_release_requirements(year: str) -> None
         name.lower().replace("_", "-"): version
         for name, version in config["dependencies"]
     }
+    if year == "2024a":
+        assert "pyarrow" not in pins
+        assert pins["arrow"] == "25.0.1"
+        pins["pyarrow"] = pins["arrow"]
+    else:
+        assert pins["pyarrow"] == "25.0.0"
     for text in requirements:
         requirement = Requirement(text)
         assert pins[requirement.name.lower().replace("_", "-")] in requirement.specifier
-    assert {name: pins[name] for name in smoke.RUNTIME_PINS} == smoke.RUNTIME_PINS
+    expected_runtime_pins = dict(smoke.RUNTIME_PINS)
+    if year == "2024a":
+        expected_runtime_pins["pyarrow"] = "25.0.1"
+    assert {name: pins[name] for name in expected_runtime_pins} == expected_runtime_pins
     assert config["version"] == "2.2.0"
     assert config["toolchain"] == {"name": "foss", "version": year}
     assert config["checksums"] == [smoke.SOURCE_SHA256]

--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,7 @@ This document lists the actionable tasks for `voiage` development. Agents should
     cleanup. Keep unsatisfied human and external outcomes open.
     *   [x] Add the stable Rust, Pydantic 2.13.4 and JSON Schema 4.26.0 provider layer for EasyBuild 2024a; native module qualification remains pending.
     *   [x] Add the Polars 1.42.1 provider layer for EasyBuild 2024a with a distinct dated-nightly Rust compiler; native module qualification remains pending.
+    *   [x] Integrate the Arrow and PyArrow 25.0.1 EasyBuild 2024a provider overlay into the parent provider contract; native module qualification remains pending.
     *   [x] Add checksum-bound xarray 2024.11.0 and scikit-learn 1.7.2 provider recipes for both EasyBuild generations; native module qualification remains pending.
     *   [x] Enforce the NLTK 3.10.3 manuscript-tool security floor and retain a
         bounded disposition for the unpatched model-persistence advisory.


### PR DESCRIPTION
The parent EasyBuild 2024a provider contract still classified PyArrow as deferred even though the checksum-bound Arrow/PyArrow 25.0.1 overlay is already present. That leaves the aggregate provider state inconsistent and obscures the remaining native qualification boundary.

This change registers the adjacent Arrow overlay as the PyArrow provider, binds its exact manifest path, SHA-256 and version, and removes the stale deferred entry. The contract continues to record native build and full-stack readiness as false. Mutation tests reject re-deferral, path, digest, version, and false native/full readiness changes. The parent manifest, documentation, changelog and task ledger are synchronized.

Validation:
- `uv run pytest -q tests/test_easybuild_overlay.py tests/test_easybuild_arrow_overlay.py` (29 passed)
- Ruff and `git diff --check`
- full `tox -p 3` (15 environments passed, 1695.32 seconds; coverage 4712 passed, 16 skipped)

Related to #1025.
