### PR TITLE
Add native EasyBuild qualification tooling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
 - Add guarded, generation-isolated native EasyBuild qualification tooling and
-  a fail-closed terminal evidence contract without claiming a native build.
+  a fail-closed terminal evidence contract that separately binds the pinned
+  candidate and reviewed tooling checkouts, without claiming a native build.
 
 - Prepare checksum-pinned voiage 2.2.0 Spack and both requested EasyBuild toolchain candidates, cluster module instructions, and an isolated Rust source-build smoke check; upstream submission and actual HPC builds remain pending.
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 - Add guarded, generation-isolated native EasyBuild qualification tooling and
   a fail-closed terminal evidence contract that separately binds the pinned
-  candidate and reviewed tooling checkouts, without claiming a native build.
+  candidate and reviewed tooling checkouts, preserves build exit codes when
+  module discovery fails, and isolates unload checks from the source checkout,
+  without claiming a native build.
 
 - Prepare checksum-pinned voiage 2.2.0 Spack and both requested EasyBuild toolchain candidates, cluster module instructions, and an isolated Rust source-build smoke check; upstream submission and actual HPC builds remain pending.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add guarded, generation-isolated native EasyBuild qualification tooling and
+  a fail-closed terminal evidence contract without claiming a native build.
+
 - Prepare checksum-pinned voiage 2.2.0 Spack and both requested EasyBuild toolchain candidates, cluster module instructions, and an isolated Rust source-build smoke check; upstream submission and actual HPC builds remain pending.
 
 - Archived the completed comprehensive pre-submission hardening programme after

--- a/docs/release/native-easybuild-qualification.md
+++ b/docs/release/native-easybuild-qualification.md
@@ -6,13 +6,22 @@ fresh VM-local workspace, Linux, Environment Modules, eight CPUs and 250 GiB
 free. It does not use a repository, virtual-environment or Spack installation
 as native evidence.
 
+Use two distinct clean checkouts: the candidate checkout remains pinned to
+`9307d9ec`, while the tooling checkout contains this driver, its receipt schema,
+validator and probe. The receipt binds both Git identities and the exact driver
+and probe bytes. Run the command from the tooling checkout; `--root` always
+names the candidate being qualified and `--tooling-root` names the reviewed
+tooling checkout.
+
 Run `foss-2023a` to a terminal receipt before starting `foss-2024a`. The two
 generations may share downloaded source archives, but use separate build,
 install and module roots. Invoke the driver only inside the prepared Linux VM:
 
 ```sh
+cd /vm/voiage-native-easybuild-tooling
 VOIAGE_VM_LOCAL_STORAGE=confirmed python3 scripts/native_easybuild_qualification.py \
-  2023a --root /vm/voiage-9307d9ec --catalogue /vm/easyconfigs-58e8b5a \
+  2023a --root /vm/voiage-9307d9ec --tooling-root "$PWD" \
+  --catalogue /vm/easyconfigs-58e8b5a \
   --workspace /vm/easybuild --source-cache /vm/prepared-sources \
   --run-id native-20260904 --execute
 ```

--- a/docs/release/native-easybuild-qualification.md
+++ b/docs/release/native-easybuild-qualification.md
@@ -1,0 +1,30 @@
+# Native EasyBuild qualification
+
+The native driver builds one maintained generation at a time and refuses to
+run without an exact clean source commit, the pinned EasyBuild catalogue, a
+fresh VM-local workspace, Linux, Environment Modules, eight CPUs and 250 GiB
+free. It does not use a repository, virtual-environment or Spack installation
+as native evidence.
+
+Run `foss-2023a` to a terminal receipt before starting `foss-2024a`. The two
+generations may share downloaded source archives, but use separate build,
+install and module roots. Invoke the driver only inside the prepared Linux VM:
+
+```sh
+VOIAGE_VM_LOCAL_STORAGE=confirmed python3 scripts/native_easybuild_qualification.py \
+  2023a --root /vm/voiage-9307d9ec --catalogue /vm/easyconfigs-58e8b5a \
+  --workspace /vm/easybuild --source-cache /vm/prepared-sources \
+  --run-id native-20260904 --execute
+```
+
+Repeat with `2024a` only after reviewing the first receipt, using the same
+`--run-id` and adding
+`--predecessor-receipt /vm/easybuild/voiage-easybuild-2023a/receipt.json`.
+The prepared cache must contain the complete release and transitive source set;
+the driver copies it into a read-only generation-local tree and disables downloads.
+A successful build
+is followed in a fresh shell by module, CLI, Rust engine, exact EVPI, Arrow,
+Polars, linkage, threaded-core and unload-isolation probes. The aggregate
+validator accepts readiness only when exact terminal receipts for both
+generations pass. Upstream submission and production-cluster qualification
+remain separate gates.

--- a/scripts/native_easybuild_probe.py
+++ b/scripts/native_easybuild_probe.py
@@ -33,7 +33,7 @@ def main() -> int:
 
     def worker(_: int) -> tuple[str, str, str]:
         import voiage as installed_voiage
-        from voiage import _core as installed_core
+        import voiage._core as installed_core
 
         return (
             installed_core.runtime_info()["engine"],
@@ -49,13 +49,13 @@ def main() -> int:
     from pyarrow import ipc
 
     import voiage
-    from voiage import _core
+    import voiage._core as native_core
     from voiage.analysis import DecisionAnalysis
 
     paths = [
         sys.executable,
         voiage.__file__ or "",
-        _core.__file__ or "",
+        native_core.__file__ or "",
         np.__file__ or "",
         pa.__file__ or "",
         pl.__file__ or "",
@@ -91,7 +91,7 @@ def main() -> int:
     arrow_objects = sorted(Path(pa.__file__).parent.glob("*.so"))
     if not polars_objects or not arrow_objects:
         raise SystemExit("Arrow or Polars native shared object is missing")
-    objects = [Path(_core.__file__), arrow_objects[0], polars_objects[0]]
+    objects = [Path(native_core.__file__), arrow_objects[0], polars_objects[0]]
     linkage_runs = [
         subprocess.run(  # noqa: S603 - resolved system inspection tool
             [ldd, str(item)], text=True, capture_output=True, check=False

--- a/scripts/native_easybuild_probe.py
+++ b/scripts/native_easybuild_probe.py
@@ -1,0 +1,187 @@
+"""Run deterministic installed-module probes and emit structured JSON."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+
+def within(path: str, prefix: Path) -> bool:
+    """Return whether an existing path is contained by the install prefix."""
+    try:
+        Path(path).resolve(strict=True).relative_to(prefix.resolve(strict=True))
+    except (FileNotFoundError, ValueError):
+        return False
+    else:
+        return True
+
+
+def main() -> int:
+    """Run the installed runtime probe matrix."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--prefix", type=Path, required=True)
+    parser.add_argument("--generation", choices=("2023a", "2024a"), required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--opposite-prefix", type=Path, required=True)
+    args = parser.parse_args()
+
+    def worker(_: int) -> tuple[str, str, str]:
+        import voiage as installed_voiage
+        from voiage import _core as installed_core
+
+        return (
+            installed_core.runtime_info()["engine"],
+            installed_voiage.__file__ or "",
+            installed_core.__file__ or "",
+        )
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        threaded = list(pool.map(worker, range(16)))
+    import numpy as np
+    import polars as pl
+    import pyarrow as pa
+    from pyarrow import ipc
+
+    import voiage
+    from voiage import _core
+    from voiage.analysis import DecisionAnalysis
+
+    paths = [
+        sys.executable,
+        voiage.__file__ or "",
+        _core.__file__ or "",
+        np.__file__ or "",
+        pa.__file__ or "",
+        pl.__file__ or "",
+    ]
+    if not all(within(item, args.prefix) for item in paths):
+        raise SystemExit("installed Python paths escape the generation prefix")
+    evpi = DecisionAnalysis(np.array([[0.0, 2.0], [2.0, 0.0]])).evpi()
+    if evpi != 1.0:
+        raise SystemExit(f"unexpected EVPI: {evpi}")
+    table = pa.table({"value": pa.array([1, None, 3], type=pa.int64())})
+    sink = pa.BufferOutputStream()
+    with ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    restored = ipc.open_stream(sink.getvalue()).read_all()
+    if pa.__version__ != "25.0.1" or not restored.equals(table):
+        raise SystemExit("Arrow version/schema/null/buffer round trip failed")
+    polars_arrow = (
+        pl.DataFrame({"value": [1, None, 3]})
+        .lazy()
+        .filter(pl.col("value").is_not_null())
+        .collect()
+        .to_arrow()
+    )
+    if pl.__version__ != "1.42.1" or polars_arrow.num_rows != 2:
+        raise SystemExit("Polars lazy/Arrow probe failed")
+    engines = [item[0] for item in threaded]
+    if engines != ["rust"] * 16:
+        raise SystemExit("threaded native core probe failed")
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        raise SystemExit("ldd is required")
+    polars_objects = sorted(Path(pl.__file__).parent.glob("*.so"))
+    arrow_objects = sorted(Path(pa.__file__).parent.glob("*.so"))
+    if not polars_objects or not arrow_objects:
+        raise SystemExit("Arrow or Polars native shared object is missing")
+    objects = [Path(_core.__file__), arrow_objects[0], polars_objects[0]]
+    linkage_runs = [
+        subprocess.run(  # noqa: S603 - resolved system inspection tool
+            [ldd, str(item)], text=True, capture_output=True, check=False
+        )
+        for item in objects
+    ]
+    transcripts = {
+        str(obj): result.stdout + result.stderr
+        for obj, result in zip(objects, linkage_runs, strict=True)
+    }
+    linkage_text = "\n".join(transcripts.values())
+    if any(item.returncode for item in linkage_runs) or "not found" in linkage_text:
+        raise SystemExit("native linkage probe failed")
+    forbidden = ("/.venv/", "/spack/", "/site-packages/voiage/")
+    if any(token in linkage_text for token in forbidden):
+        raise SystemExit("native linkage uses a forbidden environment")
+    allowed_system = (
+        Path("/lib"),
+        Path("/lib64"),
+        Path("/usr/lib"),
+        Path("/usr/lib64"),
+    )
+    targets = sorted(
+        {
+            Path(value).resolve(strict=True)
+            for value in re.findall(r"(?<!\S)(/[^\s(]+)", linkage_text)
+        }
+    )
+    for target in targets:
+        if "/easybuild/" in str(target) and not within(str(target), args.prefix):
+            raise SystemExit("native linkage crosses EasyBuild generation prefixes")
+    if any(
+        not within(str(target), args.prefix)
+        and not any(target == base or base in target.parents for base in allowed_system)
+        for target in targets
+    ):
+        raise SystemExit("native linkage target is outside exact allowed roots")
+    opposite_absent = all(
+        args.opposite_prefix.resolve() not in target.parents
+        and target != args.opposite_prefix.resolve()
+        for target in targets
+    )
+    if not opposite_absent:
+        raise SystemExit("native linkage reaches the opposite generation prefix")
+    result = {
+        "schema_version": "voiage.native-easybuild-probe.v1",
+        "generation": args.generation,
+        "paths": paths,
+        "evpi": {
+            "input": [[0.0, 2.0], [2.0, 0.0]],
+            "dtype": "float64",
+            "value": evpi,
+            "tolerance": 0.0,
+        },
+        "arrow": {
+            "version": pa.__version__,
+            "schema": str(restored.schema),
+            "null_count": restored.column(0).null_count,
+            "values": restored.column(0).to_pylist(),
+            "buffer_equal": restored.equals(table),
+            "buffer_size_positive": sink.getvalue().size > 0,
+        },
+        "polars": {
+            "version": pl.__version__,
+            "schema": {"value": "Int64"},
+            "values": polars_arrow.column(0).to_pylist(),
+            "null_count": polars_arrow.column(0).null_count,
+            "lazy": True,
+            "arrow_equal": polars_arrow.equals(pa.table({"value": [1, 3]})),
+        },
+        "linkage": {
+            "objects": [str(item) for item in objects],
+            "tool": ldd,
+            "targets": [str(item) for item in targets],
+            "transcripts": transcripts,
+        },
+        "thread": {
+            "calls": len(engines),
+            "imports_inside_worker": True,
+            "engines": engines,
+        },
+        "module": {
+            "loaded_paths_introduced": True,
+            "unload_paths_removed": True,
+            "fresh_shell": True,
+        },
+    }
+    args.output.write_text(json.dumps(result, sort_keys=True, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/native_easybuild_qualification.py
+++ b/scripts/native_easybuild_qualification.py
@@ -84,7 +84,16 @@ IDENTITY_KEYS = {
     "robot_paths",
     "robot_manifest_sha256",
     "source_cache_manifest_sha256",
+    "tooling_commit",
+    "tooling_tree",
+    "tooling_root",
+    "tooling_driver_sha256",
+    "tooling_probe_sha256",
 }
+TOOLING_FILES = (
+    "scripts/native_easybuild_qualification.py",
+    "scripts/native_easybuild_probe.py",
+)
 COMMAND_KEYS = {"stage", "argv", "exit_code", "signal", "log", "log_sha256", "parsed"}
 
 
@@ -285,13 +294,27 @@ def git_manifest_digest(checkout: Path, revision: str) -> tuple[str, bool]:
     return hashlib.sha256(("\n".join(listing) + "\n").encode()).hexdigest(), no_symlinks
 
 
-def validate_receipt(path: Path, root: Path) -> dict[str, Any]:
+def git_blob_sha256(checkout: Path, revision: str, relative: str) -> str:
+    """Hash one tracked file from an exact Git revision."""
+    return hashlib.sha256(
+        subprocess.check_output(
+            ["git", "-C", str(checkout), "show", f"{revision}:{relative}"]
+        )
+    ).hexdigest()
+
+
+def validate_receipt(
+    path: Path, root: Path, tooling_root: Path | None = None
+) -> dict[str, Any]:
     """Validate one terminal generation receipt and its artifacts."""
     if path.is_symlink() or not path.is_file():
         raise ValueError("receipt must be a regular file")
     data: Any = json.loads(path.read_text())
+    tooling_root = (tooling_root or Path(__file__).resolve().parents[1]).resolve()
     schema = json.loads(
-        (root / "specs/native-easybuild-terminal-receipt-v1.schema.json").read_text()
+        (
+            tooling_root / "specs/native-easybuild-terminal-receipt-v1.schema.json"
+        ).read_text()
     )
     try:
         jsonschema.Draft202012Validator(schema).validate(data)
@@ -353,6 +376,39 @@ def validate_receipt(path: Path, root: Path) -> dict[str, Any]:
         or not no_source_symlinks
     ):
         raise ValueError("source tree or manifest is stale")
+    try:
+        tooling_tree = subprocess.check_output(
+            [
+                "git",
+                "-C",
+                str(tooling_root),
+                "rev-parse",
+                f"{identity['tooling_commit']}^{{tree}}",
+            ],
+            text=True,
+        ).strip()
+        tooling_hashes = {
+            relative: git_blob_sha256(
+                tooling_root, identity["tooling_commit"], relative
+            )
+            for relative in TOOLING_FILES
+        }
+    except subprocess.CalledProcessError as exc:
+        raise ValueError("tooling commit is unavailable") from exc
+    if (
+        Path(identity["tooling_root"]) != tooling_root
+        or subprocess.check_output(
+            ["git", "-C", str(tooling_root), "rev-parse", "HEAD"], text=True
+        ).strip()
+        != identity["tooling_commit"]
+        or subprocess.check_output(
+            ["git", "-C", str(tooling_root), "status", "--porcelain"], text=True
+        ).strip()
+        or identity["tooling_tree"] != tooling_tree
+        or identity["tooling_driver_sha256"] != tooling_hashes[TOOLING_FILES[0]]
+        or identity["tooling_probe_sha256"] != tooling_hashes[TOOLING_FILES[1]]
+    ):
+        raise ValueError("tooling checkout identity is stale")
     expected_robot_hash = hashlib.sha256(
         json.dumps(identity["robot_paths"], separators=(",", ":")).encode()
     ).hexdigest()
@@ -544,6 +600,9 @@ def validate_receipt(path: Path, root: Path) -> dict[str, Any]:
             "catalogue_head",
             "catalogue_tree",
             "catalogue_status",
+            "tooling_head",
+            "tooling_tree",
+            "tooling_status",
             "prefix_absent",
             "module_tree_empty",
             "preinstalled_voiage_absent",
@@ -560,6 +619,9 @@ def validate_receipt(path: Path, root: Path) -> dict[str, Any]:
             or preflight_evidence["catalogue_head"] != CATALOGUE
             or preflight_evidence["catalogue_tree"] != identity["catalogue_tree"]
             or preflight_evidence["catalogue_status"] != ""
+            or preflight_evidence["tooling_head"] != identity["tooling_commit"]
+            or preflight_evidence["tooling_tree"] != identity["tooling_tree"]
+            or preflight_evidence["tooling_status"] != ""
             or not all(
                 preflight_evidence[key] is True
                 for key in (
@@ -590,6 +652,9 @@ def validate_receipt(path: Path, root: Path) -> dict[str, Any]:
                 "catalogue_head",
                 "catalogue_tree",
                 "catalogue_status",
+                "tooling_head",
+                "tooling_tree",
+                "tooling_status",
             )
         }:
             raise ValueError("postflight checkout evidence drifted")
@@ -774,7 +839,9 @@ def validate_receipt(path: Path, root: Path) -> dict[str, Any]:
     return data
 
 
-def validate_matrix(path: Path, root: Path) -> dict[str, Any]:
+def validate_matrix(
+    path: Path, root: Path, tooling_root: Path | None = None
+) -> dict[str, Any]:
     """Require terminal passing receipts for both maintained generations."""
     data: Any = json.loads(path.read_text())
     if (
@@ -829,7 +896,7 @@ def validate_matrix(path: Path, root: Path) -> dict[str, Any]:
         )
         if sha256(receipt_path) != binding["sha256"]:
             raise ValueError("matrix receipt digest is invalid")
-        receipt = validate_receipt(receipt_path, root)
+        receipt = validate_receipt(receipt_path, root, tooling_root)
         if (
             receipt["outcome"] != "passed"
             or receipt["identity"]["generation"] != generation
@@ -857,6 +924,9 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("generation", choices=GENERATIONS)
     parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--tooling-root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
     parser.add_argument("--catalogue", type=Path, required=True)
     parser.add_argument("--workspace", type=Path, required=True)
     parser.add_argument("--source-cache", type=Path, required=True)
@@ -878,10 +948,13 @@ def main() -> int:
     ):
         raise SystemExit("source and workspace roots must not be symlinks")
     root = args.root.resolve()
+    tooling_root = args.tooling_root.resolve()
     workspace = args.workspace.resolve()
     source_cache = args.source_cache.resolve()
     if args.predecessor_receipt:
-        predecessor = validate_receipt(args.predecessor_receipt.resolve(), root)
+        predecessor = validate_receipt(
+            args.predecessor_receipt.resolve(), root, tooling_root
+        )
         if (
             predecessor["outcome"] != "passed"
             or predecessor["identity"]["generation"] != "2023a"
@@ -911,6 +984,16 @@ def main() -> int:
         ["git", "-C", str(root), "status", "--porcelain"], text=True
     ).strip():
         raise SystemExit("source checkout must be clean")
+    tooling_commit = subprocess.check_output(
+        ["git", "-C", str(tooling_root), "rev-parse", "HEAD"], text=True
+    ).strip()
+    tooling_tree = subprocess.check_output(
+        ["git", "-C", str(tooling_root), "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    if subprocess.check_output(
+        ["git", "-C", str(tooling_root), "status", "--porcelain"], text=True
+    ).strip():
+        raise SystemExit("tooling checkout must be clean")
     if (
         subprocess.check_output(
             ["git", "-C", str(args.catalogue), "rev-parse", "HEAD"],
@@ -1032,6 +1115,9 @@ def main() -> int:
         "catalogue_status": subprocess.check_output(
             ["git", "-C", str(catalogue), "status", "--porcelain"], text=True
         ).strip(),
+        "tooling_head": tooling_commit,
+        "tooling_tree": tooling_tree,
+        "tooling_status": "",
         "prefix_absent": not prefix.exists(),
         "module_tree_empty": not prefix.exists(),
         "preinstalled_voiage_absent": absent_probe.returncode == 0,
@@ -1088,7 +1174,7 @@ def main() -> int:
             str(script),
             str(module_files[0].parents[1]),
             module_name,
-            str(root / "scripts/native_easybuild_probe.py"),
+            str(tooling_root / "scripts/native_easybuild_probe.py"),
             str(prefix),
             args.generation,
             str(probe_json),
@@ -1216,6 +1302,17 @@ def main() -> int:
             "catalogue_status": subprocess.check_output(
                 ["git", "-C", str(catalogue), "status", "--porcelain"], text=True
             ).strip(),
+            "tooling_head": subprocess.check_output(
+                ["git", "-C", str(tooling_root), "rev-parse", "HEAD"], text=True
+            ).strip(),
+            "tooling_tree": subprocess.check_output(
+                ["git", "-C", str(tooling_root), "rev-parse", "HEAD^{tree}"],
+                text=True,
+            ).strip(),
+            "tooling_status": subprocess.check_output(
+                ["git", "-C", str(tooling_root), "status", "--porcelain"],
+                text=True,
+            ).strip(),
         }
         expected_postflight = {key: preflight_evidence[key] for key in postflight}
         if postflight != expected_postflight:
@@ -1296,6 +1393,15 @@ def main() -> int:
             ).hexdigest(),
             "source_cache_manifest_sha256": artifacts["source_cache_inventory_sha256"]
             or "0" * 64,
+            "tooling_commit": tooling_commit,
+            "tooling_tree": tooling_tree,
+            "tooling_root": str(tooling_root),
+            "tooling_driver_sha256": git_blob_sha256(
+                tooling_root, tooling_commit, TOOLING_FILES[0]
+            ),
+            "tooling_probe_sha256": git_blob_sha256(
+                tooling_root, tooling_commit, TOOLING_FILES[1]
+            ),
         },
         "environment": {
             "allowlist": allowlist,
@@ -1335,7 +1441,7 @@ def main() -> int:
     }
     receipt_path = run_dir / "receipt.json"
     receipt_path.write_text(json.dumps(receipt, indent=2) + "\n")
-    validate_receipt(receipt_path, root)
+    validate_receipt(receipt_path, root, tooling_root)
     return code
 
 

--- a/scripts/native_easybuild_qualification.py
+++ b/scripts/native_easybuild_qualification.py
@@ -472,6 +472,7 @@ def validate_receipt(
         _exact_keys(item, COMMAND_KEYS, "command")
         parsed_keys = {
             "easybuild": {"easybuild_completed", "installed_module_full_name"},
+            "module-discovery": {"modulefile_match_count"},
             "module-probe": {"structured_probe_written"},
             "module-unload": {"voiage_absent_after_unload"},
         }[item["stage"]]
@@ -559,6 +560,7 @@ def validate_receipt(
             "module-unload.sh",
             "MODULE_ROOT",
             module_name,
+            "home",
         ]:
             raise ValueError("module command argv or discovered module name drifted")
         artifacts = _exact_keys(
@@ -1211,7 +1213,7 @@ def main() -> int:
         unload_log = run_dir / "unload.log"
         unload_script = run_dir / "module-unload.sh"
         unload_script.write_text(
-            '#!/bin/bash\nset -euo pipefail\neval "$(modulecmd bash purge)"\neval "$(modulecmd bash use "$1")"\neval "$(modulecmd bash load "$2")"\neval "$(modulecmd bash unload "$2")"\npython3 -c \'import importlib.util; raise SystemExit(importlib.util.find_spec("voiage") is not None)\'\n'
+            '#!/bin/bash\nset -euo pipefail\neval "$(modulecmd bash purge)"\neval "$(modulecmd bash use "$1")"\neval "$(modulecmd bash load "$2")"\neval "$(modulecmd bash unload "$2")"\ncd "$3"\npython3 -c \'import importlib.util; raise SystemExit(importlib.util.find_spec("voiage") is not None)\'\n'
         )
         unload_script.chmod(0o700)
         unload_code = run(
@@ -1222,6 +1224,7 @@ def main() -> int:
                 str(unload_script),
                 str(module_files[0].parents[1]),
                 module_name,
+                str(home),
             ],
             unload_log,
             env,
@@ -1236,6 +1239,7 @@ def main() -> int:
                     "module-unload.sh",
                     "MODULE_ROOT",
                     module_name,
+                    "home",
                 ],
                 "exit_code": unload_code,
                 "signal": -unload_code if unload_code < 0 else None,
@@ -1250,12 +1254,30 @@ def main() -> int:
                 {"name": name, "status": "passed"} for name in sorted(REQUIRED_PROBES)
             ]
     else:
+        if build_code == 0:
+            discovery_log = run_dir / "module-discovery.log"
+            discovery_log.write_text(
+                f"expected exactly one installed modulefile; found {len(module_files)}\n"
+            )
+            commands.append(
+                {
+                    "stage": "module-discovery",
+                    "argv": [
+                        "discover-modulefile",
+                        "install/modules/all/voiage/2.2.0*",
+                    ],
+                    "exit_code": 1,
+                    "signal": None,
+                    "log": discovery_log.name,
+                    "log_sha256": sha256(discovery_log),
+                    "parsed": {"modulefile_match_count": len(module_files)},
+                }
+            )
         code = build_code or 1
     if code != 0:
         index = next(
             (i for i, item in enumerate(commands) if item["exit_code"] != 0), 0
         )
-        commands[index]["exit_code"] = commands[index]["exit_code"] or 1
         failure = {
             "stage": commands[index]["stage"],
             "command_index": index,

--- a/scripts/native_easybuild_qualification.py
+++ b/scripts/native_easybuild_qualification.py
@@ -1,0 +1,1343 @@
+# ruff: noqa: S603, S607
+"""Guard and record sequential native EasyBuild qualification runs."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+import jsonschema
+
+BASE = "9307d9ec7fcdc808ed7931afc298fa3bebac36e8"
+CATALOGUE = "58e8b5a48767cbed1bf5669675d9638580d7259f"
+CATALOGUE_TREE = "7c1cff95bf2f5365b4ecfe173c38548e5241d188"
+CATALOGUE_MANIFEST_SHA256 = (
+    "dca2a52184a172cf712941627819b53656ce4724fbee24174e452d12e8cf83a2"
+)
+ROOT_RECIPE_SHA256 = {
+    "2023a": "653c6ad1f04c79f6e517f3d0336f4f4948459cc1d2de7e6056f37e1c1561fff0",
+    "2024a": "7a3db9d93860b0fb5afefbaed3f1cf4b77fca47cddb5258fb381f6afb94bf71f",
+}
+GENERATIONS = {
+    "2023a": [
+        "packaging/easybuild",
+        "packaging/easybuild-2023a-polars-overlay/2023a",
+        "packaging/easybuild-2023a-arrow-overlay/2023a",
+        "packaging/easybuild-2023a-rust-overlay/2023a",
+        "packaging/easybuild-2023a-overlay/2023a",
+    ],
+    "2024a": [
+        "packaging/easybuild",
+        "packaging/easybuild-2024a-polars-overlay/2024a",
+        "packaging/easybuild-2024a-arrow-overlay/2024a",
+        "packaging/easybuild-2024a-rust-overlay/2024a",
+        "packaging/easybuild-overlay/2024a",
+    ],
+}
+REQUIRED_PROBES = {
+    "module-load",
+    "cli",
+    "rust-engine",
+    "numerical-evpi",
+    "arrow-roundtrip",
+    "polars-roundtrip",
+    "linkage",
+    "generation-isolation",
+}
+RECEIPT_KEYS = {
+    "schema_version",
+    "terminal",
+    "outcome",
+    "run_root",
+    "identity",
+    "environment",
+    "resources",
+    "preflight",
+    "commands",
+    "artifacts",
+    "probes",
+    "failure",
+    "run",
+}
+IDENTITY_KEYS = {
+    "generation",
+    "source_commit",
+    "source_tree",
+    "source_relevant_tree_sha256",
+    "catalogue_root",
+    "catalogue_commit",
+    "catalogue_tree",
+    "catalogue_relevant_tree_sha256",
+    "easybuild_version",
+    "easyblocks_version",
+    "root_recipe",
+    "root_recipe_sha256",
+    "robot_paths",
+    "robot_manifest_sha256",
+    "source_cache_manifest_sha256",
+}
+COMMAND_KEYS = {"stage", "argv", "exit_code", "signal", "log", "log_sha256", "parsed"}
+
+
+def sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _regular_inside(run_root: Path, relative: str) -> Path:
+    """Resolve a declared artifact without permitting traversal or symlinks."""
+    candidate = run_root / relative
+    if Path(relative).is_absolute() or ".." in Path(relative).parts:
+        raise ValueError("artifact path escapes declared run root")
+    current = run_root
+    if current.is_symlink() or not current.is_dir():
+        raise ValueError("declared run root is not a regular directory")
+    for part in Path(relative).parts:
+        current /= part
+        if current.is_symlink():
+            raise ValueError("symlink artifact is forbidden")
+    try:
+        candidate.resolve(strict=True).relative_to(run_root.resolve(strict=True))
+    except (FileNotFoundError, ValueError) as exc:
+        raise ValueError("artifact path escapes declared run root") from exc
+    if not candidate.is_file():
+        raise ValueError("artifact must be a regular file")
+    return candidate
+
+
+def _exact_keys(value: Any, expected: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ValueError(f"{label} has unexpected or missing fields")
+    return value
+
+
+def _manifest(path: Path) -> list[dict[str, Any]]:
+    value = json.loads(path.read_text())
+    value = _exact_keys(value, {"root", "entries"}, "inventory")
+    root = path.parent / value["root"]
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("inventory root is missing or a symlink")
+    root = root.resolve(strict=True)
+    entries = value["entries"]
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("inventory is empty")
+    for item in entries:
+        relative = Path(item.get("path", ""))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError("inventory path escapes its root")
+        artifact = root / relative
+        if item.get("type") == "file":
+            _exact_keys(item, {"path", "type", "size", "sha256"}, "inventory file")
+            if (
+                artifact.is_symlink()
+                or not artifact.is_file()
+                or artifact.stat().st_size != item["size"]
+                or sha256(artifact) != item["sha256"]
+            ):
+                raise ValueError("inventory entry bytes do not match size and digest")
+        elif item.get("type") == "symlink":
+            _exact_keys(
+                item,
+                {"path", "type", "link_target", "resolved_path"},
+                "inventory symlink",
+            )
+            if (
+                not artifact.is_symlink()
+                or os.readlink(artifact) != item["link_target"]
+                or Path(item["link_target"]).is_absolute()
+            ):
+                raise ValueError("inventory symlink text is invalid")
+            try:
+                resolved = artifact.resolve(strict=True)
+                resolved_relative = resolved.relative_to(root)
+            except (FileNotFoundError, OSError, RuntimeError, ValueError) as exc:
+                raise ValueError(
+                    "inventory symlink is dangling, cyclic, or escapes root"
+                ) from exc
+            if str(resolved_relative) != item["resolved_path"]:
+                raise ValueError("inventory symlink resolved target is invalid")
+        else:
+            raise ValueError("inventory entry type is invalid")
+    return entries
+
+
+def run(argv: list[str], log: Path, env: dict[str, str]) -> int:
+    """Run a controlled command and retain its combined transcript."""
+    with log.open("wb") as stream:
+        result = subprocess.run(
+            argv, stdout=stream, stderr=subprocess.STDOUT, env=env, check=False
+        )
+    return result.returncode
+
+
+def clean_environment(home: Path) -> tuple[dict[str, str], list[str], str]:
+    """Construct the complete allowlisted environment used by native commands."""
+    allowed = {"PATH", "LANG", "LC_ALL", "TERM", "TMPDIR"}
+    env = {key: value for key, value in os.environ.items() if key in allowed}
+    env.update({"HOME": str(home), "PYTHONNOUSERSITE": "1"})
+    serialized = [f"{key}={env[key]}" for key in sorted(env)]
+    digest = hashlib.sha256(
+        json.dumps(serialized, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return env, serialized, digest
+
+
+def write_inventory(base: Path, output: Path) -> str:
+    """Write a deterministic inventory with constrained symlink evidence."""
+    entries = []
+    for item in sorted(base.rglob("*")):
+        if item.is_symlink():
+            target = os.readlink(item)
+            if Path(target).is_absolute():
+                raise RuntimeError(f"inventory contains absolute symlink: {item}")
+            try:
+                resolved = item.resolve(strict=True)
+                resolved_relative = resolved.relative_to(base.resolve(strict=True))
+            except (FileNotFoundError, OSError, RuntimeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"inventory contains unsafe symlink: {item}"
+                ) from exc
+            entries.append(
+                {
+                    "path": str(item.relative_to(base)),
+                    "type": "symlink",
+                    "link_target": target,
+                    "resolved_path": str(resolved_relative),
+                }
+            )
+        elif item.is_file():
+            entries.append(
+                {
+                    "path": str(item.relative_to(base)),
+                    "type": "file",
+                    "size": item.stat().st_size,
+                    "sha256": sha256(item),
+                }
+            )
+    if not entries:
+        raise RuntimeError(f"inventory is empty: {base}")
+    output.write_text(
+        json.dumps(
+            {"root": str(base.relative_to(output.parent)), "entries": entries},
+            sort_keys=True,
+            indent=2,
+        )
+        + "\n"
+    )
+    return sha256(output)
+
+
+def parsed_failure(log: Path) -> str:
+    """Return the last non-empty transcript line as bounded failure evidence."""
+    lines = [
+        line.strip()
+        for line in log.read_text(errors="replace").splitlines()
+        if line.strip()
+    ]
+    return lines[-1][-1000:] if lines else "command produced no diagnostic output"
+
+
+def directory_digest(base: Path) -> str:
+    """Hash the names, sizes, and bytes of a no-symlink source tree."""
+    entries = []
+    for item in sorted(base.rglob("*")):
+        if item.is_symlink():
+            raise RuntimeError("directory digest refuses symbolic links")
+        if item.is_file():
+            entries.append(
+                [str(item.relative_to(base)), item.stat().st_size, sha256(item)]
+            )
+    if not entries:
+        raise RuntimeError("directory digest refuses an empty source cache")
+    return hashlib.sha256(
+        json.dumps(entries, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def parse_build_success(log: Path, module_name: str) -> bool:
+    """Recognize EasyBuild 5.4's canonical terminal success line."""
+    text = log.read_text(errors="replace")
+    del module_name  # identity is independently derived from the installed modulefile
+    return bool(
+        re.search(
+            r"(?m)^== COMPLETED: Installation ended successfully \(took [^)]+\)$", text
+        )
+    )
+
+
+def git_manifest_digest(checkout: Path, revision: str) -> tuple[str, bool]:
+    """Hash the complete tracked tree and reject tracked symbolic links."""
+    listing = subprocess.check_output(
+        ["git", "-C", str(checkout), "ls-tree", "-r", revision], text=True
+    ).splitlines()
+    if not listing:
+        raise RuntimeError("tracked tree is empty")
+    no_symlinks = all(not line.startswith("120000 ") for line in listing)
+    return hashlib.sha256(("\n".join(listing) + "\n").encode()).hexdigest(), no_symlinks
+
+
+def validate_receipt(path: Path, root: Path) -> dict[str, Any]:
+    """Validate one terminal generation receipt and its artifacts."""
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("receipt must be a regular file")
+    data: Any = json.loads(path.read_text())
+    schema = json.loads(
+        (root / "specs/native-easybuild-terminal-receipt-v1.schema.json").read_text()
+    )
+    try:
+        jsonschema.Draft202012Validator(schema).validate(data)
+    except jsonschema.ValidationError as exc:
+        raise ValueError(f"receipt schema validation failed: {exc.message}") from exc
+    _exact_keys(data, RECEIPT_KEYS, "receipt")
+    run_meta = _exact_keys(
+        data["run"],
+        {"run_id", "started_at", "ended_at", "predecessor_receipt_sha256"},
+        "run metadata",
+    )
+    try:
+        started = datetime.fromisoformat(run_meta["started_at"])
+        ended = datetime.fromisoformat(run_meta["ended_at"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("run timestamps are invalid") from exc
+    if (
+        not run_meta["started_at"].endswith("Z")
+        or not run_meta["ended_at"].endswith("Z")
+        or started.utcoffset() != UTC.utcoffset(started)
+        or ended.utcoffset() != UTC.utcoffset(ended)
+        or ended < started
+    ):
+        raise ValueError("run timestamps are reversed")
+    if (
+        not isinstance(data, dict)
+        or data.get("schema_version") != "voiage.native-easybuild-terminal-receipt.v1"
+    ):
+        raise ValueError("invalid native EasyBuild receipt schema")
+    if data.get("terminal") is not True or data.get("outcome") not in {
+        "passed",
+        "failed_terminal",
+    }:
+        raise ValueError("receipt is not terminal")
+    identity = data.get("identity")
+    _exact_keys(identity, IDENTITY_KEYS, "identity")
+    if (identity["generation"] == "2023a") != (
+        run_meta["predecessor_receipt_sha256"] is None
+    ):
+        raise ValueError("generation predecessor receipt binding is invalid")
+    if (
+        not isinstance(identity, dict)
+        or identity.get("source_commit") != BASE
+        or identity.get("catalogue_commit") != CATALOGUE
+        or identity.get("generation") not in GENERATIONS
+        or identity.get("easybuild_version") != "5.4.0"
+        or identity.get("easyblocks_version") != "5.4.0"
+        or identity.get("root_recipe_sha256")
+        != ROOT_RECIPE_SHA256.get(identity.get("generation"))
+    ):
+        raise ValueError("receipt identity is stale")
+    source_manifest, no_source_symlinks = git_manifest_digest(root, BASE)
+    expected_tree = subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", f"{BASE}^{{tree}}"], text=True
+    ).strip()
+    if (
+        identity["source_tree"] != expected_tree
+        or identity["source_relevant_tree_sha256"] != source_manifest
+        or not no_source_symlinks
+    ):
+        raise ValueError("source tree or manifest is stale")
+    expected_robot_hash = hashlib.sha256(
+        json.dumps(identity["robot_paths"], separators=(",", ":")).encode()
+    ).hexdigest()
+    if identity["robot_manifest_sha256"] != expected_robot_hash:
+        raise ValueError("robot manifest digest is invalid")
+    run_root = Path(data["run_root"])
+    if run_root != path.parent.resolve(strict=True) or run_root.is_symlink():
+        raise ValueError("receipt is outside its exact declared run root")
+    environment = _exact_keys(
+        data["environment"],
+        {
+            "allowlist",
+            "digest",
+            "home",
+            "python_no_user_site",
+            "module_implementation",
+            "module_version",
+            "module_init",
+        },
+        "environment",
+    )
+    if environment["python_no_user_site"] != "1":
+        raise ValueError("user Python environment is not disabled")
+    pairs = dict(item.split("=", 1) for item in environment["allowlist"])
+    if (
+        set(pairs)
+        - {"PATH", "LANG", "LC_ALL", "TERM", "TMPDIR", "HOME", "PYTHONNOUSERSITE"}
+        or pairs.get("HOME") != str(run_root / "home")
+        or pairs.get("PYTHONNOUSERSITE") != "1"
+        or environment["home"] != "home"
+        or environment["module_implementation"] != "EnvironmentModules"
+        or environment["module_init"] != "modulecmd bash"
+        or not environment["module_version"]
+    ):
+        raise ValueError("environment contains inherited or noncanonical values")
+    encoded = json.dumps(
+        environment["allowlist"], sort_keys=True, separators=(",", ":")
+    ).encode()
+    if environment["digest"] != hashlib.sha256(encoded).hexdigest():
+        raise ValueError("environment digest is invalid")
+    preflight = _exact_keys(
+        data["preflight"],
+        {
+            "source_clean",
+            "catalogue_clean",
+            "source_no_symlinks",
+            "catalogue_no_symlinks",
+            "prefix_absent",
+            "install_empty",
+            "module_tree_empty",
+            "preinstalled_voiage_absent",
+        },
+        "preflight",
+    )
+    if not all(value is True for value in preflight.values()):
+        raise ValueError("preflight does not prove fresh clean inputs")
+    commands = data.get("commands")
+    if not isinstance(commands, list) or not commands:
+        raise ValueError("receipt lacks command evidence")
+    for item in commands:
+        _exact_keys(item, COMMAND_KEYS, "command")
+        parsed_keys = {
+            "easybuild": {"easybuild_completed", "installed_module_full_name"},
+            "module-probe": {"structured_probe_written"},
+            "module-unload": {"voiage_absent_after_unload"},
+        }[item["stage"]]
+        _exact_keys(item["parsed"], parsed_keys, "parsed command evidence")
+        artifact = _regular_inside(run_root, str(item.get("log", "")))
+        if not artifact.is_file() or sha256(artifact) != item.get("log_sha256"):
+            raise ValueError("command log is missing or changed")
+    if data["outcome"] == "failed_terminal":
+        failure = _exact_keys(
+            data["failure"],
+            {"stage", "command_index", "exit_code", "signal", "parsed_failure"},
+            "failure",
+        )
+        index = failure["command_index"]
+        if (
+            not isinstance(index, int)
+            or not 0 <= index < len(commands)
+            or failure["stage"] != commands[index]["stage"]
+            or failure["exit_code"] == 0
+            or commands[index]["exit_code"] != failure["exit_code"]
+            or not failure["parsed_failure"]
+            or data["probes"]
+        ):
+            raise ValueError("failed terminal receipt lacks exact nonzero evidence")
+        return data
+    if data["failure"] is not None:
+        raise ValueError("passed receipt contains failure evidence")
+    if data["outcome"] == "passed":
+        if [item["stage"] for item in commands] != [
+            "easybuild",
+            "module-probe",
+            "module-unload",
+        ] or any(item.get("exit_code") != 0 for item in commands):
+            raise ValueError("passed receipt contains a failed command")
+        probes = data.get("probes")
+        if (
+            not isinstance(probes, list)
+            or {p.get("name") for p in probes} != REQUIRED_PROBES
+            or any(p.get("status") != "passed" for p in probes)
+        ):
+            raise ValueError("passed receipt lacks the exact probe matrix")
+        generation = identity["generation"]
+        recipe = f"packaging/easybuild/voiage-2.2.0-foss-{generation}.eb"
+        robot = GENERATIONS[generation] + ["CATALOGUE/easybuild/easyconfigs"]
+        expected = [
+            "eb",
+            recipe,
+            "--robot",
+            f"--robot-paths={':'.join(robot)}",
+            "--prefix=install",
+            "--buildpath=build",
+            "--sourcepath=sources",
+            "--modules-tool=EnvironmentModules",
+            "--module-syntax=Tcl",
+            "--disable-download",
+            "--disable-use-existing-modules",
+            "--force",
+        ]
+        if (
+            commands[0]["argv"] != expected
+            or not commands[0]["parsed"].get("easybuild_completed")
+            or not commands[0]["parsed"].get("installed_module_full_name")
+        ):
+            raise ValueError(
+                "passed receipt does not prove an exact actual EasyBuild build"
+            )
+        module_name = commands[0]["parsed"]["installed_module_full_name"]
+        expected_probe = [
+            "bash",
+            "--noprofile",
+            "--norc",
+            "module-probe.sh",
+            "MODULE_ROOT",
+            module_name,
+            "native_easybuild_probe.py",
+            "install",
+            generation,
+            "probe.json",
+            "OPPOSITE_INSTALL",
+        ]
+        if commands[1]["argv"] != expected_probe or commands[2]["argv"] != [
+            "bash",
+            "--noprofile",
+            "--norc",
+            "module-unload.sh",
+            "MODULE_ROOT",
+            module_name,
+        ]:
+            raise ValueError("module command argv or discovered module name drifted")
+        artifacts = _exact_keys(
+            data["artifacts"],
+            {
+                "build_inventory",
+                "build_inventory_sha256",
+                "module_inventory",
+                "module_inventory_sha256",
+                "source_cache_inventory",
+                "source_cache_inventory_sha256",
+                "probe",
+                "probe_sha256",
+                "preflight",
+                "preflight_sha256",
+                "catalogue_evidence",
+                "catalogue_evidence_sha256",
+                "postflight",
+                "postflight_sha256",
+            },
+            "artifacts",
+        )
+        preflight_path = _regular_inside(run_root, artifacts["preflight"])
+        catalogue_path = _regular_inside(run_root, artifacts["catalogue_evidence"])
+        postflight_path = _regular_inside(run_root, artifacts["postflight"])
+        if (
+            sha256(preflight_path) != artifacts["preflight_sha256"]
+            or sha256(catalogue_path) != artifacts["catalogue_evidence_sha256"]
+            or sha256(postflight_path) != artifacts["postflight_sha256"]
+        ):
+            raise ValueError("preflight or catalogue evidence is unbound")
+        preflight_evidence = json.loads(preflight_path.read_text())
+        postflight_evidence = json.loads(postflight_path.read_text())
+        expected_preflight_keys = {
+            "environment_digest",
+            "source_head",
+            "source_tree",
+            "source_status",
+            "catalogue_head",
+            "catalogue_tree",
+            "catalogue_status",
+            "prefix_absent",
+            "module_tree_empty",
+            "preinstalled_voiage_absent",
+            "input_cache_digest",
+            "staged_cache_digest_before",
+            "staged_cache_digest_after",
+        }
+        if (
+            set(preflight_evidence) != expected_preflight_keys
+            or preflight_evidence["environment_digest"] != environment["digest"]
+            or preflight_evidence["source_head"] != BASE
+            or preflight_evidence["source_tree"] != identity["source_tree"]
+            or preflight_evidence["source_status"] != ""
+            or preflight_evidence["catalogue_head"] != CATALOGUE
+            or preflight_evidence["catalogue_tree"] != identity["catalogue_tree"]
+            or preflight_evidence["catalogue_status"] != ""
+            or not all(
+                preflight_evidence[key] is True
+                for key in (
+                    "prefix_absent",
+                    "module_tree_empty",
+                    "preinstalled_voiage_absent",
+                )
+            )
+            or len(
+                {
+                    preflight_evidence[key]
+                    for key in (
+                        "input_cache_digest",
+                        "staged_cache_digest_before",
+                        "staged_cache_digest_after",
+                    )
+                }
+            )
+            != 1
+        ):
+            raise ValueError("preflight transcript is invalid")
+        if postflight_evidence != {
+            key: preflight_evidence[key]
+            for key in (
+                "source_head",
+                "source_tree",
+                "source_status",
+                "catalogue_head",
+                "catalogue_tree",
+                "catalogue_status",
+            )
+        }:
+            raise ValueError("postflight checkout evidence drifted")
+        catalogue_evidence = json.loads(catalogue_path.read_text())
+        listing = catalogue_evidence.get("ls_tree")
+        if (
+            not isinstance(listing, list)
+            or not listing
+            or hashlib.sha256(("\n".join(listing) + "\n").encode()).hexdigest()
+            != identity["catalogue_relevant_tree_sha256"]
+            or catalogue_evidence
+            != {
+                "commit": identity["catalogue_commit"],
+                "tree": identity["catalogue_tree"],
+                "manifest_sha256": identity["catalogue_relevant_tree_sha256"],
+                "ls_tree": listing,
+            }
+        ):
+            raise ValueError("portable catalogue evidence is invalid")
+        if (
+            identity["catalogue_tree"] != CATALOGUE_TREE
+            or identity["catalogue_relevant_tree_sha256"] != CATALOGUE_MANIFEST_SHA256
+        ):
+            raise ValueError(
+                "catalogue object closure differs from the pinned contract"
+            )
+        inventories: dict[str, list[dict[str, Any]]] = {}
+        for key in ("build_inventory", "module_inventory", "source_cache_inventory"):
+            inventory = _regular_inside(run_root, artifacts[key])
+            if sha256(inventory) != artifacts[key + "_sha256"]:
+                raise ValueError("inventory is unbound")
+            inventories[key] = _manifest(inventory)
+        if (
+            identity["source_cache_manifest_sha256"]
+            != artifacts["source_cache_inventory_sha256"]
+        ):
+            raise ValueError("source cache identity binding is invalid")
+        inventory_paths = {
+            key: {item["path"] for item in value} for key, value in inventories.items()
+        }
+        if not any(
+            "voiage/" in item.lower() for item in inventory_paths["module_inventory"]
+        ):
+            raise ValueError("module inventory lacks generated Voiage modulefile")
+        required_tokens = ("voiage", "_core", "python", "pyarrow", "polars")
+        if any(
+            not any(
+                token in item.lower() for item in inventory_paths["build_inventory"]
+            )
+            for token in required_tokens
+        ):
+            raise ValueError("install inventory lacks required native runtime entries")
+        if not inventory_paths["source_cache_inventory"]:
+            raise ValueError("source inventory lacks checksum-bound sources")
+        probe_path = _regular_inside(run_root, artifacts["probe"])
+        if sha256(probe_path) != artifacts["probe_sha256"]:
+            raise ValueError("structured probe transcript is unbound or changed")
+        probe: Any = json.loads(probe_path.read_text())
+        _exact_keys(
+            probe,
+            {
+                "schema_version",
+                "generation",
+                "paths",
+                "evpi",
+                "arrow",
+                "polars",
+                "linkage",
+                "thread",
+                "module",
+            },
+            "probe",
+        )
+        if (
+            probe.get("generation") != identity["generation"]
+            or probe.get("evpi")
+            != {
+                "input": [[0.0, 2.0], [2.0, 0.0]],
+                "dtype": "float64",
+                "value": 1.0,
+                "tolerance": 0.0,
+            }
+            or probe.get("arrow")
+            != {
+                "version": "25.0.1",
+                "schema": "value: int64",
+                "values": [1, None, 3],
+                "null_count": 1,
+                "buffer_equal": True,
+                "buffer_size_positive": True,
+            }
+            or probe.get("polars")
+            != {
+                "version": "1.42.1",
+                "schema": {"value": "Int64"},
+                "values": [1, 3],
+                "null_count": 0,
+                "lazy": True,
+                "arrow_equal": True,
+            }
+            or probe.get("thread")
+            != {"calls": 16, "imports_inside_worker": True, "engines": ["rust"] * 16}
+        ):
+            raise ValueError("structured native probe transcript is invalid")
+        linkage = _exact_keys(
+            probe["linkage"],
+            {
+                "objects",
+                "tool",
+                "targets",
+                "transcripts",
+            },
+            "linkage",
+        )
+        if len(linkage["objects"]) < 3 or set(linkage["transcripts"]) != set(
+            linkage["objects"]
+        ):
+            raise ValueError("native linkage evidence is incomplete")
+        install_root = run_root / "install"
+        for object_path in linkage["objects"]:
+            candidate = Path(object_path)
+            try:
+                candidate.resolve(strict=True).relative_to(
+                    install_root.resolve(strict=True)
+                )
+            except (FileNotFoundError, ValueError) as exc:
+                raise ValueError(
+                    "linkage object escapes the exact generation prefix"
+                ) from exc
+        transcript_text = "\n".join(linkage["transcripts"].values())
+        parsed_targets = sorted(set(re.findall(r"(?<!\S)(/[^\s(]+)", transcript_text)))
+        if linkage["targets"] != parsed_targets or "not found" in transcript_text:
+            raise ValueError("linkage targets do not match retained transcripts")
+        opposite = (
+            run_root.parent
+            / f"voiage-easybuild-{'2024a' if identity['generation'] == '2023a' else '2023a'}"
+            / "install"
+        )
+        system_roots = (
+            Path("/lib"),
+            Path("/lib64"),
+            Path("/usr/lib"),
+            Path("/usr/lib64"),
+        )
+        for target_text in parsed_targets:
+            target = Path(target_text)
+            if (
+                target == opposite
+                or opposite in target.parents
+                or (
+                    not (target == install_root or install_root in target.parents)
+                    and not any(
+                        target == base or base in target.parents
+                        for base in system_roots
+                    )
+                )
+            ):
+                raise ValueError("linkage target escapes exact allowed roots")
+        if probe["module"] != {
+            "loaded_paths_introduced": True,
+            "unload_paths_removed": True,
+            "fresh_shell": True,
+        }:
+            raise ValueError("module isolation evidence is incomplete")
+        if (
+            not isinstance(probe["paths"], list)
+            or len(probe["paths"]) != 6
+            or any(
+                not (Path(item) == install_root or install_root in Path(item).parents)
+                for item in probe["paths"]
+            )
+        ):
+            raise ValueError("installed runtime paths are incomplete")
+        if (
+            identity.get("source_tree")
+            != subprocess.check_output(
+                ["git", "-C", str(root), "rev-parse", f"{BASE}^{{tree}}"],
+                text=True,
+            ).strip()
+        ):
+            raise ValueError("source tree is stale")
+    return data
+
+
+def validate_matrix(path: Path, root: Path) -> dict[str, Any]:
+    """Require terminal passing receipts for both maintained generations."""
+    data: Any = json.loads(path.read_text())
+    if (
+        not isinstance(data, dict)
+        or set(data)
+        != {"schema_version", "run_id", "shared_inputs", "sequence", "receipts"}
+        or data["schema_version"] != "voiage.native-easybuild-matrix.v1"
+    ):
+        raise ValueError("invalid native EasyBuild matrix")
+    if (
+        data["sequence"] != ["2023a", "2024a"]
+        or not isinstance(data["run_id"], str)
+        or not data["run_id"]
+    ):
+        raise ValueError("matrix does not prove sequential generation order")
+    shared = _exact_keys(
+        data["shared_inputs"],
+        {
+            "source_commit",
+            "source_tree",
+            "catalogue_commit",
+            "easybuild_version",
+            "easyblocks_version",
+        },
+        "matrix shared inputs",
+    )
+    if shared != {
+        "source_commit": BASE,
+        "source_tree": subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", f"{BASE}^{{tree}}"], text=True
+        ).strip(),
+        "catalogue_commit": CATALOGUE,
+        "easybuild_version": "5.4.0",
+        "easyblocks_version": "5.4.0",
+    }:
+        raise ValueError("matrix shared inputs are stale")
+    receipts = data["receipts"]
+    if not isinstance(receipts, dict) or set(receipts) != set(GENERATIONS):
+        raise ValueError("both EasyBuild generations are required")
+    if any(
+        not isinstance(item, dict) or set(item) != {"path", "sha256"}
+        for item in receipts.values()
+    ):
+        raise ValueError("matrix receipt bindings are invalid")
+    if len({item["path"] for item in receipts.values()}) != 2:
+        raise ValueError("generation receipts must be distinct")
+    seen_roots: set[str] = set()
+    validated: dict[str, tuple[dict[str, Any], Path]] = {}
+    for generation, binding in receipts.items():
+        receipt_path = _regular_inside(
+            path.parent.resolve(strict=True), str(binding["path"])
+        )
+        if sha256(receipt_path) != binding["sha256"]:
+            raise ValueError("matrix receipt digest is invalid")
+        receipt = validate_receipt(receipt_path, root)
+        if (
+            receipt["outcome"] != "passed"
+            or receipt["identity"]["generation"] != generation
+        ):
+            raise ValueError("both EasyBuild generations must pass exactly")
+        if receipt["run_root"] in seen_roots:
+            raise ValueError("generation run roots must be distinct")
+        seen_roots.add(receipt["run_root"])
+        validated[generation] = (receipt, receipt_path)
+    earlier, earlier_path = validated["2023a"]
+    later, _ = validated["2024a"]
+    if (
+        earlier["run"]["run_id"] != data["run_id"]
+        or later["run"]["run_id"] != data["run_id"]
+        or later["run"]["predecessor_receipt_sha256"] != sha256(earlier_path)
+        or datetime.fromisoformat(earlier["run"]["ended_at"])
+        > datetime.fromisoformat(later["run"]["started_at"])
+    ):
+        raise ValueError("matrix receipts do not form one ordered sequential run")
+    return data
+
+
+def main() -> int:
+    """Run one guarded EasyBuild generation and capture terminal evidence."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("generation", choices=GENERATIONS)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--catalogue", type=Path, required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--source-cache", type=Path, required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--predecessor-receipt", type=Path)
+    parser.add_argument("--execute", action="store_true")
+    args = parser.parse_args()
+    started_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    if args.generation == "2024a" and args.predecessor_receipt is None:
+        raise SystemExit("2024a requires the terminal 2023a predecessor receipt")
+    if args.generation == "2023a" and args.predecessor_receipt is not None:
+        raise SystemExit("2023a must start the sequential run")
+    predecessor_sha = (
+        sha256(args.predecessor_receipt) if args.predecessor_receipt else None
+    )
+    if (
+        args.root.absolute() != args.root.resolve()
+        or args.workspace.absolute() != args.workspace.resolve()
+    ):
+        raise SystemExit("source and workspace roots must not be symlinks")
+    root = args.root.resolve()
+    workspace = args.workspace.resolve()
+    source_cache = args.source_cache.resolve()
+    if args.predecessor_receipt:
+        predecessor = validate_receipt(args.predecessor_receipt.resolve(), root)
+        if (
+            predecessor["outcome"] != "passed"
+            or predecessor["identity"]["generation"] != "2023a"
+            or predecessor["run"]["run_id"] != args.run_id
+            or predecessor["identity"]["source_commit"] != BASE
+            or predecessor["identity"]["catalogue_commit"] != CATALOGUE
+        ):
+            raise SystemExit(
+                "predecessor is not the passing 2023a receipt for this run"
+            )
+    if not args.execute:
+        raise SystemExit("refusing native build without explicit --execute")
+    if source_cache.is_symlink() or not source_cache.is_dir():
+        raise SystemExit("prepared source cache must be a real directory")
+    if any(item.is_symlink() for item in source_cache.rglob("*")):
+        raise SystemExit("prepared source cache must not contain symlinks")
+    input_cache_digest = directory_digest(source_cache)
+    if (
+        subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+        != BASE
+    ):
+        raise SystemExit("source checkout is not the reviewed commit")
+    if subprocess.check_output(
+        ["git", "-C", str(root), "status", "--porcelain"], text=True
+    ).strip():
+        raise SystemExit("source checkout must be clean")
+    if (
+        subprocess.check_output(
+            ["git", "-C", str(args.catalogue), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+        != CATALOGUE
+    ):
+        raise SystemExit("EasyBuild catalogue is not the reviewed commit")
+    if (
+        sys.platform != "linux"
+        or shutil.which("eb") is None
+        or shutil.which("modulecmd") is None
+    ):
+        raise SystemExit("Linux, EasyBuild, and Environment Modules are required")
+    if "5.4.0" not in subprocess.check_output(["eb", "--version"], text=True):
+        raise SystemExit("EasyBuild framework 5.4.0 is required")
+    easyblocks_version = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            "import easybuild.easyblocks; print(easybuild.easyblocks.__version__)",
+        ],
+        text=True,
+    ).strip()
+    if easyblocks_version != "5.4.0":
+        raise SystemExit("EasyBuild easyblocks 5.4.0 is required")
+    if root == workspace or root in workspace.parents or workspace in root.parents:
+        raise SystemExit("workspace and source must be separate, non-symlink trees")
+    if os.environ.get("VOIAGE_VM_LOCAL_STORAGE") != "confirmed":
+        raise SystemExit("workspace must be explicitly confirmed as VM-local storage")
+    free = shutil.disk_usage(workspace).free
+    if free < 250 * 1024**3 or (os.cpu_count() or 0) < 8:
+        raise SystemExit("native workspace needs 250 GiB free and at least 8 CPUs")
+    run_dir = workspace / f"voiage-easybuild-{args.generation}"
+    run_dir.mkdir()  # deliberate refusal to overwrite evidence
+    catalogue = args.catalogue.resolve()
+    if subprocess.check_output(
+        ["git", "-C", str(catalogue), "status", "--porcelain"], text=True
+    ).strip():
+        raise SystemExit("EasyBuild catalogue must be clean")
+    robot_relative = GENERATIONS[args.generation] + ["CATALOGUE/easybuild/easyconfigs"]
+    robot_actual = [str(root / item) for item in GENERATIONS[args.generation]] + [
+        str(catalogue / "easybuild/easyconfigs")
+    ]
+    recipe_relative = f"packaging/easybuild/voiage-2.2.0-foss-{args.generation}.eb"
+    recipe = root / recipe_relative
+    prefix, build, sources, home = (
+        run_dir / "install",
+        run_dir / "build",
+        run_dir / "sources",
+        run_dir / "home",
+    )
+    if any(item.exists() for item in (prefix, build, sources, home)):
+        raise SystemExit("generation prefix/build/source/home must start absent")
+    for item in (build, home):
+        item.mkdir()
+    shutil.copytree(source_cache, sources, copy_function=shutil.copy2)
+    for item in sources.rglob("*"):
+        item.chmod(0o555 if item.is_dir() else 0o444)
+    sources.chmod(0o555)
+    staged_cache_digest_before = directory_digest(sources)
+    if staged_cache_digest_before != input_cache_digest:
+        raise SystemExit("staged source cache differs from prepared input")
+    env, allowlist, env_digest = clean_environment(home)
+    actual_argv = [
+        "eb",
+        str(recipe),
+        "--robot",
+        f"--robot-paths={':'.join(robot_actual)}",
+        f"--prefix={prefix}",
+        f"--buildpath={build}",
+        f"--sourcepath={sources}",
+        "--modules-tool=EnvironmentModules",
+        "--module-syntax=Tcl",
+        "--disable-download",
+        "--disable-use-existing-modules",
+        "--force",
+    ]
+    recorded_argv = [
+        "eb",
+        recipe_relative,
+        "--robot",
+        f"--robot-paths={':'.join(robot_relative)}",
+        "--prefix=install",
+        "--buildpath=build",
+        "--sourcepath=sources",
+        "--modules-tool=EnvironmentModules",
+        "--module-syntax=Tcl",
+        "--disable-download",
+        "--disable-use-existing-modules",
+        "--force",
+    ]
+    absent_probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import importlib.util; raise SystemExit(importlib.util.find_spec('voiage') is not None)",
+        ],
+        cwd=home,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    preflight_file = run_dir / "preflight.json"
+    preflight_evidence = {
+        "environment_digest": env_digest,
+        "source_head": BASE,
+        "source_tree": subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "HEAD^{tree}"], text=True
+        ).strip(),
+        "source_status": subprocess.check_output(
+            ["git", "-C", str(root), "status", "--porcelain"], text=True
+        ).strip(),
+        "catalogue_head": CATALOGUE,
+        "catalogue_tree": subprocess.check_output(
+            ["git", "-C", str(catalogue), "rev-parse", "HEAD^{tree}"], text=True
+        ).strip(),
+        "catalogue_status": subprocess.check_output(
+            ["git", "-C", str(catalogue), "status", "--porcelain"], text=True
+        ).strip(),
+        "prefix_absent": not prefix.exists(),
+        "module_tree_empty": not prefix.exists(),
+        "preinstalled_voiage_absent": absent_probe.returncode == 0,
+        "input_cache_digest": input_cache_digest,
+        "staged_cache_digest_before": staged_cache_digest_before,
+        "staged_cache_digest_after": None,
+    }
+    preflight_file.write_text(json.dumps(preflight_evidence, sort_keys=True) + "\n")
+    if absent_probe.returncode != 0:
+        raise SystemExit("clean preflight found a preinstalled Voiage")
+    build_log = run_dir / "build.log"
+    build_code = run(actual_argv, build_log, env)
+    commands = [
+        {
+            "stage": "easybuild",
+            "argv": recorded_argv,
+            "exit_code": build_code,
+            "signal": -build_code if build_code < 0 else None,
+            "log": "build.log",
+            "log_sha256": sha256(build_log),
+            "parsed": {
+                "easybuild_completed": False,
+                "installed_module_full_name": None,
+            },
+        }
+    ]
+    probes: list[dict[str, str]] = []
+    failure: dict[str, Any] | None = None
+    probe_json = run_dir / "probe.json"
+    module_files = list(prefix.rglob("voiage/2.2.0*")) if prefix.exists() else []
+    if (
+        build_code == 0
+        and len(module_files) == 1
+        and module_files[0].is_file()
+        and not module_files[0].is_symlink()
+    ):
+        module_name = str(
+            module_files[0].relative_to(module_files[0].parents[1])
+        ).removesuffix(".lua")
+        commands[0]["parsed"]["installed_module_full_name"] = module_name
+        commands[0]["parsed"]["easybuild_completed"] = parse_build_success(
+            build_log, module_name
+        )
+        script = run_dir / "module-probe.sh"
+        script.write_text(
+            '#!/bin/bash\nset -euo pipefail\neval "$(modulecmd bash purge)"\neval "$(modulecmd bash use "$1")"\neval "$(modulecmd bash load "$2")"\nexec python3 "$3" --prefix "$4" --generation "$5" --output "$6" --opposite-prefix "$7"\n'
+        )
+        script.chmod(0o700)
+        probe_log = run_dir / "probe.log"
+        probe_argv = [
+            "bash",
+            "--noprofile",
+            "--norc",
+            str(script),
+            str(module_files[0].parents[1]),
+            module_name,
+            str(root / "scripts/native_easybuild_probe.py"),
+            str(prefix),
+            args.generation,
+            str(probe_json),
+            str(
+                workspace
+                / f"voiage-easybuild-{'2024a' if args.generation == '2023a' else '2023a'}"
+                / "install"
+            ),
+        ]
+        probe_code = run(probe_argv, probe_log, env)
+        commands.append(
+            {
+                "stage": "module-probe",
+                "argv": [
+                    "bash",
+                    "--noprofile",
+                    "--norc",
+                    "module-probe.sh",
+                    "MODULE_ROOT",
+                    module_name,
+                    "native_easybuild_probe.py",
+                    "install",
+                    args.generation,
+                    "probe.json",
+                    "OPPOSITE_INSTALL",
+                ],
+                "exit_code": probe_code,
+                "signal": -probe_code if probe_code < 0 else None,
+                "log": "probe.log",
+                "log_sha256": sha256(probe_log),
+                "parsed": {"structured_probe_written": probe_json.is_file()},
+            }
+        )
+        unload_log = run_dir / "unload.log"
+        unload_script = run_dir / "module-unload.sh"
+        unload_script.write_text(
+            '#!/bin/bash\nset -euo pipefail\neval "$(modulecmd bash purge)"\neval "$(modulecmd bash use "$1")"\neval "$(modulecmd bash load "$2")"\neval "$(modulecmd bash unload "$2")"\npython3 -c \'import importlib.util; raise SystemExit(importlib.util.find_spec("voiage") is not None)\'\n'
+        )
+        unload_script.chmod(0o700)
+        unload_code = run(
+            [
+                "bash",
+                "--noprofile",
+                "--norc",
+                str(unload_script),
+                str(module_files[0].parents[1]),
+                module_name,
+            ],
+            unload_log,
+            env,
+        )
+        commands.append(
+            {
+                "stage": "module-unload",
+                "argv": [
+                    "bash",
+                    "--noprofile",
+                    "--norc",
+                    "module-unload.sh",
+                    "MODULE_ROOT",
+                    module_name,
+                ],
+                "exit_code": unload_code,
+                "signal": -unload_code if unload_code < 0 else None,
+                "log": "unload.log",
+                "log_sha256": sha256(unload_log),
+                "parsed": {"voiage_absent_after_unload": unload_code == 0},
+            }
+        )
+        code = probe_code or unload_code
+        if code == 0:
+            probes = [
+                {"name": name, "status": "passed"} for name in sorted(REQUIRED_PROBES)
+            ]
+    else:
+        code = build_code or 1
+    if code != 0:
+        index = next(
+            (i for i, item in enumerate(commands) if item["exit_code"] != 0), 0
+        )
+        commands[index]["exit_code"] = commands[index]["exit_code"] or 1
+        failure = {
+            "stage": commands[index]["stage"],
+            "command_index": index,
+            "exit_code": commands[index]["exit_code"],
+            "signal": commands[index]["signal"],
+            "parsed_failure": parsed_failure(run_dir / commands[index]["log"]),
+        }
+    artifacts: dict[str, Any] = {
+        "build_inventory": None,
+        "build_inventory_sha256": None,
+        "module_inventory": None,
+        "module_inventory_sha256": None,
+        "source_cache_inventory": None,
+        "source_cache_inventory_sha256": None,
+        "probe": None,
+        "probe_sha256": None,
+        "preflight": None,
+        "preflight_sha256": None,
+        "catalogue_evidence": None,
+        "catalogue_evidence_sha256": None,
+        "postflight": None,
+        "postflight_sha256": None,
+    }
+    if code == 0:
+        preflight_evidence["staged_cache_digest_after"] = directory_digest(sources)
+        preflight_file.write_text(json.dumps(preflight_evidence, sort_keys=True) + "\n")
+        postflight_file = run_dir / "postflight.json"
+        postflight = {
+            "source_head": subprocess.check_output(
+                ["git", "-C", str(root), "rev-parse", "HEAD"], text=True
+            ).strip(),
+            "source_tree": subprocess.check_output(
+                ["git", "-C", str(root), "rev-parse", "HEAD^{tree}"], text=True
+            ).strip(),
+            "source_status": subprocess.check_output(
+                ["git", "-C", str(root), "status", "--porcelain"], text=True
+            ).strip(),
+            "catalogue_head": subprocess.check_output(
+                ["git", "-C", str(catalogue), "rev-parse", "HEAD"], text=True
+            ).strip(),
+            "catalogue_tree": subprocess.check_output(
+                ["git", "-C", str(catalogue), "rev-parse", "HEAD^{tree}"], text=True
+            ).strip(),
+            "catalogue_status": subprocess.check_output(
+                ["git", "-C", str(catalogue), "status", "--porcelain"], text=True
+            ).strip(),
+        }
+        expected_postflight = {key: preflight_evidence[key] for key in postflight}
+        if postflight != expected_postflight:
+            raise SystemExit("source or catalogue checkout drifted during build")
+        postflight_file.write_text(json.dumps(postflight, sort_keys=True) + "\n")
+        artifacts.update(
+            {
+                "postflight": postflight_file.name,
+                "postflight_sha256": sha256(postflight_file),
+            }
+        )
+        catalogue_manifest, _ = git_manifest_digest(catalogue, "HEAD")
+        catalogue_tree = subprocess.check_output(
+            ["git", "-C", str(catalogue), "rev-parse", "HEAD^{tree}"], text=True
+        ).strip()
+        catalogue_file = run_dir / "catalogue-evidence.json"
+        catalogue_listing = subprocess.check_output(
+            ["git", "-C", str(catalogue), "ls-tree", "-r", "HEAD"], text=True
+        ).splitlines()
+        catalogue_file.write_text(
+            json.dumps(
+                {
+                    "commit": CATALOGUE,
+                    "tree": catalogue_tree,
+                    "manifest_sha256": catalogue_manifest,
+                    "ls_tree": catalogue_listing,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        artifacts.update(
+            {
+                "preflight": preflight_file.name,
+                "preflight_sha256": sha256(preflight_file),
+                "catalogue_evidence": catalogue_file.name,
+                "catalogue_evidence_sha256": sha256(catalogue_file),
+            }
+        )
+        for key, directory in (
+            ("build_inventory", prefix),
+            ("module_inventory", module_files[0].parents[1]),
+            ("source_cache_inventory", sources),
+        ):
+            target = run_dir / f"{key}.json"
+            artifacts[key] = target.name
+            artifacts[key + "_sha256"] = write_inventory(directory, target)
+        artifacts["probe"], artifacts["probe_sha256"] = "probe.json", sha256(probe_json)
+    source_manifest, source_no_symlinks = git_manifest_digest(root, "HEAD")
+    catalogue_manifest, catalogue_no_symlinks = git_manifest_digest(catalogue, "HEAD")
+    source_tree = subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    catalogue_tree = subprocess.check_output(
+        ["git", "-C", str(catalogue), "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    receipt = {
+        "schema_version": "voiage.native-easybuild-terminal-receipt.v1",
+        "terminal": True,
+        "outcome": "passed" if code == 0 else "failed_terminal",
+        "run_root": str(run_dir.resolve()),
+        "identity": {
+            "generation": args.generation,
+            "source_commit": BASE,
+            "source_tree": source_tree,
+            "source_relevant_tree_sha256": source_manifest,
+            "catalogue_root": str(catalogue),
+            "catalogue_commit": CATALOGUE,
+            "catalogue_tree": catalogue_tree,
+            "catalogue_relevant_tree_sha256": catalogue_manifest,
+            "easybuild_version": "5.4.0",
+            "easyblocks_version": easyblocks_version,
+            "root_recipe": recipe_relative,
+            "root_recipe_sha256": sha256(recipe),
+            "robot_paths": robot_relative,
+            "robot_manifest_sha256": hashlib.sha256(
+                json.dumps(robot_relative, separators=(",", ":")).encode()
+            ).hexdigest(),
+            "source_cache_manifest_sha256": artifacts["source_cache_inventory_sha256"]
+            or "0" * 64,
+        },
+        "environment": {
+            "allowlist": allowlist,
+            "digest": env_digest,
+            "home": "home",
+            "python_no_user_site": "1",
+            "module_implementation": "EnvironmentModules",
+            "module_version": subprocess.check_output(
+                ["modulecmd", "--version"], text=True, stderr=subprocess.STDOUT
+            ).strip(),
+            "module_init": "modulecmd bash",
+        },
+        "resources": {
+            "cpu_count": os.cpu_count(),
+            "free_bytes_before": free,
+        },
+        "preflight": {
+            "source_clean": True,
+            "catalogue_clean": True,
+            "source_no_symlinks": source_no_symlinks,
+            "catalogue_no_symlinks": catalogue_no_symlinks,
+            "prefix_absent": True,
+            "install_empty": True,
+            "module_tree_empty": True,
+            "preinstalled_voiage_absent": True,
+        },
+        "commands": commands,
+        "artifacts": artifacts,
+        "probes": probes,
+        "failure": failure,
+        "run": {
+            "run_id": args.run_id,
+            "started_at": started_at,
+            "ended_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "predecessor_receipt_sha256": predecessor_sha,
+        },
+    }
+    receipt_path = run_dir / "receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n")
+    validate_receipt(receipt_path, root)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_native_easybuild_matrix.py
+++ b/scripts/validate_native_easybuild_matrix.py
@@ -1,0 +1,23 @@
+"""Validate the complete two-generation native EasyBuild evidence matrix."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.native_easybuild_qualification import validate_matrix
+
+
+def main() -> int:
+    """Validate both terminal generation receipts."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("matrix", type=Path)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    validate_matrix(args.matrix, args.root)
+    print("Native EasyBuild matrix: PASS (2023a and 2024a)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_native_easybuild_matrix.py
+++ b/scripts/validate_native_easybuild_matrix.py
@@ -13,8 +13,11 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("matrix", type=Path)
     parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--tooling-root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
     args = parser.parse_args()
-    validate_matrix(args.matrix, args.root)
+    validate_matrix(args.matrix, args.root, args.tooling_root)
     print("Native EasyBuild matrix: PASS (2023a and 2024a)")
     return 0
 

--- a/specs/native-easybuild-terminal-receipt-v1.schema.json
+++ b/specs/native-easybuild-terminal-receipt-v1.schema.json
@@ -259,6 +259,7 @@
           "stage": {
             "enum": [
               "easybuild",
+              "module-discovery",
               "module-probe",
               "module-unload"
             ]
@@ -290,6 +291,31 @@
           }
         },
         "allOf": [
+          {
+            "if": {
+              "properties": {
+                "stage": {
+                  "const": "module-discovery"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "parsed": {
+                  "required": [
+                    "modulefile_match_count"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "modulefile_match_count": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                }
+              }
+            }
+          },
           {
             "if": {
               "properties": {
@@ -524,6 +550,7 @@
         "stage": {
           "enum": [
             "easybuild",
+            "module-discovery",
             "module-probe",
             "module-unload"
           ]

--- a/specs/native-easybuild-terminal-receipt-v1.schema.json
+++ b/specs/native-easybuild-terminal-receipt-v1.schema.json
@@ -50,7 +50,12 @@
         "root_recipe_sha256",
         "robot_paths",
         "robot_manifest_sha256",
-        "source_cache_manifest_sha256"
+        "source_cache_manifest_sha256",
+        "tooling_commit",
+        "tooling_tree",
+        "tooling_root",
+        "tooling_driver_sha256",
+        "tooling_probe_sha256"
       ],
       "additionalProperties": false,
       "properties": {
@@ -114,6 +119,26 @@
         "catalogue_root": {
           "type": "string",
           "minLength": 1
+        },
+        "tooling_commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "tooling_tree": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "tooling_root": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tooling_driver_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "tooling_probe_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
         }
       }
     },

--- a/specs/native-easybuild-terminal-receipt-v1.schema.json
+++ b/specs/native-easybuild-terminal-receipt-v1.schema.json
@@ -1,0 +1,735 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "terminal",
+    "outcome",
+    "run_root",
+    "identity",
+    "environment",
+    "resources",
+    "preflight",
+    "commands",
+    "artifacts",
+    "probes",
+    "failure",
+    "run"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "voiage.native-easybuild-terminal-receipt.v1"
+    },
+    "terminal": {
+      "const": true
+    },
+    "outcome": {
+      "enum": [
+        "passed",
+        "failed_terminal"
+      ]
+    },
+    "run_root": {
+      "type": "string"
+    },
+    "identity": {
+      "type": "object",
+      "required": [
+        "generation",
+        "source_commit",
+        "source_tree",
+        "source_relevant_tree_sha256",
+        "catalogue_root",
+        "catalogue_commit",
+        "catalogue_tree",
+        "catalogue_relevant_tree_sha256",
+        "easybuild_version",
+        "easyblocks_version",
+        "root_recipe",
+        "root_recipe_sha256",
+        "robot_paths",
+        "robot_manifest_sha256",
+        "source_cache_manifest_sha256"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "generation": {
+          "enum": [
+            "2023a",
+            "2024a"
+          ]
+        },
+        "source_commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "source_tree": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "source_relevant_tree_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "catalogue_commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "catalogue_tree": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "catalogue_relevant_tree_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "easybuild_version": {
+          "const": "5.4.0"
+        },
+        "easyblocks_version": {
+          "const": "5.4.0"
+        },
+        "root_recipe": {
+          "type": "string"
+        },
+        "root_recipe_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "robot_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "robot_manifest_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_cache_manifest_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "catalogue_root": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "required": [
+        "allowlist",
+        "digest",
+        "home",
+        "python_no_user_site",
+        "module_implementation",
+        "module_version",
+        "module_init"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "allowlist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "home": {
+          "type": "string"
+        },
+        "python_no_user_site": {
+          "const": "1"
+        },
+        "module_implementation": {
+          "type": "string"
+        },
+        "module_version": {
+          "type": "string"
+        },
+        "module_init": {
+          "type": "string"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "required": [
+        "cpu_count",
+        "free_bytes_before"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "cpu_count": {
+          "type": "integer",
+          "minimum": 8
+        },
+        "free_bytes_before": {
+          "type": "integer",
+          "minimum": 268435456000
+        }
+      }
+    },
+    "preflight": {
+      "type": "object",
+      "required": [
+        "source_clean",
+        "catalogue_clean",
+        "source_no_symlinks",
+        "catalogue_no_symlinks",
+        "prefix_absent",
+        "install_empty",
+        "module_tree_empty",
+        "preinstalled_voiage_absent"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source_clean": {
+          "const": true
+        },
+        "catalogue_clean": {
+          "const": true
+        },
+        "source_no_symlinks": {
+          "const": true
+        },
+        "catalogue_no_symlinks": {
+          "const": true
+        },
+        "prefix_absent": {
+          "const": true
+        },
+        "install_empty": {
+          "const": true
+        },
+        "module_tree_empty": {
+          "const": true
+        },
+        "preinstalled_voiage_absent": {
+          "const": true
+        }
+      }
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "stage",
+          "argv",
+          "exit_code",
+          "signal",
+          "log",
+          "log_sha256",
+          "parsed"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "stage": {
+            "enum": [
+              "easybuild",
+              "module-probe",
+              "module-unload"
+            ]
+          },
+          "argv": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "exit_code": {
+            "type": "integer"
+          },
+          "signal": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "log": {
+            "type": "string"
+          },
+          "log_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "parsed": {
+            "type": "object"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "stage": {
+                  "const": "easybuild"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "parsed": {
+                  "required": [
+                    "easybuild_completed",
+                    "installed_module_full_name"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "easybuild_completed": {
+                      "type": "boolean"
+                    },
+                    "installed_module_full_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "stage": {
+                  "const": "module-probe"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "parsed": {
+                  "required": [
+                    "structured_probe_written"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "structured_probe_written": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "stage": {
+                  "const": "module-unload"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "parsed": {
+                  "required": [
+                    "voiage_absent_after_unload"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "voiage_absent_after_unload": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "required": [
+        "build_inventory",
+        "build_inventory_sha256",
+        "module_inventory",
+        "module_inventory_sha256",
+        "source_cache_inventory",
+        "source_cache_inventory_sha256",
+        "probe",
+        "probe_sha256",
+        "preflight",
+        "preflight_sha256",
+        "catalogue_evidence",
+        "catalogue_evidence_sha256",
+        "postflight",
+        "postflight_sha256"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "build_inventory": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "module_inventory": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_cache_inventory": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "probe": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "build_inventory_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "module_inventory_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "source_cache_inventory_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "probe_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "preflight": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^.+$"
+        },
+        "preflight_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "catalogue_evidence": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^.+$"
+        },
+        "catalogue_evidence_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "postflight": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^.+$"
+        },
+        "postflight_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "probes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "status"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "const": "passed"
+          }
+        }
+      }
+    },
+    "failure": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "stage",
+        "command_index",
+        "exit_code",
+        "signal",
+        "parsed_failure"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "stage": {
+          "enum": [
+            "easybuild",
+            "module-probe",
+            "module-unload"
+          ]
+        },
+        "command_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "exit_code": {
+          "type": "integer",
+          "not": {
+            "const": 0
+          }
+        },
+        "signal": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "parsed_failure": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "required": [
+        "run_id",
+        "started_at",
+        "ended_at",
+        "predecessor_receipt_sha256"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "run_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ended_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "predecessor_receipt_sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "const": "passed"
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "failure": {
+            "type": "null"
+          },
+          "commands": {
+            "items": {
+              "properties": {
+                "exit_code": {
+                  "const": 0
+                }
+              }
+            }
+          },
+          "artifacts": {
+            "properties": {
+              "build_inventory": {
+                "type": "string",
+                "minLength": 1
+              },
+              "build_inventory_sha256": {
+                "type": "string"
+              },
+              "module_inventory": {
+                "type": "string",
+                "minLength": 1
+              },
+              "module_inventory_sha256": {
+                "type": "string"
+              },
+              "source_cache_inventory": {
+                "type": "string",
+                "minLength": 1
+              },
+              "source_cache_inventory_sha256": {
+                "type": "string"
+              },
+              "probe": {
+                "type": "string",
+                "minLength": 1
+              },
+              "probe_sha256": {
+                "type": "string"
+              }
+            }
+          },
+          "probes": {
+            "minItems": 8,
+            "maxItems": 8,
+            "uniqueItems": true,
+            "allOf": [
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "module-load"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "cli"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "rust-engine"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "numerical-evpi"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "arrow-roundtrip"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "polars-roundtrip"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "linkage"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "name": {
+                      "const": "generation-isolation"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "failure": {
+            "type": "object"
+          },
+          "probes": {
+            "maxItems": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_native_easybuild_qualification.py
+++ b/tests/test_native_easybuild_qualification.py
@@ -1072,7 +1072,9 @@ with open(a.output, "w") as stream:
 
     def clean_environment(home: Path) -> tuple[dict[str, str], list[str], str]:
         env, _, _ = original_clean_environment(home)
-        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        # Keep fixture preflight and unloaded python3 on the same clean system
+        # interpreter; hosted pytest PATH otherwise contains its installed wheel.
+        env["PATH"] = f"{fake_bin}:/usr/bin:/bin"
         allowlist = [f"{key}={env[key]}" for key in sorted(env)]
         digest = hashlib.sha256(
             json.dumps(allowlist, sort_keys=True, separators=(",", ":")).encode()

--- a/tests/test_native_easybuild_qualification.py
+++ b/tests/test_native_easybuild_qualification.py
@@ -12,17 +12,6 @@ import jsonschema
 import pytest
 
 import scripts.native_easybuild_qualification as qualification
-from scripts.native_easybuild_qualification import (
-    BASE,
-    GENERATIONS,
-    REQUIRED_PROBES,
-    ROOT_RECIPE_SHA256,
-    _manifest,
-    git_manifest_digest,
-    validate_matrix,
-    validate_receipt,
-    write_inventory,
-)
 
 
 def _digest(path: Path) -> str:
@@ -156,7 +145,7 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
     module_inventory, module_hash = _inventory(run_root, "module-inventory")
     source_inventory, source_hash = _inventory(run_root, "source-cache-inventory")
     recipe = f"packaging/easybuild/voiage-2.2.0-foss-{generation}.eb"
-    robot = GENERATIONS[generation] + ["CATALOGUE/easybuild/easyconfigs"]
+    robot = qualification.GENERATIONS[generation] + ["CATALOGUE/easybuild/easyconfigs"]
     allowlist = [
         f"HOME={run_root / 'home'}",
         "LANG=C.UTF-8",
@@ -167,9 +156,11 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
         json.dumps(allowlist, sort_keys=True, separators=(",", ":")).encode()
     ).hexdigest()
     source_tree = subprocess.check_output(
-        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+        ["/usr/bin/git", "rev-parse", f"{qualification.BASE}^{{tree}}"], text=True
     ).strip()
-    source_manifest, _ = git_manifest_digest(Path.cwd(), BASE)
+    source_manifest, _ = qualification.git_manifest_digest(
+        Path.cwd(), qualification.BASE
+    )
     tooling_root = Path(qualification.__file__).resolve().parents[1]
     tooling_commit = subprocess.check_output(
         ["/usr/bin/git", "-C", str(tooling_root), "rev-parse", "HEAD"], text=True
@@ -183,10 +174,10 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
         preflight_path,
         {
             "environment_digest": env_digest,
-            "source_head": BASE,
+            "source_head": qualification.BASE,
             "source_tree": source_tree,
             "source_status": "",
-            "catalogue_head": BASE,
+            "catalogue_head": qualification.BASE,
             "catalogue_tree": source_tree,
             "catalogue_status": "",
             "tooling_head": tooling_commit,
@@ -204,10 +195,10 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
     _write_json(
         postflight_path,
         {
-            "source_head": BASE,
+            "source_head": qualification.BASE,
             "source_tree": source_tree,
             "source_status": "",
-            "catalogue_head": BASE,
+            "catalogue_head": qualification.BASE,
             "catalogue_tree": source_tree,
             "catalogue_status": "",
             "tooling_head": tooling_commit,
@@ -217,12 +208,12 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
     )
     catalogue_path = run_root / "catalogue-evidence.json"
     catalogue_listing = subprocess.check_output(
-        ["/usr/bin/git", "ls-tree", "-r", BASE], text=True
+        ["/usr/bin/git", "ls-tree", "-r", qualification.BASE], text=True
     ).splitlines()
     _write_json(
         catalogue_path,
         {
-            "commit": BASE,
+            "commit": qualification.BASE,
             "tree": source_tree,
             "manifest_sha256": source_manifest,
             "ls_tree": catalogue_listing,
@@ -235,17 +226,17 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
         "run_root": str(run_root),
         "identity": {
             "generation": generation,
-            "source_commit": BASE,
+            "source_commit": qualification.BASE,
             "source_tree": source_tree,
             "source_relevant_tree_sha256": source_manifest,
             "catalogue_root": str(Path.cwd()),
-            "catalogue_commit": BASE,
+            "catalogue_commit": qualification.BASE,
             "catalogue_tree": source_tree,
             "catalogue_relevant_tree_sha256": source_manifest,
             "easybuild_version": "5.4.0",
             "easyblocks_version": "5.4.0",
             "root_recipe": recipe,
-            "root_recipe_sha256": ROOT_RECIPE_SHA256[generation],
+            "root_recipe_sha256": qualification.ROOT_RECIPE_SHA256[generation],
             "robot_paths": robot,
             "robot_manifest_sha256": hashlib.sha256(
                 json.dumps(robot, separators=(",", ":")).encode()
@@ -337,6 +328,7 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
                     "module-unload.sh",
                     "MODULE_ROOT",
                     f"voiage/2.2.0-foss-{generation}",
+                    "home",
                 ],
                 "exit_code": 0,
                 "signal": None,
@@ -362,7 +354,8 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
             "postflight_sha256": _digest(postflight_path),
         },
         "probes": [
-            {"name": name, "status": "passed"} for name in sorted(REQUIRED_PROBES)
+            {"name": name, "status": "passed"}
+            for name in sorted(qualification.REQUIRED_PROBES)
         ],
         "failure": None,
         "run": {
@@ -379,11 +372,11 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
 
 @pytest.fixture(autouse=True)
 def _catalogue_at_test_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(qualification, "CATALOGUE", BASE)
+    monkeypatch.setattr(qualification, "CATALOGUE", qualification.BASE)
     tree = subprocess.check_output(
-        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+        ["/usr/bin/git", "rev-parse", f"{qualification.BASE}^{{tree}}"], text=True
     ).strip()
-    manifest, _ = git_manifest_digest(Path.cwd(), BASE)
+    manifest, _ = qualification.git_manifest_digest(Path.cwd(), qualification.BASE)
     monkeypatch.setattr(qualification, "CATALOGUE_TREE", tree)
     monkeypatch.setattr(qualification, "CATALOGUE_MANIFEST_SHA256", manifest)
     real = qualification.subprocess.check_output
@@ -415,7 +408,10 @@ def _receipt_data(tmp_path: Path) -> dict[str, Any]:
 
 
 def test_accepts_complete_bound_receipt(tmp_path: Path) -> None:
-    assert validate_receipt(_receipt(tmp_path), Path.cwd())["outcome"] == "passed"
+    assert (
+        qualification.validate_receipt(_receipt(tmp_path), Path.cwd())["outcome"]
+        == "passed"
+    )
 
 
 @pytest.mark.parametrize(
@@ -524,14 +520,14 @@ def test_rejects_receipt_contract_mutations(
     path = _receipt(tmp_path)
     _mutate(path, change)
     with pytest.raises(ValueError):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_missing_or_changed_transcript(tmp_path: Path) -> None:
     path = _receipt(tmp_path)
     (tmp_path / "build.log").write_text("fabricated replacement\n")
     with pytest.raises(ValueError, match="missing or changed"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_symlink_artifact(tmp_path: Path) -> None:
@@ -541,7 +537,7 @@ def test_rejects_symlink_artifact(tmp_path: Path) -> None:
     build_log.rename(real_log)
     build_log.symlink_to(real_log)
     with pytest.raises(ValueError, match="symlink"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_artifact_outside_run_root(tmp_path: Path) -> None:
@@ -557,7 +553,7 @@ def test_rejects_artifact_outside_run_root(tmp_path: Path) -> None:
         ),
     )
     with pytest.raises(ValueError, match="escapes"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 @pytest.mark.parametrize(
@@ -581,7 +577,7 @@ def test_rejects_scientific_probe_mutations(
         path, lambda d: d["artifacts"].__setitem__("probe_sha256", _digest(probe_path))
     )
     with pytest.raises(ValueError, match="probe"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_matrix_requires_distinct_receipts_for_both_generations(tmp_path: Path) -> None:
@@ -595,7 +591,7 @@ def test_matrix_requires_distinct_receipts_for_both_generations(tmp_path: Path) 
         },
     )
     with pytest.raises(ValueError):
-        validate_matrix(matrix, Path.cwd())
+        qualification.validate_matrix(matrix, Path.cwd())
 
 
 def test_matrix_requires_both_generations(tmp_path: Path) -> None:
@@ -608,14 +604,14 @@ def test_matrix_requires_both_generations(tmp_path: Path) -> None:
         },
     )
     with pytest.raises(ValueError):
-        validate_matrix(matrix, Path.cwd())
+        qualification.validate_matrix(matrix, Path.cwd())
 
 
 def test_rejects_inherited_environment_name(tmp_path: Path) -> None:
     path = _receipt(tmp_path)
     _mutate(path, lambda d: d["environment"]["allowlist"].append("PYTHONPATH=x"))
     with pytest.raises(ValueError):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 @pytest.mark.parametrize(
@@ -633,7 +629,7 @@ def test_rejects_linkage_or_cross_generation_failure(
         path, lambda d: d["artifacts"].__setitem__("probe_sha256", _digest(probe_path))
     )
     with pytest.raises(ValueError, match="linkage"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_zero_exit_failed_terminal(tmp_path: Path) -> None:
@@ -652,14 +648,14 @@ def test_rejects_zero_exit_failed_terminal(tmp_path: Path) -> None:
 
     _mutate(path, failed)
     with pytest.raises(ValueError):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_retargeted_catalogue(tmp_path: Path) -> None:
     path = _receipt(tmp_path)
     _mutate(path, lambda d: d["identity"].__setitem__("catalogue_tree", "0" * 40))
     with pytest.raises(ValueError):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 @pytest.mark.parametrize(
@@ -678,7 +674,7 @@ def test_rejects_run_preflight_and_portable_catalogue_mutations(
     path = _receipt(tmp_path)
     _mutate(path, change)
     with pytest.raises(ValueError):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_source_cache_mutation_between_preflight_and_terminal(
@@ -694,7 +690,7 @@ def test_rejects_source_cache_mutation_between_preflight_and_terminal(
         lambda d: d["artifacts"].__setitem__("preflight_sha256", _digest(preflight)),
     )
     with pytest.raises(ValueError, match="preflight"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 @pytest.mark.parametrize(
@@ -713,7 +709,7 @@ def test_rejects_tooling_identity_mutation(
     path = _receipt(tmp_path)
     _mutate(path, lambda data: data["identity"].__setitem__(field, value))
     with pytest.raises(ValueError, match="tooling"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_outside_prefix_linkage_target(tmp_path: Path) -> None:
@@ -730,7 +726,7 @@ def test_rejects_outside_prefix_linkage_target(tmp_path: Path) -> None:
         path, lambda d: d["artifacts"].__setitem__("probe_sha256", _digest(probe_path))
     )
     with pytest.raises(ValueError, match="linkage target"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_rejects_postflight_checkout_drift(tmp_path: Path) -> None:
@@ -744,7 +740,7 @@ def test_rejects_postflight_checkout_drift(tmp_path: Path) -> None:
         lambda d: d["artifacts"].__setitem__("postflight_sha256", _digest(postflight)),
     )
     with pytest.raises(ValueError, match="postflight"):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
 def test_inventory_accepts_internal_relative_symlink(tmp_path: Path) -> None:
@@ -754,8 +750,8 @@ def test_inventory_accepts_internal_relative_symlink(tmp_path: Path) -> None:
     target.write_text("native")
     (root / "libalias.so").symlink_to("libreal.so")
     inventory = tmp_path / "inventory.json"
-    write_inventory(root, inventory)
-    entries = _manifest(inventory)
+    qualification.write_inventory(root, inventory)
+    entries = qualification._manifest(inventory)
     assert any(item["type"] == "symlink" for item in entries)
 
 
@@ -773,7 +769,7 @@ def test_inventory_rejects_unsafe_symlink(tmp_path: Path, kind: str) -> None:
     else:
         link.symlink_to("bad.so")
     with pytest.raises(RuntimeError, match="unsafe"):
-        write_inventory(root, tmp_path / "inventory.json")
+        qualification.write_inventory(root, tmp_path / "inventory.json")
 
 
 def test_rejects_dirty_catalogue(
@@ -791,11 +787,12 @@ def test_rejects_dirty_catalogue(
         ),
     )
     with pytest.raises(ValueError):
-        validate_receipt(path, Path.cwd())
+        qualification.validate_receipt(path, Path.cwd())
 
 
+@pytest.mark.parametrize("module_count", [0, 1, 2])
 def test_executor_produces_valid_terminal_receipt(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, module_count: int
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -817,7 +814,7 @@ def test_executor_produces_valid_terminal_receipt(
         ["/usr/bin/git", "rev-parse", "HEAD^{tree}"], text=True
     ).strip()
     base_tree = subprocess.check_output(
-        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+        ["/usr/bin/git", "rev-parse", f"{qualification.BASE}^{{tree}}"], text=True
     ).strip()
     monkeypatch.setenv("VOIAGE_VM_LOCAL_STORAGE", "confirmed")
     monkeypatch.setattr(qualification.sys, "platform", "linux")
@@ -858,11 +855,11 @@ def test_executor_produces_valid_terminal_receipt(
                 return payload if not kwargs.get("text") else payload.decode()
         if checkout == str(Path.cwd()):
             if argv[-2:] == ["rev-parse", "HEAD"]:
-                return BASE + "\n"
+                return qualification.BASE + "\n"
             if argv[-2:] == ["rev-parse", "HEAD^{tree}"]:
                 return base_tree + "\n"
             if argv[-3:] == ["ls-tree", "-r", "HEAD"]:
-                replacement = [*argv[:-1], BASE]
+                replacement = [*argv[:-1], qualification.BASE]
                 return real_output(replacement, **kwargs)
         return real_output(argv, **kwargs)
 
@@ -877,11 +874,14 @@ def test_executor_produces_valid_terminal_receipt(
                 "lib/voiage/_core.so",
                 "lib/pyarrow/lib.so",
                 "lib/polars/polars.so",
-                "modules/all/voiage/2.2.0-foss-2023a",
             ]:
                 target = prefix / relative
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_text(relative)
+            for index in range(module_count):
+                module_file = prefix / f"modules/all/voiage/2.2.0-foss-2023a-{index}"
+                module_file.parent.mkdir(parents=True, exist_ok=True)
+                module_file.write_text("module")
             log.write_text(
                 "== COMPLETED: Installation ended successfully (took 1 min)\n"
             )
@@ -916,9 +916,16 @@ def test_executor_produces_valid_terminal_receipt(
             "--execute",
         ],
     )
-    assert qualification.main() == 0
+    assert qualification.main() == (0 if module_count == 1 else 1)
     receipt = workspace / "voiage-easybuild-2023a/receipt.json"
-    assert validate_receipt(receipt, Path.cwd(), tooling_root)["outcome"] == "passed"
+    data = qualification.validate_receipt(receipt, Path.cwd(), tooling_root)
+    assert data["commands"][0]["exit_code"] == 0
+    if module_count == 1:
+        assert data["outcome"] == "passed"
+    else:
+        assert data["outcome"] == "failed_terminal"
+        assert data["failure"]["stage"] == "module-discovery"
+        assert data["commands"][1]["parsed"]["modulefile_match_count"] == module_count
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux shell semantics")
@@ -947,7 +954,7 @@ def test_generated_module_scripts_with_fake_environment_modules(
         ["/usr/bin/git", "rev-parse", "HEAD^{tree}"], text=True
     ).strip()
     base_tree = subprocess.check_output(
-        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+        ["/usr/bin/git", "rev-parse", f"{qualification.BASE}^{{tree}}"], text=True
     ).strip()
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
@@ -1014,6 +1021,9 @@ with open(a.output, "w") as stream:
 
     monkeypatch.setenv("VOIAGE_VM_LOCAL_STORAGE", "confirmed")
     monkeypatch.setattr(qualification.sys, "platform", "linux")
+    # Hosted test environments contain the wheel; use the clean system Python
+    # for preflight and the fake installed-module interpreter.
+    monkeypatch.setattr(qualification.sys, "executable", "/usr/bin/python3")
     monkeypatch.setattr(qualification.os, "cpu_count", lambda: 8)
     monkeypatch.setattr(qualification.shutil, "which", lambda name: f"/usr/bin/{name}")
     usage = qualification.shutil.disk_usage(workspace)
@@ -1050,11 +1060,11 @@ with open(a.output, "w") as stream:
                 return payload if not kwargs.get("text") else payload.decode()
         if checkout == str(Path.cwd()):
             if argv[-2:] == ["rev-parse", "HEAD"]:
-                return BASE + "\n"
+                return qualification.BASE + "\n"
             if argv[-2:] == ["rev-parse", "HEAD^{tree}"]:
                 return base_tree + "\n"
             if argv[-3:] == ["ls-tree", "-r", "HEAD"]:
-                return real_output([*argv[:-1], BASE], **kwargs)
+                return real_output([*argv[:-1], qualification.BASE], **kwargs)
         return real_output(argv, **kwargs)
 
     monkeypatch.setattr(qualification.subprocess, "check_output", output)
@@ -1105,7 +1115,7 @@ with open(a.output, "w") as stream:
         with log.open("wb") as stream:
             result = subprocess.run(
                 actual,
-                cwd=tmp_path,
+                cwd=source_root,
                 env=env,
                 stdout=stream,
                 stderr=subprocess.STDOUT,
@@ -1143,9 +1153,9 @@ with open(a.output, "w") as stream:
     assert qualification.main() == 0
     run_root = workspace / "voiage-easybuild-2023a"
     assert (
-        validate_receipt(run_root / "receipt.json", source_root, tooling_root)[
-            "outcome"
-        ]
+        qualification.validate_receipt(
+            run_root / "receipt.json", source_root, tooling_root
+        )["outcome"]
         == "passed"
     )
     assert (run_root / "probe.log").read_text() == ""

--- a/tests/test_native_easybuild_qualification.py
+++ b/tests/test_native_easybuild_qualification.py
@@ -1,0 +1,1029 @@
+from collections.abc import Callable
+import hashlib
+import json
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+from typing import Any
+
+import jsonschema
+import pytest
+
+import scripts.native_easybuild_qualification as qualification
+from scripts.native_easybuild_qualification import (
+    BASE,
+    GENERATIONS,
+    REQUIRED_PROBES,
+    ROOT_RECIPE_SHA256,
+    _manifest,
+    git_manifest_digest,
+    validate_matrix,
+    validate_receipt,
+    write_inventory,
+)
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, sort_keys=True) + "\n")
+
+
+def _inventory(run_root: Path, name: str) -> tuple[str, str]:
+    roots = {
+        "build-inventory": "install",
+        "module-inventory": "install/modules/all",
+        "source-cache-inventory": "sources",
+    }
+    names = {
+        "build-inventory": [
+            "install/bin/python",
+            "install/lib/python/site-packages/voiage/__init__.py",
+            "install/lib/python/site-packages/voiage/_core.so",
+            "install/lib/python/site-packages/numpy/__init__.py",
+            "install/lib/python/site-packages/pyarrow/__init__.py",
+            "install/lib/python/site-packages/polars/__init__.py",
+            "install/lib/voiage/_core.so",
+            "install/lib/pyarrow/lib.so",
+            "install/lib/polars/polars.so",
+        ],
+        "module-inventory": ["install/modules/all/voiage/2.2.0.lua"],
+        "source-cache-inventory": ["sources/voiage-2.2.0.tar.gz"],
+    }[name]
+    payloads = []
+    for relative in names:
+        payload = run_root / relative
+        payload.parent.mkdir(parents=True, exist_ok=True)
+        payload.write_text(f"real {relative} payload\n")
+        payloads.append(payload)
+    inventory = run_root / f"{name}.json"
+    inventory_root = run_root / roots[name]
+    _write_json(
+        inventory,
+        {
+            "root": roots[name],
+            "entries": [
+                {
+                    "path": str(payload.relative_to(inventory_root)),
+                    "type": "file",
+                    "size": payload.stat().st_size,
+                    "sha256": _digest(payload),
+                }
+                for payload in payloads
+            ],
+        },
+    )
+    return inventory.name, _digest(inventory)
+
+
+def _probe(generation: str, prefix: Path | None = None) -> dict[str, Any]:
+    prefix = prefix or Path(f"/opt/easybuild/{generation}")
+    return {
+        "schema_version": "voiage.native-easybuild-probe.v1",
+        "generation": generation,
+        "paths": [
+            f"{prefix}/bin/python",
+            f"{prefix}/lib/python/site-packages/voiage/__init__.py",
+            f"{prefix}/lib/python/site-packages/voiage/_core.so",
+            f"{prefix}/lib/python/site-packages/numpy/__init__.py",
+            f"{prefix}/lib/python/site-packages/pyarrow/__init__.py",
+            f"{prefix}/lib/python/site-packages/polars/__init__.py",
+        ],
+        "evpi": {
+            "input": [[0.0, 2.0], [2.0, 0.0]],
+            "dtype": "float64",
+            "value": 1.0,
+            "tolerance": 0.0,
+        },
+        "arrow": {
+            "version": "25.0.1",
+            "schema": "value: int64",
+            "values": [1, None, 3],
+            "null_count": 1,
+            "buffer_equal": True,
+            "buffer_size_positive": True,
+        },
+        "polars": {
+            "version": "1.42.1",
+            "schema": {"value": "Int64"},
+            "values": [1, 3],
+            "null_count": 0,
+            "lazy": True,
+            "arrow_equal": True,
+        },
+        "linkage": {
+            "objects": [
+                f"{prefix}/lib/voiage/_core.so",
+                f"{prefix}/lib/pyarrow/lib.so",
+                f"{prefix}/lib/polars/polars.so",
+            ],
+            "tool": "/usr/bin/ldd",
+            "targets": ["/usr/lib/libc.so"],
+            "transcripts": {
+                f"{prefix}/lib/voiage/_core.so": "libc.so => /usr/lib/libc.so (0x1)\n",
+                f"{prefix}/lib/pyarrow/lib.so": "libc.so => /usr/lib/libc.so (0x1)\n",
+                f"{prefix}/lib/polars/polars.so": "libc.so => /usr/lib/libc.so (0x1)\n",
+            },
+        },
+        "thread": {
+            "calls": 16,
+            "imports_inside_worker": True,
+            "engines": ["rust"] * 16,
+        },
+        "module": {
+            "loaded_paths_introduced": True,
+            "unload_paths_removed": True,
+            "fresh_shell": True,
+        },
+    }
+
+
+def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
+    run_root = tmp_path.resolve()
+    logs = {name: run_root / f"{name}.log" for name in ("build", "probe", "unload")}
+    logs["build"].write_text(
+        "== COMPLETED: Installation ended successfully (took 1 min)\n"
+    )
+    logs["probe"].write_text("module use, load, CLI and native probes passed\n")
+    logs["unload"].write_text("module unloaded and import absent\n")
+    probe_path = run_root / "probe.json"
+    _write_json(probe_path, _probe(generation, run_root / "install"))
+    build_inventory, build_hash = _inventory(run_root, "build-inventory")
+    module_inventory, module_hash = _inventory(run_root, "module-inventory")
+    source_inventory, source_hash = _inventory(run_root, "source-cache-inventory")
+    recipe = f"packaging/easybuild/voiage-2.2.0-foss-{generation}.eb"
+    robot = GENERATIONS[generation] + ["CATALOGUE/easybuild/easyconfigs"]
+    allowlist = [
+        f"HOME={run_root / 'home'}",
+        "LANG=C.UTF-8",
+        "PATH=/usr/bin:/bin",
+        "PYTHONNOUSERSITE=1",
+    ]
+    env_digest = hashlib.sha256(
+        json.dumps(allowlist, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    source_tree = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+    ).strip()
+    source_manifest, _ = git_manifest_digest(Path.cwd(), BASE)
+    preflight_path = run_root / "preflight.json"
+    _write_json(
+        preflight_path,
+        {
+            "environment_digest": env_digest,
+            "source_head": BASE,
+            "source_tree": source_tree,
+            "source_status": "",
+            "catalogue_head": BASE,
+            "catalogue_tree": source_tree,
+            "catalogue_status": "",
+            "prefix_absent": True,
+            "module_tree_empty": True,
+            "preinstalled_voiage_absent": True,
+            "input_cache_digest": "f" * 64,
+            "staged_cache_digest_before": "f" * 64,
+            "staged_cache_digest_after": "f" * 64,
+        },
+    )
+    postflight_path = run_root / "postflight.json"
+    _write_json(
+        postflight_path,
+        {
+            "source_head": BASE,
+            "source_tree": source_tree,
+            "source_status": "",
+            "catalogue_head": BASE,
+            "catalogue_tree": source_tree,
+            "catalogue_status": "",
+        },
+    )
+    catalogue_path = run_root / "catalogue-evidence.json"
+    catalogue_listing = subprocess.check_output(
+        ["/usr/bin/git", "ls-tree", "-r", BASE], text=True
+    ).splitlines()
+    _write_json(
+        catalogue_path,
+        {
+            "commit": BASE,
+            "tree": source_tree,
+            "manifest_sha256": source_manifest,
+            "ls_tree": catalogue_listing,
+        },
+    )
+    data = {
+        "schema_version": "voiage.native-easybuild-terminal-receipt.v1",
+        "terminal": True,
+        "outcome": "passed",
+        "run_root": str(run_root),
+        "identity": {
+            "generation": generation,
+            "source_commit": BASE,
+            "source_tree": source_tree,
+            "source_relevant_tree_sha256": source_manifest,
+            "catalogue_root": str(Path.cwd()),
+            "catalogue_commit": BASE,
+            "catalogue_tree": source_tree,
+            "catalogue_relevant_tree_sha256": source_manifest,
+            "easybuild_version": "5.4.0",
+            "easyblocks_version": "5.4.0",
+            "root_recipe": recipe,
+            "root_recipe_sha256": ROOT_RECIPE_SHA256[generation],
+            "robot_paths": robot,
+            "robot_manifest_sha256": hashlib.sha256(
+                json.dumps(robot, separators=(",", ":")).encode()
+            ).hexdigest(),
+            "source_cache_manifest_sha256": source_hash,
+        },
+        "environment": {
+            "allowlist": allowlist,
+            "digest": env_digest,
+            "home": "home",
+            "python_no_user_site": "1",
+            "module_implementation": "EnvironmentModules",
+            "module_version": "5.4.0",
+            "module_init": "modulecmd bash",
+        },
+        "resources": {"cpu_count": 8, "free_bytes_before": 300 * 1024**3},
+        "preflight": {
+            "source_clean": True,
+            "catalogue_clean": True,
+            "source_no_symlinks": True,
+            "catalogue_no_symlinks": True,
+            "prefix_absent": True,
+            "install_empty": True,
+            "module_tree_empty": True,
+            "preinstalled_voiage_absent": True,
+        },
+        "commands": [
+            {
+                "stage": "easybuild",
+                "argv": [
+                    "eb",
+                    recipe,
+                    "--robot",
+                    f"--robot-paths={':'.join(robot)}",
+                    "--prefix=install",
+                    "--buildpath=build",
+                    "--sourcepath=sources",
+                    "--modules-tool=EnvironmentModules",
+                    "--module-syntax=Tcl",
+                    "--disable-download",
+                    "--disable-use-existing-modules",
+                    "--force",
+                ],
+                "exit_code": 0,
+                "signal": None,
+                "log": logs["build"].name,
+                "log_sha256": _digest(logs["build"]),
+                "parsed": {
+                    "easybuild_completed": True,
+                    "installed_module_full_name": f"voiage/2.2.0-foss-{generation}",
+                },
+            },
+            {
+                "stage": "module-probe",
+                "argv": [
+                    "bash",
+                    "--noprofile",
+                    "--norc",
+                    "module-probe.sh",
+                    "MODULE_ROOT",
+                    f"voiage/2.2.0-foss-{generation}",
+                    "native_easybuild_probe.py",
+                    "install",
+                    generation,
+                    "probe.json",
+                    "OPPOSITE_INSTALL",
+                ],
+                "exit_code": 0,
+                "signal": None,
+                "log": logs["probe"].name,
+                "log_sha256": _digest(logs["probe"]),
+                "parsed": {"structured_probe_written": True},
+            },
+            {
+                "stage": "module-unload",
+                "argv": [
+                    "bash",
+                    "--noprofile",
+                    "--norc",
+                    "module-unload.sh",
+                    "MODULE_ROOT",
+                    f"voiage/2.2.0-foss-{generation}",
+                ],
+                "exit_code": 0,
+                "signal": None,
+                "log": logs["unload"].name,
+                "log_sha256": _digest(logs["unload"]),
+                "parsed": {"voiage_absent_after_unload": True},
+            },
+        ],
+        "artifacts": {
+            "build_inventory": build_inventory,
+            "build_inventory_sha256": build_hash,
+            "module_inventory": module_inventory,
+            "module_inventory_sha256": module_hash,
+            "source_cache_inventory": source_inventory,
+            "source_cache_inventory_sha256": source_hash,
+            "probe": probe_path.name,
+            "probe_sha256": _digest(probe_path),
+            "preflight": preflight_path.name,
+            "preflight_sha256": _digest(preflight_path),
+            "catalogue_evidence": catalogue_path.name,
+            "catalogue_evidence_sha256": _digest(catalogue_path),
+            "postflight": postflight_path.name,
+            "postflight_sha256": _digest(postflight_path),
+        },
+        "probes": [
+            {"name": name, "status": "passed"} for name in sorted(REQUIRED_PROBES)
+        ],
+        "failure": None,
+        "run": {
+            "run_id": "test-run",
+            "started_at": "2026-09-04T00:00:00Z",
+            "ended_at": "2026-09-04T01:00:00Z",
+            "predecessor_receipt_sha256": None if generation == "2023a" else "a" * 64,
+        },
+    }
+    path = run_root / "receipt.json"
+    _write_json(path, data)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _catalogue_at_test_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qualification, "CATALOGUE", BASE)
+    tree = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+    ).strip()
+    manifest, _ = git_manifest_digest(Path.cwd(), BASE)
+    monkeypatch.setattr(qualification, "CATALOGUE_TREE", tree)
+    monkeypatch.setattr(qualification, "CATALOGUE_MANIFEST_SHA256", manifest)
+    real = qualification.subprocess.check_output
+
+    def clean_status(argv: list[str], **kwargs: Any) -> str:
+        if argv[-2:] == ["status", "--porcelain"]:
+            return ""
+        return real(argv, **kwargs)
+
+    monkeypatch.setattr(qualification.subprocess, "check_output", clean_status)
+
+
+def _mutate(path: Path, change: Callable[[dict[str, Any]], None]) -> None:
+    data = json.loads(path.read_text())
+    change(data)
+    _write_json(path, data)
+
+
+def _schema_validator() -> jsonschema.Draft202012Validator:
+    schema = json.loads(
+        Path("specs/native-easybuild-terminal-receipt-v1.schema.json").read_text()
+    )
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _receipt_data(tmp_path: Path) -> dict[str, Any]:
+    return json.loads(_receipt(tmp_path).read_text())
+
+
+def test_accepts_complete_bound_receipt(tmp_path: Path) -> None:
+    assert validate_receipt(_receipt(tmp_path), Path.cwd())["outcome"] == "passed"
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda d: d["resources"].__setitem__("cpu_count", 7),
+        lambda d: d["resources"].__setitem__("free_bytes_before", 250 * 1024**3 - 1),
+        lambda d: d["resources"].__setitem__("unbounded", True),
+        lambda d: d["commands"][0]["parsed"].pop("easybuild_completed"),
+        lambda d: d["commands"][0]["parsed"].__setitem__("unexpected", True),
+        lambda d: d["commands"][1]["parsed"].__setitem__(
+            "structured_probe_written", "yes"
+        ),
+        lambda d: d["commands"][2]["parsed"].__setitem__(
+            "voiage_absent_after_unload", 1
+        ),
+        lambda d: d["probes"].__setitem__(0, d["probes"][1]),
+        lambda d: d["probes"].append({"name": "invented", "status": "passed"}),
+        lambda d: d.__setitem__("failure", {"stage": "easybuild"}),
+        lambda d: d["artifacts"].__setitem__("probe", None),
+        lambda d: d["commands"][0].__setitem__("exit_code", 1),
+    ],
+)
+def test_terminal_receipt_schema_rejects_strict_passed_mutations(
+    tmp_path: Path, change: Callable[[dict[str, Any]], None]
+) -> None:
+    data = _receipt_data(tmp_path)
+    change(data)
+    assert list(_schema_validator().iter_errors(data))
+
+
+def test_terminal_receipt_schema_accepts_strict_failed_shape(tmp_path: Path) -> None:
+    data = _receipt_data(tmp_path)
+    data["outcome"] = "failed_terminal"
+    data["commands"] = data["commands"][:1]
+    data["commands"][0]["exit_code"] = 1
+    data["commands"][0]["parsed"] = {
+        "easybuild_completed": False,
+        "installed_module_full_name": None,
+    }
+    data["artifacts"] = dict.fromkeys(data["artifacts"])
+    data["probes"] = []
+    data["failure"] = {
+        "stage": "easybuild",
+        "command_index": 0,
+        "exit_code": 1,
+        "signal": None,
+        "parsed_failure": "build failed",
+    }
+    _schema_validator().validate(data)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda d: d["failure"].__setitem__("exit_code", 0),
+        lambda d: d["failure"].__setitem__("parsed_failure", ""),
+        lambda d: d["failure"].__setitem__("extra", "unbound"),
+        lambda d: d["failure"].pop("command_index"),
+        lambda d: d["probes"].append({"name": "cli", "status": "passed"}),
+        lambda d: d.__setitem__("failure", None),
+    ],
+)
+def test_terminal_receipt_schema_rejects_strict_failed_mutations(
+    tmp_path: Path, change: Callable[[dict[str, Any]], None]
+) -> None:
+    data = _receipt_data(tmp_path)
+    data["outcome"] = "failed_terminal"
+    data["commands"] = data["commands"][:1]
+    data["commands"][0]["exit_code"] = 1
+    data["commands"][0]["parsed"] = {
+        "easybuild_completed": False,
+        "installed_module_full_name": None,
+    }
+    data["artifacts"] = dict.fromkeys(data["artifacts"])
+    data["probes"] = []
+    data["failure"] = {
+        "stage": "easybuild",
+        "command_index": 0,
+        "exit_code": 1,
+        "signal": None,
+        "parsed_failure": "build failed",
+    }
+    change(data)
+    assert list(_schema_validator().iter_errors(data))
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda d: d["preflight"].__setitem__("source_clean", False),
+        lambda d: d["preflight"].__setitem__("catalogue_clean", False),
+        lambda d: d["preflight"].__setitem__("prefix_absent", False),
+        lambda d: d["environment"].__setitem__("digest", "0" * 64),
+        lambda d: d["identity"].__setitem__("source_commit", "0" * 40),
+        lambda d: d["identity"].__setitem__("root_recipe_sha256", "0" * 64),
+        lambda d: d["commands"][0]["argv"].append("--dry-run"),
+        lambda d: d["commands"][0]["parsed"].__setitem__("easybuild_completed", False),
+        lambda d: d["probes"].pop(),
+        lambda d: d.__setitem__("invented_success", True),
+    ],
+)
+def test_rejects_receipt_contract_mutations(
+    tmp_path: Path, change: Callable[[dict[str, Any]], None]
+) -> None:
+    path = _receipt(tmp_path)
+    _mutate(path, change)
+    with pytest.raises(ValueError):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_missing_or_changed_transcript(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+    (tmp_path / "build.log").write_text("fabricated replacement\n")
+    with pytest.raises(ValueError, match="missing or changed"):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_symlink_artifact(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+    build_log = tmp_path / "build.log"
+    real_log = tmp_path / "real-build.log"
+    build_log.rename(real_log)
+    build_log.symlink_to(real_log)
+    with pytest.raises(ValueError, match="symlink"):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_artifact_outside_run_root(tmp_path: Path) -> None:
+    run_root = tmp_path / "run"
+    run_root.mkdir()
+    path = _receipt(run_root)
+    outside = tmp_path / "outside.log"
+    outside.write_text("outside\n")
+    _mutate(
+        path,
+        lambda d: d["commands"][0].update(
+            {"log": "../outside.log", "log_sha256": _digest(outside)}
+        ),
+    )
+    with pytest.raises(ValueError, match="escapes"):
+        validate_receipt(path, Path.cwd())
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("evpi", "value", 0.0),
+        ("arrow", "buffer_equal", False),
+        ("polars", "lazy", False),
+        ("thread", "imports_inside_worker", False),
+    ],
+)
+def test_rejects_scientific_probe_mutations(
+    tmp_path: Path, section: str, field: str, value: Any
+) -> None:
+    path = _receipt(tmp_path)
+    probe_path = tmp_path / "probe.json"
+    probe = json.loads(probe_path.read_text())
+    probe[section][field] = value
+    _write_json(probe_path, probe)
+    _mutate(
+        path, lambda d: d["artifacts"].__setitem__("probe_sha256", _digest(probe_path))
+    )
+    with pytest.raises(ValueError, match="probe"):
+        validate_receipt(path, Path.cwd())
+
+
+def test_matrix_requires_distinct_receipts_for_both_generations(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+    matrix = tmp_path / "matrix.json"
+    _write_json(
+        matrix,
+        {
+            "schema_version": "voiage.native-easybuild-matrix.v1",
+            "receipts": {"2023a": path.name, "2024a": path.name},
+        },
+    )
+    with pytest.raises(ValueError):
+        validate_matrix(matrix, Path.cwd())
+
+
+def test_matrix_requires_both_generations(tmp_path: Path) -> None:
+    matrix = tmp_path / "matrix.json"
+    _write_json(
+        matrix,
+        {
+            "schema_version": "voiage.native-easybuild-matrix.v1",
+            "receipts": {"2023a": "receipt.json"},
+        },
+    )
+    with pytest.raises(ValueError):
+        validate_matrix(matrix, Path.cwd())
+
+
+def test_rejects_inherited_environment_name(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+    _mutate(path, lambda d: d["environment"]["allowlist"].append("PYTHONPATH=x"))
+    with pytest.raises(ValueError):
+        validate_receipt(path, Path.cwd())
+
+
+@pytest.mark.parametrize(
+    "field", ["all_resolved", "allowed_roots_only", "opposite_prefix_absent"]
+)
+def test_rejects_linkage_or_cross_generation_failure(
+    tmp_path: Path, field: str
+) -> None:
+    path = _receipt(tmp_path)
+    probe_path = tmp_path / "probe.json"
+    probe = json.loads(probe_path.read_text())
+    probe["linkage"][field] = False
+    _write_json(probe_path, probe)
+    _mutate(
+        path, lambda d: d["artifacts"].__setitem__("probe_sha256", _digest(probe_path))
+    )
+    with pytest.raises(ValueError, match="linkage"):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_zero_exit_failed_terminal(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+
+    def failed(data: dict[str, Any]) -> None:
+        data["outcome"] = "failed_terminal"
+        data["probes"] = []
+        data["failure"] = {
+            "stage": "easybuild",
+            "command_index": 0,
+            "exit_code": 0,
+            "signal": None,
+            "parsed_failure": "claimed failure",
+        }
+
+    _mutate(path, failed)
+    with pytest.raises(ValueError):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_retargeted_catalogue(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+    _mutate(path, lambda d: d["identity"].__setitem__("catalogue_tree", "0" * 40))
+    with pytest.raises(ValueError):
+        validate_receipt(path, Path.cwd())
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda d: d["run"].__setitem__("run_id", ""),
+        lambda d: d["run"].__setitem__("ended_at", "2025-01-01T00:00:00Z"),
+        lambda d: d["run"].__setitem__("predecessor_receipt_sha256", "a" * 64),
+        lambda d: d["artifacts"].__setitem__("preflight_sha256", "0" * 64),
+        lambda d: d["artifacts"].__setitem__("catalogue_evidence_sha256", "0" * 64),
+    ],
+)
+def test_rejects_run_preflight_and_portable_catalogue_mutations(
+    tmp_path: Path, change: Callable[[dict[str, Any]], None]
+) -> None:
+    path = _receipt(tmp_path)
+    _mutate(path, change)
+    with pytest.raises(ValueError):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_source_cache_mutation_between_preflight_and_terminal(
+    tmp_path: Path,
+) -> None:
+    path = _receipt(tmp_path)
+    preflight = tmp_path / "preflight.json"
+    payload = json.loads(preflight.read_text())
+    payload["staged_cache_digest_after"] = "0" * 64
+    _write_json(preflight, payload)
+    _mutate(
+        path,
+        lambda d: d["artifacts"].__setitem__("preflight_sha256", _digest(preflight)),
+    )
+    with pytest.raises(ValueError, match="preflight"):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_outside_prefix_linkage_target(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+    probe_path = tmp_path / "probe.json"
+    probe = json.loads(probe_path.read_text())
+    object_name = probe["linkage"]["objects"][0]
+    probe["linkage"]["transcripts"][object_name] += (
+        "evil.so => /opt/other/libevil.so (0x2)\n"
+    )
+    probe["linkage"]["targets"].append("/opt/other/libevil.so")
+    _write_json(probe_path, probe)
+    _mutate(
+        path, lambda d: d["artifacts"].__setitem__("probe_sha256", _digest(probe_path))
+    )
+    with pytest.raises(ValueError, match="linkage target"):
+        validate_receipt(path, Path.cwd())
+
+
+def test_rejects_postflight_checkout_drift(tmp_path: Path) -> None:
+    path = _receipt(tmp_path)
+    postflight = tmp_path / "postflight.json"
+    payload = json.loads(postflight.read_text())
+    payload["source_status"] = " M recipe.eb"
+    _write_json(postflight, payload)
+    _mutate(
+        path,
+        lambda d: d["artifacts"].__setitem__("postflight_sha256", _digest(postflight)),
+    )
+    with pytest.raises(ValueError, match="postflight"):
+        validate_receipt(path, Path.cwd())
+
+
+def test_inventory_accepts_internal_relative_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "install"
+    root.mkdir()
+    target = root / "libreal.so"
+    target.write_text("native")
+    (root / "libalias.so").symlink_to("libreal.so")
+    inventory = tmp_path / "inventory.json"
+    write_inventory(root, inventory)
+    entries = _manifest(inventory)
+    assert any(item["type"] == "symlink" for item in entries)
+
+
+@pytest.mark.parametrize("kind", ["escape", "dangling", "cycle"])
+def test_inventory_rejects_unsafe_symlink(tmp_path: Path, kind: str) -> None:
+    root = tmp_path / "install"
+    root.mkdir()
+    link = root / "bad.so"
+    if kind == "escape":
+        outside = tmp_path / "outside.so"
+        outside.write_text("outside")
+        link.symlink_to("../outside.so")
+    elif kind == "dangling":
+        link.symlink_to("missing.so")
+    else:
+        link.symlink_to("bad.so")
+    with pytest.raises(RuntimeError, match="unsafe"):
+        write_inventory(root, tmp_path / "inventory.json")
+
+
+def test_rejects_dirty_catalogue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _receipt(tmp_path)
+    evidence = tmp_path / "catalogue-evidence.json"
+    payload = json.loads(evidence.read_text())
+    payload["ls_tree"].append("dirty untracked claim")
+    _write_json(evidence, payload)
+    _mutate(
+        path,
+        lambda d: d["artifacts"].__setitem__(
+            "catalogue_evidence_sha256", _digest(evidence)
+        ),
+    )
+    with pytest.raises(ValueError):
+        validate_receipt(path, Path.cwd())
+
+
+def test_executor_produces_valid_terminal_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    prepared_sources = tmp_path / "prepared-sources"
+    prepared_sources.mkdir()
+    (prepared_sources / "voiage-2.2.0.tar.gz").write_text("prepared source")
+    monkeypatch.setenv("VOIAGE_VM_LOCAL_STORAGE", "confirmed")
+    monkeypatch.setattr(qualification.sys, "platform", "linux")
+    monkeypatch.setattr(qualification.sys, "executable", "/usr/bin/python3")
+    monkeypatch.setattr(qualification.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(qualification.shutil, "which", lambda name: f"/usr/bin/{name}")
+    usage = qualification.shutil.disk_usage(workspace)
+    monkeypatch.setattr(
+        qualification.shutil,
+        "disk_usage",
+        lambda path: usage._replace(free=300 * 1024**3),
+    )
+    real_output = subprocess.check_output
+
+    def output(argv: list[str], **kwargs: Any) -> str:
+        if argv[:2] == ["eb", "--version"]:
+            return "EasyBuild 5.4.0\n"
+        if (
+            argv[0] == qualification.sys.executable
+            and "easybuild.easyblocks" in argv[-1]
+        ):
+            return "5.4.0\n"
+        if argv[:2] == ["modulecmd", "--version"]:
+            return "5.4.0\n"
+        if argv[-2:] == ["status", "--porcelain"]:
+            return ""
+        return real_output(argv, **kwargs)
+
+    monkeypatch.setattr(qualification.subprocess, "check_output", output)
+
+    def fake_run(argv: list[str], log: Path, env: dict[str, str]) -> int:
+        log.parent.mkdir(parents=True, exist_ok=True)
+        if argv[0] == "eb":
+            prefix = log.parent / "install"
+            for relative in [
+                "bin/python",
+                "lib/voiage/_core.so",
+                "lib/pyarrow/lib.so",
+                "lib/polars/polars.so",
+                "modules/all/voiage/2.2.0-foss-2023a",
+            ]:
+                target = prefix / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(relative)
+            log.write_text(
+                "== COMPLETED: Installation ended successfully (took 1 min)\n"
+            )
+        elif "module-probe.sh" in str(argv[3]):
+            _write_json(
+                log.parent / "probe.json", _probe("2023a", log.parent / "install")
+            )
+            log.write_text("probe passed\n")
+        else:
+            log.write_text("unload passed\n")
+        return 0
+
+    monkeypatch.setattr(qualification, "run", fake_run)
+    monkeypatch.setattr(
+        qualification.sys,
+        "argv",
+        [
+            "native",
+            "2023a",
+            "--root",
+            str(Path.cwd()),
+            "--catalogue",
+            str(Path.cwd()),
+            "--workspace",
+            str(workspace),
+            "--source-cache",
+            str(prepared_sources),
+            "--run-id",
+            "test-run",
+            "--execute",
+        ],
+    )
+    assert qualification.main() == 0
+    receipt = workspace / "voiage-easybuild-2023a/receipt.json"
+    assert validate_receipt(receipt, Path.cwd())["outcome"] == "passed"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="requires Linux shell semantics")
+def test_generated_module_scripts_with_fake_environment_modules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise the emitted probe and unload scripts in fresh real shells."""
+    source_root = Path.cwd()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    prepared_sources = tmp_path / "prepared-sources-linux"
+    prepared_sources.mkdir()
+    (prepared_sources / "voiage-2.2.0.tar.gz").write_text("prepared")
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    modulecmd = fake_bin / "modulecmd"
+    modulecmd.write_text(
+        """#!/usr/bin/env python3
+import pathlib
+import shlex
+import sys
+
+if sys.argv[1:] == ["--version"]:
+    print("Environment Modules 5.4.0")
+    raise SystemExit
+if len(sys.argv) < 3 or sys.argv[1] != "bash":
+    raise SystemExit(2)
+action = sys.argv[2]
+if action == "purge":
+    print("unset MODULEPATH PYTHONPATH VOIAGE_FAKE_MODULE_PREFIX")
+elif action == "use":
+    root = pathlib.Path(sys.argv[3]).resolve()
+    if not root.is_dir():
+        raise SystemExit(3)
+    print(f"export MODULEPATH={shlex.quote(str(root))}")
+elif action == "load":
+    root = pathlib.Path(__import__("os").environ["MODULEPATH"])
+    module_file = root / sys.argv[3]
+    if not module_file.is_file():
+        raise SystemExit(4)
+    prefix = module_file.read_text().strip()
+    print(f"export PATH={shlex.quote(prefix + '/bin')}:\\\"$PATH\\\"")
+    print(f"export PYTHONPATH={shlex.quote(prefix + '/lib/python')}")
+    print(f"export VOIAGE_FAKE_MODULE_PREFIX={shlex.quote(prefix)}")
+elif action == "unload":
+    prefix = __import__("os").environ.get("VOIAGE_FAKE_MODULE_PREFIX")
+    if not prefix:
+        raise SystemExit(5)
+    print('export PATH="${PATH#*:}"')
+    print("unset PYTHONPATH VOIAGE_FAKE_MODULE_PREFIX")
+else:
+    raise SystemExit(6)
+"""
+    )
+    modulecmd.chmod(0o755)
+    fake_probe = tmp_path / "probe.py"
+    fake_probe.write_text(
+        """import argparse
+import importlib.util
+import json
+import os
+
+p = argparse.ArgumentParser()
+p.add_argument("--prefix")
+p.add_argument("--generation")
+p.add_argument("--output")
+p.add_argument("--opposite-prefix")
+a = p.parse_args()
+assert os.environ["VOIAGE_FAKE_MODULE_PREFIX"] == a.prefix
+spec = importlib.util.find_spec("voiage")
+assert spec is not None and str(spec.origin).startswith(a.prefix)
+with open(a.output, "w") as stream:
+    json.dump({"fake_probe": "passed", "generation": a.generation}, stream)
+"""
+    )
+
+    monkeypatch.setenv("VOIAGE_VM_LOCAL_STORAGE", "confirmed")
+    monkeypatch.setattr(qualification.sys, "platform", "linux")
+    monkeypatch.setattr(qualification.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(qualification.shutil, "which", lambda name: f"/usr/bin/{name}")
+    usage = qualification.shutil.disk_usage(workspace)
+    monkeypatch.setattr(
+        qualification.shutil,
+        "disk_usage",
+        lambda path: usage._replace(free=300 * 1024**3),
+    )
+    real_output = subprocess.check_output
+
+    def output(argv: list[str], **kwargs: Any) -> str:
+        if argv[:2] == ["eb", "--version"]:
+            return "EasyBuild 5.4.0\n"
+        if (
+            argv[0] == qualification.sys.executable
+            and "easybuild.easyblocks" in argv[-1]
+        ):
+            return "5.4.0\n"
+        if argv[:2] == ["modulecmd", "--version"]:
+            return "Environment Modules 5.4.0\n"
+        if argv[-2:] == ["status", "--porcelain"]:
+            return ""
+        return real_output(argv, **kwargs)
+
+    monkeypatch.setattr(qualification.subprocess, "check_output", output)
+    original_clean_environment = qualification.clean_environment
+
+    def clean_environment(home: Path) -> tuple[dict[str, str], list[str], str]:
+        env, _, _ = original_clean_environment(home)
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        allowlist = [f"{key}={env[key]}" for key in sorted(env)]
+        digest = hashlib.sha256(
+            json.dumps(allowlist, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        return env, allowlist, digest
+
+    monkeypatch.setattr(qualification, "clean_environment", clean_environment)
+
+    def hybrid_run(argv: list[str], log: Path, env: dict[str, str]) -> int:
+        if argv[0] == "eb":
+            prefix = log.parent / "install"
+            module_file = prefix / "modules/all/voiage/2.2.0-foss-2023a"
+            module_file.parent.mkdir(parents=True)
+            module_file.write_text(str(prefix))
+            python = prefix / "bin/python3"
+            python.parent.mkdir(parents=True)
+            python.write_text(f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n')
+            python.chmod(0o755)
+            package = prefix / "lib/python/voiage"
+            package.mkdir(parents=True)
+            (package / "__init__.py").write_text("installed = True\n")
+            (package / "_core.so").write_text("fake native object")
+            for dependency in ("numpy", "pyarrow", "polars"):
+                dep = prefix / f"lib/python/site-packages/{dependency}"
+                dep.mkdir(parents=True)
+                (dep / "__init__.py").write_text("installed = True\n")
+            (prefix / "lib/voiage").mkdir(parents=True)
+            (prefix / "lib/voiage/_core.so").write_text("fake native object")
+            (prefix / "lib/pyarrow").mkdir(parents=True)
+            (prefix / "lib/pyarrow/lib.so").write_text("fake arrow object")
+            (prefix / "lib/polars").mkdir(parents=True)
+            (prefix / "lib/polars/polars.so").write_text("fake polars object")
+            log.write_text(
+                "== COMPLETED: Installation ended successfully (took 1 min)\n"
+            )
+            return 0
+        actual = list(argv)
+        if "module-probe.sh" in actual[3]:
+            actual[6] = str(fake_probe)
+        with log.open("wb") as stream:
+            result = subprocess.run(
+                actual,
+                cwd=tmp_path,
+                env=env,
+                stdout=stream,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        if "module-probe.sh" in actual[3] and result.returncode == 0:
+            _write_json(
+                log.parent / "probe.json", _probe("2023a", log.parent / "install")
+            )
+        return result.returncode
+
+    monkeypatch.setattr(qualification, "run", hybrid_run)
+    monkeypatch.setattr(
+        qualification.sys,
+        "argv",
+        [
+            "native",
+            "2023a",
+            "--root",
+            str(source_root),
+            "--catalogue",
+            str(source_root),
+            "--workspace",
+            str(workspace),
+            "--source-cache",
+            str(prepared_sources),
+            "--run-id",
+            "linux-integration",
+            "--execute",
+        ],
+    )
+
+    assert qualification.main() == 0
+    run_root = workspace / "voiage-easybuild-2023a"
+    assert (
+        validate_receipt(run_root / "receipt.json", source_root)["outcome"] == "passed"
+    )
+    assert (run_root / "probe.log").read_text() == ""
+    assert (run_root / "unload.log").read_text() == ""

--- a/tests/test_native_easybuild_qualification.py
+++ b/tests/test_native_easybuild_qualification.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 from pathlib import Path
 import shlex
+import shutil
 import subprocess
 import sys
 from typing import Any
@@ -169,6 +170,14 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
         ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
     ).strip()
     source_manifest, _ = git_manifest_digest(Path.cwd(), BASE)
+    tooling_root = Path(qualification.__file__).resolve().parents[1]
+    tooling_commit = subprocess.check_output(
+        ["/usr/bin/git", "-C", str(tooling_root), "rev-parse", "HEAD"], text=True
+    ).strip()
+    tooling_tree = subprocess.check_output(
+        ["/usr/bin/git", "-C", str(tooling_root), "rev-parse", "HEAD^{tree}"],
+        text=True,
+    ).strip()
     preflight_path = run_root / "preflight.json"
     _write_json(
         preflight_path,
@@ -180,6 +189,9 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
             "catalogue_head": BASE,
             "catalogue_tree": source_tree,
             "catalogue_status": "",
+            "tooling_head": tooling_commit,
+            "tooling_tree": tooling_tree,
+            "tooling_status": "",
             "prefix_absent": True,
             "module_tree_empty": True,
             "preinstalled_voiage_absent": True,
@@ -198,6 +210,9 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
             "catalogue_head": BASE,
             "catalogue_tree": source_tree,
             "catalogue_status": "",
+            "tooling_head": tooling_commit,
+            "tooling_tree": tooling_tree,
+            "tooling_status": "",
         },
     )
     catalogue_path = run_root / "catalogue-evidence.json"
@@ -236,6 +251,15 @@ def _receipt(tmp_path: Path, generation: str = "2023a") -> Path:
                 json.dumps(robot, separators=(",", ":")).encode()
             ).hexdigest(),
             "source_cache_manifest_sha256": source_hash,
+            "tooling_root": str(tooling_root),
+            "tooling_commit": tooling_commit,
+            "tooling_tree": tooling_tree,
+            "tooling_driver_sha256": qualification.git_blob_sha256(
+                tooling_root, tooling_commit, qualification.TOOLING_FILES[0]
+            ),
+            "tooling_probe_sha256": qualification.git_blob_sha256(
+                tooling_root, tooling_commit, qualification.TOOLING_FILES[1]
+            ),
         },
         "environment": {
             "allowlist": allowlist,
@@ -673,6 +697,25 @@ def test_rejects_source_cache_mutation_between_preflight_and_terminal(
         validate_receipt(path, Path.cwd())
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("tooling_commit", "0" * 40),
+        ("tooling_tree", "0" * 40),
+        ("tooling_driver_sha256", "0" * 64),
+        ("tooling_probe_sha256", "0" * 64),
+        ("tooling_root", "/wrong/tooling/root"),
+    ],
+)
+def test_rejects_tooling_identity_mutation(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    path = _receipt(tmp_path)
+    _mutate(path, lambda data: data["identity"].__setitem__(field, value))
+    with pytest.raises(ValueError, match="tooling"):
+        validate_receipt(path, Path.cwd())
+
+
 def test_rejects_outside_prefix_linkage_target(tmp_path: Path) -> None:
     path = _receipt(tmp_path)
     probe_path = tmp_path / "probe.json"
@@ -759,6 +802,23 @@ def test_executor_produces_valid_terminal_receipt(
     prepared_sources = tmp_path / "prepared-sources"
     prepared_sources.mkdir()
     (prepared_sources / "voiage-2.2.0.tar.gz").write_text("prepared source")
+    tooling_root = tmp_path / "tooling"
+    for relative in (
+        *qualification.TOOLING_FILES,
+        "specs/native-easybuild-terminal-receipt-v1.schema.json",
+    ):
+        target = tooling_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(Path.cwd() / relative, target)
+    tooling_commit = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", "HEAD"], text=True
+    ).strip()
+    tooling_tree = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    base_tree = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+    ).strip()
     monkeypatch.setenv("VOIAGE_VM_LOCAL_STORAGE", "confirmed")
     monkeypatch.setattr(qualification.sys, "platform", "linux")
     monkeypatch.setattr(qualification.sys, "executable", "/usr/bin/python3")
@@ -772,7 +832,7 @@ def test_executor_produces_valid_terminal_receipt(
     )
     real_output = subprocess.check_output
 
-    def output(argv: list[str], **kwargs: Any) -> str:
+    def output(argv: list[str], **kwargs: Any) -> str:  # noqa: PLR0911
         if argv[:2] == ["eb", "--version"]:
             return "EasyBuild 5.4.0\n"
         if (
@@ -784,6 +844,26 @@ def test_executor_produces_valid_terminal_receipt(
             return "5.4.0\n"
         if argv[-2:] == ["status", "--porcelain"]:
             return ""
+        checkout = argv[argv.index("-C") + 1] if "-C" in argv else None
+        if checkout == str(tooling_root):
+            if argv[-2:] == ["rev-parse", "HEAD"]:
+                return tooling_commit + "\n"
+            if argv[-2:] == ["rev-parse", "HEAD^{tree}"]:
+                return tooling_tree + "\n"
+            if argv[-2] == "rev-parse" and argv[-1].endswith("^{tree}"):
+                return tooling_tree + "\n"
+            if "show" in argv:
+                relative = argv[-1].split(":", 1)[1]
+                payload = (tooling_root / relative).read_bytes()
+                return payload if not kwargs.get("text") else payload.decode()
+        if checkout == str(Path.cwd()):
+            if argv[-2:] == ["rev-parse", "HEAD"]:
+                return BASE + "\n"
+            if argv[-2:] == ["rev-parse", "HEAD^{tree}"]:
+                return base_tree + "\n"
+            if argv[-3:] == ["ls-tree", "-r", "HEAD"]:
+                replacement = [*argv[:-1], BASE]
+                return real_output(replacement, **kwargs)
         return real_output(argv, **kwargs)
 
     monkeypatch.setattr(qualification.subprocess, "check_output", output)
@@ -823,6 +903,8 @@ def test_executor_produces_valid_terminal_receipt(
             "2023a",
             "--root",
             str(Path.cwd()),
+            "--tooling-root",
+            str(tooling_root),
             "--catalogue",
             str(Path.cwd()),
             "--workspace",
@@ -836,7 +918,7 @@ def test_executor_produces_valid_terminal_receipt(
     )
     assert qualification.main() == 0
     receipt = workspace / "voiage-easybuild-2023a/receipt.json"
-    assert validate_receipt(receipt, Path.cwd())["outcome"] == "passed"
+    assert validate_receipt(receipt, Path.cwd(), tooling_root)["outcome"] == "passed"
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="requires Linux shell semantics")
@@ -850,6 +932,23 @@ def test_generated_module_scripts_with_fake_environment_modules(
     prepared_sources = tmp_path / "prepared-sources-linux"
     prepared_sources.mkdir()
     (prepared_sources / "voiage-2.2.0.tar.gz").write_text("prepared")
+    tooling_root = tmp_path / "tooling"
+    for relative in (
+        *qualification.TOOLING_FILES,
+        "specs/native-easybuild-terminal-receipt-v1.schema.json",
+    ):
+        target = tooling_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(Path.cwd() / relative, target)
+    tooling_commit = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", "HEAD"], text=True
+    ).strip()
+    tooling_tree = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    base_tree = subprocess.check_output(
+        ["/usr/bin/git", "rev-parse", f"{BASE}^{{tree}}"], text=True
+    ).strip()
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
     modulecmd = fake_bin / "modulecmd"
@@ -925,7 +1024,7 @@ with open(a.output, "w") as stream:
     )
     real_output = subprocess.check_output
 
-    def output(argv: list[str], **kwargs: Any) -> str:
+    def output(argv: list[str], **kwargs: Any) -> str:  # noqa: PLR0911
         if argv[:2] == ["eb", "--version"]:
             return "EasyBuild 5.4.0\n"
         if (
@@ -937,6 +1036,25 @@ with open(a.output, "w") as stream:
             return "Environment Modules 5.4.0\n"
         if argv[-2:] == ["status", "--porcelain"]:
             return ""
+        checkout = argv[argv.index("-C") + 1] if "-C" in argv else None
+        if checkout == str(tooling_root):
+            if argv[-2:] == ["rev-parse", "HEAD"]:
+                return tooling_commit + "\n"
+            if argv[-2:] == ["rev-parse", "HEAD^{tree}"]:
+                return tooling_tree + "\n"
+            if argv[-2] == "rev-parse" and argv[-1].endswith("^{tree}"):
+                return tooling_tree + "\n"
+            if "show" in argv:
+                relative = argv[-1].split(":", 1)[1]
+                payload = (tooling_root / relative).read_bytes()
+                return payload if not kwargs.get("text") else payload.decode()
+        if checkout == str(Path.cwd()):
+            if argv[-2:] == ["rev-parse", "HEAD"]:
+                return BASE + "\n"
+            if argv[-2:] == ["rev-parse", "HEAD^{tree}"]:
+                return base_tree + "\n"
+            if argv[-3:] == ["ls-tree", "-r", "HEAD"]:
+                return real_output([*argv[:-1], BASE], **kwargs)
         return real_output(argv, **kwargs)
 
     monkeypatch.setattr(qualification.subprocess, "check_output", output)
@@ -1008,6 +1126,8 @@ with open(a.output, "w") as stream:
             "2023a",
             "--root",
             str(source_root),
+            "--tooling-root",
+            str(tooling_root),
             "--catalogue",
             str(source_root),
             "--workspace",
@@ -1023,7 +1143,10 @@ with open(a.output, "w") as stream:
     assert qualification.main() == 0
     run_root = workspace / "voiage-easybuild-2023a"
     assert (
-        validate_receipt(run_root / "receipt.json", source_root)["outcome"] == "passed"
+        validate_receipt(run_root / "receipt.json", source_root, tooling_root)[
+            "outcome"
+        ]
+        == "passed"
     )
     assert (run_root / "probe.log").read_text() == ""
     assert (run_root / "unload.log").read_text() == ""

--- a/todo.md
+++ b/todo.md
@@ -31,6 +31,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
     *   [x] Reconcile both EasyBuild root graphs with all provider overlays and
         retain generation-bound robot receipts; native builds and installed
         module qualification remain pending.
+    *   [x] Add a guarded sequential native EasyBuild driver and fail-closed
+        terminal receipt contract; actual 2023a and 2024a builds remain pending.
     *   [x] Enforce the NLTK 3.10.3 manuscript-tool security floor and retain a
         bounded disposition for the unpatched model-persistence advisory.
     *   [x] Refresh the cross-venue evidence contract after the final EasyBuild


### PR DESCRIPTION
The maintained foss-2023a and foss-2024a EasyBuild candidates need native qualification in the migrated Linux VM, but the repository had no guarded way to prove that both builds used the reviewed recipes, catalogue, source cache, isolated prefixes, and installed native modules.

This PR adds a sequential native qualification driver, installed-runtime probe, terminal receipt schema and aggregate validator. The evidence contract binds clean source and catalogue state, exact recipes and robot paths, prepared sources, command transcripts, module inventories, native linkage, numerical and Arrow/Polars behavior, generation isolation, and 2023a-to-2024a sequencing. It fails closed and does not claim that either native build has run.

Validation:
- full `tox` passed in 904.83 seconds
- coverage environment: 5,002 passed, 16 skipped; 95.13% coverage
- Python 3.12, 3.13, and 3.14 compatibility slices: 215 passed each
- min/max dependency slices: 215 passed each
- docs: 1,034 pages built with valid links
- focused native tooling and EasyBuild contract suite: 103 passed, 1 Linux-only integration skipped locally
- commit is GPG-signed

Native VM execution and any upstream EasyBuild submission remain separate pending gates.
