### PR TITLE
Fix EasyBuild 2024a Polars module binding

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+- Correct the EasyBuild 2024a root graph to request the lowercase `polars`
+  module name declared by the checksum-bound Polars recipe; native build and
+  full-stack qualification remain pending.
+
 - Integrate the checksum-bound Arrow and PyArrow 25.0.1 EasyBuild 2024a provider overlay into the parent provider contract while retaining native build and full-stack qualification as pending gates.
 
 - Added a checksum-bound Arrow and PyArrow 25.0.1 provider overlay for the

--- a/packaging/easybuild-overlay/manifest.json
+++ b/packaging/easybuild-overlay/manifest.json
@@ -61,7 +61,7 @@
     "evidence/support-source-smoke.json": "c47184212972d63403a926c4ac3bb8708e05e2746e63c0db22fd1bc2cb56883c",
     "evidence/support-source-smoke.log": "213a3411b7432caaf73bd8f837551eb64e9b8d15891ff38ae5d3923a5106b454",
     "history/manifest-0b43545c.json": "5c16a76588db712e1e6c044cc86b83a3c3842fb7dbdbadfc56042be13f163174",
-    "providers.json": "5ba158176be8230f20c2bc4562633ccb0d1cf946d89c9f112bc0cf6592248615",
+    "providers.json": "2c011f64a67873d054460de63ae6399b14c8d22ef235314e867218f8f21fbaef",
     "scientific-consumer-sources.json": "a11019c4b655cfc990ddbb0393eb967874986f75dd02c85b452cc05988de400e",
     "source-manifest-python31214.json": "a7a7b146f18c07628785dc7969be41e259eae0ef05fb8f794a972030d3bcebbe",
     "source-manifest.json": "bfee658562db323e1af1c371017de5542121812254c52d7212e90ee4fc8596de"

--- a/packaging/easybuild-overlay/providers.json
+++ b/packaging/easybuild-overlay/providers.json
@@ -348,6 +348,16 @@
     "pyarrow": "packaging/easybuild-2024a-arrow-overlay"
   },
   "external_provider_evidence": {
+    "polars": {
+      "version": "1.42.1",
+      "manifest": "packaging/easybuild-2024a-polars-overlay/manifest.json",
+      "manifest_sha256": "f13c67822c5bed7558ba818aba44e4bcf790ae998c9c69509c806ec962b3c978",
+      "native_build_executed": false,
+      "full_voiage_ready": false,
+      "consumer_recipe": "packaging/easybuild/voiage-2.2.0-foss-2024a.eb",
+      "consumer_recipe_sha256": "ec947fec1e8285f1bd127cbc73ae55b45fe8047c687fcd5548ecc4b8507fe903",
+      "consumer_dependency": "polars/1.42.1"
+    },
     "pyarrow": {
       "version": "25.0.1",
       "manifest": "packaging/easybuild-2024a-arrow-overlay/manifest.json",
@@ -355,7 +365,7 @@
       "native_build_executed": false,
       "full_voiage_ready": false,
       "consumer_recipe": "packaging/easybuild/voiage-2.2.0-foss-2024a.eb",
-      "consumer_recipe_sha256": "372e30dee9f40874514ac09c89c61d9cf3677f80edabda0cebb49955540b365f",
+      "consumer_recipe_sha256": "ec947fec1e8285f1bd127cbc73ae55b45fe8047c687fcd5548ecc4b8507fe903",
       "consumer_dependency": "Arrow/25.0.1"
     }
   }

--- a/packaging/easybuild/voiage-2.2.0-foss-2024a.eb
+++ b/packaging/easybuild/voiage-2.2.0-foss-2024a.eb
@@ -29,7 +29,7 @@ dependencies = [
     ('xarray', '2024.11.0'),
     ('scikit-learn', '1.7.2'),
     ('Arrow', '25.0.1'),
-    ('Polars', '1.42.1'),
+    ('polars', '1.42.1'),
     ('pydantic', '2.13.4'),
     ('jsonschema', '4.26.0'),
     ('typing_extensions', '4.16.0'),

--- a/tests/test_easybuild_2024a_polars_overlay.py
+++ b/tests/test_easybuild_2024a_polars_overlay.py
@@ -30,9 +30,11 @@ class _Names(ast.NodeTransformer):
         return node
 
 
-def _recipe(name: str) -> dict[str, Any]:
-    values: dict[str, Any] = {"SYSTEM": {"name": "system", "version": ""}}
-    path = ROOT / "2024a" / name
+def _recipe_path(path: Path) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "SOURCE_TAR_GZ": "source.tar.gz",
+        "SYSTEM": {"name": "system", "version": ""},
+    }
     for node in ast.parse(path.read_text()).body:
         if not isinstance(node, ast.Assign):
             continue
@@ -41,6 +43,10 @@ def _recipe(name: str) -> dict[str, Any]:
             if isinstance(target, ast.Name):
                 values[target.id] = value
     return values
+
+
+def _recipe(name: str) -> dict[str, Any]:
+    return _recipe_path(ROOT / "2024a" / name)
 
 
 def test_manifest_binds_every_retained_byte_and_fail_closed_flags() -> None:
@@ -226,6 +232,16 @@ def test_recipes_preserve_stable_and_dated_nightly_compiler_roles() -> None:
         assert recipe["pip_no_index"] is True
         assert recipe["download_dep_fail"] is True
         assert recipe["sanity_pip_check"] is True
+
+
+def test_root_consumer_uses_the_recipe_declared_lowercase_module_name() -> None:
+    root_recipe = _recipe_path(
+        ROOT.parents[1] / "packaging/easybuild/voiage-2.2.0-foss-2024a.eb"
+    )
+    polars_recipe = _recipe("polars-1.42.1-GCCcore-13.3.0.eb")
+    assert polars_recipe["name"] == "polars"
+    assert ("polars", "1.42.1") in root_recipe["dependencies"]
+    assert not any(name == "Polars" for name, *_ in root_recipe["dependencies"])
 
 
 def test_provider_roles_and_robot_evidence_match_recipes() -> None:

--- a/tests/test_easybuild_overlay.py
+++ b/tests/test_easybuild_overlay.py
@@ -326,15 +326,26 @@ def test_ctypes_refresh_changes_context_only_and_security_sources_are_bound() ->
     )
 
 
-def _validate_pyarrow_provider_integration(providers: dict[str, object]) -> None:
+def _validate_external_provider_integration(providers: dict[str, object]) -> None:
     assert providers["deferred_voiage_dependencies"] == []
     assert "pyarrow" not in providers["providers"]
     overlays = providers["external_provider_overlays"]
     evidence = providers["external_provider_evidence"]
     assert isinstance(overlays, dict)
     assert isinstance(evidence, dict)
+    assert overlays["polars"] == "packaging/easybuild-2024a-polars-overlay"
     assert overlays["pyarrow"] == "packaging/easybuild-2024a-arrow-overlay"
     assert evidence == {
+        "polars": {
+            "version": "1.42.1",
+            "manifest": "packaging/easybuild-2024a-polars-overlay/manifest.json",
+            "manifest_sha256": "f13c67822c5bed7558ba818aba44e4bcf790ae998c9c69509c806ec962b3c978",
+            "native_build_executed": False,
+            "full_voiage_ready": False,
+            "consumer_recipe": "packaging/easybuild/voiage-2.2.0-foss-2024a.eb",
+            "consumer_recipe_sha256": "ec947fec1e8285f1bd127cbc73ae55b45fe8047c687fcd5548ecc4b8507fe903",
+            "consumer_dependency": "polars/1.42.1",
+        },
         "pyarrow": {
             "version": "25.0.1",
             "manifest": "packaging/easybuild-2024a-arrow-overlay/manifest.json",
@@ -342,10 +353,29 @@ def _validate_pyarrow_provider_integration(providers: dict[str, object]) -> None
             "native_build_executed": False,
             "full_voiage_ready": False,
             "consumer_recipe": "packaging/easybuild/voiage-2.2.0-foss-2024a.eb",
-            "consumer_recipe_sha256": "372e30dee9f40874514ac09c89c61d9cf3677f80edabda0cebb49955540b365f",
+            "consumer_recipe_sha256": "ec947fec1e8285f1bd127cbc73ae55b45fe8047c687fcd5548ecc4b8507fe903",
             "consumer_dependency": "Arrow/25.0.1",
-        }
+        },
     }
+    polars_binding = evidence["polars"]
+    assert isinstance(polars_binding, dict)
+    polars_manifest_path = ROOT.parents[1] / polars_binding["manifest"]
+    assert (
+        hashlib.sha256(polars_manifest_path.read_bytes()).hexdigest()
+        == polars_binding["manifest_sha256"]
+    )
+    polars_manifest = json.loads(polars_manifest_path.read_text())
+    assert polars_manifest["native_builds_executed"] is False
+    assert polars_manifest["full_voiage_graph"] is False
+    polars_consumer_path = ROOT.parents[1] / polars_binding["consumer_recipe"]
+    assert (
+        hashlib.sha256(polars_consumer_path.read_bytes()).hexdigest()
+        == polars_binding["consumer_recipe_sha256"]
+    )
+    polars_consumer = _recipe(polars_consumer_path)
+    assert ("polars", "1.42.1") in polars_consumer["dependencies"]
+    assert not any(name == "Polars" for name, *_ in polars_consumer["dependencies"])
+    assert polars_binding["consumer_dependency"] == "polars/1.42.1"
     binding = evidence["pyarrow"]
     assert isinstance(binding, dict)
     manifest_path = ROOT.parents[1] / binding["manifest"]
@@ -370,7 +400,7 @@ def _validate_pyarrow_provider_integration(providers: dict[str, object]) -> None
 
 def test_pyarrow_external_provider_is_bound_and_fail_closed() -> None:
     providers = json.loads((ROOT / "providers.json").read_text())
-    _validate_pyarrow_provider_integration(providers)
+    _validate_external_provider_integration(providers)
 
 
 @pytest.mark.parametrize(
@@ -407,4 +437,30 @@ def test_pyarrow_external_provider_rejects_mutated_evidence(mutation: str) -> No
     else:
         binding["version"] = "25.0.0"
     with pytest.raises((AssertionError, FileNotFoundError)):
-        _validate_pyarrow_provider_integration(mutated)
+        _validate_external_provider_integration(mutated)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["path", "digest", "native", "full", "version", "consumer_digest", "name"],
+)
+def test_polars_external_provider_rejects_mutated_evidence(mutation: str) -> None:
+    providers = json.loads((ROOT / "providers.json").read_text())
+    mutated = copy.deepcopy(providers)
+    binding = mutated["external_provider_evidence"]["polars"]
+    if mutation == "path":
+        mutated["external_provider_overlays"]["polars"] = "packaging/missing"
+    elif mutation == "digest":
+        binding["manifest_sha256"] = "0" * 64
+    elif mutation == "native":
+        binding["native_build_executed"] = True
+    elif mutation == "full":
+        binding["full_voiage_ready"] = True
+    elif mutation == "version":
+        binding["version"] = "1.42.0"
+    elif mutation == "consumer_digest":
+        binding["consumer_recipe_sha256"] = "0" * 64
+    else:
+        binding["consumer_dependency"] = "Polars/1.42.1"
+    with pytest.raises((AssertionError, FileNotFoundError)):
+        _validate_external_provider_integration(mutated)

--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
     cleanup. Keep unsatisfied human and external outcomes open.
     *   [x] Add the stable Rust, Pydantic 2.13.4 and JSON Schema 4.26.0 provider layer for EasyBuild 2024a; native module qualification remains pending.
     *   [x] Add the Polars 1.42.1 provider layer for EasyBuild 2024a with a distinct dated-nightly Rust compiler; native module qualification remains pending.
+    *   [x] Reconcile the EasyBuild 2024a root dependency with the provider's
+        lowercase `polars` module name; native full-graph qualification remains
+        pending.
     *   [x] Integrate the Arrow and PyArrow 25.0.1 EasyBuild 2024a provider overlay into the parent provider contract; native module qualification remains pending.
     *   [x] Add checksum-bound xarray 2024.11.0 and scikit-learn 1.7.2 provider recipes for both EasyBuild generations; native module qualification remains pending.
     *   [x] Add the checksum-bound Arrow and PyArrow 25.0.1 provider layer for EasyBuild 2023a; native module qualification remains pending.


### PR DESCRIPTION
The EasyBuild 2024a root recipe requested `Polars/1.42.1`, while the checksum-bound provider recipe declares the lowercase module `polars/1.42.1`. That case mismatch prevents the parent graph from resolving the retained provider.

This change binds the root dependency to the recipe-declared lowercase name, records the Polars overlay as immutable external provider evidence, refreshes the affected manifest hashes, and adds mutation-resistant integration coverage. Native build and full Voiage graph qualification remain pending.

Validation:
- `uv lock --upgrade`, restored unchanged project lock, then `python scripts/dependency_frontier.py . --strict`
- focused EasyBuild overlay tests: 33 passed
- Ruff: passed
- full `tox -p 3`: all 15 environments passed

Related to #1025 and #1053.
