### PR TITLE
docs(readiness): refresh cross-venue evidence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@
   overlays and retain sanitized 108-module robot evidence, while keeping native
   build and installed-module qualification pending.
 
+- Refresh the cross-venue evidence contract for the current v2.2 release,
+  pyOpenSci-first execution, language bindings, and HPC package state while
+  binding the final EasyBuild root merge and retaining native builds,
+  submissions, and venue outcomes as explicit pending gates.
+
 - Add a checksum-bound, offline Polars 1.42.1 EasyBuild 2023a provider with an exact dated-nightly Rust boundary and canonical Voiage consumer binding; native build, full-stack and upstream gates remain false.
 
 - Correct the EasyBuild 2024a root graph to request the lowercase `polars`

--- a/conductor/tracks/remaining_backlog_delivery_20260831/remaining-issue-register-20260831.md
+++ b/conductor/tracks/remaining_backlog_delivery_20260831/remaining-issue-register-20260831.md
@@ -20,7 +20,7 @@ authoritative. The dependency dashboard is ongoing operational tracking.
 | #656 | Healthy Renovate operation and actual Codecov OIDC upload/status | Repair controls, merge through protected checks, then verify the external service result |
 | #620 | Public Scorecard 10/10 outcome | Retain honest solo-maintainer exceptions; do not fabricate review or contributor diversity |
 | #615 | R distribution evidence and distinct-article assessment | Preserve technical installation/standards evidence; defer a duplicate R Journal manuscript |
-| #614 | Current cross-venue contracts and unfinished child evidence | Refresh active routing and evidence after each merged change |
+| #614 | Current cross-venue contracts and unfinished child evidence | The successor refresh routes current work through #1037 and #1025 and binds PR #1087's tree-equal final-root merge; native HPC qualification and all venue actions/outcomes remain pending |
 | #555 | Accepted Yggdrasil/JLL and General registration/indexing | Keep upstream acceptance separate from local ABI/build evidence |
 | #471 | Genuine non-author research use and attributable engagement | Retain historical use and automated replay without inventing new human participation |
 | #312 | Journal-first prerequisite, later arXiv action and announcement | Preserve historical attempts; do not present the incomplete replacement as a submission |

--- a/roadmap.md
+++ b/roadmap.md
@@ -331,15 +331,18 @@ acceptance evidence.
 The same track now owns a versioned cross-venue submission contract covering
 all retained package registries and archives plus potential pyOpenSci,
 rOpenSci, R Journal, Journal of Statistical Software, NumFOCUS, HPSF, and
-related routes. Issues #614--#617 own the contract and future decision lanes.
+related routes. Issues #614--#617 supplied the historical contract and decision
+lanes; current execution is reconciled through the active owners below.
 The repository validates evidence paths, unresolved gates, and authority
 boundaries in tox and hosted CI. Passing that gate means the repository is
 prepared to evaluate a route; it does not authorize an inquiry or submission.
-The next execution sequence is issue-backed: #614 maintains all contract
-evidence; #616 closes Python community-review evidence; #615 closes the R
-installation/API/statistical-standards evidence; #622 prepares portable HPC
-recipes; and #617 makes explicit non-duplication decisions for distinct future
-routes. Author and external decisions remain outside these repository tasks.
+The current execution sequence is issue-backed: #614 maintains all contract
+evidence; #296 owns the paper, journal, and identifier boundaries; #1037 owns
+the pyOpenSci-first route; #615 retains the R review lane; #1025 owns current
+HPC build and package evidence; and #1026 retains sustainability and persistent
+identifier work after #617's completed non-duplication assessment. Historical
+#616 and #622 supplied repository readiness and initial HPC recipe evidence.
+Author and external decisions remain outside these repository tasks.
 
 Conductor-to-GitHub traceability is complete and archived in
 `conductor/archive/conductor-github-cross-reference-reconciliation_20260724/`.

--- a/scripts/validate_submission_readiness.py
+++ b/scripts/validate_submission_readiness.py
@@ -10,6 +10,54 @@ import shutil
 import subprocess
 from typing import Any
 
+ROOT_REFRESH_PLACEHOLDER = "REPLACE_AFTER_FINAL_ROOT_PR_MERGES"
+CURRENT_ISSUE_LANES = {
+    "contract": 614,
+    "paper_and_author_boundaries": 296,
+    "python_community_review": 1037,
+    "r_community_and_journal_readiness": 615,
+    "distinct_publication_and_sustainability_assessment": 1026,
+    "hpc_distribution": 1025,
+}
+HISTORICAL_COMPLETED_ISSUE_LANES = {
+    "paper_and_author_boundaries": 299,
+    "python_community_repository_readiness": 616,
+    "distinct_publication_and_sustainability_assessment": 617,
+    "initial_hpc_recipe_contract": 622,
+}
+EXPECTED_EXECUTION_LANE_ISSUES = {
+    "contract-maintenance": 614,
+    "paper-and-author-boundaries": 296,
+    "python-community-review": 1037,
+    "r-community-and-journal-readiness": 615,
+    "distinct-publication-and-sustainability-assessment": 1026,
+    "hpc-distribution-readiness": 1025,
+}
+EXPECTED_RELEASE_EVIDENCE = {
+    "version": "2.2.0",
+    "release_commit": "7af563c8cb373057d30662650b3f332f39e05b83",
+    "github_and_pypi_published": True,
+}
+EXPECTED_FINAL_ROOT_BASE = "fea90d41898ac31c970b0c2b7a8a80ef3366ab96"
+EXPECTED_FINAL_ROOT_PR = {
+    "number": 1087,
+    "head_sha": "614224cf4cab2514ece333345ff25f7441fddeba",
+    "merge_sha": EXPECTED_FINAL_ROOT_BASE,
+    "reviewed_tree": "44a79dedb8cf4c8ce6a62f12d549bb6e7585b2ef",
+    "merged_tree": "44a79dedb8cf4c8ce6a62f12d549bb6e7585b2ef",
+    "tree_equal": True,
+    "terminal_checks": 40,
+}
+EXPECTED_EXTERNAL_OUTCOMES = {
+    "pyopensci_acceptance": "pending_external",
+    "joss_acceptance": "pending_external",
+    "arxiv_announcement": "pending_external",
+    "spack_upstream_acceptance": "pending_external",
+    "easybuild_upstream_acceptance": "pending_external",
+    "binarybuilder_jll_acceptance": "pending_external",
+    "julia_general_indexing": "pending_external",
+}
+
 READINESS = {"published", "ready", "conditional", "blocked", "consideration", "retired"}
 REQUIREMENT_STATUS = {"satisfied", "pending", "external", "not_applicable"}
 TARGET_KINDS = {
@@ -219,6 +267,113 @@ def validate_contract(path: Path, root: Path) -> dict[str, Any]:
     payload: Any = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict) or payload.get("schema_version") != "1.0":
         raise ValueError("submission contract must use schema_version 1.0")
+
+    evidence_refresh = payload.get("evidence_refresh")
+    if not isinstance(evidence_refresh, dict):
+        raise TypeError("evidence_refresh must be an object")
+    _non_empty(evidence_refresh.get("reviewed_at"), "evidence_refresh reviewed_at")
+    refresh_path = Path(
+        _non_empty(evidence_refresh.get("evidence"), "evidence_refresh evidence")
+    )
+    if refresh_path.is_absolute() or ".." in refresh_path.parts:
+        raise ValueError("evidence_refresh evidence path is unsafe")
+    if not (root / refresh_path).is_file():
+        raise ValueError("evidence_refresh evidence path does not exist")
+    refresh_record: Any = json.loads((root / refresh_path).read_text(encoding="utf-8"))
+    expected_refresh_sha = evidence_refresh.get("evidence_sha256")
+    actual_refresh_sha = hashlib.sha256((root / refresh_path).read_bytes()).hexdigest()
+    if expected_refresh_sha != actual_refresh_sha:
+        raise ValueError("evidence_refresh record SHA-256 does not match")
+    if (
+        not isinstance(refresh_record, dict)
+        or refresh_record.get("schema_version")
+        != "voiage.cross-venue-evidence-refresh.v1"
+        or refresh_record.get("reviewed_at") != evidence_refresh.get("reviewed_at")
+        or refresh_record.get("state") != evidence_refresh.get("state")
+        or refresh_record.get("final_root_pr") != evidence_refresh.get("final_root_pr")
+    ):
+        raise ValueError("evidence_refresh record binding is invalid")
+    if refresh_record.get("current_issue_lanes") != CURRENT_ISSUE_LANES:
+        raise ValueError("evidence_refresh current issue lanes are stale")
+    if (
+        refresh_record.get("historical_completed_issue_lanes")
+        != HISTORICAL_COMPLETED_ISSUE_LANES
+    ):
+        raise ValueError("evidence_refresh historical issue lanes are stale")
+    if refresh_record.get("release") != EXPECTED_RELEASE_EVIDENCE:
+        raise ValueError("evidence_refresh release evidence is stale")
+    if refresh_record.get("external_outcomes") != EXPECTED_EXTERNAL_OUTCOMES:
+        raise ValueError("evidence_refresh external outcomes must remain pending")
+    repository_state = refresh_record.get("repository_state")
+    expected_repository_state = {
+        "pyopensci_declarations_confirmed": True,
+        "pyopensci_survey_completed": False,
+        "pyopensci_human_written_submission_supplied": False,
+        "pyopensci_submission_performed": False,
+        "joss_submission_performed": False,
+        "arxiv_submission_currently_verified": False,
+        "spack_recipe_prepared": True,
+        "spack_current_native_build_complete": False,
+        "spack_upstream_submission_performed": False,
+        "easybuild_provider_recipes_prepared": True,
+        "easybuild_final_root_graph_merged": evidence_refresh.get("state")
+        == "complete",
+        "easybuild_native_foss_builds_complete": False,
+        "easybuild_upstream_submission_performed": False,
+        "yggdrasil_v2_2_update_submitted": False,
+        "binarybuilder_jll_accepted": False,
+        "julia_general_registration_submitted": False,
+        "julia_general_indexed": False,
+    }
+    if repository_state != expected_repository_state:
+        raise ValueError("evidence_refresh repository state is incomplete or stale")
+    base_main = refresh_record.get("base_main")
+    if (
+        not isinstance(base_main, str)
+        or len(base_main) != 40
+        or any(character not in "0123456789abcdef" for character in base_main)
+    ):
+        raise ValueError("evidence_refresh base_main must be an exact commit")
+    root_pr = evidence_refresh.get("final_root_pr")
+    if not isinstance(root_pr, dict):
+        raise TypeError("evidence_refresh final_root_pr must be an object")
+    if evidence_refresh.get("state") == "awaiting_final_root_pr_merge":
+        if root_pr != {
+            "number": None,
+            "head_sha": None,
+            "merge_sha": None,
+            "reviewed_tree": None,
+            "merged_tree": None,
+            "tree_equal": None,
+            "terminal_checks": None,
+            "placeholder": ROOT_REFRESH_PLACEHOLDER,
+        }:
+            raise ValueError("pending final-root refresh must retain exact placeholder")
+    elif evidence_refresh.get("state") == "complete":
+        hex_fields = ("head_sha", "merge_sha", "reviewed_tree", "merged_tree")
+        if (
+            not isinstance(root_pr.get("number"), int)
+            or any(
+                not isinstance(root_pr.get(field), str)
+                or len(root_pr[field]) != 40
+                or any(
+                    character not in "0123456789abcdef" for character in root_pr[field]
+                )
+                for field in hex_fields
+            )
+            or root_pr.get("reviewed_tree") != root_pr.get("merged_tree")
+            or root_pr.get("tree_equal") is not True
+            or not isinstance(root_pr.get("terminal_checks"), int)
+            or root_pr["terminal_checks"] < 1
+            or "placeholder" in root_pr
+        ):
+            raise ValueError(
+                "complete final-root refresh lacks authoritative merge evidence"
+            )
+        if root_pr != EXPECTED_FINAL_ROOT_PR or base_main != EXPECTED_FINAL_ROOT_BASE:
+            raise ValueError("complete final-root refresh is not bound to PR #1087")
+    else:
+        raise ValueError("evidence_refresh state must be pending or complete")
     targets = payload.get("targets")
     if not isinstance(targets, list) or not targets:
         raise ValueError("submission contract targets must be a non-empty array")
@@ -298,6 +453,11 @@ def validate_contract(path: Path, root: Path) -> dict[str, Any]:
     required = payload.get("required_target_ids")
     if not isinstance(required, list) or not set(required) <= identifiers:
         raise ValueError("required_target_ids must resolve to declared targets")
+    refreshed_evidence_targets = evidence_refresh.get("target_ids")
+    if not isinstance(refreshed_evidence_targets, list) or not set(required) <= set(
+        refreshed_evidence_targets
+    ):
+        raise ValueError("evidence_refresh must cover every required target")
 
     criteria_refresh = payload.get("criteria_refresh")
     if not isinstance(criteria_refresh, dict):
@@ -331,6 +491,11 @@ def validate_contract(path: Path, root: Path) -> dict[str, Any]:
         issue_url = _non_empty(lane.get("issue_url"), f"{lane_id} issue_url")
         if not issue_url.startswith("https://github.com/edithatogo/voiage/issues/"):
             raise ValueError(f"{lane_id} issue_url must be a voiage GitHub issue")
+        expected_issue = EXPECTED_EXECUTION_LANE_ISSUES.get(lane_id)
+        if expected_issue is None or issue_url != (
+            f"https://github.com/edithatogo/voiage/issues/{expected_issue}"
+        ):
+            raise ValueError(f"{lane_id} must route to its current open issue")
         _non_empty(lane.get("repository_outcome"), f"{lane_id} repository_outcome")
         lane_targets = lane.get("targets")
         if not isinstance(lane_targets, list) or not lane_targets:
@@ -341,6 +506,8 @@ def validate_contract(path: Path, root: Path) -> dict[str, Any]:
         planned_targets.update(lane_targets)
     if not set(required) <= planned_targets:
         raise ValueError("every required target must belong to an execution lane")
+    if lane_ids != set(EXPECTED_EXECUTION_LANE_ISSUES):
+        raise ValueError("execution lanes must match the current issue routes")
     return {"target_count": len(targets), "targets": sorted(identifiers)}
 
 

--- a/specs/submission-readiness/README.md
+++ b/specs/submission-readiness/README.md
@@ -10,6 +10,12 @@ The dated current baseline is
 revisions used by the canonical comprehensive-hardening track and must be
 refreshed before candidate freeze or any external venue action.
 
+Repository evidence state is refreshed separately in
+`cross-venue-evidence-refresh-20260903.json`. It binds the terminal checks and
+exact tree-equal merge for final-root PR #1087 while retaining native HPC
+qualification and upstream action as pending. A status refresh never extends
+the lifetime of the dated external criteria baseline before an external action.
+
 The contract records repository evidence and outstanding gates without
 authorizing external action. Preparation, submission, review, acceptance,
 publication, and indexing are distinct states. Criteria URLs must be refreshed
@@ -24,14 +30,19 @@ only repository work:
 
 - #614 maintains criteria, evidence, authority, and status boundaries for all
   destinations;
-- #299 maintains the preprint/JOSS/RRID package while preserving author and
-  editorial decisions as external;
-- #616 prepares the Python package for the selected pyOpenSci-first route while
-  preserving inquiry and submission as separate maintainer actions;
+- #296 owns the current paper, journal, and identifier boundaries while #312
+  retains the later-arXiv action; historical #299 supplied the repository
+  manuscript package;
+- #1037 governs the current pyOpenSci-first execution while preserving the
+  private survey, human-written communication, authenticated submission, and
+  venue outcomes as separate gates; historical #616 supplied repository
+  readiness evidence;
 - #615 matures the R package for possible rOpenSci and R Journal routes;
-- #617 records whether a distinct JSS, NumFOCUS, or Zenodo outcome is justified;
-- #622 prepares portable Spack/EasyBuild recipes before any HPC upstream or
-  curation decision.
+- #1026 retains current sustainability and persistent-identifier work after
+  historical #617 recorded the distinct-publication decision;
+- #1025 maintains current Spack/EasyBuild recipe and build evidence before any
+  HPC upstream or curation decision; historical #622 supplied the initial
+  locally testable recipe contract.
 
 No lane authorizes an inquiry, upload, submission, application, review, or
 acceptance claim. Those actions remain human or external even after all

--- a/specs/submission-readiness/cross-venue-evidence-refresh-20260903.json
+++ b/specs/submission-readiness/cross-venue-evidence-refresh-20260903.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "voiage.cross-venue-evidence-refresh.v1",
+  "reviewed_at": "2026-09-03",
+  "state": "complete",
+  "base_main": "fea90d41898ac31c970b0c2b7a8a80ef3366ab96",
+  "final_root_pr": {
+    "number": 1087,
+    "head_sha": "614224cf4cab2514ece333345ff25f7441fddeba",
+    "merge_sha": "fea90d41898ac31c970b0c2b7a8a80ef3366ab96",
+    "reviewed_tree": "44a79dedb8cf4c8ce6a62f12d549bb6e7585b2ef",
+    "merged_tree": "44a79dedb8cf4c8ce6a62f12d549bb6e7585b2ef",
+    "tree_equal": true,
+    "terminal_checks": 40
+  },
+  "current_issue_lanes": {
+    "contract": 614,
+    "paper_and_author_boundaries": 296,
+    "python_community_review": 1037,
+    "r_community_and_journal_readiness": 615,
+    "distinct_publication_and_sustainability_assessment": 1026,
+    "hpc_distribution": 1025
+  },
+  "historical_completed_issue_lanes": {
+    "paper_and_author_boundaries": 299,
+    "python_community_repository_readiness": 616,
+    "distinct_publication_and_sustainability_assessment": 617,
+    "initial_hpc_recipe_contract": 622
+  },
+  "release": {
+    "version": "2.2.0",
+    "release_commit": "7af563c8cb373057d30662650b3f332f39e05b83",
+    "github_and_pypi_published": true
+  },
+  "repository_state": {
+    "pyopensci_declarations_confirmed": true,
+    "pyopensci_survey_completed": false,
+    "pyopensci_human_written_submission_supplied": false,
+    "pyopensci_submission_performed": false,
+    "joss_submission_performed": false,
+    "arxiv_submission_currently_verified": false,
+    "spack_recipe_prepared": true,
+    "spack_current_native_build_complete": false,
+    "spack_upstream_submission_performed": false,
+    "easybuild_provider_recipes_prepared": true,
+    "easybuild_final_root_graph_merged": true,
+    "easybuild_native_foss_builds_complete": false,
+    "easybuild_upstream_submission_performed": false,
+    "yggdrasil_v2_2_update_submitted": false,
+    "binarybuilder_jll_accepted": false,
+    "julia_general_registration_submitted": false,
+    "julia_general_indexed": false
+  },
+  "external_outcomes": {
+    "pyopensci_acceptance": "pending_external",
+    "joss_acceptance": "pending_external",
+    "arxiv_announcement": "pending_external",
+    "spack_upstream_acceptance": "pending_external",
+    "easybuild_upstream_acceptance": "pending_external",
+    "binarybuilder_jll_acceptance": "pending_external",
+    "julia_general_indexing": "pending_external"
+  },
+  "boundary": "This refresh establishes only the tree-equal final EasyBuild root merge. Native HPC qualification, upstream action, authenticated submission, review, acceptance, publication, identifier assignment, and indexing remain pending."
+}

--- a/specs/submission-readiness/targets.json
+++ b/specs/submission-readiness/targets.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "reviewed_at": "2026-08-29",
+  "reviewed_at": "2026-09-03",
   "policy": {
     "states_are_distinct": ["prepared", "submitted", "under_review", "accepted", "published", "indexed"],
     "no_external_action_from_contract": true,
@@ -13,6 +13,22 @@
     "source_manifest": "specs/submission-readiness/current-requirements-source-manifest-20260829.json",
     "target_ids": ["arxiv", "joss", "pyopensci", "ropensci", "r-journal", "journal-of-statistical-software", "numfocus", "pypi", "testpypi", "conda-forge", "cran", "r-universe", "crates-io", "julia-general", "yggdrasil", "software-heritage", "zenodo", "scicrunch-rrid", "spack", "easybuild", "hpsf", "e4s"]
   },
+  "evidence_refresh": {
+    "reviewed_at": "2026-09-03",
+    "state": "complete",
+    "evidence": "specs/submission-readiness/cross-venue-evidence-refresh-20260903.json",
+    "evidence_sha256": "7ed1fd45bf299d8b2e60e326f19158a9b760c187fab4fd4ddd68761358239ca6",
+    "target_ids": ["arxiv", "joss", "pyopensci", "ropensci", "r-journal", "journal-of-statistical-software", "numfocus", "pypi", "testpypi", "conda-forge", "cran", "r-universe", "crates-io", "julia-general", "yggdrasil", "software-heritage", "zenodo", "scicrunch-rrid", "spack", "easybuild", "hpsf", "e4s"],
+    "final_root_pr": {
+      "number": 1087,
+      "head_sha": "614224cf4cab2514ece333345ff25f7441fddeba",
+      "merge_sha": "fea90d41898ac31c970b0c2b7a8a80ef3366ab96",
+      "reviewed_tree": "44a79dedb8cf4c8ce6a62f12d549bb6e7585b2ef",
+      "merged_tree": "44a79dedb8cf4c8ce6a62f12d549bb6e7585b2ef",
+      "tree_equal": true,
+      "terminal_checks": 40
+    }
+  },
   "execution_lanes": [
     {
       "id": "contract-maintenance",
@@ -22,15 +38,15 @@
     },
     {
       "id": "paper-and-author-boundaries",
-      "issue_url": "https://github.com/edithatogo/voiage/issues/299",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/296",
       "targets": ["arxiv", "joss", "scicrunch-rrid"],
       "repository_outcome": "Maintain the locally validated manuscript, metadata package, recorded author affirmations, and developer-use evidence while leaving upload, curation, engagement, and editorial decisions external."
     },
     {
       "id": "python-community-review",
-      "issue_url": "https://github.com/edithatogo/voiage/issues/616",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/1037",
       "targets": ["pyopensci"],
-      "repository_outcome": "Maintain a current criteria-to-evidence matrix and complete all repository-controlled Python-package expectations before an author decides whether to inquire."
+      "repository_outcome": "Maintain the current pyOpenSci packet and explicit survey, human-written communication, authenticated submission, partner-route, and external-outcome boundaries."
     },
     {
       "id": "r-community-and-journal-readiness",
@@ -40,15 +56,15 @@
     },
     {
       "id": "distinct-publication-and-sustainability-assessment",
-      "issue_url": "https://github.com/edithatogo/voiage/issues/617",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/1026",
       "targets": ["journal-of-statistical-software", "numfocus", "zenodo"],
       "repository_outcome": "Record a non-duplication and eligibility decision before creating any venue-specific manuscript, application, or deposition package."
     },
     {
       "id": "hpc-distribution-readiness",
-      "issue_url": "https://github.com/edithatogo/voiage/issues/622",
+      "issue_url": "https://github.com/edithatogo/voiage/issues/1025",
       "targets": ["spack", "easybuild", "hpsf", "e4s"],
-      "repository_outcome": "Create locally validated portable package recipes before any upstream HPC packaging or curation decision."
+      "repository_outcome": "Maintain current recipes, graph evidence, native-build and module-smoke gates, and separate upstream submission, review, and indexing states."
     }
   ],
   "required_target_ids": [
@@ -99,7 +115,8 @@
         {"id": "package-baseline", "status": "satisfied", "evidence": ["README.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", "pyproject.toml"]},
         {"id": "method-provenance-and-overlap", "status": "satisfied", "evidence": ["README.md", "paper.md", "docs/astro-site/src/content/docs/methods/index.mdx"]},
         {"id": "maintenance-commitment", "status": "satisfied", "evidence": ["GOVERNANCE.md", "SUPPORT.md", "docs/release/pyopensci-readiness.md", "specs/submission-readiness/pyopensci-evidence.json"]},
-        {"id": "ai-affirmation", "status": "pending", "evidence": ["paper.md", "paper/joss-editorial-assurance.json", "AI_CONTRIBUTIONS.md", "specs/submission-readiness/pyopensci-submission-staging.json"]}
+        {"id": "ai-affirmation", "status": "satisfied", "evidence": ["AI_CONTRIBUTIONS.md", "AI_USAGE.md", "specs/submission-readiness/pyopensci-submission-staging.json", "conductor/tracks/v2_2_release_and_venue_submissions_20260830/maintainer-venue-decision-20260831.json"]},
+        {"id": "survey-and-human-written-submission", "status": "pending", "evidence": ["docs/release/pyopensci-submission-draft.md", "specs/submission-readiness/pyopensci-submission-staging.json", "conductor/tracks/v2_2_release_and_venue_submissions_20260830/venue-next-actions-20260831.md"]}
       ],
       "acceptance_evidence": ["pyOpenSci review issue", "pyOpenSci approval label and catalogue entry"],
       "next_decision": "Personal declarations are confirmed and previous requests #271 and #272 are withdrawn. Complete the private pre-review survey, supply a human-written submission body, and perform the authenticated pyOpenSci submission. The maintainer's separate commitment to write later review communication personally is confirmed. The subsequent eligible JOSS route is already authorized; arXiv remains deferred until an actual journal submission and later author action."
@@ -170,7 +187,7 @@
       "authority": {"prepare": "repository", "submit": "external-system", "accept": "external"},
       "requirements": [
         {"id": "release-workflow", "status": "satisfied", "evidence": [".github/workflows/release.yml"]},
-        {"id": "published-release", "status": "satisfied", "evidence": ["docs/release/release-evidence.md"]}
+        {"id": "published-release", "status": "satisfied", "evidence": ["specs/submission-readiness/pyopensci-submission-candidate.json", "conductor/tracks/v2_2_release_and_venue_submissions_20260830/release-2.2.0-publication-receipt-20260830.json"]}
       ],
       "acceptance_evidence": ["PyPI version page", "Trusted-publishing provenance"],
       "next_decision": "Maintain tag-driven release and provenance contracts."
@@ -184,7 +201,7 @@
       "authority": {"prepare": "repository", "submit": "external-system", "accept": "external"},
       "requirements": [
         {"id": "test-release-workflow", "status": "satisfied", "evidence": [".github/workflows/release.yml"]},
-        {"id": "install-smoke", "status": "satisfied", "evidence": ["docs/release/release-evidence.md"]}
+        {"id": "install-smoke", "status": "satisfied", "evidence": ["specs/submission-readiness/pyopensci-submission-candidate.json", "conductor/tracks/v2_2_release_and_venue_submissions_20260830/release-2.2.0-publication-receipt-20260830.json"]}
       ],
       "acceptance_evidence": ["TestPyPI version page", "Workflow upload evidence"],
       "next_decision": "Keep as the release-candidate gate before PyPI."
@@ -253,8 +270,8 @@
       "criteria_url": "https://pkgdocs.julialang.org/dev/creating-packages/",
       "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
       "requirements": [
-        {"id": "package-contract", "status": "satisfied", "evidence": ["bindings/julia/Project.toml", "bindings/julia/test/runtests.jl"]},
-        {"id": "jll-dependency", "status": "external", "evidence": ["docs/release/binding-submission-checklist.md"]}
+        {"id": "package-contract", "status": "satisfied", "evidence": ["bindings/julia/Project.toml", "bindings/julia/test/runtests.jl", "bindings/julia/README.md"]},
+        {"id": "jll-dependency", "status": "external", "evidence": ["docs/release/yggdrasil-v2-2-candidate-20260831.md", "bindings/julia/README.md"]}
       ],
       "acceptance_evidence": ["Registrator PR", "General registry merge", "TagBot release"],
       "next_decision": "Wait for the JLL, then run clean-depot tests before Registrator."
@@ -262,16 +279,17 @@
     {
       "id": "yggdrasil",
       "kind": "package_registry",
-      "readiness": "conditional",
+      "readiness": "blocked",
       "scope": "Cross-platform voiage_ffi_jll native-library recipe.",
       "criteria_url": "https://docs.binarybuilder.org/stable/",
       "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
       "requirements": [
-        {"id": "recipe-submitted", "status": "satisfied", "evidence": ["docs/release/binding-submission-checklist.md", "conductor/archive/research_software_registry_readiness_20260721/release-2.1.0-registry-candidate-receipt-20260821.json"]},
+        {"id": "historical-v2-1-recipe-submitted", "status": "satisfied", "evidence": ["docs/release/binding-submission-checklist.md", "conductor/archive/research_software_registry_readiness_20260721/release-2.1.0-registry-candidate-receipt-20260821.json"]},
+        {"id": "v2-2-candidate-update-and-submission", "status": "pending", "evidence": ["docs/release/yggdrasil-v2-2-candidate-20260831.md"]},
         {"id": "binarybuilder-acceptance", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
       ],
       "acceptance_evidence": ["Merged Yggdrasil recipe", "Registered JLL package and artifacts"],
-      "next_decision": "Respond to BinaryBuilder review; JLL acceptance precedes Julia General."
+      "next_decision": "The v2.2 candidate is local and has not updated historical PR #14292; submit it separately, then await platform builds and JLL acceptance before Julia General."
     },
     {
       "id": "software-heritage",
@@ -323,11 +341,12 @@
       "criteria_url": "https://spack.readthedocs.io/en/latest/package_review_guide.html",
       "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
       "requirements": [
-        {"id": "recipe", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]},
-        {"id": "platform-build-review", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+        {"id": "recipe-preparation", "status": "satisfied", "evidence": ["packaging/spack/package.py", "docs/release/hpc-distribution-handoff.md"]},
+        {"id": "current-security-native-build-and-module-smoke", "status": "pending", "evidence": ["docs/release/hpc-distribution-handoff.md", "conductor/tracks/remaining_backlog_delivery_20260831/remaining-issue-register-20260831.md"]},
+        {"id": "upstream-review-and-indexing", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
       ],
       "acceptance_evidence": ["Spack package PR", "Maintainer approval and merge", "Indexed package"],
-      "next_decision": "Prepare only when the retained distribution design has a tested package recipe."
+      "next_decision": "Complete the Python 3.12.14 native build, linkage checks, numerical and Arrow probes, and module smoke before a separately authorized upstream submission."
     },
     {
       "id": "easybuild",
@@ -337,11 +356,13 @@
       "criteria_url": "https://docs.easybuild.io/contributing/",
       "authority": {"prepare": "repository", "submit": "human", "accept": "external"},
       "requirements": [
-        {"id": "easyconfig", "status": "pending", "evidence": ["docs/release/binding-submission-checklist.md"]},
-        {"id": "upstream-review", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
+        {"id": "easyconfig-and-provider-preparation", "status": "satisfied", "evidence": ["packaging/easybuild/voiage-2.2.0-foss-2023a.eb", "packaging/easybuild/voiage-2.2.0-foss-2024a.eb", "packaging/easybuild-2023a-overlay/manifest.json", "packaging/easybuild-overlay/manifest.json"]},
+        {"id": "final-root-graph-validation", "status": "satisfied", "evidence": ["specs/submission-readiness/cross-venue-evidence-refresh-20260903.json"]},
+        {"id": "native-foss-build-and-module-smoke", "status": "pending", "evidence": ["docs/release/hpc-distribution-handoff.md", "conductor/tracks/remaining_backlog_delivery_20260831/remaining-issue-register-20260831.md"]},
+        {"id": "upstream-review-and-indexing", "status": "external", "evidence": ["docs/release/registry_audit_snapshot.json"]}
       ],
       "acceptance_evidence": ["EasyBuild easyconfigs PR", "Maintainer merge and indexed easyconfig"],
-      "next_decision": "Prepare after a stable HPC installation contract exists."
+      "next_decision": "Complete native foss builds, numerical and Arrow probes, and module smoke before upstream submission."
     },
     {
       "id": "hpsf",

--- a/tests/test_submission_readiness_contract.py
+++ b/tests/test_submission_readiness_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -68,6 +69,198 @@ def test_submission_contract_requires_current_criteria_refresh_evidence() -> Non
 
     assert set(contract["required_target_ids"]) <= set(refresh["target_ids"])
     assert (ROOT / refresh["evidence"]).is_file()
+
+
+def test_submission_contract_separates_criteria_and_status_refreshes() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    refresh = contract["evidence_refresh"]
+    record = json.loads((ROOT / refresh["evidence"]).read_text(encoding="utf-8"))
+
+    assert contract["criteria_refresh"]["reviewed_at"] == "2026-08-29"
+    assert refresh["reviewed_at"] == "2026-09-03"
+    assert set(contract["required_target_ids"]) <= set(refresh["target_ids"])
+    assert record["state"] == refresh["state"]
+    assert record["final_root_pr"] == refresh["final_root_pr"]
+
+
+def test_submission_contract_routes_current_execution_issues() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    lanes = {lane["id"]: lane for lane in contract["execution_lanes"]}
+
+    assert lanes["python-community-review"]["issue_url"].endswith("/1037")
+    assert lanes["hpc-distribution-readiness"]["issue_url"].endswith("/1025")
+    assert lanes["paper-and-author-boundaries"]["issue_url"].endswith("/296")
+    assert lanes["distinct-publication-and-sustainability-assessment"][
+        "issue_url"
+    ].endswith("/1026")
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value", "message"),
+    [
+        ("current_issue_lanes", "paper_and_author_boundaries", 299, "current issue"),
+        (
+            "historical_completed_issue_lanes",
+            "distinct_publication_and_sustainability_assessment",
+            614,
+            "historical issue",
+        ),
+        ("release", "github_and_pypi_published", False, "release evidence"),
+        ("external_outcomes", "pyopensci_acceptance", "accepted", "remain pending"),
+        (
+            "repository_state",
+            "easybuild_final_root_graph_merged",
+            False,
+            "repository state",
+        ),
+    ],
+)
+def test_submission_contract_rejects_rebound_evidence_refresh_fields(
+    tmp_path: Path, section: str, field: str, value: object, message: str
+) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    source = ROOT / contract["evidence_refresh"]["evidence"]
+    record = json.loads(source.read_text(encoding="utf-8"))
+    record[section][field] = value
+    evidence = tmp_path / "refresh.json"
+    evidence.write_text(json.dumps(record), encoding="utf-8")
+    contract["evidence_refresh"]["evidence"] = "refresh.json"
+    contract["evidence_refresh"]["evidence_sha256"] = hashlib.sha256(
+        evidence.read_bytes()
+    ).hexdigest()
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        validate_contract(invalid, tmp_path)
+
+
+def test_submission_contract_rejects_closed_execution_issue_route(
+    tmp_path: Path,
+) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    lane = next(
+        item
+        for item in contract["execution_lanes"]
+        if item["id"] == "paper-and-author-boundaries"
+    )
+    lane["issue_url"] = "https://github.com/edithatogo/voiage/issues/299"
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="current open issue"):
+        validate_contract(invalid, ROOT)
+
+
+def test_complete_refresh_requires_root_merge_in_repository_state(
+    tmp_path: Path,
+) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    source = ROOT / contract["evidence_refresh"]["evidence"]
+    record = json.loads(source.read_text(encoding="utf-8"))
+    root_pr = {
+        "number": 1087,
+        "head_sha": "1" * 40,
+        "merge_sha": "2" * 40,
+        "reviewed_tree": "3" * 40,
+        "merged_tree": "3" * 40,
+        "tree_equal": True,
+        "terminal_checks": 42,
+    }
+    record["state"] = "complete"
+    record["final_root_pr"] = root_pr
+    record["repository_state"]["easybuild_final_root_graph_merged"] = False
+    evidence = tmp_path / "refresh.json"
+    evidence.write_text(json.dumps(record), encoding="utf-8")
+    contract["evidence_refresh"].update(
+        {
+            "state": "complete",
+            "final_root_pr": root_pr,
+            "evidence": "refresh.json",
+            "evidence_sha256": hashlib.sha256(evidence.read_bytes()).hexdigest(),
+        }
+    )
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="repository state"):
+        validate_contract(invalid, tmp_path)
+
+
+def test_complete_refresh_rejects_rebound_root_merge_identity(tmp_path: Path) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    source = ROOT / contract["evidence_refresh"]["evidence"]
+    record = json.loads(source.read_text(encoding="utf-8"))
+    record["final_root_pr"]["head_sha"] = "1" * 40
+    contract["evidence_refresh"]["final_root_pr"]["head_sha"] = "1" * 40
+    evidence = tmp_path / "refresh.json"
+    evidence.write_text(json.dumps(record), encoding="utf-8")
+    contract["evidence_refresh"].update(
+        {
+            "evidence": "refresh.json",
+            "evidence_sha256": hashlib.sha256(evidence.read_bytes()).hexdigest(),
+        }
+    )
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="bound to PR #1087"):
+        validate_contract(invalid, tmp_path)
+
+
+def test_submission_contract_rejects_non_commit_refresh_base(tmp_path: Path) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    source = ROOT / contract["evidence_refresh"]["evidence"]
+    record = json.loads(source.read_text(encoding="utf-8"))
+    record["base_main"] = "main"
+    evidence = tmp_path / "refresh.json"
+    evidence.write_text(json.dumps(record), encoding="utf-8")
+    contract["evidence_refresh"].update(
+        {
+            "evidence": "refresh.json",
+            "evidence_sha256": hashlib.sha256(evidence.read_bytes()).hexdigest(),
+        }
+    )
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="exact commit"):
+        validate_contract(invalid, tmp_path)
+
+
+def test_submission_contract_preserves_current_human_and_hpc_gates() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    targets = {target["id"]: target for target in contract["targets"]}
+    requirements = {
+        target_id: {item["id"]: item["status"] for item in target["requirements"]}
+        for target_id, target in targets.items()
+    }
+
+    assert requirements["pyopensci"]["ai-affirmation"] == "satisfied"
+    assert requirements["pyopensci"]["survey-and-human-written-submission"] == "pending"
+    assert (
+        requirements["spack"]["current-security-native-build-and-module-smoke"]
+        == "pending"
+    )
+    assert requirements["spack"]["upstream-review-and-indexing"] == "external"
+    assert requirements["easybuild"]["final-root-graph-validation"] == "satisfied"
+    assert requirements["easybuild"]["native-foss-build-and-module-smoke"] == "pending"
+    assert requirements["easybuild"]["upstream-review-and-indexing"] == "external"
+    assert (
+        requirements["yggdrasil"]["v2-2-candidate-update-and-submission"] == "pending"
+    )
+
+
+def test_submission_contract_rejects_false_complete_evidence_refresh(
+    tmp_path: Path,
+) -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    contract["evidence_refresh"]["state"] = "awaiting_final_root_pr_merge"
+    invalid = tmp_path / "targets.json"
+    invalid.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="record binding"):
+        validate_contract(invalid, ROOT)
 
 
 def test_pyopensci_matrix_records_commitment_but_defers_external_inquiry() -> None:

--- a/todo.md
+++ b/todo.md
@@ -22,6 +22,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
         module qualification remain pending.
     *   [x] Enforce the NLTK 3.10.3 manuscript-tool security floor and retain a
         bounded disposition for the unpatched model-persistence advisory.
+    *   [x] Refresh the cross-venue evidence contract after the final EasyBuild
+        root-graph PR merge, binding PR #1087's exact tree-equal merge and
+        terminal checks while retaining native, upstream, and venue gates (#614).
 
 *   [~] Deliver the hardened v2.2.0 release through
     `conductor/tracks/v2_2_release_and_venue_submissions_20260830/` (#1037).


### PR DESCRIPTION
The cross-venue readiness contract still pointed at closed execution issues and could not distinguish the merged EasyBuild root graph from native HPC qualification or external venue outcomes. That made the remaining repository-owned refresh criterion difficult to assess without conflating completed repository evidence with human and third-party gates.

This PR adds a checksum-bound evidence refresh record for all 22 targets, routes active work to current open issues, records the historical completed lanes separately, and binds PR #1087's exact reviewed head, squash merge, tree equality, and 40 terminal checks. The validator now enforces the full refresh record, including release and base commits, current issue routes, repository state, pending authenticated actions, and pending external outcomes. Mutation tests cover stale or rebound evidence.

Only the final EasyBuild root-graph criterion becomes satisfied. Native Spack/EasyBuild builds, module smoke tests, upstream submissions, pyOpenSci/JOSS/arXiv actions, and all venue outcomes remain pending.

Validation:
- `tox` (all environments passed after initializing the pinned astro-polyglot submodule; 4,942 coverage tests passed, 15 skipped, 95.13% coverage)
- `uv run pytest -q tests/test_submission_readiness_contract.py` (30 passed)
- `uv run python scripts/validate_submission_readiness.py --root .`
- Ruff, formatting, and diff checks

Related: #614
