### PR TITLE
fix(quality): repair Ruff preview findings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,5 @@
 # Changelog
 
-- Add guarded, generation-isolated native EasyBuild qualification tooling and
-  a fail-closed terminal evidence contract that separately binds the pinned
-  candidate and reviewed tooling checkouts, preserves build exit codes when
-  module discovery fails, and isolates unload checks from the source checkout,
-  without claiming a native build.
-
 - Prepare checksum-pinned voiage 2.2.0 Spack and both requested EasyBuild toolchain candidates, cluster module instructions, and an isolated Rust source-build smoke check; upstream submission and actual HPC builds remain pending.
 
 - Archived the completed comprehensive pre-submission hardening programme after
@@ -14,14 +8,9 @@
 
 ## Unreleased
 
-- Repair the Actions dependency update so Rust MSRV release lanes stay at 1.85,
-  nightly sanitizer, Miri and fuzz commands use the installed toolchain, and
-  uv workflow checks track 0.12.5. Preserve the historical R qualification
-  receipt and mark the changed conformance workflow pending fresh hosted evidence.
-
-- Bind the Spack Polars runtime recipe to PyPI's exact checksum-verified sdist
-  URL so Spack cannot drop the `_32` suffix while deriving the source filename.
-  Include the authentic current URL and historical solver logs in the Git tree.
+- Repair the bounded Ruff 0.16 dependency-preview findings across repository
+  scripts while preserving runtime behavior and the current dependency and
+  Python-support policy.
 
 - Reconcile both EasyBuild root graphs with their checksum-bound provider
   overlays and retain sanitized 108-module robot evidence, while keeping native

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+- Add guarded, generation-isolated native EasyBuild qualification tooling and
+  a fail-closed terminal evidence contract that separately binds the pinned
+  candidate and reviewed tooling checkouts, preserves build exit codes when
+  module discovery fails, and isolates unload checks from the source checkout,
+  without claiming a native build.
+
 - Prepare checksum-pinned voiage 2.2.0 Spack and both requested EasyBuild toolchain candidates, cluster module instructions, and an isolated Rust source-build smoke check; upstream submission and actual HPC builds remain pending.
 
 - Archived the completed comprehensive pre-submission hardening programme after
@@ -11,6 +17,15 @@
 - Repair the bounded Ruff 0.16 dependency-preview findings across repository
   scripts while preserving runtime behavior and the current dependency and
   Python-support policy.
+
+- Repair the Actions dependency update so Rust MSRV release lanes stay at 1.85,
+  nightly sanitizer, Miri and fuzz commands use the installed toolchain, and
+  uv workflow checks track 0.12.5. Preserve the historical R qualification
+  receipt and mark the changed conformance workflow pending fresh hosted evidence.
+
+- Bind the Spack Polars runtime recipe to PyPI's exact checksum-verified sdist
+  URL so Spack cannot drop the `_32` suffix while deriving the source filename.
+  Include the authentic current URL and historical solver logs in the Git tree.
 
 - Reconcile both EasyBuild root graphs with their checksum-bound provider
   overlays and retain sanitized 108-module robot evidence, while keeping native

--- a/scripts/benchmark_perspective_interchange.py
+++ b/scripts/benchmark_perspective_interchange.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
 from io import BytesIO
 import json
 from pathlib import Path
 from statistics import median
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import pyarrow as pa
 import pyarrow.parquet as pq

--- a/scripts/check_mutation_cohort.py
+++ b/scripts/check_mutation_cohort.py
@@ -62,13 +62,17 @@ def cohort_identity(repo: Path, config_path: Path) -> dict[str, object]:
     lock_data = lock_path.read_bytes()
     lock = tomllib.loads(lock_data.decode("utf-8"))
     packages = cast("list[dict[str, object]]", lock["package"])
-    mutmut_packages = [package for package in packages if package.get("name") == "mutmut"]
+    mutmut_packages = [
+        package for package in packages if package.get("name") == "mutmut"
+    ]
     if len(mutmut_packages) != 1:
         raise ValueError("uv.lock must contain exactly one Mutmut package record")
     mutmut_package = mutmut_packages[0]
     locked_version = mutmut_package.get("version")
     if not isinstance(locked_version, str):
-        raise ValueError("Mutmut lock record must contain a version")
+        # Invalid serialized lock content is a value-domain failure, while this
+        # function's Path arguments have valid types.
+        raise ValueError("Mutmut lock record must contain a version")  # noqa: TRY004
     # Bind the cohort to the mutation tool's complete lock record, not the
     # entire application lockfile. Unrelated runtime dependency updates must
     # not require re-reviewing an unchanged mutation baseline.

--- a/scripts/dependency_frontier.py
+++ b/scripts/dependency_frontier.py
@@ -42,7 +42,7 @@ def declared_requirements(config: dict[str, object]) -> list[tuple[str, Requirem
 def release_metadata(name: str) -> dict[str, object]:
     """Return release metadata from the official PyPI JSON API."""
     url = f"https://pypi.org/pypi/{name}/json"
-    with urllib.request.urlopen(url, timeout=20) as response:  # noqa: S310
+    with urllib.request.urlopen(url, timeout=20) as response:
         payload = json.load(response)
     assert isinstance(payload, dict)
     return payload

--- a/scripts/dependency_frontier.py
+++ b/scripts/dependency_frontier.py
@@ -42,7 +42,7 @@ def declared_requirements(config: dict[str, object]) -> list[tuple[str, Requirem
 def release_metadata(name: str) -> dict[str, object]:
     """Return release metadata from the official PyPI JSON API."""
     url = f"https://pypi.org/pypi/{name}/json"
-    with urllib.request.urlopen(url, timeout=20) as response:
+    with urllib.request.urlopen(url, timeout=20) as response:  # noqa: S310 -- fixed HTTPS PyPI endpoint
         payload = json.load(response)
     assert isinstance(payload, dict)
     return payload

--- a/scripts/free_threaded_arrow_probe.py
+++ b/scripts/free_threaded_arrow_probe.py
@@ -10,6 +10,7 @@ import pyarrow as pa
 
 
 def main() -> None:
+    """Verify Arrow round-trip behavior under free-threaded Python."""
     source = pa.table({"id": [1, 2], "value": [1.5, 2.5]})
     restored = pl.from_arrow(source).to_arrow()
     assert restored.to_pydict() == source.to_pydict()

--- a/scripts/hpc_package_smoke.py
+++ b/scripts/hpc_package_smoke.py
@@ -130,7 +130,7 @@ def run_smoke(output: Path, source_archive: Path | None = None) -> None:
             work = Path(directory)
             archive = work / "voiage-2.2.0.tar.gz"
             if source_archive is None:
-                with urlopen(SOURCE_URL, timeout=120) as response:  # noqa: S310 - fixed HTTPS source
+                with urlopen(SOURCE_URL, timeout=120) as response:
                     archive.write_bytes(response.read())
             else:
                 archive.write_bytes(source_archive.read_bytes())

--- a/scripts/hpc_package_smoke.py
+++ b/scripts/hpc_package_smoke.py
@@ -130,7 +130,7 @@ def run_smoke(output: Path, source_archive: Path | None = None) -> None:
             work = Path(directory)
             archive = work / "voiage-2.2.0.tar.gz"
             if source_archive is None:
-                with urlopen(SOURCE_URL, timeout=120) as response:
+                with urlopen(SOURCE_URL, timeout=120) as response:  # noqa: S310 -- fixed HTTPS source
                     archive.write_bytes(response.read())
             else:
                 archive.write_bytes(source_archive.read_bytes())

--- a/scripts/pre_silicon_evidence.py
+++ b/scripts/pre_silicon_evidence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import hashlib
 import json
 from pathlib import Path
@@ -396,7 +396,7 @@ def build_manifest(target: str, output_root: Path, probe_only: bool) -> dict[str
     ]
     return {
         "schema_version": "1.0",
-        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
         "track": metadata["track"],
         "target": target,
         "evidence_kind": "ci_pre_silicon",

--- a/scripts/repo_harness.py
+++ b/scripts/repo_harness.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass
 import json
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 
@@ -229,12 +230,17 @@ def check_conflict_markers(root: Path) -> list[Finding]:
         "coverage_html_report",
         "target",
     }
-    tracked = subprocess.run(
-        ["git", "-C", str(root), "ls-files", "-z"],
-        capture_output=True,
-        check=False,
+    git = shutil.which("git")
+    tracked = (
+        subprocess.run(  # noqa: S603 -- executable is resolved from the host PATH.
+            [git, "-C", str(root), "ls-files", "-z"],
+            capture_output=True,
+            check=False,
+        )
+        if git is not None
+        else None
     )
-    if tracked.returncode == 0:
+    if tracked is not None and tracked.returncode == 0:
         candidates = [
             root / relative.decode("utf-8", errors="surrogateescape")
             for relative in tracked.stdout.split(b"\0")

--- a/scripts/run_vop_research_use.py
+++ b/scripts/run_vop_research_use.py
@@ -23,6 +23,7 @@ def _sha256(path: Path) -> str:
 
 
 def main() -> None:
+    """Run the governed VoP research-use workflow."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--vop-root", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
@@ -38,6 +39,7 @@ def main() -> None:
     sys.path.insert(0, str(args.vop_root / "src"))
     from vop_poc_nz.cea_model_core import run_cea
     from vop_poc_nz.pipeline.analysis import load_parameters
+
     from voiage import __version__
     from voiage.methods.basic import evpi
 

--- a/scripts/simple_validation.py
+++ b/scripts/simple_validation.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Simple validation script to ensure the voiage library is working correctly.
-"""
+"""Validate that the voiage library works correctly."""
 
 import sys
 
@@ -56,11 +54,11 @@ def validate_core_functionality():
         evpi_da_result = analysis.evpi()
         print(f"✅ DecisionAnalysis EVPI calculated successfully: {evpi_da_result:.2f}")
 
-        return True
-
     except Exception as e:
         print(f"❌ Error in core functionality validation: {e}")
         return False
+    else:
+        return True
 
 
 def validate_structural_functionality():
@@ -76,7 +74,7 @@ def validate_structural_functionality():
 
         # Create simple modelers for testing
         def simple_modeler1(psa_samples):
-            """Simple modeler for testing."""
+            """Create net benefits for a simple model test."""
             n_samples = psa_samples.n_samples
             # Create net benefits for 2 strategies
             nb_values = np.random.rand(n_samples, 2) * 1000
@@ -130,11 +128,11 @@ def validate_structural_functionality():
         )
         print(f"✅ Structural EVPI calculated successfully: {result:.2f}")
 
-        return True
-
     except Exception as e:
         print(f"❌ Error in structural functionality validation: {e}")
         return False
+    else:
+        return True
 
 
 def validate_cli_functionality():
@@ -153,11 +151,11 @@ def validate_cli_functionality():
         else:
             print("✅ CLI app is available")
 
-        return True
-
     except Exception as e:
         print(f"❌ Error in CLI functionality validation: {e}")
         return False
+    else:
+        return True
 
 
 def validate_web_api_functionality():
@@ -174,15 +172,15 @@ def validate_web_api_functionality():
         if app:
             print("✅ Web API app is available")
 
-        return True
-
     except Exception as e:
         print(f"❌ Error in web API functionality validation: {e}")
         return False
+    else:
+        return True
 
 
 def main():
-    """Main validation function."""
+    """Run the validation checks."""
     print("🚀 Starting voiage simple validation...")
     print("=" * 50)
 

--- a/scripts/validate_and_enrich_bibliography.py
+++ b/scripts/validate_and_enrich_bibliography.py
@@ -25,9 +25,10 @@ def validate_doi(doi: str) -> bool:
 
     try:
         response = requests.get(f"https://api.crossref.org/works/{doi}", timeout=10)
-        return response.status_code == 200
     except requests.RequestException:
         return False
+    else:
+        return response.status_code == 200
 
 
 def enrich_from_crossref(doi: str) -> dict[str, Any] | None:
@@ -117,16 +118,33 @@ def format_bibtex_entry(fields: dict[str, str]) -> str:
     entry_lines = [f"@{entry_type}{{{entry_key},"]
 
     # Add fields in a consistent order
-    field_order = ["title", "author", "journal", "year", "volume", "number", "pages", "doi", "url", "publisher"]
+    field_order = [
+        "title",
+        "author",
+        "journal",
+        "year",
+        "volume",
+        "number",
+        "pages",
+        "doi",
+        "url",
+        "publisher",
+    ]
 
     # Add ordered fields first
-    for field in field_order:
-        if fields.get(field):
-            entry_lines.append(f"  {field} = {{{fields[field]}}},")
+    entry_lines.extend(
+        f"  {field} = {{{fields[field]}}},"
+        for field in field_order
+        if fields.get(field)
+    )
 
     # Add any remaining fields
     for field, value in fields.items():
-        if field not in ["entry_type", "entry_key"] and value and field not in field_order:
+        if (
+            field not in ["entry_type", "entry_key"]
+            and value
+            and field not in field_order
+        ):
             entry_lines.append(f"  {field} = {{{value}}},")
 
     # Close the entry
@@ -181,7 +199,9 @@ def process_bibliography_file(input_file: Path, output_file: Path) -> None:
                     enriched_count += 1
                     print("    ↻ Enriched with Crossref data")
             else:
-                print(f"  ✗ Invalid DOI for {fields.get('entry_key', 'unknown')}: {doi}")
+                print(
+                    f"  ✗ Invalid DOI for {fields.get('entry_key', 'unknown')}: {doi}"
+                )
 
         # Format the entry back
         processed_entry = format_bibtex_entry(fields)
@@ -202,7 +222,7 @@ def process_bibliography_file(input_file: Path, output_file: Path) -> None:
 
 
 def main():
-    """Main function to validate and enrich bibliography."""
+    """Validate and enrich the bibliography."""
     # Process the references file
     input_path = Path("paper/references_corrected.bib")
     output_path = Path("paper/references_enriched.bib")

--- a/tests/test_repo_harness.py
+++ b/tests/test_repo_harness.py
@@ -88,6 +88,20 @@ def test_conflict_scan_uses_git_tracked_files_when_available(tmp_path: Path) -> 
     assert [finding.path for finding in findings] == ["tracked.py"]
 
 
+def test_conflict_scan_falls_back_when_git_is_unavailable(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """The source scan remains functional when Git is not on the host PATH."""
+    source = tmp_path / "source.py"
+    source.write_text(">>>>>>> unresolved\n", encoding="utf-8")
+    monkeypatch.setattr("scripts.repo_harness.shutil.which", lambda _name: None)
+
+    findings = check_conflict_markers(tmp_path)
+
+    assert [finding.path for finding in findings] == ["source.py"]
+
+
 def test_sphinx_build_configuration_is_rejected(tmp_path: Path) -> None:
     """The harness prevents a second documentation toolchain from returning."""
     (tmp_path / "docs").mkdir()

--- a/todo.md
+++ b/todo.md
@@ -35,6 +35,8 @@ This document lists the actionable tasks for `voiage` development. Agents should
     *   [x] Refresh the cross-venue evidence contract after the final EasyBuild
         root-graph PR merge, binding PR #1087's exact tree-equal merge and
         terminal checks while retaining native, upstream, and venue gates (#614).
+    *   [x] Repair the bounded Ruff 0.16 dependency-preview findings without
+        promoting the preview dependency or widening Python support.
 
 *   [~] Deliver the hardened v2.2.0 release through
     `conductor/tracks/v2_2_release_and_venue_submissions_20260830/` (#1037).


### PR DESCRIPTION
## Summary
- repair the bounded Ruff 0.16 dependency preview findings across repository scripts
- preserve runtime behavior and current dependency and Python support policy
- add a regression test for repository harness operation without Git on PATH

## Validation
- full tox: all environments passed except the first docs attempt before submodule initialization
- `tox -e docs` passed after initializing repository submodules
