### PR TITLE
feat(conductor): guard execution packet handoffs

### DIFF
--- a/conductor/github-cross-references.json
+++ b/conductor/github-cross-references.json
@@ -44,7 +44,7 @@
         "url": "https://github.com/edithatogo/voiage/issues/1022",
         "state": "closed"
       },
-      "parent_issue_url": null,
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1111",
       "subissues": [
         "https://github.com/edithatogo/voiage/issues/616",
         "https://github.com/edithatogo/voiage/issues/471"
@@ -5605,6 +5605,83 @@
         }
       ],
       "pull_request_evidence": "PRs #1038, #1046, #1047, #1051 and #1052 merged through protected checks. Signed immutable v2.2.0 is publicly verified. Personal declarations and withdrawals are confirmed; survey, human-written text, actual submissions and venue outcomes remain separate."
+    },
+    {
+      "track_id": "agent_safe_engineering_20260907",
+      "metadata_track_id": "agent_safe_engineering_20260907",
+      "path": "conductor/tracks/agent_safe_engineering_20260907",
+      "lifecycle": "active",
+      "issue": {"number": 1110, "url": "https://github.com/edithatogo/voiage/issues/1110", "state": "open"},
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1111",
+      "subissues": [],
+      "pull_requests": [],
+      "pull_request_evidence": "none_found"
+    },
+    {
+      "track_id": "execution_packet_guard_20260907",
+      "metadata_track_id": "execution_packet_guard_20260907",
+      "path": "conductor/tracks/execution_packet_guard_20260907",
+      "lifecycle": "active",
+      "issue": {"number": 1111, "url": "https://github.com/edithatogo/voiage/issues/1111", "state": "open"},
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1110",
+      "subissues": [],
+      "pull_requests": [{"number": 1109, "url": "https://github.com/edithatogo/voiage/pull/1109", "status": "open", "evidence": ["implementation-head:ae548db790cbecfd29d8d6f42c77de0fb8250d66"]}],
+      "pull_request_evidence": "PR #1109 open; hosted checks pending remediation"
+    },
+    {
+      "track_id": "version_identity_contracts_20260907",
+      "metadata_track_id": "version_identity_contracts_20260907",
+      "path": "conductor/tracks/version_identity_contracts_20260907",
+      "lifecycle": "active",
+      "issue": {"number": 1112, "url": "https://github.com/edithatogo/voiage/issues/1112", "state": "open"},
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1110",
+      "subissues": [],
+      "pull_requests": [],
+      "pull_request_evidence": "none_found"
+    },
+    {
+      "track_id": "native_structured_logging_20260907",
+      "metadata_track_id": "native_structured_logging_20260907",
+      "path": "conductor/tracks/native_structured_logging_20260907",
+      "lifecycle": "active",
+      "issue": {"number": 1113, "url": "https://github.com/edithatogo/voiage/issues/1113", "state": "open"},
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1110",
+      "subissues": [],
+      "pull_requests": [],
+      "pull_request_evidence": "none_found"
+    },
+    {
+      "track_id": "logging_privacy_resilience_20260907",
+      "metadata_track_id": "logging_privacy_resilience_20260907",
+      "path": "conductor/tracks/logging_privacy_resilience_20260907",
+      "lifecycle": "active",
+      "issue": {"number": 1114, "url": "https://github.com/edithatogo/voiage/issues/1114", "state": "open"},
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1110",
+      "subissues": [],
+      "pull_requests": [],
+      "pull_request_evidence": "none_found"
+    },
+    {
+      "track_id": "vop_logging_version_pilot_20260907",
+      "metadata_track_id": "vop_logging_version_pilot_20260907",
+      "path": "conductor/tracks/vop_logging_version_pilot_20260907",
+      "lifecycle": "active",
+      "issue": {"number": 1115, "url": "https://github.com/edithatogo/voiage/issues/1115", "state": "open"},
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1110",
+      "subissues": [],
+      "pull_requests": [],
+      "pull_request_evidence": "none_found"
+    },
+    {
+      "track_id": "optional_native_telemetry_20260907",
+      "metadata_track_id": "optional_native_telemetry_20260907",
+      "path": "conductor/tracks/optional_native_telemetry_20260907",
+      "lifecycle": "active",
+      "issue": {"number": 1116, "url": "https://github.com/edithatogo/voiage/issues/1116", "state": "open"},
+      "parent_issue_url": "https://github.com/edithatogo/voiage/issues/1110",
+      "subissues": [],
+      "pull_requests": [],
+      "pull_request_evidence": "none_found"
     },
     {
       "track_id": "remaining_backlog_delivery_20260831",

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -1063,3 +1063,31 @@ track at the top of this registry; completed repository slices stay closed.
 ## [x] Track: Legacy Archive Record — Voi Frontier Architecture Dependency Governance 20260625
 *Link: [./archive/voi-frontier-architecture-dependency-governance_20260625/index.md](./archive/voi-frontier-architecture-dependency-governance_20260625/index.md)*
 *Status: archived historical record; registration was normalized without changing its substantive outcome.*
+
+---
+- [ ] **Track: Agent-safe engineering improvements**
+  *Link: [./tracks/agent_safe_engineering_20260907/index.md](./tracks/agent_safe_engineering_20260907/index.md)*
+
+---
+- [~] **Track: Execution packet readiness and drift controls**
+  *Link: [./tracks/execution_packet_guard_20260907/index.md](./tracks/execution_packet_guard_20260907/index.md)*
+
+---
+- [ ] **Track: Version identities and compatibility policy**
+  *Link: [./tracks/version_identity_contracts_20260907/index.md](./tracks/version_identity_contracts_20260907/index.md)*
+
+---
+- [ ] **Track: Minimal Rust structured logging**
+  *Link: [./tracks/native_structured_logging_20260907/index.md](./tracks/native_structured_logging_20260907/index.md)*
+
+---
+- [ ] **Track: Logging privacy and bounded delivery**
+  *Link: [./tracks/logging_privacy_resilience_20260907/index.md](./tracks/logging_privacy_resilience_20260907/index.md)*
+
+---
+- [ ] **Track: VOP-to-VOI version and logging pilot**
+  *Link: [./tracks/vop_logging_version_pilot_20260907/index.md](./tracks/vop_logging_version_pilot_20260907/index.md)*
+
+---
+- [ ] **Track: Optional native telemetry qualification**
+  *Link: [./tracks/optional_native_telemetry_20260907/index.md](./tracks/optional_native_telemetry_20260907/index.md)*

--- a/conductor/tracks/agent_safe_engineering_20260907/AGENTS.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/AGENTS.md
@@ -1,0 +1,23 @@
+# Scope for this engineering programme
+
+Before changing any implementation file for this track, read worker-guide.md,
+spec.md and the selected packet in packets.json. Every implementation slice needs
+an exact file allowlist, baseline hashes, acceptance witness and satisfied
+prerequisite evidence. candidate_write_scope is not a final write allowlist.
+
+All implementation_ready flags start false. Do not set one true solely because
+the packet parses or its plan exists. Until G01 lands, the integrator explicitly
+checks readiness. G01 itself needs the reviewed negative-test design in G01.1.
+
+Do not edit another track, overwrite evidence, relax quality gates, or infer
+scientific and release decisions. Follow worker-guide.md for escalation and
+parallel ownership. Planning completion is not implementation completion.
+
+## Repository admission
+
+Read [repository-boundaries.md](./repository-boundaries.md) before any scope
+refinement. One slice has one delivery repository. Generic inference, game
+solving, simulation, source acquisition and shared automation stay with their
+owners. Future Rust-first providers may have distinct APIs/ABIs; validate the
+chosen scientific and interchange contract. Existing Voiage compatibility
+promises remain in force. Do not edit a sibling repository from this track.

--- a/conductor/tracks/agent_safe_engineering_20260907/START_HERE.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/START_HERE.md
@@ -1,0 +1,21 @@
+# Engineering programme implementation entry
+
+Start execution_packet_guard_20260907 T1.1. G01 parent tasks summarize that
+child's evidence; do not implement them again. The orchestration ownership map
+also delegates version identities, logging/privacy and the first pilot.
+
+G02–G08 may perform their source/contract investigation after checking file
+reservations. Their packets.json validation_commands are concrete existing
+baseline commands. Full implementation remains dependent on G01 and accepted
+per-package decisions. A candidate directory is never a final write allowlist.
+
+For each residual G package, the first deliverable is the named JSON contract
+or measurement artifact in its candidate_write_scope. Limit this first change
+to that artifact and the package's plan/evidence records; no runtime files yet.
+The integrator then records the exact implementation files and reference tests.
+This stages genuinely unresolved numerical/platform decisions rather than
+asking a weaker worker to invent them. Generic inference, game and simulation
+engines remain outside this repository.
+
+Read orchestration.md for child readiness, repository-boundaries.md for scope,
+and implementation-readiness.md for the complete active-track inventory.

--- a/conductor/tracks/agent_safe_engineering_20260907/assessment.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/assessment.md
@@ -1,0 +1,42 @@
+# Evidence and further recommendations
+
+Review date: 2026-09-07; source baseline `1207cef9`. These are bounded findings from the inspected files, not a claim of an exhaustive absence scan.
+
+| Package | Existing evidence and gap | Recommendation |
+| --- | --- | --- |
+| G01 | The existing harness checks repository conventions but does not yet enforce these task packets or dependency readiness. | Execution packets and drift enforcement |
+| G02 | Cargo-deny and preview qualification already exist; all-features success alone does not establish minimal or separately enabled feature support. | Rust dependency and feature qualification |
+| G03 | Installed consumer and sanitizer contracts exist; a dedicated Rust public-API comparison was not found in the inspected workflows. | API and ABI compatibility witnesses |
+| G04 | CI and Operational Assurance both collect full Python coverage; nextest/sccache is already an observation lane. Duplication may be intentional and must be measured. | CI cost and failure reproducibility |
+| G05 | EVPI/ENBS/sample-matrix fuzzing and Miri already run; extend their case coverage instead of adding duplicate workflows. | Numerical adversarial assurance |
+| G06 | The integrated roadmap proposes restartable execution; cancellation, resource limits and partial-result semantics need explicit acceptance witnesses before implementation. | Bounded jobs and recoverable computation |
+| G07 | Capability registries and consumer checks exist; user-facing discovery must reflect the installed artifact and bounded method maturity rather than narrative feature lists. | Capability discovery and reproducible user reports |
+| G08 | Renovate, SBOMs and release assurance already exist. Improve evidence consumption, expiry and recovery instead of creating a second update bot. | Automation and release evidence lifecycle |
+
+## Current primary sources
+
+These sources establish tool capabilities, not compatibility with this repository. Qualify pinned candidates before adoption.
+
+- [Cargo feature semantics](https://doc.rust-lang.org/cargo/reference/features.html): supports the feature-matrix investigation (G02).
+- [cargo-semver-checks upstream](https://github.com/obi1kenobi/cargo-semver-checks): Rust API comparisons use explicit baselines; tool/rustdoc compatibility needs qualification (G03).
+- [nextest resource groups](https://nexte.st/docs/configuration/test-groups/) and [run replay](https://nexte.st/docs/features/record-replay-rerun/): extend the existing observation lane with bounded resources and reproducible failure investigation (G04).
+- [GitHub artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations): investigate verification at artifact consumption, in addition to existing generation (G08).
+
+## Earlier roadmap handoffs
+
+| Earlier package | This track supplies | Activation boundary |
+| --- | --- | --- |
+| V01, V02, F01 | G01 packet/claim discipline; G05 independent witnesses | Refine semantic and scientific contracts first |
+| V03–V08, F02, F05 | G05 numerical assurance; G06 job-state contracts | Method-specific algorithm and tolerance review still required |
+| V09–V11, F03, F07 | Bounded research packets and explicit unsupported states | Research feasibility does not grant stable promotion |
+| V12, F08 | G03 installed-consumer compatibility; G07 discovery | Each binding/producer needs actual acceptance evidence |
+| F04 | G02 feature/MSRV and G04 measured CI qualification | No dependency upgrades from registry snapshots alone |
+| F06 | G05 witnesses and G07 provenance | Economic assumptions and joint evidence remain method-owned |
+
+## Owner-library review and scope refinement
+
+The [repository allocation](./repository-boundaries.md) refines this assessment
+using live GitHub inspection. It distinguishes existing integrations, planned
+fixtures, candidate producers, and deferred capabilities. It narrows G01 to a
+local policy/profile, G03 to explicit compatibility promises, and G06 to VOI-job
+lifecycle control. No generic engine or sibling implementation is authorized.

--- a/conductor/tracks/agent_safe_engineering_20260907/boundary-validation.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/boundary-validation.json
@@ -1,0 +1,32 @@
+{
+  "recorded_at": "2026-09-06T14:27:59+00:00",
+  "scope": "Repository allocation and Rust-successor compatibility planning refinement",
+  "conductor_validation": {
+    "errors": 0,
+    "warnings": 0
+  },
+  "focused_governance_tests_passed": 38,
+  "packets": 8,
+  "pending_tasks": 24,
+  "github_source_observations": 26,
+  "public_repositories_inspected": 21,
+  "schema_negative_checks": [
+    "non-Voiage delivery repository rejected",
+    "external_write_authorized=true rejected"
+  ],
+  "checks": [
+    "unique packet IDs and dependency ordering",
+    "read-first paths exist",
+    "local Markdown links resolve",
+    "source blob identity format",
+    "all implementation tasks remain pending",
+    "Vale zero errors and warnings",
+    "git diff --check"
+  ],
+  "limits": [
+    "Source and README inspection is not compiled or installed compatibility evidence.",
+    "Schema constraints do not sandbox an agent or replace G01 semantic enforcement.",
+    "No upstream repository changes, dependency additions, new issues or runtime implementations.",
+    "Full tox and hosted CI were not repeated for this planning-only refinement."
+  ]
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/github-integration-review.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/github-integration-review.json
@@ -1,0 +1,217 @@
+{
+  "observed_on": "2026-09-07",
+  "account": "edithatogo",
+  "provider": "GitHub plugin",
+  "discovery": "Owner-filtered repository listing plus user:edithatogo fork:false repository search pages 1-3; page 3 empty. Discovery does not prove exhaustive source assessment.",
+  "scope": "Selected public scientific and engineering repositories; private repository details omitted from public planning artifacts.",
+  "observations": [
+    {
+      "repository": "edithatogo/mars",
+      "path": "README.md",
+      "blob_sha": "7cbf90d89e451b4cf90f25d3f218de7404ebb398",
+      "url": "https://github.com/edithatogo/mars/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-95"
+    },
+    {
+      "repository": "edithatogo/innovate",
+      "path": "README.md",
+      "blob_sha": "ea4d7b0ad0ae8cdb3856cf99867abb886e23980c",
+      "url": "https://github.com/edithatogo/innovate/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/kairos",
+      "path": "README.md",
+      "blob_sha": "92dfade6819dc54f7cb99f4f80bbbf96082255f6",
+      "url": "https://github.com/edithatogo/kairos/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-95"
+    },
+    {
+      "repository": "edithatogo/UOGTO",
+      "path": "README.md",
+      "blob_sha": "adca2658e6d106cbb03af90958894f0568c27462",
+      "url": "https://github.com/edithatogo/UOGTO/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-95"
+    },
+    {
+      "repository": "edithatogo/new-drug-reimbursement-game",
+      "path": "README.md",
+      "blob_sha": "12050dc31462bb6a531829481c5aae0e3e95c32f",
+      "url": "https://github.com/edithatogo/new-drug-reimbursement-game/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/vop_poc_nz",
+      "path": "README.md",
+      "blob_sha": "305eb5ee0c5e42b7ac5eeebf9c62c29679546595",
+      "url": "https://github.com/edithatogo/vop_poc_nz/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/lifecourse",
+      "path": "README.md",
+      "blob_sha": "cc487a19b52f68fe9f72e7804571719a8724f93a",
+      "url": "https://github.com/edithatogo/lifecourse/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/ginsim",
+      "path": "README.md",
+      "blob_sha": "5c6c8a3debd377ca5efa0c187ddef85aeb109f66",
+      "url": "https://github.com/edithatogo/ginsim/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/mchs",
+      "path": "README.md",
+      "blob_sha": "e87884ce601afb568c7f41108bb22b22576316f7",
+      "url": "https://github.com/edithatogo/mchs/blob/master/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-95"
+    },
+    {
+      "repository": "edithatogo/NwauCore.jl",
+      "path": "README.md",
+      "blob_sha": "61286de82703c8637b664e755a705cf9147103c3",
+      "url": "https://github.com/edithatogo/NwauCore.jl/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-65"
+    },
+    {
+      "repository": "edithatogo/NationalWeightedActivityUnitWrapper.jl",
+      "path": "README.md",
+      "blob_sha": "807efcf0a7384c197d22ea7742122284284096f0",
+      "url": "https://github.com/edithatogo/NationalWeightedActivityUnitWrapper.jl/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-65"
+    },
+    {
+      "repository": "edithatogo/rareburden-commons",
+      "path": "README.md",
+      "blob_sha": "511332bed6d6605d0a991b2a53f46f8f1c14264f",
+      "url": "https://github.com/edithatogo/rareburden-commons/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/reimbursement-atlas",
+      "path": "README.md",
+      "blob_sha": "a27b4ed7837ecc5463248a14f8da56acd0820a37",
+      "url": "https://github.com/edithatogo/reimbursement-atlas/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/global-medicines-atlas",
+      "path": "README.md",
+      "blob_sha": "ca9acc995d7bc72231ce2db1d9f4b24d5a5c93e2",
+      "url": "https://github.com/edithatogo/global-medicines-atlas/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/riopa-infrastructure",
+      "path": "README.md",
+      "blob_sha": "b451053695c5a79110e736d0a2f0287e8091fa28",
+      "url": "https://github.com/edithatogo/riopa-infrastructure/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-65"
+    },
+    {
+      "repository": "edithatogo/conductor-next",
+      "path": "README.md",
+      "blob_sha": "8dca97e5b9c4757de83f27719ea2ab2751bea505",
+      "url": "https://github.com/edithatogo/conductor-next/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/repository-standards",
+      "path": "README.md",
+      "blob_sha": "4de338e02a848faebae2c85dbd477823fee71eee",
+      "url": "https://github.com/edithatogo/repository-standards/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/renovate-config",
+      "path": "README.md",
+      "blob_sha": "1f0a2ed4e8a1e979dcb1dcc3e2285d9662951a70",
+      "url": "https://github.com/edithatogo/renovate-config/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-65"
+    },
+    {
+      "repository": "edithatogo/astro-polyglot",
+      "path": "README.md",
+      "blob_sha": "ce4b6dc1b7459d2877eea8c6d43d02962f4a04ee",
+      "url": "https://github.com/edithatogo/astro-polyglot/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/sourceright",
+      "path": "README.md",
+      "blob_sha": "41c011ecb434f2377a90df1155d522bb4f70a80b",
+      "url": "https://github.com/edithatogo/sourceright/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-65"
+    },
+    {
+      "repository": "edithatogo/standardflow",
+      "path": "README.md",
+      "blob_sha": "f42908ccaa5fb9158a185946cc500033c56ea42a",
+      "url": "https://github.com/edithatogo/standardflow/blob/main/README.md",
+      "evidence_level": "README inspection; no runtime qualification",
+      "read_lines": "1-65"
+    },
+    {
+      "repository": "edithatogo/mars",
+      "path": "rust-runtime/Cargo.toml",
+      "blob_sha": "2c969237a99c2f2c0e4d205ba655a3ce4d2b48b2",
+      "url": "https://github.com/edithatogo/mars/blob/main/rust-runtime/Cargo.toml",
+      "evidence_level": "source/manifest inspection; not compiled",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/kairos",
+      "path": "Cargo.toml",
+      "blob_sha": "ed04fc6c64706a187a766fd30eb705439b3e3086",
+      "url": "https://github.com/edithatogo/kairos/blob/main/Cargo.toml",
+      "evidence_level": "source/manifest inspection; not compiled",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/new-drug-reimbursement-game",
+      "path": "ecosystem.lock.toml",
+      "blob_sha": "b43d2a0b46fc39813ec0063c81123720359ba9ba",
+      "url": "https://github.com/edithatogo/new-drug-reimbursement-game/blob/main/ecosystem.lock.toml",
+      "evidence_level": "source/manifest inspection; not compiled",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/new-drug-reimbursement-game",
+      "path": "Cargo.toml",
+      "blob_sha": "a89b09b6cc34a341c1a545b24a4091c2112c5032",
+      "url": "https://github.com/edithatogo/new-drug-reimbursement-game/blob/main/Cargo.toml",
+      "evidence_level": "source/manifest inspection; not compiled",
+      "read_lines": "1-100"
+    },
+    {
+      "repository": "edithatogo/innovate",
+      "path": "docs/architecture_principles.md",
+      "blob_sha": "29ee730e074f00886cadb3bd8b8e17b5cf9b8afd",
+      "url": "https://github.com/edithatogo/innovate/blob/main/docs/architecture_principles.md",
+      "evidence_level": "source/manifest inspection; not compiled",
+      "read_lines": "1-100"
+    }
+  ]
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/implementation-readiness.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/implementation-readiness.md
@@ -1,0 +1,64 @@
+# Active-track implementation readiness
+
+Preparation date: 2026-09-07. All nine active tracks have an entry handoff.
+Prepared means a worker can execute the next eligible step without choosing its
+scope from scratch. It does not mean prerequisites or external gates passed.
+Implementation checkboxes remain unchanged.
+
+| Track | Start state | First action |
+| --- | --- | --- |
+| execution_packet_guard_20260907 | Ready for bounded preflight | START_HERE.md, T1.1 ownership/profile witness |
+| version_identity_contracts_20260907 | Waiting for execution guard | Source inventory may proceed read-only; then T1.1 |
+| native_structured_logging_20260907 | Waiting for version contracts | Prepare event/correlation inventory; then T1.1 |
+| logging_privacy_resilience_20260907 | Waiting for native event contract | Prepare adversarial cases without shared-file edits |
+| vop_logging_version_pilot_20260907 | Waiting for logging/privacy acceptance | Inspect existing producer export and pin candidates |
+| optional_native_telemetry_20260907 | Waiting for pilot and demonstrated need | Read-only dependency/use-case evaluation only |
+| agent_safe_engineering_20260907 | Parent coordination; residual G02–G08 design packets | START_HERE.md; never duplicate delegated child slices |
+| remaining_backlog_delivery_20260831 | Evidence reconciliation first | implementation-handoff.md; resolve closed #1053 versus incomplete plan |
+| v2_2_release_and_venue_submissions_20260830 | External R14 prerequisites | implementation-handoff.md; retain survey/text and editorial gates |
+
+## Planning defaults workers may rely on
+
+- Package release authority remains Cargo; wire, event, algorithm, RNG and
+  checkpoint identities are separate explicit fields, not derived implicitly
+  from the package number. Existing synchronization policy is preserved.
+- Version evolution starts with one existing contract. Preserve immutable old
+  fixtures. Reject unknown incompatible major versions. Do not silently infer
+  currencies, weights, units, RNG or algorithm defaults during migration.
+- Native instrumentation uses application-owned subscribers and optional
+  structured events. Never initialize global logging on import/library entry.
+- No exporter/network runtime enters the minimal numerical dependency graph.
+  Disabled logging must preserve results and deterministic hashes.
+- Redaction occurs before sink serialization; allowlisted event attributes are
+  the default. Retention and sink credentials belong to the application.
+- Queue and overhead limits require a measured, recorded numeric budget before
+  implementation. Do not pretend an arbitrary unmeasured threshold is accepted.
+- Scientific result diagnostics and durable audit records are not sampled logs.
+- Every new Rust provider may have its own API; adapters uphold only named
+  interchange/semantic contracts and Voiage's existing public promises.
+
+## Orchestration and handoff
+
+Use orchestration.md for the dependency chain and ownership rules. The six
+child implementation-packet.json files reserve exact implementation paths,
+record existing input hashes, identify proposed new files and enumerate phase
+commands/expected results. Check hashes after rebasing; regenerate a packet
+only after reviewing the changed inputs. A hash match establishes input identity,
+not scientific approval or test success.
+
+The parent G packages deliberately start with design/measurement artifacts.
+Algorithm choices, dependency qualification and numerical thresholds are actual
+work items; they cannot be manufactured during planning. Until those steps pass,
+a weaker worker is restricted to the explicitly bounded preflight artifact.
+
+One clean worktree per worker, two implementation workers maximum initially,
+one integration pilot, and one integrator for shared files. No parallel edits
+to the same source, lock, schema or workflow. Merge prerequisites first and
+revalidate dependent source hashes. Missing native runners or human artifacts
+block only their tracks; independent preflight can continue.
+
+The planning changes remain local until delivered through the repository PR
+workflow. Latest observed main is b58a43ca (a PostCSS update after baseline
+1207cef9). Before implementation, integrate the accepted planning revision with
+current main and rerun the affected checks. Do not overwrite the original dirty
+checkout or assume this worktree is main.

--- a/conductor/tracks/agent_safe_engineering_20260907/index.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/index.md
@@ -2,6 +2,8 @@
 
 Status: new; all implementation tasks pending.
 
+GitHub issue: https://github.com/edithatogo/voiage/issues/1110
+
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
 - [Task packets](./packets.json)

--- a/conductor/tracks/agent_safe_engineering_20260907/index.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/index.md
@@ -1,0 +1,19 @@
+# Track: Agent-safe engineering improvements
+
+Status: new; all implementation tasks pending.
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Task packets](./packets.json)
+- [Worker instructions](./worker-guide.md)
+- [Metadata](./metadata.json)
+- [Evidence](./evidence.jsonl)
+- [Evidence and recommendations](./assessment.md)
+- [Packet schema](./packet-schema.json)
+- [Planning validation](./planning-validation.json)
+- [Repository boundaries and integration order](./repository-boundaries.md)
+- [GitHub inspection receipt](./github-integration-review.json)
+- [Boundary refinement validation](./boundary-validation.json)
+- [Logging/versioning tracks and orchestration](./orchestration.md)
+- [Programme start](./START_HERE.md)
+- [Active-track readiness](./implementation-readiness.md)

--- a/conductor/tracks/agent_safe_engineering_20260907/metadata.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/metadata.json
@@ -5,6 +5,7 @@
   "created_at": "2026-09-06T14:18:03Z",
   "updated_at": "2026-09-06T14:26:59Z",
   "description": "Bounded Rust-first engineering improvements and agent execution contracts",
+  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1110"},
   "evidence_schema": "1.0",
   "authorization": {
     "instruction": "Consider further improvements and incorporate them into Conductor; make implementation safe for less capable agents.",

--- a/conductor/tracks/agent_safe_engineering_20260907/metadata.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/metadata.json
@@ -5,7 +5,9 @@
   "created_at": "2026-09-06T14:18:03Z",
   "updated_at": "2026-09-06T14:26:59Z",
   "description": "Bounded Rust-first engineering improvements and agent execution contracts",
-  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1110"},
+  "github_cross_reference": {
+    "issue": "https://github.com/edithatogo/voiage/issues/1110"
+  },
   "evidence_schema": "1.0",
   "authorization": {
     "instruction": "Consider further improvements and incorporate them into Conductor; make implementation safe for less capable agents.",

--- a/conductor/tracks/agent_safe_engineering_20260907/metadata.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/metadata.json
@@ -1,0 +1,22 @@
+{
+  "track_id": "agent_safe_engineering_20260907",
+  "type": "chore",
+  "status": "new",
+  "created_at": "2026-09-06T14:18:03Z",
+  "updated_at": "2026-09-06T14:26:59Z",
+  "description": "Bounded Rust-first engineering improvements and agent execution contracts",
+  "evidence_schema": "1.0",
+  "authorization": {
+    "instruction": "Consider further improvements and incorporate them into Conductor; make implementation safe for less capable agents.",
+    "scope": "planning and execution guidance; implementation remains pending"
+  },
+  "gates": [
+    {
+      "id": "packet-readiness",
+      "kind": "repository",
+      "status": "pending",
+      "evidence": "G01 must validate refined implementation packets before downstream implementation starts."
+    }
+  ],
+  "scope_refinement": "2026-09-07 owner instruction: focused repository allocation; Rust successors need not match third-party API/ABI; inspect own GitHub libraries."
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/orchestration.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/orchestration.md
@@ -1,0 +1,81 @@
+# Logging and versioning delivery orchestration
+
+All six tracks are new and unimplemented. The owner requested planning, not
+automatic execution of this queue. Root AGENTS.md governs actual implementation
+and verification. Existing active backlog/venue tracks retain their ownership.
+
+## Canonical sequence
+
+| Order | Track | Prerequisite | Owns |
+| --- | --- | --- | --- |
+| 1 | [Execution guard](../execution_packet_guard_20260907/index.md) | Ownership preflight | Voiage packet profile and bounded drift checks |
+| 2 | [Version identities](../version_identity_contracts_20260907/index.md) | Execution guard accepted | Version policy, compatibility matrix and one migration |
+| 3 | [Native logging](../native_structured_logging_20260907/index.md) | Version identities accepted | Minimal Rust events and host-owned correlation |
+| 4 | [Privacy and resilience](../logging_privacy_resilience_20260907/index.md) | Native logging accepted | Privacy tests, bounded delivery and failure behavior |
+| 5 | [VOP pilot](../vop_logging_version_pilot_20260907/index.md) | Privacy and resilience accepted | One installed producer-to-consumer workflow |
+| 6 | [Optional telemetry](../optional_native_telemetry_20260907/index.md) | Pilot accepted and need demonstrated | One optional native exporter qualification |
+
+Acceptance requires recorded upstream AC results, exact source revision and
+contract hashes, not just an archived directory or completed checkbox. If no
+telemetry need is demonstrated, record deferred status separately; do not mark
+an unimplemented exporter complete. No dashboard or collector service is built
+inside Voiage.
+
+## Parallel investigations and integration barriers
+
+Before implementation, source inventory, privacy adversarial-case design and
+producer-export inspection may proceed in parallel in read-only mode. After
+the version contract freezes, native logging implementation may run alongside
+privacy-test preparation in separate worktrees. Privacy implementation waits
+for the accepted event contract. The pilot may prepare fixtures early, but
+installed-consumer qualification waits for accepted logging/privacy behavior.
+Exporter research is independent; exporter implementation is last.
+
+Maximum initial work in progress: two implementation workers plus one
+integrator; only one integration pilot. The integrator serializes all edits to
+Cargo/uv lockfiles, shared schemas, version manifests, root governance files
+and required CI names. Logging and privacy workers both target voiage/logging.py
+and native diagnostics; they must not edit those files simultaneously.
+Every task reserves exact paths before changing code. Separate worktrees and
+target/tox directories are mandatory; no shared mutable caches during testing.
+
+Merge the upstream contract first, then rebase dependent work and revalidate
+its recorded hashes. A changed event/version contract reopens affected packet
+readiness and tests. No bulk merge or silent acceptance of stale fixtures.
+Unavailable external providers block their adapter only, not base VOI work.
+
+## Scope transfer from the engineering programme
+
+These tracks are authoritative for their listed slices:
+
+- G01 execution guard implementation moves to execution_packet_guard_20260907.
+  The parent keeps repository allocation and upstream reuse decisions.
+- G03 version-identity/evolution details move to version_identity_contracts_20260907.
+  Broader public API/ABI witness work remains G03 and must reuse these identities.
+- G06 retains general VOI job/checkpoint state; logging shutdown and telemetry
+  transport live in the logging tracks. No second simulation scheduler is added.
+- G07 logging/correlation and the first VOP integration pilot use these tracks.
+  Broader capability discovery remains G07.
+- G08 retains release recovery/automation; version policy and telemetry failure
+  evidence are consumed from these tracks rather than reimplemented.
+
+Parent packet IDs remain navigation references, not parallel authorization to
+implement these transferred slices. Any overlap is resolved by this ownership
+map before implementation. New task files name references and anticipated tests;
+workers must freeze actual commands and exact files before code, as required
+by the shared worker guide. Planning does not claim runnable new tests already exist.
+
+## Per-phase acceptance and handoff
+
+Each phase has three pending steps: freeze its bounded packet, implement after
+an intended behavioral red test, and validate/review. The final two steps
+reconcile all ACs and completion evidence. Changes requiring more than five
+implementation files must be split into additional reviewed task checkboxes.
+The integrator handles shared policy changes separately.
+
+Handoffs include track/task/AC ID, repository, source SHA/tree, contract hashes,
+owner, exact files, toolchain, commands, exit status, count, result digest,
+unresolved risks and next eligible task. Use the configured evidence helper;
+do not manufacture hash-chain records. Stop after two unresolved attempts at
+the same failure; retain the reproducer and diff. Never change a fixture,
+version policy, error tolerance or coverage threshold to conceal failure.

--- a/conductor/tracks/agent_safe_engineering_20260907/packet-schema.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/packet-schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Engineering planning packets; structural validation only",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "baseline",
+    "enforcement",
+    "packets"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0"
+    },
+    "baseline": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "enforcement": {
+      "enum": [
+        "manual_until_G01",
+        "validated_by_G01"
+      ]
+    },
+    "packets": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "acceptance",
+          "stop_condition",
+          "rollback",
+          "id",
+          "status",
+          "depends_on",
+          "implementation_ready",
+          "read_first",
+          "candidate_write_scope",
+          "required_before_implementation",
+          "validation_commands",
+          "delivery_repository",
+          "capability_scope",
+          "external_write_authorized",
+          "compatibility_scope"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "acceptance": {
+            "type": "string",
+            "minLength": 1
+          },
+          "stop_condition": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rollback": {
+            "type": "string",
+            "minLength": 1
+          },
+          "id": {
+            "type": "string",
+            "pattern": "^G0[1-8]$"
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "in_progress",
+              "complete"
+            ]
+          },
+          "depends_on": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^G0[1-8]$"
+            },
+            "uniqueItems": true
+          },
+          "implementation_ready": {
+            "type": "boolean"
+          },
+          "read_first": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "candidate_write_scope": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "required_before_implementation": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "validation_commands": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "delivery_repository": {
+            "const": "edithatogo/voiage"
+          },
+          "capability_scope": {
+            "type": "string",
+            "minLength": 1
+          },
+          "external_write_authorized": {
+            "const": false
+          },
+          "compatibility_scope": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/packets.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/packets.json
@@ -1,0 +1,361 @@
+{
+  "schema_version": "1.0",
+  "baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "enforcement": "manual_until_G01",
+  "packets": [
+    {
+      "id": "G01",
+      "title": "Execution packets and drift enforcement",
+      "status": "pending",
+      "depends_on": [],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        "scripts/repo_harness.py",
+        "tests/test_repo_harness.py",
+        "AGENTS.md",
+        "conductor/workflow.md"
+      ],
+      "candidate_write_scope": [
+        "scripts/repo_harness.py",
+        "tests/test_repo_harness.py",
+        "AGENTS.md",
+        "conductor/workflow.md",
+        "scripts/validate_execution_packets.py",
+        "tests/test_execution_packets.py"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "Mutate one valid packet at a time: cycle, ../ traversal, symlink escape, missing prerequisite evidence, changed baseline hash, unknown field, and out-of-scope changed file must each exit nonzero; a valid read-only audit exits zero. Include staged, unstaged and untracked paths. A packet never grants shell or publication permission. Reject an absent capability owner, cross-repository write scope or implicit third-party API/ABI requirement. Assess conductor-next reuse before generic validator implementation.",
+      "validation_commands": [
+        "python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q"
+      ],
+      "stop_condition": "A local scope checker can detect drift but cannot prove scientific correctness or sandbox an agent. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "Voiage-specific execution packets and drift enforcement",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    },
+    {
+      "id": "G02",
+      "title": "Rust dependency and feature qualification",
+      "status": "pending",
+      "depends_on": [
+        "G01"
+      ],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        "rust/Cargo.toml",
+        "rust/Cargo.lock",
+        "rust/deny.toml",
+        ".github/workflows/rust-security.yml",
+        ".github/workflows/dependency-preview.yml",
+        "tests/test_dependency_promotion_policy.py"
+      ],
+      "candidate_write_scope": [
+        "rust/Cargo.toml",
+        "rust/Cargo.lock",
+        "rust/deny.toml",
+        ".github/workflows/rust-security.yml",
+        ".github/workflows/dependency-preview.yml",
+        "tests/test_dependency_promotion_policy.py",
+        "conductor/tracks/agent_safe_engineering_20260907/dependency-feature-matrix.json"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "A deliberately unavailable optional backend must leave the minimal supported build usable; an MSRV-incompatible candidate must fail its qualification lane. The matrix must name unsupported combinations and verify locked resolution. Native alternatives precede any non-Rust dependency proposal.",
+      "validation_commands": [
+        "python -m pytest tests/test_dependency_promotion_policy.py tests/test_dependency_frontier_script.py -q"
+      ],
+      "stop_condition": "Registry freshness is not compatibility. Tooling MSRV and library MSRV are distinct; no preview promotion from one passing platform. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "Voiage-specific rust dependency and feature qualification",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    },
+    {
+      "id": "G03",
+      "title": "Voiage compatibility and replaceable providers",
+      "status": "pending",
+      "depends_on": [
+        "G01"
+      ],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        "rust/crates/voiage-ffi/src/lib.rs",
+        "tests/test_ffi_sanitizer_contract.py",
+        "tests/test_consumer_matrix.py",
+        "scripts/check_consumer_matrix.py",
+        ".github/workflows/bindings-ci.yml"
+      ],
+      "candidate_write_scope": [
+        "rust/crates/voiage-ffi/src/lib.rs",
+        "tests/test_ffi_sanitizer_contract.py",
+        "tests/test_consumer_matrix.py",
+        "scripts/check_consumer_matrix.py",
+        ".github/workflows/bindings-ci.yml",
+        "tests/fixtures/compatibility_witnesses/"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "Removing a public Rust item fails the API check; changing an exported C signature fails a compiled consumer; additive compatible API passes. Pin baseline/toolchain and retain a bounded documented suppression only with a regression witness. Do not regenerate old fixtures from the candidate. Different provider APIs must translate to the same input semantics without becoming part of the Voiage public API; wrong units/weights fail.",
+      "validation_commands": [
+        "python -m pytest tests/test_consumer_matrix.py tests/test_ffi_sanitizer_contract.py -q"
+      ],
+      "stop_condition": "A new release/version decision and deliberate breaking change require maintainer disposition, not automatic version bumping. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "Voiage-specific api and abi compatibility witnesses",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    },
+    {
+      "id": "G04",
+      "title": "CI cost and failure reproducibility",
+      "status": "pending",
+      "depends_on": [
+        "G01"
+      ],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        ".github/workflows/ci.yml",
+        ".github/workflows/operational-assurance.yml",
+        ".github/workflows/dependency-preview.yml",
+        "tox.ini",
+        "tests/test_exact_head_workflows.py"
+      ],
+      "candidate_write_scope": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/operational-assurance.yml",
+        ".github/workflows/dependency-preview.yml",
+        "tox.ini",
+        "tests/test_exact_head_workflows.py",
+        "conductor/tracks/agent_safe_engineering_20260907/ci-measurements.json"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "Artifact from another source head, lock or interpreter is rejected. Failed subprocess, cancelled shard and missing coverage artifact cannot produce green aggregation. Cold/warm timing and exact test counts establish any claimed saving; retries retain first failure and flaky status.",
+      "validation_commands": [
+        "python -m pytest tests/test_exact_head_workflows.py tests/test_repo_harness.py -q"
+      ],
+      "stop_condition": "Do not weaken required checks, coverage thresholds or security controls to reduce duration. Hosted ruleset changes are separate from workflow implementation. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "Voiage-specific ci cost and failure reproducibility",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    },
+    {
+      "id": "G05",
+      "title": "Numerical adversarial assurance",
+      "status": "pending",
+      "depends_on": [
+        "G01"
+      ],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        "rust/fuzz/fuzz_targets/",
+        "rust/crates/voiage-numerics/src/",
+        "rust/crates/voiage-test-support/",
+        ".github/workflows/rust-fuzz.yml",
+        ".github/workflows/rust-miri.yml"
+      ],
+      "candidate_write_scope": [
+        "rust/fuzz/fuzz_targets/",
+        "rust/crates/voiage-numerics/src/",
+        "rust/crates/voiage-test-support/",
+        ".github/workflows/rust-fuzz.yml",
+        ".github/workflows/rust-miri.yml",
+        "conductor/tracks/agent_safe_engineering_20260907/numerical-case-register.json"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "For risk-neutral EVPI, a constant added to every action for each sample leaves EVPI unchanged; a positive utility scaling scales EVPI. Analytic references and declared floating-point tolerances test accuracy. Error estimates, RNG changes and unstable reductions must not be hidden by clamping or tolerance inflation.",
+      "validation_commands": [
+        "cargo test --manifest-path rust/Cargo.toml --locked -p voiage-numerics"
+      ],
+      "stop_condition": "Properties are conditional on the estimand and assumptions. A shared implementation on both sides is not an independent oracle. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "Voiage-specific numerical adversarial assurance",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    },
+    {
+      "id": "G06",
+      "title": "Bounded jobs and recoverable computation",
+      "status": "pending",
+      "depends_on": [
+        "G01"
+      ],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        "rust/crates/voiage-domain/src/",
+        "rust/crates/voiage-diagnostics/src/",
+        "rust/crates/voiage-numerics/src/",
+        "voiage/parallel/"
+      ],
+      "candidate_write_scope": [
+        "rust/crates/voiage-domain/src/",
+        "rust/crates/voiage-diagnostics/src/",
+        "rust/crates/voiage-numerics/src/",
+        "voiage/parallel/",
+        "conductor/tracks/agent_safe_engineering_20260907/execution-state-contract.json"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "Budget zero performs zero model evaluations; cancellation at a defined batch boundary cannot yield a complete result. Interrupted write retains the last valid checkpoint. Resume rejects changed model/input/RNG/algorithm identities. Deterministic replay matches the declared CPU tolerance.",
+      "validation_commands": [
+        "cargo test --manifest-path rust/Cargo.toml --locked -p voiage-domain -p voiage-diagnostics -p voiage-numerics"
+      ],
+      "stop_condition": "No hard memory guarantee for external callbacks; report cooperative limits honestly. Structural contracts require integrator review before broad kernel edits. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "VOI calculation budgets, cancellation and checkpoints; no DES/ABM event scheduler",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    },
+    {
+      "id": "G07",
+      "title": "Capability discovery and reproducible user reports",
+      "status": "pending",
+      "depends_on": [
+        "G01",
+        "G03"
+      ],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        "voiage/contracts/capabilities.py",
+        "voiage/cli.py",
+        "scripts/check_consumer_matrix.py",
+        "tests/test_consumer_matrix.py",
+        "docs/astro-site/src/content/docs/"
+      ],
+      "candidate_write_scope": [
+        "voiage/contracts/capabilities.py",
+        "voiage/cli.py",
+        "scripts/check_consumer_matrix.py",
+        "tests/test_consumer_matrix.py",
+        "docs/astro-site/src/content/docs/",
+        "conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "Missing optional module, unsupported method/shape and stale schema return structured actionable errors. Dry run performs no model evaluation. Installed-wheel report agrees with actual dispatch. Default reports omit paths, credentials and patient-level data; explicit inclusion is documented.",
+      "validation_commands": [
+        "python -m pytest tests/test_consumer_matrix.py tests/test_astro_docs_contract.py -q"
+      ],
+      "stop_condition": "A diagnostic report is not an attestation of scientific suitability; retain experimental labels and avoid silently downloading models. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "Voiage-specific capability discovery and reproducible user reports",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    },
+    {
+      "id": "G08",
+      "title": "Automation and release evidence lifecycle",
+      "status": "pending",
+      "depends_on": [
+        "G01",
+        "G02",
+        "G04"
+      ],
+      "read_first": [
+        "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md",
+        "renovate.json",
+        ".github/workflows/sbom.yml",
+        ".github/workflows/release.yml",
+        "scripts/dependency_frontier.py",
+        "tests/test_dependency_delivery_controls.py",
+        "tests/test_python_release_workflow.py"
+      ],
+      "candidate_write_scope": [
+        "renovate.json",
+        ".github/workflows/sbom.yml",
+        ".github/workflows/release.yml",
+        "scripts/dependency_frontier.py",
+        "tests/test_dependency_delivery_controls.py",
+        "tests/test_python_release_workflow.py",
+        "conductor/tracks/agent_safe_engineering_20260907/automation-policy.json"
+      ],
+      "implementation_ready": false,
+      "required_before_implementation": [
+        "Approved repository allocation, capability/adapter owner, excluded responsibilities and integration disposition",
+        "Exact file subset and baseline content hashes",
+        "One named owner and upstream evidence revisions",
+        "Failing acceptance test with expected result",
+        "Selected toolchain and exact commands",
+        "Integrator review of scientific/shared-contract changes",
+        "Use START_HERE.md readiness matrix; transferred child slices are never implemented from parent checkboxes"
+      ],
+      "acceptance": "Wrong artifact digest or signer identity, expired exception, missing platform receipt and partially published release remain distinct failed/pending states. Canaries do not automatically promote scientific features or mutate historical release bytes. A replay cannot publish a different artifact under an existing version.",
+      "validation_commands": [
+        "python -m pytest tests/test_dependency_delivery_controls.py tests/test_python_release_workflow.py tests/test_rust_release_workflow.py -q"
+      ],
+      "stop_condition": "No release, registry submission, credentials change or paid runner is authorized by these planning records. Publishing remains a separate accountable action. Stop if the slice duplicates an external capability owner or introduces a reverse/cyclic dependency.",
+      "rollback": "Revert only the task commit through a reviewed PR; preserve old receipts and public artifacts. Never reset shared work.",
+      "delivery_repository": "edithatogo/voiage",
+      "capability_scope": "Voiage-specific automation and release evidence lifecycle",
+      "external_write_authorized": false,
+      "compatibility_scope": "Existing Voiage promises only; providers require explicit semantic/interchange conformance, not API/ABI equivalence."
+    }
+  ]
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/plan.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/plan.md
@@ -1,0 +1,75 @@
+# Plan: Agent-safe engineering improvements
+
+All tasks are pending. Repository allocation precedes implementation;
+[repository-boundaries.md](./repository-boundaries.md) orders the separate
+integration pilots and defines the external capabilities excluded from this repo. Follow [worker-guide.md](./worker-guide.md). A package is not an atomic implementation task: finish its bounded design packet before implementation.
+
+## G01: Execution packets and drift enforcement
+
+Implementation authority is delegated to [execution_packet_guard](../execution_packet_guard_20260907/index.md).
+The following parent tasks are tracking summaries only; do not execute duplicate work.
+
+Prerequisites: none; planning preflight is ready.
+
+- [ ] G01.1 — Confirm repository allocations and exclusions in repository-boundaries.md, inspect conductor-next reuse, and freeze the Voiage-specific validator profile; read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G01-AC).
+- [ ] G01.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q` plus affected checks (G01-AC).
+- [ ] G01.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G01-AC).
+
+## G02: Rust dependency and feature qualification
+
+Prerequisites: G01.
+
+- [ ] G02.1 — Read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G02-AC).
+- [ ] G02.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `python -m pytest tests/test_dependency_promotion_policy.py tests/test_dependency_frontier_script.py -q` plus affected checks (G02-AC).
+- [ ] G02.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G02-AC).
+
+## G03: Voiage compatibility and replaceable providers
+
+Version identity/evolution implementation follows [version_identity_contracts](../version_identity_contracts_20260907/index.md).
+Use [orchestration.md](./orchestration.md) to exclude transferred logging/pilot work from G06–G08.
+
+Prerequisites: G01.
+
+- [ ] G03.1 — Read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G03-AC).
+- [ ] G03.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `python -m pytest tests/test_consumer_matrix.py tests/test_ffi_sanitizer_contract.py -q` plus affected checks (G03-AC).
+- [ ] G03.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G03-AC).
+
+## G04: CI cost and failure reproducibility
+
+Prerequisites: G01.
+
+- [ ] G04.1 — Read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G04-AC).
+- [ ] G04.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `python -m pytest tests/test_exact_head_workflows.py tests/test_repo_harness.py -q` plus affected checks (G04-AC).
+- [ ] G04.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G04-AC).
+
+## G05: Numerical adversarial assurance
+
+Prerequisites: G01.
+
+- [ ] G05.1 — Read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G05-AC).
+- [ ] G05.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `cargo test --manifest-path rust/Cargo.toml --locked -p voiage-numerics` plus affected checks (G05-AC).
+- [ ] G05.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G05-AC).
+
+## G06: Bounded jobs and recoverable computation
+
+Prerequisites: G01.
+
+- [ ] G06.1 — Read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G06-AC).
+- [ ] G06.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `cargo test --manifest-path rust/Cargo.toml --locked -p voiage-domain -p voiage-diagnostics -p voiage-numerics` plus affected checks (G06-AC).
+- [ ] G06.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G06-AC).
+
+## G07: Capability discovery and reproducible user reports
+
+Prerequisites: G01, G03.
+
+- [ ] G07.1 — Use the ordered integration pilots in repository-boundaries.md to select at most one producer contract; read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G07-AC).
+- [ ] G07.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `python -m pytest tests/test_consumer_matrix.py tests/test_astro_docs_contract.py -q` plus affected checks (G07-AC).
+- [ ] G07.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G07-AC).
+
+## G08: Automation and release evidence lifecycle
+
+Prerequisites: G01, G02, G04.
+
+- [ ] G08.1 — Read the packet inputs; verify the observed gap against HEAD, identify one bounded change and freeze the exact files, baseline hashes, acceptance fixture and toolchain. Record existing behavior and intended failure (G08-AC).
+- [ ] G08.2 — Write and run the negative/analytic witness first; implement the frozen slice only after prerequisites and integrator review are recorded. Run `python -m pytest tests/test_dependency_delivery_controls.py tests/test_python_release_workflow.py tests/test_rust_release_workflow.py -q` plus affected checks (G08-AC).
+- [ ] G08.3 — Review the diff against the packet; run required final gates, bind evidence to source and environment, and update plan/metadata only for proven completion (G08-AC).

--- a/conductor/tracks/agent_safe_engineering_20260907/planning-validation.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/planning-validation.json
@@ -1,0 +1,35 @@
+{
+  "recorded_at": "2026-09-06T14:20:14+00:00",
+  "scope": "planning and workflow guidance only",
+  "baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "conductor_full_validation": {
+    "errors": 0,
+    "warnings": 0
+  },
+  "focused_tests": {
+    "initial_passed": 38,
+    "after_workflow_refinement_passed": 30,
+    "note": "Second count overlaps initial tests; do not add counts."
+  },
+  "packet_validation": {
+    "packages": 8,
+    "pending_tasks": 24,
+    "unique_ids": true,
+    "acyclic_order": true,
+    "read_paths_exist": true,
+    "local_links_resolve": true
+  },
+  "vale": {
+    "errors": 0,
+    "warnings": 0
+  },
+  "full_tox": "Not rerun for planning-only changes; runtime, dependencies and tests unchanged from merged baseline. Focused governance checks run above.",
+  "hosted_checks": "not run for this local planning change",
+  "implementation": "pending; semantic enforcement is manual until G01",
+  "review": [
+    "Preserved existing active tracks and original dirty checkout.",
+    "No automatic scientific decisions, fixture rewrites, release or hidden backend promotion.",
+    "Packet candidate paths require exact per-slice refinement before code edits.",
+    "Structural JSON validation does not establish readiness or sandbox execution."
+  ]
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/preparation-validation.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/preparation-validation.json
@@ -1,0 +1,21 @@
+{
+  "scope": "Implementation preparation only",
+  "active_tracks": 9,
+  "child_phase_packets": 6,
+  "focused_tests_passed": 75,
+  "conductor_errors": 0,
+  "conductor_warnings": 0,
+  "hashes": "Final input hashes verified after parent-packet refinement",
+  "initial_failures": [
+    "Metadata Unicode serialization normalized without semantic changes",
+    "Preparation-induced stale parent packet hash refreshed after review"
+  ],
+  "external_boundaries": [
+    "#1053 closed versus incomplete local plan requires reconciliation",
+    "#1025 native qualification remains open",
+    "#1037 survey/text and venue evidence remains pending"
+  ],
+  "implementation_started": false,
+  "full_tox": "Not repeated for planning-only changes",
+  "hosted_checks": "Not run for this local preparation"
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md
@@ -1,0 +1,170 @@
+# Repository boundaries and integration order
+
+Decision date: 2026-09-07. This refines the local planning contract following the
+owner's request for focused repositories and future Rust-first replacements.
+It creates no sibling repositories, tracks, issues or runtime dependencies.
+
+## Placement rule
+
+`voiage` owns the value of information calculation: decision/utility inputs,
+VOI estimators, estimator diagnostics, VOI-specific job control, result contracts
+and thin supported bindings. It consumes model outcomes and evidence; it does
+not become a general simulation, statistics, data acquisition, ontology,
+publication, dashboard hosting or agent-management platform.
+
+Every implementation packet must name exactly one delivery repository, one
+capability owner, one adapter owner, and explicit excluded responsibilities.
+One PR changes one repository and one behavioral slice. A shared owner may
+maintain multiple cohesive crates; a crate does not automatically need its own
+repository. Do not create a new repository for every feature or adapter.
+
+Use the existing owner first. Extract a component only when it has a coherent
+independent purpose, demonstrated second consumer, independent release/security
+needs and a named maintenance owner. If ownership is unclear, freeze a small
+interface proposal and defer implementation; do not absorb the feature into
+`voiage` as a shortcut. No new catch-all integration repository is proposed.
+
+## Candidate ownership and admission
+
+The linked [GitHub receipt](./github-integration-review.json) records source
+blob identities and read ranges. README statements describe candidate scope,
+not verified runtime maturity. Validate current source, license, installed
+behavior and export semantics before admitting any dependency.
+
+| Capability | Proposed or established home | Voiage boundary and first action | Admission order |
+| --- | --- | --- | --- |
+| VOI kernels and uncertainty decisions | `voiage` | Own the calculation and minimal input/result contract | Core first |
+| General spline fitting/replay | [mars](https://github.com/edithatogo/mars) | Reuse optional surrogate artifacts; do not implement a second MARS trainer | Pilot 2 |
+| Diffusion/adoption models | [innovate](https://github.com/edithatogo/innovate) | Consume adoption uncertainty with times/units; fitting remains producer-owned | After first model handoff |
+| Deterministic simulation time/events/DES/ABM | [kairos](https://github.com/edithatogo/kairos) | Model outputs or optional model callback; never a second scheduler in VOI | Later native pilot |
+| General game solving | Rust incubator in [new-drug-reimbursement-game](https://github.com/edithatogo/new-drug-reimbursement-game) | Application consumes VOI; general solver remains outside VOI, extraction decision stays with owner | Later application pilot |
+| Game-theory semantics | [UOGTO](https://github.com/edithatogo/UOGTO) | Optional semantic identifiers, not an RDF engine inside numerical kernels | With game pilot |
+| CEA/DCEA models and decision context | [vop_poc_nz](https://github.com/edithatogo/vop_poc_nz) | Extend existing `specs/integration/vop-voiage` contracts; no parallel DCEA application | Pilot 1 |
+| Disease/population microsimulation | [lifecourse](https://github.com/edithatogo/lifecourse) | Producer-side PSA export; retain dependence, weights, costs and QALYs | After Pilot 1 |
+| Genetic insurance policy models | [ginsim](https://github.com/edithatogo/ginsim) | Consumer/use-case benchmark only; policy equilibria remain external | Deferred application |
+| Funding formulas | [mchs](https://github.com/edithatogo/mchs) | Cost/funding output with calculator/year provenance; no NWAU formulas in VOI | Deferred costing input |
+| Burden evidence | [rareburden-commons](https://github.com/edithatogo/rareburden-commons) | Governed aggregate uncertainty exports; synthetic status retained | Deferred evidence pilot |
+| Tariff/reimbursement evidence | [reimbursement-atlas](https://github.com/edithatogo/reimbursement-atlas) | Reviewed derived inputs; tariffs are not automatically costs or utilities | Deferred evidence pilot |
+| Medicine terminology/regulatory/funding records | [global-medicines-atlas](https://github.com/edithatogo/global-medicines-atlas) | Separate governed enrichment step, not a base dependency | Deferred evidence pilot |
+| Spatial/public-data provenance | [riopa-infrastructure](https://github.com/edithatogo/riopa-infrastructure) | Optional research-object references; no second spatial archive | Deferred evidence pilot |
+| Generic agent packet/lease engine | [conductor-next](https://github.com/edithatogo/conductor-next) | G01 keeps VOI policy/profile here; investigate generic enforcement upstream | Preflight now |
+| Estate CI/security policy | [repository-standards](https://github.com/edithatogo/repository-standards) | G04/G08 consume bounded profiles with local numerical gates | Preflight now |
+| Dependency update policy | [renovate-config](https://github.com/edithatogo/renovate-config) | Already extended locally; no second dependency-update bot | Maintain existing |
+| Polyglot documentation | [astro-polyglot](https://github.com/edithatogo/astro-polyglot) | Already a local gitlink; extraction/rendering stays upstream | Maintain existing |
+| Citation evidence | [sourceright](https://github.com/edithatogo/sourceright) | Already a local gitlink; development/report tooling only | Maintain existing |
+| Research diagrams/checklists | [standardflow](https://github.com/edithatogo/standardflow) | Optional exported report consumer; no renderer inside VOI core | Defer |
+
+`NwauCore.jl` and `NationalWeightedActivityUnitWrapper.jl` describe themselves as
+thin MCHS CLI wrappers, not independent numerical cores. Do not add both as
+providers or mistake their names for separate formula authorities. Archived
+source projects are historical references, not new acquisition dependencies.
+Unrelated publishing, legal-corpus and application repositories are outside this
+numerical integration plan. Private repository details are not copied here.
+
+## Source findings that affect the order
+
+- Existing `specs/ecosystem/fixtures/manifest.json` already reserves `mars`,
+  `innovate` and `lifecourse`, but labels all three fixtures planned. Extend
+  that ownership; do not call it installed interoperability.
+- `mars/rust-runtime/Cargo.toml` describes portable replay and has unconditional
+  PyO3. First qualify producer-export/replay fixtures. Do not assume Rust training
+  is implemented or import a Python-linked crate into the minimal core. A future
+  producer-side feature split requires its own accepted change.
+- `innovate/docs/architecture_principles.md` retains Python-reference semantics
+  while describing a Rust trajectory. This plan does not rewrite that producer's
+  compatibility policy. A future separately designed Rust successor is allowed
+  through a new adapter and declared semantic differences.
+- The reimbursement game's `ecosystem.lock.toml` and README already assign
+  simulation to Kairos, semantics to UOGTO, and VOI to Voiage. Retain that directed
+  ownership. Its pinned Voiage revision is historical; requalify against an exact
+  release/commit before making a new compatibility claim.
+- Kairos lists an active pre-release project and many optional crates. Select
+  the minimal qualified capability rather than importing the whole workspace.
+- Atlas and RareBurden READMEs explicitly bound evidence maturity. Repository
+  availability is not permission to treat estimates or sources as qualified data.
+
+## Compatibility policy for Rust-first successors
+
+There are four separate promises. Record which ones an integration actually makes:
+
+1. **Scientific semantics:** estimand, units, joint uncertainty, timing, missing
+   data and decision conventions. Test these with independent reference cases.
+2. **Interchange:** a named version of an input/output contract. An adapter may
+   translate to it without matching either library's public programming API.
+3. **Public API:** required only for a deliberately supported adapter/API surface,
+   including Voiage's existing public releases within its version policy.
+4. **ABI:** required only for an explicitly supported binary boundary, such as
+   Voiage's versioned C ABI. Rust-to-Rust crates do not imply a stable Rust ABI.
+
+A Rust-first successor may use idiomatic types, ownership, errors and concurrency,
+remove legacy concepts and expose a different API. It need not clone Python/R
+classes, function names, signatures, serialization internals or binary layout.
+Do not force py-earth, scikit-learn, BCEA, dampack, heemod or other third-party
+API equivalence into a new core by default. A temporary compatibility facade is
+optional, separately owned, versioned and removable with a migration policy.
+
+Represent the provider behind a narrow port or versioned artifact. Do not expose
+its object types in Voiage's public contract. Prefer portable data exchange for
+initial integration; choose Rust traits for source-level composition only after
+feature/MSRV qualification. Use C ABI only for a demonstrated binary consumer.
+No universal intermediate representation or new schema framework is needed for
+the first pilot; reuse the existing compatible VOI contract where sufficient.
+
+A replacement test must use two deliberately different toy provider APIs that
+produce semantically equivalent inputs; both must yield the reference VOI result
+through their adapters. A provider with different weighting, units or estimand
+must fail validation or report the difference explicitly. Numerical agreement is
+not assumed across different methods; declare tolerances and scope in advance.
+Maintain existing promised contracts until an explicit versioned migration lands.
+
+## Ordered delivery with small repository scope
+
+| Order | Deliverable | Owner / writes | Exit criterion |
+| --- | --- | --- | --- |
+| 0 | Confirm this capability map and exclusions in G01.1 | Voiage planning only | Every slice has one home and no ownership cycle |
+| 1 | Refine VOI packet validator profile and upstream-tool gap | Voiage G01; upstream proposal only | No generic Conductor engine duplicated locally |
+| 2 | Freeze minimal producer/result semantics and existing VOP baseline | Voiage contracts; separate producer acceptance | One reference result, wrong-unit/weight/schema cases rejected |
+| 3 | Pilot 1: one VOP-to-VOI workflow | One consumer adapter PR, separate producer PR if needed | Producer export and installed VOI consumer pass exact revisions |
+| 4 | Pilot 2: one MARS artifact/replay workflow | MARS owns training/replay; Voiage owns VOI use | Held-out/reference error assessed; no unconditional Python in base |
+| 5 | Choose one next integration from diffusion or microsimulation | Existing producer home | Reuse the same port without widening core scope |
+| 6 | Evaluate Kairos/game/evidence applications individually | Respective owner repositories | Independent maturity and rights gates satisfied |
+
+G02–G05 engineering investigations can run alongside steps 0–2 under disjoint
+file reservations. G06 owns the lifecycle of a VOI calculation, not simulation
+time/events. Do not make the first integration wait for a complete generic game
+runtime, distributed simulator, inference framework or public-data platform.
+Initially allow one integration pilot in flight and at most two implementation
+workers overall. Freeze/merge the producer's export first, then its consumer;
+a second repo's PR has its own tests, authorization and source binding.
+An unavailable producer blocks only its adapter, never base installation.
+
+For every candidate record one disposition: reuse now, qualify adapter,
+producer-side improvement, future Rust successor, defer, or exclude. Record
+which repository implements it and who accepts handoff. These are proposed
+allocations; no upstream owner has accepted a task merely because it appears here.
+
+## Allocation of the earlier twenty packages
+
+This allocation narrows the programme, rather than treating every roadmap item
+as a feature to add to the Voiage repository.
+
+| Packages | Voiage-owned slice | Keep outside Voiage |
+| --- | --- | --- |
+| V01–V02 | VOI capability census and estimator assurance | Generic research/agent governance engine |
+| V03–V04 | EVSI regression, moment and importance estimators | General MARS/ML training and inference libraries |
+| V05 | Study-likelihood interface and small analytic reference models | Complete clinical-trial or disease-model platform |
+| V06 | ENBS/research-design objective and bounded study decision logic | General economic modelling or optimization framework |
+| V07 | Multilevel/unbiased VOI estimator implementation | General-purpose distributed computation system |
+| V08 | VOI semantics for supported realistic-data variants | Data cleaning, causal inference and missing-data modelling platforms |
+| V09 | VOI decision objective and acquisition boundary | General Bayesian experimental-design/SBI engine; select an owner later |
+| V10 | Explicitly accepted VOI variants and diagnostic contracts | Broad application catalogue, simulation or policy dashboard |
+| V11 | Information value inputs/results for strategic decisions | General game solvers; use the existing game-runtime incubator |
+| V12 | Voiage's own thin bindings and installed conformance | Bindings for every upstream library |
+| F01 | Minimal VOI sample, unit, weight and result contracts | Universal evidence graph or ontology framework |
+| F02 | Posterior sample/diagnostic consumption | MCMC, HMC, VI, SBI inference engines; owner unresolved and deferred |
+| F03 | VOI objective adapter | General acquisition/optimization framework; no new repo assumed |
+| F04 | VOI feature/MSRV, allocation and numerical backend qualification | Reimplementation of Arrow, tensor or GPU libraries |
+| F05 | Bounded VOI calculation cancellation/checkpoints | DES/ABM scheduling, cloud/HPC platform and generic workflow engine |
+| F06 | Economic outcome and uncertainty interchange | NMA/survival/costing/evidence-synthesis engines; qualify producers |
+| F07 | Public-health VOI examples and input/output contracts | Disease simulation, source harvesting and data lake operations |
+| F08 | Voiage producer/consumer port and minimal report | Shared docs engines, publication clients and broad integration platform |

--- a/conductor/tracks/agent_safe_engineering_20260907/spec.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/spec.md
@@ -1,0 +1,102 @@
+# Specification
+
+## Authority and scope
+
+Baseline: `1207cef979311d1f39b3e41c32e165907303dec2`. Read AGENTS.md, active workflows, tests and the integrated roadmap at `docs/reviews/roadmaps/voi-methods-expansion.md`. Executable contracts take precedence over historical descriptions. Existing backlog and venue tracks retain their owners and external gates.
+
+This track adds engineering acceptance criteria to the earlier V01–V12/F01–F08 roadmap. It does not authorize implementing all twenty method packages. G01 is the prerequisite for machine-enforced packet readiness; until it lands, an integrator performs the same checks explicitly. No claim of automated enforcement is made now.
+
+## Repository ownership and successor policy
+
+[Repository boundaries](./repository-boundaries.md) is normative for this track.
+Each slice stays in one repository. The earlier twenty packages are allocated
+between VOI responsibilities and external capability owners. Producer integrations
+require semantic/interchange conformance, not default third-party API/ABI parity.
+Existing Voiage promises retain their explicit compatibility requirements.
+
+## Acceptance criteria
+
+### G01: Execution packets and drift enforcement
+
+First inspect conductor-next for reusable generic enforcement; keep a Voiage
+policy/profile here and propose missing generic functionality upstream. Build a
+bounded read-only packet validator that rejects missing prerequisites, unknown task IDs, dependency cycles, unsafe paths, stale input hashes, unsupported evidence states and writes outside the selected task scope. Hook it into the existing harness only after negative tests pass.
+
+**G01-AC:** Mutate one valid packet at a time: cycle, ../ traversal, symlink escape, missing prerequisite evidence, changed baseline hash, unknown field, and out-of-scope changed file must each exit nonzero; a valid read-only audit exits zero. Include staged, unstaged and untracked paths. A packet never grants shell or publication permission.
+
+Boundary: A local scope checker can detect drift but cannot prove scientific correctness or sandbox an agent.
+
+### G02: Rust dependency and feature qualification
+
+Inventory default, no-default, each supported feature and documented combinations per crate and target; qualify MSRV separately from latest Rust tooling. Record dependency size, compile time, native/non-native transitive boundaries and exact exclusions. Extend existing checks without silently raising Rust 1.85.
+
+**G02-AC:** A deliberately unavailable optional backend must leave the minimal supported build usable; an MSRV-incompatible candidate must fail its qualification lane. The matrix must name unsupported combinations and verify locked resolution. Native alternatives precede any non-Rust dependency proposal.
+
+Boundary: Registry freshness is not compatibility. Tooling MSRV and library MSRV are distinct; no preview promotion from one passing platform.
+
+### G03: Voiage compatibility and replaceable providers
+
+Apply compatibility checks to Voiage's own promised surfaces, not all external
+providers. Qualify cargo-semver-checks against an explicit release revision and supported feature/target matrix. Keep compiled C ABI and installed Python/R/Julia witnesses because Rust API checks do not establish foreign ABI or wire compatibility.
+
+**G03-AC:** Removing a public Rust item fails the API check; changing an exported C signature fails a compiled consumer; additive compatible API passes. Pin baseline/toolchain and retain a bounded documented suppression only with a regression witness. Do not regenerate old fixtures from the candidate. Two toy providers with
+different APIs must translate to the same semantic contract and reference VOI
+result; wrong units or weights must be rejected.
+
+Boundary: A new release/version decision and deliberate breaking change require maintainer disposition, not automatic version bumping.
+
+### G04: CI cost and failure reproducibility
+
+Measure durations and overlapping inventories first. Propose shared immutable build/coverage artifacts only when source, interpreter, lock, features and coverage settings match. Add nextest resource groups and replay evaluation to the existing preview lane. Keep required job names and fail-closed aggregate results.
+
+**G04-AC:** Artifact from another source head, lock or interpreter is rejected. Failed subprocess, cancelled shard and missing coverage artifact cannot produce green aggregation. Cold/warm timing and exact test counts establish any claimed saving; retries retain first failure and flaky status.
+
+Boundary: Do not weaken required checks, coverage thresholds or security controls to reduce duration. Hosted ruleset changes are separate from workflow implementation.
+
+### G05: Numerical adversarial assurance
+
+Select one missing numerical family per PR. Add independent analytic or high-precision reference cases, extreme scales, ties, non-finite inputs and weighted/dependent samples where supported. Persist minimized fuzz failures and test unsafe ownership paths with the existing tools.
+
+**G05-AC:** For risk-neutral EVPI, a constant added to every action for each sample leaves EVPI unchanged; a positive utility scaling scales EVPI. Analytic references and declared floating-point tolerances test accuracy. Error estimates, RNG changes and unstable reductions must not be hidden by clamping or tolerance inflation.
+
+Boundary: Properties are conditional on the estimand and assumptions. A shared implementation on both sides is not an independent oracle.
+
+### G06: Bounded jobs and recoverable computation
+
+Keep general time/event simulation in Kairos; design a VOI-job-specific
+Rust-owned execution state machine with evaluation/memory budgets, cooperative cancellation and distinct complete/partial/failed states. Define resume identity and checkpoint atomicity before adding one bounded kernel integration; thin bindings translate states without numerical policy.
+
+**G06-AC:** Budget zero performs zero model evaluations; cancellation at a defined batch boundary cannot yield a complete result. Interrupted write retains the last valid checkpoint. Resume rejects changed model/input/RNG/algorithm identities. Deterministic replay matches the declared CPU tolerance.
+
+Boundary: No hard memory guarantee for external callbacks; report cooperative limits honestly. Structural contracts require integrator review before broad kernel edits.
+
+### G07: Capability discovery and reproducible user reports
+
+Specify a stable JSON capability/diagnostic report including installed backend, supported estimator/shape, error code, algorithm identity and provenance. Reuse existing registries and add a CLI dry-run/validation path after checking existing command behavior. Include a small complete source-to-report example and accessible plots.
+
+**G07-AC:** Missing optional module, unsupported method/shape and stale schema return structured actionable errors. Dry run performs no model evaluation. Installed-wheel report agrees with actual dispatch. Default reports omit paths, credentials and patient-level data; explicit inclusion is documented.
+
+Boundary: A diagnostic report is not an attestation of scientific suitability; retain experimental labels and avoid silently downloading models.
+
+### G08: Automation and release evidence lifecycle
+
+Inventory automation owners/triggers/secrets/retention and stale exceptions. Design dependency-group canaries with minimal and installed-consumer checks, expiring advisory dispositions, and verification of artifact provenance before reuse. Rehearse a failed partial polyglot release locally with immutable artifacts and idempotent recovery.
+
+**G08-AC:** Wrong artifact digest or signer identity, expired exception, missing platform receipt and partially published release remain distinct failed/pending states. Canaries do not automatically promote scientific features or mutate historical release bytes. A replay cannot publish a different artifact under an existing version.
+
+Boundary: No release, registry submission, credentials change or paid runner is authorized by these planning records. Publishing remains a separate accountable action.
+
+## Non-functional requirements
+
+Rust owns stable numerics and execution semantics. Prefer Rust dependencies and existing tools; justify every non-Rust runtime addition. Stable CPU behavior, bounded resources, portable artifacts and installed-consumer compatibility are required. No blanket refactors, automatic baseline regeneration, expanded tolerance, reduced tests or security exceptions to get green checks.
+
+## Out of scope and external boundaries
+
+No runtime features are implemented by initializing this track. No GitHub issues, release, submissions, paid infrastructure, research acceptance or publication are created. No existing unfinished track is closed or silently superseded. A maintainer resolves scientific assumptions and public compatibility decisions before a worker writes dependent code.
+
+## Detailed logging/versioning execution authority
+
+The six tracks linked in [orchestration.md](./orchestration.md) own the transferred
+execution-guard, versioning, logging, privacy, pilot and optional-telemetry slices.
+Parent acceptance criteria remain requirements; implementation is recorded only
+in the owning child track. No duplicate implementation is authorized.

--- a/conductor/tracks/agent_safe_engineering_20260907/worker-guide.md
+++ b/conductor/tracks/agent_safe_engineering_20260907/worker-guide.md
@@ -1,0 +1,117 @@
+# Worker guide
+
+## Start here
+
+Read the root AGENTS.md, this track's spec.md, plan.md, packets.json and the
+selected packet's read_first files. Commands run from the repository root.
+Use the existing project environment; do not install an arbitrary latest tool.
+A missing file, command or fixture is a preflight finding, not permission to
+invent an alternative. Report its exact path and resolve it before implementation.
+
+Select one pending `.1` task whose prerequisites are satisfied. Record your
+branch, worktree, current source revision and owner in the task handoff. Never
+infer exclusive ownership from a directory name. Preserve existing dirty files.
+Do not start another task because the first one is blocked.
+
+## Turn a package into a safe implementation slice
+
+The packet's candidate_write_scope is an investigation boundary, not a blanket
+write permission. Before `.2`, name at most five exact implementation files and
+one behavioral outcome. If the slice needs more files, split it into separately
+reviewed substeps. Add the new checkboxes to plan.md and retain acceptance IDs.
+Never use an entire source directory as the final write allowlist.
+
+Record baseline SHA-256 values for the read/write inputs, selected test fixture,
+expected red failure, expected green result, exact command arguments and tool
+versions. Pin upstream prerequisite evidence. Distinguish test tooling failures
+from the intended behavioral red failure. A zero-test collection is not success.
+
+An integrator reviews shared schemas, public API, numerical assumptions,
+lockfiles and workflow changes. A worker may implement a frozen decision, but
+must not infer a scientific estimand, raise MSRV, change compatibility policy or
+relax an acceptance threshold. G01's validator will check structural readiness;
+its success will not replace this semantic review.
+
+## Parallel schedule
+
+G01 preflight comes first. G02, G03, G04, G05 and G06 can investigate independently
+while G01 is prepared, but their implementation waits for G01 and an exact packet.
+G07 implementation follows G03; G08 follows G02 and G04. Within each package,
+`.1` precedes `.2` and `.2` precedes `.3`.
+
+The integrator owns shared files: AGENTS.md, conductor/workflow.md, registry,
+root roadmap/task list, public schemas, lockfiles and required workflow names.
+G03 and G07 both touch consumer checks; G04 and G08 both touch automation. Their
+exact file reservations must be disjoint or those edits run sequentially.
+G05 and G06 kernel changes also serialize when they share a source file.
+
+Use separate worktrees and caches; initially allow at most two implementation
+workers and one integrator. Lower concurrency if memory or review capacity is
+insufficient. No concurrent tox processes may write the same environment.
+No automatic takeover, branch cleanup or shared-file rewrite is allowed.
+
+## Validation and evidence
+
+For runtime/dependency work follow AGENTS.md's frontier preflight in the isolated
+checkout. Keep unrelated lock refreshes separate from the functional patch;
+resolve an incompatible candidate before proceeding. Use the existing locked
+native commands, for example `cargo test --manifest-path rust/Cargo.toml --locked`.
+Run the selected packet's focused checks and applicable formatting/type checks.
+
+Run `tox run-parallel -p 2` for the final candidate under AGENTS.md. Reuse eligible
+unchanged evidence with its exact input binding. A failed check requires the
+failed and affected checks again; runtime/dependency/shared-test changes require
+the broader gate. Never substitute this packet for required hosted checks.
+
+At every handoff record: task ID; acceptance ID; source SHA/tree; changed files;
+command; environment/toolchain; exit status; test count; artifact digest; unresolved
+risk; next allowed action. Keep secret values and patient data out of evidence.
+Append evidence with the configured Conductor helper; never invent ledger hashes.
+No completed checkbox without actual verification and the required commit record.
+
+## Stop conditions
+
+Stop dependent implementation if input hashes drift, scope expands, a prerequisite
+is missing, the oracle is ambiguous, an API break is discovered, or two attempted
+fixes leave the same failure unresolved. Preserve the diff and record a minimal
+reproducer and exact next decision. Independent preflight may continue.
+
+Never alter golden/reference bytes, drop failing tests, increase error tolerances,
+turn errors into warnings, label a partial job complete, or promote an experimental
+backend to force a passing result. New tests must be capable of rejecting a
+plausible wrong implementation, not merely repeat its formula.
+
+Rollback means reverting the owned change through the repository workflow.
+Do not reset shared work, delete history, rewrite release artifacts, deploy,
+publish or close an external gate. Track creation authorizes none of those actions.
+
+## Structural packet check
+
+Use the installed jsonschema Python API from the project environment:
+
+```bash
+python - <<'PYTHON'
+import json
+from pathlib import Path
+from jsonschema import Draft202012Validator
+root = Path("conductor/tracks/agent_safe_engineering_20260907")
+schema = json.loads((root / "packet-schema.json").read_text())
+Draft202012Validator.check_schema(schema)
+Draft202012Validator(schema).validate(json.loads((root / "packets.json").read_text()))
+PYTHON
+```
+
+This checks fields and types; it does not check dependency readiness, exact path
+ownership or baseline hashes. Those checks remain explicit integrator duties
+until G01 implements them.
+G01 should reuse this schema and add semantic checks, not create another packet
+format. Freeze the schema change together with its validator tests.
+
+## Repository admission
+
+Read [repository-boundaries.md](./repository-boundaries.md) before any scope
+refinement. One slice has one delivery repository. Generic inference, game
+solving, simulation, source acquisition and shared automation stay with their
+owners. Future Rust-first providers may have distinct APIs/ABIs; validate the
+chosen scientific and interchange contract. Existing Voiage compatibility
+promises remain in force. Do not edit a sibling repository from this track.

--- a/conductor/tracks/execution_packet_guard_20260907/AGENTS.md
+++ b/conductor/tracks/execution_packet_guard_20260907/AGENTS.md
@@ -1,0 +1,3 @@
+# Worker boundary
+
+Read spec.md, plan.md and ../agent_safe_engineering_20260907/worker-guide.md before any implementation. Read ../agent_safe_engineering_20260907/orchestration.md for prerequisite and file reservations. One phase at a time; freeze exact files and behavioral witnesses first. Stop when scope, dependency evidence, scientific semantics or baseline changes. No sibling repository writes, invented test commands, weakened gates or external actions.

--- a/conductor/tracks/execution_packet_guard_20260907/START_HERE.md
+++ b/conductor/tracks/execution_packet_guard_20260907/START_HERE.md
@@ -1,0 +1,25 @@
+# Implementation handoff: Execution packet readiness and drift controls
+
+Prepared; current eligibility: **ready_for_preflight**.
+
+1. Read spec.md, plan.md, implementation-packet.json and the shared orchestration.
+2. Use a clean, isolated worktree from the accepted planning commit. Compare the
+   packet input hashes with its current files; changed inputs require review.
+3. Confirm prerequisite tracks have source-bound acceptance evidence. Reading a
+   packet or a green schema check does not satisfy a prerequisite.
+4. Run existing baseline checks: `python -m pytest tests/test_repo_harness.py -q`.
+5. Start T1.1. Reserved paths include proposed new files; do not claim they exist.
+   Author the specified acceptance tests before implementing behavior.
+6. Use `python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q` for focused verification. Run native checks for Rust changes and
+   the final local gate required by AGENTS.md. Record actual commands/results.
+
+Each phase in implementation-packet.json states the behavior, observable result,
+exact test command and ordered task IDs. Shared dependency/workflow files are
+integrator-only. No package upgrade is implicit; follow isolated dependency
+frontier preflight before runtime/dependency work. Dependencies remain unchosen
+until their existing qualification task supplies a compatible pinned graph.
+
+The first task is bounded contract/design work. It must produce the exact
+negative-test witness before code. No scientific assumptions or ABI policy may
+be invented by the worker. Preserve runtime-neutral interchange and independent
+provider APIs as specified in repository-boundaries.md.

--- a/conductor/tracks/execution_packet_guard_20260907/implementation-packet.json
+++ b/conductor/tracks/execution_packet_guard_20260907/implementation-packet.json
@@ -15,7 +15,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "scripts/repo_harness.py": "1975411fc9840548605a69563d2dfcf8453ff6d763c0548bb692e8b5f4006f84",
+    "scripts/repo_harness.py": "831b4125a964c3a29f7ed55ae9e0da51aaf45a61185130371c6b8c425f10ecd3",
     "tests/test_repo_harness.py": "55d5cd31288056b74364b341a696e98ece576d83df1d848705376702119c9e84",
     "conductor/tracks/agent_safe_engineering_20260907/packets.json": "86ba041c455255a606af81b61214dd5255980aabc868362907b127d6dda07a0e"
   },

--- a/conductor/tracks/execution_packet_guard_20260907/implementation-packet.json
+++ b/conductor/tracks/execution_packet_guard_20260907/implementation-packet.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "1.0",
+  "prepared_at": "2026-09-07T02:55:24Z",
+  "track_id": "execution_packet_guard_20260907",
+  "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "preparation_state": "prepared",
+  "execution_state": "ready_for_preflight",
+  "prerequisite_tracks": [],
+  "delivery_repository": "edithatogo/voiage",
+  "read_before_start": [
+    "scripts/repo_harness.py",
+    "tests/test_repo_harness.py",
+    "conductor/tracks/agent_safe_engineering_20260907/packets.json",
+    "conductor/tracks/agent_safe_engineering_20260907/orchestration.md",
+    "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
+  ],
+  "input_sha256": {
+    "scripts/repo_harness.py": "1975411fc9840548605a69563d2dfcf8453ff6d763c0548bb692e8b5f4006f84",
+    "tests/test_repo_harness.py": "55d5cd31288056b74364b341a696e98ece576d83df1d848705376702119c9e84",
+    "conductor/tracks/agent_safe_engineering_20260907/packets.json": "86ba041c455255a606af81b61214dd5255980aabc868362907b127d6dda07a0e"
+  },
+  "reserved_implementation_files": [
+    "scripts/validate_execution_packets.py",
+    "tests/test_execution_packets.py",
+    "scripts/repo_harness.py",
+    "tests/test_repo_harness.py"
+  ],
+  "initial_file_state": {
+    "scripts/validate_execution_packets.py": "new-file-must-be-absent",
+    "tests/test_execution_packets.py": "new-file-must-be-absent",
+    "scripts/repo_harness.py": "692bfd9f4f6956b9d1d10d5fabb491572b8d101f17e5e8aac97cccab4fbbb96f",
+    "tests/test_repo_harness.py": "55d5cd31288056b74364b341a696e98ece576d83df1d848705376702119c9e84"
+  },
+  "integrator_only": [
+    "rust/Cargo.toml",
+    "rust/Cargo.lock",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "rust/crates/voiage-python/Cargo.toml",
+    "uv.lock",
+    ".github/workflows/ci.yml",
+    "conductor/tracks.md"
+  ],
+  "phases": [
+    {
+      "phase": 1,
+      "task_ids": [
+        "T1.1",
+        "T1.2",
+        "T1.3"
+      ],
+      "acceptance_id": "AC1",
+      "title": "Ownership",
+      "implementation": "Confirm capability allocation and conductor-next reuse; freeze the local policy/profile and exact file allowlist.",
+      "expected_result": "A generic agent engine is not introduced into Voiage; every task has one repository and owner.",
+      "prerequisite": "upstream-tracks-accepted",
+      "focused_command": "python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 2,
+      "task_ids": [
+        "T2.1",
+        "T2.2",
+        "T2.3"
+      ],
+      "acceptance_id": "AC2",
+      "title": "Schema",
+      "implementation": "Write negative tests for missing fields, unknown task IDs, duplicate IDs and dependency cycles before implementing packet validation.",
+      "expected_result": "Invalid packets exit nonzero; the valid fixture passes; no shell command is executed by validation.",
+      "prerequisite": "phase-1-accepted",
+      "focused_command": "python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 3,
+      "task_ids": [
+        "T3.1",
+        "T3.2",
+        "T3.3"
+      ],
+      "acceptance_id": "AC3",
+      "title": "Scope",
+      "implementation": "Test absolute paths, traversal, symlink escape and staged/unstaged/untracked out-of-scope changes before adding path checks.",
+      "expected_result": "Each escape is rejected without changing any file.",
+      "prerequisite": "phase-2-accepted",
+      "focused_command": "python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 4,
+      "task_ids": [
+        "T4.1",
+        "T4.2",
+        "T4.3"
+      ],
+      "acceptance_id": "AC4",
+      "title": "Readiness",
+      "implementation": "Test stale baseline hashes, missing prerequisite evidence and unsupported result states before adding readiness checks.",
+      "expected_result": "A pending or failed prerequisite cannot authorize implementation.",
+      "prerequisite": "phase-3-accepted",
+      "focused_command": "python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 5,
+      "task_ids": [
+        "T5.1",
+        "T5.2",
+        "T5.3"
+      ],
+      "acceptance_id": "AC5",
+      "title": "Harness",
+      "implementation": "Integrate the bounded checker into the existing harness and test a realistic worker handoff.",
+      "expected_result": "An intentionally drifted handoff fails; a valid handoff retains its source and environment identity.",
+      "prerequisite": "phase-4-accepted",
+      "focused_command": "python -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    }
+  ],
+  "native_command": "cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked",
+  "final_command": "tox run-parallel -p 2",
+  "stop_conditions": [
+    "Input hashes changed without rebase review",
+    "Foreign file reservation or lease",
+    "Unaccepted prerequisite or ambiguous oracle",
+    "Scope requires another repository",
+    "Two unsuccessful repairs to same failure"
+  ],
+  "rollback": "Revert only owned commit through reviewed PR; preserve artifacts and old versions.",
+  "completion": "All phase ACs, final local/native checks, reviewed diff and required hosted source-bound evidence; external release not included.",
+  "hash_review": "Refreshed after reviewed preparation changes to parent packet; implementation not started."
+}

--- a/conductor/tracks/execution_packet_guard_20260907/index.md
+++ b/conductor/tracks/execution_packet_guard_20260907/index.md
@@ -1,0 +1,12 @@
+# Track: Execution packet readiness and drift controls
+
+Status: in progress.
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [Evidence](./evidence.jsonl)
+- [Orchestration](../agent_safe_engineering_20260907/orchestration.md)
+- [Worker guide](../agent_safe_engineering_20260907/worker-guide.md)
+- [Implementation start](./START_HERE.md)
+- [Implementation packet](./implementation-packet.json)

--- a/conductor/tracks/execution_packet_guard_20260907/index.md
+++ b/conductor/tracks/execution_packet_guard_20260907/index.md
@@ -2,6 +2,8 @@
 
 Status: in progress.
 
+GitHub issue: https://github.com/edithatogo/voiage/issues/1111
+
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
 - [Metadata](./metadata.json)

--- a/conductor/tracks/execution_packet_guard_20260907/metadata.json
+++ b/conductor/tracks/execution_packet_guard_20260907/metadata.json
@@ -5,7 +5,9 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T04:20:00Z",
   "description": "Execution packet readiness and drift controls",
-  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1111"},
+  "github_cross_reference": {
+    "issue": "https://github.com/edithatogo/voiage/issues/1111"
+  },
   "evidence_schema": "1.0",
   "depends_on": [],
   "authorization": {

--- a/conductor/tracks/execution_packet_guard_20260907/metadata.json
+++ b/conductor/tracks/execution_packet_guard_20260907/metadata.json
@@ -1,0 +1,26 @@
+{
+  "track_id": "execution_packet_guard_20260907",
+  "type": "chore",
+  "status": "in_progress",
+  "created_at": "2026-09-07T01:59:07Z",
+  "updated_at": "2026-09-07T04:20:00Z",
+  "description": "Execution packet readiness and drift controls",
+  "evidence_schema": "1.0",
+  "depends_on": [],
+  "authorization": {
+    "scope": "Implement execution packet validation and harness integration",
+    "source": "Owner request to prepare and implement the selected Conductor track"
+  },
+  "gates": [
+    {
+      "id": "prerequisites",
+      "kind": "repository",
+      "status": "pending",
+      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+    }
+  ],
+  "implementation_preparation": {
+    "packet": "implementation-packet.json",
+    "state": "ready_for_preflight"
+  }
+}

--- a/conductor/tracks/execution_packet_guard_20260907/metadata.json
+++ b/conductor/tracks/execution_packet_guard_20260907/metadata.json
@@ -5,6 +5,7 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T04:20:00Z",
   "description": "Execution packet readiness and drift controls",
+  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1111"},
   "evidence_schema": "1.0",
   "depends_on": [],
   "authorization": {

--- a/conductor/tracks/execution_packet_guard_20260907/plan.md
+++ b/conductor/tracks/execution_packet_guard_20260907/plan.md
@@ -1,0 +1,38 @@
+# Implementation plan: Execution packet readiness and drift controls
+
+Implementation is in progress. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: none. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+
+## Phase 1: Ownership
+
+- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [ ] T1.2 — Confirm capability allocation and conductor-next reuse; freeze the local policy/profile and exact file allowlist. (AC1).
+- [ ] T1.3 — Validate: A generic agent engine is not introduced into Voiage; every task has one repository and owner. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+
+## Phase 2: Schema
+
+- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [ ] T2.2 — Write negative tests for missing fields, unknown task IDs, duplicate IDs and dependency cycles before implementing packet validation. (AC2).
+- [ ] T2.3 — Validate: Invalid packets exit nonzero; the valid fixture passes; no shell command is executed by validation. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+
+## Phase 3: Scope
+
+- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [ ] T3.2 — Test absolute paths, traversal, symlink escape and staged/unstaged/untracked out-of-scope changes before adding path checks. (AC3).
+- [ ] T3.3 — Validate: Each escape is rejected without changing any file. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+
+## Phase 4: Readiness
+
+- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [ ] T4.2 — Test stale baseline hashes, missing prerequisite evidence and unsupported result states before adding readiness checks. (AC4).
+- [ ] T4.3 — Validate: A pending or failed prerequisite cannot authorize implementation. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+
+## Phase 5: Harness
+
+- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [ ] T5.2 — Integrate the bounded checker into the existing harness and test a realistic worker handoff. (AC5).
+- [ ] T5.3 — Validate: An intentionally drifted handoff fails; a valid handoff retains its source and environment identity. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+
+## Final acceptance
+
+- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/conductor/tracks/execution_packet_guard_20260907/spec.md
+++ b/conductor/tracks/execution_packet_guard_20260907/spec.md
@@ -1,0 +1,51 @@
+# Specification: Execution packet readiness and drift controls
+
+## Scope and authority
+
+Baseline: `1207cef979311d1f39b3e41c32e165907303dec2`. Follow root AGENTS.md and the parent programme repository boundaries. This track owns only the named Voiage slice; it authorizes no sibling changes or external operations.
+
+## Required context
+
+- `scripts/repo_harness.py`
+- `tests/test_repo_harness.py`
+- `conductor/tracks/agent_safe_engineering_20260907/packets.json`
+
+## Acceptance criteria
+
+### AC1: Ownership
+
+Confirm capability allocation and conductor-next reuse; freeze the local policy/profile and exact file allowlist.
+
+Acceptance: A generic agent engine is not introduced into Voiage; every task has one repository and owner.
+
+### AC2: Schema
+
+Write negative tests for missing fields, unknown task IDs, duplicate IDs and dependency cycles before implementing packet validation.
+
+Acceptance: Invalid packets exit nonzero; the valid fixture passes; no shell command is executed by validation.
+
+### AC3: Scope
+
+Test absolute paths, traversal, symlink escape and staged/unstaged/untracked out-of-scope changes before adding path checks.
+
+Acceptance: Each escape is rejected without changing any file.
+
+### AC4: Readiness
+
+Test stale baseline hashes, missing prerequisite evidence and unsupported result states before adding readiness checks.
+
+Acceptance: A pending or failed prerequisite cannot authorize implementation.
+
+### AC5: Harness
+
+Integrate the bounded checker into the existing harness and test a realistic worker handoff.
+
+Acceptance: An intentionally drifted handoff fails; a valid handoff retains its source and environment identity.
+
+## Non-functional and external boundaries
+
+Rust-first dependencies; no silent numerical fallback, global logging initialization, API-policy change, tolerance inflation or golden-fixture rewrite. Preserve current version synchronization and declared public compatibility. Applications own telemetry sinks and retention. No cloud account, paid runner, publication, registry submission or release is included.
+
+## Verification
+
+Freeze exact test commands in the first task of each phase before implementation. Existing context files above are starting points, not unrestricted write permission. Add meaningful negative tests before code; test collection of zero is failure. Final candidate uses `tox run-parallel -p 2` under AGENTS.md and affected native gates, including `cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked` for Rust changes. Required hosted checks apply to the delivered PR revision.

--- a/conductor/tracks/logging_privacy_resilience_20260907/AGENTS.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/AGENTS.md
@@ -1,0 +1,3 @@
+# Worker boundary
+
+Read spec.md, plan.md and ../agent_safe_engineering_20260907/worker-guide.md before any implementation. Read ../agent_safe_engineering_20260907/orchestration.md for prerequisite and file reservations. One phase at a time; freeze exact files and behavioral witnesses first. Stop when scope, dependency evidence, scientific semantics or baseline changes. No sibling repository writes, invented test commands, weakened gates or external actions.

--- a/conductor/tracks/logging_privacy_resilience_20260907/START_HERE.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/START_HERE.md
@@ -1,0 +1,25 @@
+# Implementation handoff: Logging privacy and bounded delivery
+
+Prepared; current eligibility: **waiting_for_prerequisites**.
+
+1. Read spec.md, plan.md, implementation-packet.json and the shared orchestration.
+2. Use a clean, isolated worktree from the accepted planning commit. Compare the
+   packet input hashes with its current files; changed inputs require review.
+3. Confirm prerequisite tracks have source-bound acceptance evidence. Reading a
+   packet or a green schema check does not satisfy a prerequisite.
+4. Run existing baseline checks: `python -m pytest tests/test_logging_contract.py -q`.
+5. Start T1.1. Reserved paths include proposed new files; do not claim they exist.
+   Author the specified acceptance tests before implementing behavior.
+6. Use `python -m pytest tests/test_logging_resilience.py tests/test_logging_contract.py -q` for focused verification. Run native checks for Rust changes and
+   the final local gate required by AGENTS.md. Record actual commands/results.
+
+Each phase in implementation-packet.json states the behavior, observable result,
+exact test command and ordered task IDs. Shared dependency/workflow files are
+integrator-only. No package upgrade is implicit; follow isolated dependency
+frontier preflight before runtime/dependency work. Dependencies remain unchosen
+until their existing qualification task supplies a compatible pinned graph.
+
+The first task is bounded contract/design work. It must produce the exact
+negative-test witness before code. No scientific assumptions or ABI policy may
+be invented by the worker. Preserve runtime-neutral interchange and independent
+provider APIs as specified in repository-boundaries.md.

--- a/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "1.0",
+  "prepared_at": "2026-09-07T02:55:24Z",
+  "track_id": "logging_privacy_resilience_20260907",
+  "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "preparation_state": "prepared",
+  "execution_state": "waiting_for_prerequisites",
+  "prerequisite_tracks": [
+    "native_structured_logging_20260907"
+  ],
+  "delivery_repository": "edithatogo/voiage",
+  "read_before_start": [
+    "voiage/logging.py",
+    "tests/test_logging_contract.py",
+    "voiage/assurance_policy.py",
+    "conductor/tracks/agent_safe_engineering_20260907/orchestration.md",
+    "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
+  ],
+  "input_sha256": {
+    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
+    "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61"
+  },
+  "reserved_implementation_files": [
+    "tests/test_logging_resilience.py",
+    "voiage/logging.py",
+    "voiage/assurance_policy.py",
+    "tests/test_logging_contract.py"
+  ],
+  "initial_file_state": {
+    "tests/test_logging_resilience.py": "new-file-must-be-absent",
+    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61",
+    "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b"
+  },
+  "integrator_only": [
+    "rust/Cargo.toml",
+    "rust/Cargo.lock",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "rust/crates/voiage-python/Cargo.toml",
+    "uv.lock",
+    ".github/workflows/ci.yml",
+    "conductor/tracks.md"
+  ],
+  "phases": [
+    {
+      "phase": 1,
+      "task_ids": [
+        "T1.1",
+        "T1.2",
+        "T1.3"
+      ],
+      "acceptance_id": "AC1",
+      "title": "Privacy",
+      "implementation": "Define event field allowlists and deployment-owned retention/redaction policy.",
+      "expected_result": "Raw patient records, parameter draws, credentials and sensitive filesystem paths are excluded by default; no universal retention period is invented.",
+      "prerequisite": "upstream-tracks-accepted",
+      "focused_command": "python -m pytest tests/test_logging_resilience.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 2,
+      "task_ids": [
+        "T2.1",
+        "T2.2",
+        "T2.3"
+      ],
+      "acceptance_id": "AC2",
+      "title": "Adversarial",
+      "implementation": "Write nested secret, exception, object-formatting, Unicode and forged-correlation tests before extending sanitization.",
+      "expected_result": "All secret sentinels are absent from emitted records; untrusted fields cannot impersonate trusted correlation fields.",
+      "prerequisite": "phase-1-accepted",
+      "focused_command": "python -m pytest tests/test_logging_resilience.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 3,
+      "task_ids": [
+        "T3.1",
+        "T3.2",
+        "T3.3"
+      ],
+      "acceptance_id": "AC3",
+      "title": "Queue",
+      "implementation": "Specify bounded queue capacity, severity-aware drop behavior and low-cardinality loss counters before implementing an optional queue.",
+      "expected_result": "A full queue has deterministic bounded behavior; numerical execution does not wait indefinitely; audit evidence is never silently dropped through this queue.",
+      "prerequisite": "phase-2-accepted",
+      "focused_command": "python -m pytest tests/test_logging_resilience.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 4,
+      "task_ids": [
+        "T4.1",
+        "T4.2",
+        "T4.3"
+      ],
+      "acceptance_id": "AC4",
+      "title": "Failure",
+      "implementation": "Inject disk-full, failed writer, recursive logging and stalled sink behavior.",
+      "expected_result": "Logging failures do not mask the original calculation error or deadlock computation; loss is observable without recursive failure.",
+      "prerequisite": "phase-3-accepted",
+      "focused_command": "python -m pytest tests/test_logging_resilience.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 5,
+      "task_ids": [
+        "T5.1",
+        "T5.2",
+        "T5.3"
+      ],
+      "acceptance_id": "AC5",
+      "title": "Shutdown",
+      "implementation": "Test cancellation, flush timeout and process shutdown ownership.",
+      "expected_result": "Applications control shutdown; bounded flushing reports incomplete delivery; hosts are not terminated and retention stays deployment-owned.",
+      "prerequisite": "phase-4-accepted",
+      "focused_command": "python -m pytest tests/test_logging_resilience.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    }
+  ],
+  "native_command": "cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked",
+  "final_command": "tox run-parallel -p 2",
+  "stop_conditions": [
+    "Input hashes changed without rebase review",
+    "Foreign file reservation or lease",
+    "Unaccepted prerequisite or ambiguous oracle",
+    "Scope requires another repository",
+    "Two unsuccessful repairs to same failure"
+  ],
+  "rollback": "Revert only owned commit through reviewed PR; preserve artifacts and old versions.",
+  "completion": "All phase ACs, final local/native checks, reviewed diff and required hosted source-bound evidence; external release not included.",
+  "hash_review": "Refreshed after reviewed preparation changes to parent packet; implementation not started."
+}

--- a/conductor/tracks/logging_privacy_resilience_20260907/index.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/index.md
@@ -2,6 +2,8 @@
 
 Status: new.
 
+GitHub issue: https://github.com/edithatogo/voiage/issues/1114
+
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
 - [Metadata](./metadata.json)

--- a/conductor/tracks/logging_privacy_resilience_20260907/index.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/index.md
@@ -1,0 +1,12 @@
+# Track: Logging privacy and bounded delivery
+
+Status: new.
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [Evidence](./evidence.jsonl)
+- [Orchestration](../agent_safe_engineering_20260907/orchestration.md)
+- [Worker guide](../agent_safe_engineering_20260907/worker-guide.md)
+- [Implementation start](./START_HERE.md)
+- [Implementation packet](./implementation-packet.json)

--- a/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
@@ -5,6 +5,7 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Logging privacy and bounded delivery",
+  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1114"},
   "evidence_schema": "1.0",
   "depends_on": [
     "native_structured_logging_20260907"

--- a/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
@@ -5,7 +5,9 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Logging privacy and bounded delivery",
-  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1114"},
+  "github_cross_reference": {
+    "issue": "https://github.com/edithatogo/voiage/issues/1114"
+  },
   "evidence_schema": "1.0",
   "depends_on": [
     "native_structured_logging_20260907"

--- a/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
@@ -1,0 +1,28 @@
+{
+  "track_id": "logging_privacy_resilience_20260907",
+  "type": "feature",
+  "status": "new",
+  "created_at": "2026-09-07T01:59:07Z",
+  "updated_at": "2026-09-07T02:55:24Z",
+  "description": "Logging privacy and bounded delivery",
+  "evidence_schema": "1.0",
+  "depends_on": [
+    "native_structured_logging_20260907"
+  ],
+  "authorization": {
+    "scope": "Detailed track planning; implementation remains pending",
+    "source": "Owner request to create comprehensive granular tracks and sequencing"
+  },
+  "gates": [
+    {
+      "id": "prerequisites",
+      "kind": "repository",
+      "status": "pending",
+      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+    }
+  ],
+  "implementation_preparation": {
+    "packet": "implementation-packet.json",
+    "state": "waiting_for_prerequisites"
+  }
+}

--- a/conductor/tracks/logging_privacy_resilience_20260907/plan.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/plan.md
@@ -1,0 +1,38 @@
+# Implementation plan: Logging privacy and bounded delivery
+
+All tasks are pending. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: native_structured_logging_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+
+## Phase 1: Privacy
+
+- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [ ] T1.2 — Define event field allowlists and deployment-owned retention/redaction policy. (AC1).
+- [ ] T1.3 — Validate: Raw patient records, parameter draws, credentials and sensitive filesystem paths are excluded by default; no universal retention period is invented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+
+## Phase 2: Adversarial
+
+- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [ ] T2.2 — Write nested secret, exception, object-formatting, Unicode and forged-correlation tests before extending sanitization. (AC2).
+- [ ] T2.3 — Validate: All secret sentinels are absent from emitted records; untrusted fields cannot impersonate trusted correlation fields. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+
+## Phase 3: Queue
+
+- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [ ] T3.2 — Specify bounded queue capacity, severity-aware drop behavior and low-cardinality loss counters before implementing an optional queue. (AC3).
+- [ ] T3.3 — Validate: A full queue has deterministic bounded behavior; numerical execution does not wait indefinitely; audit evidence is never silently dropped through this queue. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+
+## Phase 4: Failure
+
+- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [ ] T4.2 — Inject disk-full, failed writer, recursive logging and stalled sink behavior. (AC4).
+- [ ] T4.3 — Validate: Logging failures do not mask the original calculation error or deadlock computation; loss is observable without recursive failure. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+
+## Phase 5: Shutdown
+
+- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [ ] T5.2 — Test cancellation, flush timeout and process shutdown ownership. (AC5).
+- [ ] T5.3 — Validate: Applications control shutdown; bounded flushing reports incomplete delivery; hosts are not terminated and retention stays deployment-owned. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+
+## Final acceptance
+
+- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/conductor/tracks/logging_privacy_resilience_20260907/spec.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/spec.md
@@ -1,0 +1,51 @@
+# Specification: Logging privacy and bounded delivery
+
+## Scope and authority
+
+Baseline: `1207cef979311d1f39b3e41c32e165907303dec2`. Follow root AGENTS.md and the parent programme repository boundaries. This track owns only the named Voiage slice; it authorizes no sibling changes or external operations.
+
+## Required context
+
+- `voiage/logging.py`
+- `tests/test_logging_contract.py`
+- `voiage/assurance_policy.py`
+
+## Acceptance criteria
+
+### AC1: Privacy
+
+Define event field allowlists and deployment-owned retention/redaction policy.
+
+Acceptance: Raw patient records, parameter draws, credentials and sensitive filesystem paths are excluded by default; no universal retention period is invented.
+
+### AC2: Adversarial
+
+Write nested secret, exception, object-formatting, Unicode and forged-correlation tests before extending sanitization.
+
+Acceptance: All secret sentinels are absent from emitted records; untrusted fields cannot impersonate trusted correlation fields.
+
+### AC3: Queue
+
+Specify bounded queue capacity, severity-aware drop behavior and low-cardinality loss counters before implementing an optional queue.
+
+Acceptance: A full queue has deterministic bounded behavior; numerical execution does not wait indefinitely; audit evidence is never silently dropped through this queue.
+
+### AC4: Failure
+
+Inject disk-full, failed writer, recursive logging and stalled sink behavior.
+
+Acceptance: Logging failures do not mask the original calculation error or deadlock computation; loss is observable without recursive failure.
+
+### AC5: Shutdown
+
+Test cancellation, flush timeout and process shutdown ownership.
+
+Acceptance: Applications control shutdown; bounded flushing reports incomplete delivery; hosts are not terminated and retention stays deployment-owned.
+
+## Non-functional and external boundaries
+
+Rust-first dependencies; no silent numerical fallback, global logging initialization, API-policy change, tolerance inflation or golden-fixture rewrite. Preserve current version synchronization and declared public compatibility. Applications own telemetry sinks and retention. No cloud account, paid runner, publication, registry submission or release is included.
+
+## Verification
+
+Freeze exact test commands in the first task of each phase before implementation. Existing context files above are starting points, not unrestricted write permission. Add meaningful negative tests before code; test collection of zero is failure. Final candidate uses `tox run-parallel -p 2` under AGENTS.md and affected native gates, including `cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked` for Rust changes. Required hosted checks apply to the delivered PR revision.

--- a/conductor/tracks/native_structured_logging_20260907/AGENTS.md
+++ b/conductor/tracks/native_structured_logging_20260907/AGENTS.md
@@ -1,0 +1,3 @@
+# Worker boundary
+
+Read spec.md, plan.md and ../agent_safe_engineering_20260907/worker-guide.md before any implementation. Read ../agent_safe_engineering_20260907/orchestration.md for prerequisite and file reservations. One phase at a time; freeze exact files and behavioral witnesses first. Stop when scope, dependency evidence, scientific semantics or baseline changes. No sibling repository writes, invented test commands, weakened gates or external actions.

--- a/conductor/tracks/native_structured_logging_20260907/START_HERE.md
+++ b/conductor/tracks/native_structured_logging_20260907/START_HERE.md
@@ -1,0 +1,25 @@
+# Implementation handoff: Minimal Rust structured logging
+
+Prepared; current eligibility: **waiting_for_prerequisites**.
+
+1. Read spec.md, plan.md, implementation-packet.json and the shared orchestration.
+2. Use a clean, isolated worktree from the accepted planning commit. Compare the
+   packet input hashes with its current files; changed inputs require review.
+3. Confirm prerequisite tracks have source-bound acceptance evidence. Reading a
+   packet or a green schema check does not satisfy a prerequisite.
+4. Run existing baseline checks: `python -m pytest tests/test_logging_contract.py -q`.
+5. Start T1.1. Reserved paths include proposed new files; do not claim they exist.
+   Author the specified acceptance tests before implementing behavior.
+6. Use `python -m pytest tests/test_native_logging_contract.py tests/test_logging_contract.py -q` for focused verification. Run native checks for Rust changes and
+   the final local gate required by AGENTS.md. Record actual commands/results.
+
+Each phase in implementation-packet.json states the behavior, observable result,
+exact test command and ordered task IDs. Shared dependency/workflow files are
+integrator-only. No package upgrade is implicit; follow isolated dependency
+frontier preflight before runtime/dependency work. Dependencies remain unchosen
+until their existing qualification task supplies a compatible pinned graph.
+
+The first task is bounded contract/design work. It must produce the exact
+negative-test witness before code. No scientific assumptions or ABI policy may
+be invented by the worker. Preserve runtime-neutral interchange and independent
+provider APIs as specified in repository-boundaries.md.

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -1,0 +1,143 @@
+{
+  "schema_version": "1.0",
+  "prepared_at": "2026-09-07T02:55:24Z",
+  "track_id": "native_structured_logging_20260907",
+  "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "preparation_state": "prepared",
+  "execution_state": "waiting_for_prerequisites",
+  "prerequisite_tracks": [
+    "version_identity_contracts_20260907"
+  ],
+  "delivery_repository": "edithatogo/voiage",
+  "read_before_start": [
+    "voiage/logging.py",
+    "tests/test_logging_contract.py",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "rust/crates/voiage-python/Cargo.toml",
+    "conductor/tracks/agent_safe_engineering_20260907/orchestration.md",
+    "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
+  ],
+  "input_sha256": {
+    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "e04c9c128b3dbacaf00175524a526503ebf0f76be1b6a77c156a0e5c0ceee2d8",
+    "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
+  },
+  "reserved_implementation_files": [
+    "rust/crates/voiage-diagnostics/src/telemetry.rs",
+    "tests/test_native_logging_contract.py",
+    "voiage/logging.py",
+    "rust/crates/voiage-diagnostics/src/lib.rs",
+    "rust/crates/voiage-python/src/lib.rs"
+  ],
+  "initial_file_state": {
+    "rust/crates/voiage-diagnostics/src/telemetry.rs": "new-file-must-be-absent",
+    "tests/test_native_logging_contract.py": "new-file-must-be-absent",
+    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
+    "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3"
+  },
+  "integrator_only": [
+    "rust/Cargo.toml",
+    "rust/Cargo.lock",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "rust/crates/voiage-python/Cargo.toml",
+    "uv.lock",
+    ".github/workflows/ci.yml",
+    "conductor/tracks.md"
+  ],
+  "phases": [
+    {
+      "phase": 1,
+      "task_ids": [
+        "T1.1",
+        "T1.2",
+        "T1.3"
+      ],
+      "acceptance_id": "AC1",
+      "title": "Events",
+      "implementation": "Freeze the minimal versioned event fields, severity policy and run/analysis/trace correlation mapping.",
+      "expected_result": "Scientific results, audit evidence and operational logs have distinct contracts; diagnostics remain available with logging disabled.",
+      "prerequisite": "upstream-tracks-accepted",
+      "focused_command": "python -m pytest tests/test_native_logging_contract.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 2,
+      "task_ids": [
+        "T2.1",
+        "T2.2",
+        "T2.3"
+      ],
+      "acceptance_id": "AC2",
+      "title": "Dependency",
+      "implementation": "Qualify tracing with minimal features and the supported MSRV; record compile-time and disabled-path costs.",
+      "expected_result": "No exporter, network client or mandatory async runtime enters the numerical core.",
+      "prerequisite": "phase-1-accepted",
+      "focused_command": "python -m pytest tests/test_native_logging_contract.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 3,
+      "task_ids": [
+        "T3.1",
+        "T3.2",
+        "T3.3"
+      ],
+      "acceptance_id": "AC3",
+      "title": "Ownership",
+      "implementation": "Test host-installed subscriber coexistence before implementing application-owned configuration.",
+      "expected_result": "Importing/calling the library never installs a global subscriber or replaces host handlers; repeated setup does not duplicate events.",
+      "prerequisite": "phase-2-accepted",
+      "focused_command": "python -m pytest tests/test_native_logging_contract.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 4,
+      "task_ids": [
+        "T4.1",
+        "T4.2",
+        "T4.3"
+      ],
+      "acceptance_id": "AC4",
+      "title": "Bridge",
+      "implementation": "Implement and test one Python-to-Rust correlation path and context isolation across parallel calls.",
+      "expected_result": "Two concurrent runs do not exchange IDs; nested spans preserve parentage; absent tracing remains valid.",
+      "prerequisite": "phase-3-accepted",
+      "focused_command": "python -m pytest tests/test_native_logging_contract.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 5,
+      "task_ids": [
+        "T5.1",
+        "T5.2",
+        "T5.3"
+      ],
+      "acceptance_id": "AC5",
+      "title": "Numerics",
+      "implementation": "Compare logging disabled/enabled for a deterministic reference kernel and benchmark the boundary.",
+      "expected_result": "Results and deterministic hashes agree; timestamps/trace IDs never enter calculation identities; the reviewed overhead budget passes.",
+      "prerequisite": "phase-4-accepted",
+      "focused_command": "python -m pytest tests/test_native_logging_contract.py tests/test_logging_contract.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    }
+  ],
+  "native_command": "cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked",
+  "final_command": "tox run-parallel -p 2",
+  "stop_conditions": [
+    "Input hashes changed without rebase review",
+    "Foreign file reservation or lease",
+    "Unaccepted prerequisite or ambiguous oracle",
+    "Scope requires another repository",
+    "Two unsuccessful repairs to same failure"
+  ],
+  "rollback": "Revert only owned commit through reviewed PR; preserve artifacts and old versions.",
+  "completion": "All phase ACs, final local/native checks, reviewed diff and required hosted source-bound evidence; external release not included.",
+  "hash_review": "Refreshed after reviewed preparation changes to parent packet; implementation not started."
+}

--- a/conductor/tracks/native_structured_logging_20260907/index.md
+++ b/conductor/tracks/native_structured_logging_20260907/index.md
@@ -1,0 +1,12 @@
+# Track: Minimal Rust structured logging
+
+Status: new.
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [Evidence](./evidence.jsonl)
+- [Orchestration](../agent_safe_engineering_20260907/orchestration.md)
+- [Worker guide](../agent_safe_engineering_20260907/worker-guide.md)
+- [Implementation start](./START_HERE.md)
+- [Implementation packet](./implementation-packet.json)

--- a/conductor/tracks/native_structured_logging_20260907/index.md
+++ b/conductor/tracks/native_structured_logging_20260907/index.md
@@ -2,6 +2,8 @@
 
 Status: new.
 
+GitHub issue: https://github.com/edithatogo/voiage/issues/1113
+
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
 - [Metadata](./metadata.json)

--- a/conductor/tracks/native_structured_logging_20260907/metadata.json
+++ b/conductor/tracks/native_structured_logging_20260907/metadata.json
@@ -5,6 +5,7 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Minimal Rust structured logging",
+  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1113"},
   "evidence_schema": "1.0",
   "depends_on": [
     "version_identity_contracts_20260907"

--- a/conductor/tracks/native_structured_logging_20260907/metadata.json
+++ b/conductor/tracks/native_structured_logging_20260907/metadata.json
@@ -5,7 +5,9 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Minimal Rust structured logging",
-  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1113"},
+  "github_cross_reference": {
+    "issue": "https://github.com/edithatogo/voiage/issues/1113"
+  },
   "evidence_schema": "1.0",
   "depends_on": [
     "version_identity_contracts_20260907"

--- a/conductor/tracks/native_structured_logging_20260907/metadata.json
+++ b/conductor/tracks/native_structured_logging_20260907/metadata.json
@@ -1,0 +1,28 @@
+{
+  "track_id": "native_structured_logging_20260907",
+  "type": "feature",
+  "status": "new",
+  "created_at": "2026-09-07T01:59:07Z",
+  "updated_at": "2026-09-07T02:55:24Z",
+  "description": "Minimal Rust structured logging",
+  "evidence_schema": "1.0",
+  "depends_on": [
+    "version_identity_contracts_20260907"
+  ],
+  "authorization": {
+    "scope": "Detailed track planning; implementation remains pending",
+    "source": "Owner request to create comprehensive granular tracks and sequencing"
+  },
+  "gates": [
+    {
+      "id": "prerequisites",
+      "kind": "repository",
+      "status": "pending",
+      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+    }
+  ],
+  "implementation_preparation": {
+    "packet": "implementation-packet.json",
+    "state": "waiting_for_prerequisites"
+  }
+}

--- a/conductor/tracks/native_structured_logging_20260907/plan.md
+++ b/conductor/tracks/native_structured_logging_20260907/plan.md
@@ -1,0 +1,38 @@
+# Implementation plan: Minimal Rust structured logging
+
+All tasks are pending. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: version_identity_contracts_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+
+## Phase 1: Events
+
+- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [ ] T1.2 — Freeze the minimal versioned event fields, severity policy and run/analysis/trace correlation mapping. (AC1).
+- [ ] T1.3 — Validate: Scientific results, audit evidence and operational logs have distinct contracts; diagnostics remain available with logging disabled. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+
+## Phase 2: Dependency
+
+- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [ ] T2.2 — Qualify tracing with minimal features and the supported MSRV; record compile-time and disabled-path costs. (AC2).
+- [ ] T2.3 — Validate: No exporter, network client or mandatory async runtime enters the numerical core. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+
+## Phase 3: Ownership
+
+- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [ ] T3.2 — Test host-installed subscriber coexistence before implementing application-owned configuration. (AC3).
+- [ ] T3.3 — Validate: Importing/calling the library never installs a global subscriber or replaces host handlers; repeated setup does not duplicate events. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+
+## Phase 4: Bridge
+
+- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [ ] T4.2 — Implement and test one Python-to-Rust correlation path and context isolation across parallel calls. (AC4).
+- [ ] T4.3 — Validate: Two concurrent runs do not exchange IDs; nested spans preserve parentage; absent tracing remains valid. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+
+## Phase 5: Numerics
+
+- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [ ] T5.2 — Compare logging disabled/enabled for a deterministic reference kernel and benchmark the boundary. (AC5).
+- [ ] T5.3 — Validate: Results and deterministic hashes agree; timestamps/trace IDs never enter calculation identities; the reviewed overhead budget passes. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+
+## Final acceptance
+
+- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/conductor/tracks/native_structured_logging_20260907/spec.md
+++ b/conductor/tracks/native_structured_logging_20260907/spec.md
@@ -1,0 +1,52 @@
+# Specification: Minimal Rust structured logging
+
+## Scope and authority
+
+Baseline: `1207cef979311d1f39b3e41c32e165907303dec2`. Follow root AGENTS.md and the parent programme repository boundaries. This track owns only the named Voiage slice; it authorizes no sibling changes or external operations.
+
+## Required context
+
+- `voiage/logging.py`
+- `tests/test_logging_contract.py`
+- `rust/crates/voiage-diagnostics/Cargo.toml`
+- `rust/crates/voiage-python/Cargo.toml`
+
+## Acceptance criteria
+
+### AC1: Events
+
+Freeze the minimal versioned event fields, severity policy and run/analysis/trace correlation mapping.
+
+Acceptance: Scientific results, audit evidence and operational logs have distinct contracts; diagnostics remain available with logging disabled.
+
+### AC2: Dependency
+
+Qualify tracing with minimal features and the supported MSRV; record compile-time and disabled-path costs.
+
+Acceptance: No exporter, network client or mandatory async runtime enters the numerical core.
+
+### AC3: Ownership
+
+Test host-installed subscriber coexistence before implementing application-owned configuration.
+
+Acceptance: Importing/calling the library never installs a global subscriber or replaces host handlers; repeated setup does not duplicate events.
+
+### AC4: Bridge
+
+Implement and test one Python-to-Rust correlation path and context isolation across parallel calls.
+
+Acceptance: Two concurrent runs do not exchange IDs; nested spans preserve parentage; absent tracing remains valid.
+
+### AC5: Numerics
+
+Compare logging disabled/enabled for a deterministic reference kernel and benchmark the boundary.
+
+Acceptance: Results and deterministic hashes agree; timestamps/trace IDs never enter calculation identities; the reviewed overhead budget passes.
+
+## Non-functional and external boundaries
+
+Rust-first dependencies; no silent numerical fallback, global logging initialization, API-policy change, tolerance inflation or golden-fixture rewrite. Preserve current version synchronization and declared public compatibility. Applications own telemetry sinks and retention. No cloud account, paid runner, publication, registry submission or release is included.
+
+## Verification
+
+Freeze exact test commands in the first task of each phase before implementation. Existing context files above are starting points, not unrestricted write permission. Add meaningful negative tests before code; test collection of zero is failure. Final candidate uses `tox run-parallel -p 2` under AGENTS.md and affected native gates, including `cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked` for Rust changes. Required hosted checks apply to the delivered PR revision.

--- a/conductor/tracks/optional_native_telemetry_20260907/AGENTS.md
+++ b/conductor/tracks/optional_native_telemetry_20260907/AGENTS.md
@@ -1,0 +1,3 @@
+# Worker boundary
+
+Read spec.md, plan.md and ../agent_safe_engineering_20260907/worker-guide.md before any implementation. Read ../agent_safe_engineering_20260907/orchestration.md for prerequisite and file reservations. One phase at a time; freeze exact files and behavioral witnesses first. Stop when scope, dependency evidence, scientific semantics or baseline changes. No sibling repository writes, invented test commands, weakened gates or external actions.

--- a/conductor/tracks/optional_native_telemetry_20260907/START_HERE.md
+++ b/conductor/tracks/optional_native_telemetry_20260907/START_HERE.md
@@ -1,0 +1,25 @@
+# Implementation handoff: Optional native telemetry qualification
+
+Prepared; current eligibility: **waiting_for_prerequisites**.
+
+1. Read spec.md, plan.md, implementation-packet.json and the shared orchestration.
+2. Use a clean, isolated worktree from the accepted planning commit. Compare the
+   packet input hashes with its current files; changed inputs require review.
+3. Confirm prerequisite tracks have source-bound acceptance evidence. Reading a
+   packet or a green schema check does not satisfy a prerequisite.
+4. Run existing baseline checks: `python -m pytest tests/test_dependency_promotion_policy.py -q`.
+5. Start T1.1. Reserved paths include proposed new files; do not claim they exist.
+   Author the specified acceptance tests before implementing behavior.
+6. Use `python -m pytest tests/test_optional_telemetry_contract.py tests/test_dependency_promotion_policy.py -q` for focused verification. Run native checks for Rust changes and
+   the final local gate required by AGENTS.md. Record actual commands/results.
+
+Each phase in implementation-packet.json states the behavior, observable result,
+exact test command and ordered task IDs. Shared dependency/workflow files are
+integrator-only. No package upgrade is implicit; follow isolated dependency
+frontier preflight before runtime/dependency work. Dependencies remain unchosen
+until their existing qualification task supplies a compatible pinned graph.
+
+The first task is bounded contract/design work. It must produce the exact
+negative-test witness before code. No scientific assumptions or ABI policy may
+be invented by the worker. Preserve runtime-neutral interchange and independent
+provider APIs as specified in repository-boundaries.md.

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "1.0",
+  "prepared_at": "2026-09-07T02:55:24Z",
+  "track_id": "optional_native_telemetry_20260907",
+  "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "preparation_state": "prepared",
+  "execution_state": "waiting_for_prerequisites",
+  "prerequisite_tracks": [
+    "vop_logging_version_pilot_20260907"
+  ],
+  "delivery_repository": "edithatogo/voiage",
+  "read_before_start": [
+    "rust/Cargo.toml",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "tests/test_dependency_promotion_policy.py",
+    "conductor/tracks/agent_safe_engineering_20260907/orchestration.md",
+    "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
+  ],
+  "input_sha256": {
+    "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "e04c9c128b3dbacaf00175524a526503ebf0f76be1b6a77c156a0e5c0ceee2d8",
+    "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f"
+  },
+  "reserved_implementation_files": [
+    "rust/crates/voiage-diagnostics/src/otel_export.rs",
+    "tests/test_optional_telemetry_contract.py",
+    "rust/crates/voiage-diagnostics/src/lib.rs",
+    "tests/test_dependency_promotion_policy.py"
+  ],
+  "initial_file_state": {
+    "rust/crates/voiage-diagnostics/src/otel_export.rs": "new-file-must-be-absent",
+    "tests/test_optional_telemetry_contract.py": "new-file-must-be-absent",
+    "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
+    "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f"
+  },
+  "integrator_only": [
+    "rust/Cargo.toml",
+    "rust/Cargo.lock",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "rust/crates/voiage-python/Cargo.toml",
+    "uv.lock",
+    ".github/workflows/ci.yml",
+    "conductor/tracks.md"
+  ],
+  "phases": [
+    {
+      "phase": 1,
+      "task_ids": [
+        "T1.1",
+        "T1.2",
+        "T1.3"
+      ],
+      "acceptance_id": "AC1",
+      "title": "Need",
+      "implementation": "Use pilot measurements to select one concrete telemetry use case and acceptance budget; record defer if no need is demonstrated.",
+      "expected_result": "No exporter or dashboard is added solely for novelty; deferral is explicit and not feature completion.",
+      "prerequisite": "upstream-tracks-accepted",
+      "focused_command": "python -m pytest tests/test_optional_telemetry_contract.py tests/test_dependency_promotion_policy.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 2,
+      "task_ids": [
+        "T2.1",
+        "T2.2",
+        "T2.3"
+      ],
+      "acceptance_id": "AC2",
+      "title": "Qualify",
+      "implementation": "Qualify a pinned Rust OpenTelemetry SDK/bridge/exporter combination with minimal feature and MSRV tests.",
+      "expected_result": "Signals and semantic-convention versions are recorded; base installation has no exporter requirement.",
+      "prerequisite": "phase-1-accepted",
+      "focused_command": "python -m pytest tests/test_optional_telemetry_contract.py tests/test_dependency_promotion_policy.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 3,
+      "task_ids": [
+        "T3.1",
+        "T3.2",
+        "T3.3"
+      ],
+      "acceptance_id": "AC3",
+      "title": "Signal",
+      "implementation": "Add one optional trace export path before metrics/log export; verify context propagation with a local test collector.",
+      "expected_result": "Correct parentage and attributes arrive; network export requires application opt-in.",
+      "prerequisite": "phase-2-accepted",
+      "focused_command": "python -m pytest tests/test_optional_telemetry_contract.py tests/test_dependency_promotion_policy.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 4,
+      "task_ids": [
+        "T4.1",
+        "T4.2",
+        "T4.3"
+      ],
+      "acceptance_id": "AC4",
+      "title": "Limits",
+      "implementation": "Test sampling, label-cardinality limits, bounded retries, collector outage and shutdown.",
+      "expected_result": "No run IDs or arbitrary parameter values become metric labels; unavailable collectors cannot block numerical work indefinitely.",
+      "prerequisite": "phase-3-accepted",
+      "focused_command": "python -m pytest tests/test_optional_telemetry_contract.py tests/test_dependency_promotion_policy.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 5,
+      "task_ids": [
+        "T5.1",
+        "T5.2",
+        "T5.3"
+      ],
+      "acceptance_id": "AC5",
+      "title": "Consumer",
+      "implementation": "Verify feature-off, feature-on and incompatible-toolchain lanes plus numerical equivalence.",
+      "expected_result": "Supported CPU baseline remains usable; unsupported combinations fail explicitly; dashboard/collector hosting stays outside this repository.",
+      "prerequisite": "phase-4-accepted",
+      "focused_command": "python -m pytest tests/test_optional_telemetry_contract.py tests/test_dependency_promotion_policy.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    }
+  ],
+  "native_command": "cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked",
+  "final_command": "tox run-parallel -p 2",
+  "stop_conditions": [
+    "Input hashes changed without rebase review",
+    "Foreign file reservation or lease",
+    "Unaccepted prerequisite or ambiguous oracle",
+    "Scope requires another repository",
+    "Two unsuccessful repairs to same failure"
+  ],
+  "rollback": "Revert only owned commit through reviewed PR; preserve artifacts and old versions.",
+  "completion": "All phase ACs, final local/native checks, reviewed diff and required hosted source-bound evidence; external release not included.",
+  "hash_review": "Refreshed after reviewed preparation changes to parent packet; implementation not started."
+}

--- a/conductor/tracks/optional_native_telemetry_20260907/index.md
+++ b/conductor/tracks/optional_native_telemetry_20260907/index.md
@@ -1,0 +1,12 @@
+# Track: Optional native telemetry qualification
+
+Status: new.
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [Evidence](./evidence.jsonl)
+- [Orchestration](../agent_safe_engineering_20260907/orchestration.md)
+- [Worker guide](../agent_safe_engineering_20260907/worker-guide.md)
+- [Implementation start](./START_HERE.md)
+- [Implementation packet](./implementation-packet.json)

--- a/conductor/tracks/optional_native_telemetry_20260907/index.md
+++ b/conductor/tracks/optional_native_telemetry_20260907/index.md
@@ -2,6 +2,8 @@
 
 Status: new.
 
+GitHub issue: https://github.com/edithatogo/voiage/issues/1116
+
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
 - [Metadata](./metadata.json)

--- a/conductor/tracks/optional_native_telemetry_20260907/metadata.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/metadata.json
@@ -5,6 +5,7 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Optional native telemetry qualification",
+  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1116"},
   "evidence_schema": "1.0",
   "depends_on": [
     "vop_logging_version_pilot_20260907"

--- a/conductor/tracks/optional_native_telemetry_20260907/metadata.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/metadata.json
@@ -1,0 +1,28 @@
+{
+  "track_id": "optional_native_telemetry_20260907",
+  "type": "feature",
+  "status": "new",
+  "created_at": "2026-09-07T01:59:07Z",
+  "updated_at": "2026-09-07T02:55:24Z",
+  "description": "Optional native telemetry qualification",
+  "evidence_schema": "1.0",
+  "depends_on": [
+    "vop_logging_version_pilot_20260907"
+  ],
+  "authorization": {
+    "scope": "Detailed track planning; implementation remains pending",
+    "source": "Owner request to create comprehensive granular tracks and sequencing"
+  },
+  "gates": [
+    {
+      "id": "prerequisites",
+      "kind": "repository",
+      "status": "pending",
+      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+    }
+  ],
+  "implementation_preparation": {
+    "packet": "implementation-packet.json",
+    "state": "waiting_for_prerequisites"
+  }
+}

--- a/conductor/tracks/optional_native_telemetry_20260907/metadata.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/metadata.json
@@ -5,7 +5,9 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Optional native telemetry qualification",
-  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1116"},
+  "github_cross_reference": {
+    "issue": "https://github.com/edithatogo/voiage/issues/1116"
+  },
   "evidence_schema": "1.0",
   "depends_on": [
     "vop_logging_version_pilot_20260907"

--- a/conductor/tracks/optional_native_telemetry_20260907/plan.md
+++ b/conductor/tracks/optional_native_telemetry_20260907/plan.md
@@ -1,0 +1,38 @@
+# Implementation plan: Optional native telemetry qualification
+
+All tasks are pending. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: vop_logging_version_pilot_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+
+## Phase 1: Need
+
+- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [ ] T1.2 — Use pilot measurements to select one concrete telemetry use case and acceptance budget; record defer if no need is demonstrated. (AC1).
+- [ ] T1.3 — Validate: No exporter or dashboard is added solely for novelty; deferral is explicit and not feature completion. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+
+## Phase 2: Qualify
+
+- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [ ] T2.2 — Qualify a pinned Rust OpenTelemetry SDK/bridge/exporter combination with minimal feature and MSRV tests. (AC2).
+- [ ] T2.3 — Validate: Signals and semantic-convention versions are recorded; base installation has no exporter requirement. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+
+## Phase 3: Signal
+
+- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [ ] T3.2 — Add one optional trace export path before metrics/log export; verify context propagation with a local test collector. (AC3).
+- [ ] T3.3 — Validate: Correct parentage and attributes arrive; network export requires application opt-in. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+
+## Phase 4: Limits
+
+- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [ ] T4.2 — Test sampling, label-cardinality limits, bounded retries, collector outage and shutdown. (AC4).
+- [ ] T4.3 — Validate: No run IDs or arbitrary parameter values become metric labels; unavailable collectors cannot block numerical work indefinitely. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+
+## Phase 5: Consumer
+
+- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [ ] T5.2 — Verify feature-off, feature-on and incompatible-toolchain lanes plus numerical equivalence. (AC5).
+- [ ] T5.3 — Validate: Supported CPU baseline remains usable; unsupported combinations fail explicitly; dashboard/collector hosting stays outside this repository. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+
+## Final acceptance
+
+- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/conductor/tracks/optional_native_telemetry_20260907/spec.md
+++ b/conductor/tracks/optional_native_telemetry_20260907/spec.md
@@ -1,0 +1,51 @@
+# Specification: Optional native telemetry qualification
+
+## Scope and authority
+
+Baseline: `1207cef979311d1f39b3e41c32e165907303dec2`. Follow root AGENTS.md and the parent programme repository boundaries. This track owns only the named Voiage slice; it authorizes no sibling changes or external operations.
+
+## Required context
+
+- `rust/Cargo.toml`
+- `rust/crates/voiage-diagnostics/Cargo.toml`
+- `tests/test_dependency_promotion_policy.py`
+
+## Acceptance criteria
+
+### AC1: Need
+
+Use pilot measurements to select one concrete telemetry use case and acceptance budget; record defer if no need is demonstrated.
+
+Acceptance: No exporter or dashboard is added solely for novelty; deferral is explicit and not feature completion.
+
+### AC2: Qualify
+
+Qualify a pinned Rust OpenTelemetry SDK/bridge/exporter combination with minimal feature and MSRV tests.
+
+Acceptance: Signals and semantic-convention versions are recorded; base installation has no exporter requirement.
+
+### AC3: Signal
+
+Add one optional trace export path before metrics/log export; verify context propagation with a local test collector.
+
+Acceptance: Correct parentage and attributes arrive; network export requires application opt-in.
+
+### AC4: Limits
+
+Test sampling, label-cardinality limits, bounded retries, collector outage and shutdown.
+
+Acceptance: No run IDs or arbitrary parameter values become metric labels; unavailable collectors cannot block numerical work indefinitely.
+
+### AC5: Consumer
+
+Verify feature-off, feature-on and incompatible-toolchain lanes plus numerical equivalence.
+
+Acceptance: Supported CPU baseline remains usable; unsupported combinations fail explicitly; dashboard/collector hosting stays outside this repository.
+
+## Non-functional and external boundaries
+
+Rust-first dependencies; no silent numerical fallback, global logging initialization, API-policy change, tolerance inflation or golden-fixture rewrite. Preserve current version synchronization and declared public compatibility. Applications own telemetry sinks and retention. No cloud account, paid runner, publication, registry submission or release is included.
+
+## Verification
+
+Freeze exact test commands in the first task of each phase before implementation. Existing context files above are starting points, not unrestricted write permission. Add meaningful negative tests before code; test collection of zero is failure. Final candidate uses `tox run-parallel -p 2` under AGENTS.md and affected native gates, including `cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked` for Rust changes. Required hosted checks apply to the delivered PR revision.

--- a/conductor/tracks/remaining_backlog_delivery_20260831/index.md
+++ b/conductor/tracks/remaining_backlog_delivery_20260831/index.md
@@ -41,3 +41,5 @@ branch and worktree are pruned, before issue #1053 may close.
 The durable ref manifest excludes rotating `refs/codex/turn-diffs/*` app state,
 labels that namespace transient, and separately binds every ordered stash
 reflog entry by object ID, selector, and subject.
+
+- [Prepared continuation handoff](./implementation-handoff.md)

--- a/conductor/tracks/remaining_backlog_delivery_20260831/metadata.json
+++ b/conductor/tracks/remaining_backlog_delivery_20260831/metadata.json
@@ -3,7 +3,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-08-31T12:11:38Z",
-  "updated_at": "2026-09-03T16:50:59Z",
+  "updated_at": "2026-09-07T02:55:24Z",
   "description": "Complete the authorized remaining backlog, protected PR delivery, issue reconciliation and verified cleanup.",
   "evidence_schema": "1.0",
   "authorization": {
@@ -23,5 +23,6 @@
       "status": "pending",
       "evidence": "Individual issue acceptance criteria remain authoritative; no human or venue outcome inferred."
     }
-  ]
+  ],
+  "continuation_handoff": "implementation-handoff.md"
 }

--- a/conductor/tracks/v2_2_release_and_venue_submissions_20260830/index.md
+++ b/conductor/tracks/v2_2_release_and_venue_submissions_20260830/index.md
@@ -39,3 +39,5 @@ the post-merge receipt records the later result. R14 awaits survey completion an
 declarations are confirmed and prior requests withdrawn; journal-first
 sequencing supersedes the earlier arXiv prerequisite. No venue submission or
 acceptance is inferred from completed repository work.
+
+- [Prepared continuation handoff](./implementation-handoff.md)

--- a/conductor/tracks/v2_2_release_and_venue_submissions_20260830/metadata.json
+++ b/conductor/tracks/v2_2_release_and_venue_submissions_20260830/metadata.json
@@ -3,7 +3,7 @@
   "type": "chore",
   "status": "in_progress",
   "created_at": "2026-08-30T02:37:17Z",
-  "updated_at": "2026-08-31T09:58:39Z",
+  "updated_at": "2026-09-07T02:55:24Z",
   "description": "Publish the repository-hardened v2.2.0 release, then pursue pyOpenSci first, JOSS partner fast-track, and rOpenSci with fail-closed external evidence.",
   "evidence_schema": "1.0",
   "authorization": {
@@ -59,5 +59,6 @@
     "status": "venue_packet_repairs_merged",
     "evidence": "venue-packet-merge-receipt-20260831.json",
     "remaining_human_actions": "venue-next-actions-20260831.md"
-  }
+  },
+  "continuation_handoff": "implementation-handoff.md"
 }

--- a/conductor/tracks/version_identity_contracts_20260907/AGENTS.md
+++ b/conductor/tracks/version_identity_contracts_20260907/AGENTS.md
@@ -1,0 +1,3 @@
+# Worker boundary
+
+Read spec.md, plan.md and ../agent_safe_engineering_20260907/worker-guide.md before any implementation. Read ../agent_safe_engineering_20260907/orchestration.md for prerequisite and file reservations. One phase at a time; freeze exact files and behavioral witnesses first. Stop when scope, dependency evidence, scientific semantics or baseline changes. No sibling repository writes, invented test commands, weakened gates or external actions.

--- a/conductor/tracks/version_identity_contracts_20260907/START_HERE.md
+++ b/conductor/tracks/version_identity_contracts_20260907/START_HERE.md
@@ -1,0 +1,25 @@
+# Implementation handoff: Version identities and compatibility policy
+
+Prepared; current eligibility: **waiting_for_prerequisites**.
+
+1. Read spec.md, plan.md, implementation-packet.json and the shared orchestration.
+2. Use a clean, isolated worktree from the accepted planning commit. Compare the
+   packet input hashes with its current files; changed inputs require review.
+3. Confirm prerequisite tracks have source-bound acceptance evidence. Reading a
+   packet or a green schema check does not satisfy a prerequisite.
+4. Run existing baseline checks: `python -m pytest tests/test_version_sync.py -q`.
+5. Start T1.1. Reserved paths include proposed new files; do not claim they exist.
+   Author the specified acceptance tests before implementing behavior.
+6. Use `python -m pytest tests/test_version_identity_contracts.py tests/test_version_sync.py -q` for focused verification. Run native checks for Rust changes and
+   the final local gate required by AGENTS.md. Record actual commands/results.
+
+Each phase in implementation-packet.json states the behavior, observable result,
+exact test command and ordered task IDs. Shared dependency/workflow files are
+integrator-only. No package upgrade is implicit; follow isolated dependency
+frontier preflight before runtime/dependency work. Dependencies remain unchosen
+until their existing qualification task supplies a compatible pinned graph.
+
+The first task is bounded contract/design work. It must produce the exact
+negative-test witness before code. No scientific assumptions or ABI policy may
+be invented by the worker. Preserve runtime-neutral interchange and independent
+provider APIs as specified in repository-boundaries.md.

--- a/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
+++ b/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": "1.0",
+  "prepared_at": "2026-09-07T02:55:24Z",
+  "track_id": "version_identity_contracts_20260907",
+  "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "preparation_state": "prepared",
+  "execution_state": "waiting_for_prerequisites",
+  "prerequisite_tracks": [
+    "execution_packet_guard_20260907"
+  ],
+  "delivery_repository": "edithatogo/voiage",
+  "read_before_start": [
+    "voiage/versioning.py",
+    "scripts/validate_version_sync.py",
+    "tests/test_version_sync.py",
+    "rust/Cargo.toml",
+    "conductor/tracks/agent_safe_engineering_20260907/orchestration.md",
+    "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
+  ],
+  "input_sha256": {
+    "voiage/versioning.py": "a097ac4b7ccec2d02ba45318b0d7afff9b8cc61627eb43dac4dde67e4cab804b",
+    "scripts/validate_version_sync.py": "1512cdc797be9424d83e9ae517c7b5357a91a019b6f610c23406d2a5986f131a",
+    "tests/test_version_sync.py": "c43baf7b983994a89fc3ae128c2d3fa4782efcf3d7b45b3d43c2b6ea0994342d",
+    "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36"
+  },
+  "reserved_implementation_files": [
+    "specs/version-identities.json",
+    "tests/test_version_identity_contracts.py",
+    "voiage/versioning.py",
+    "tests/test_version_sync.py"
+  ],
+  "initial_file_state": {
+    "specs/version-identities.json": "new-file-must-be-absent",
+    "tests/test_version_identity_contracts.py": "new-file-must-be-absent",
+    "voiage/versioning.py": "a097ac4b7ccec2d02ba45318b0d7afff9b8cc61627eb43dac4dde67e4cab804b",
+    "tests/test_version_sync.py": "c43baf7b983994a89fc3ae128c2d3fa4782efcf3d7b45b3d43c2b6ea0994342d"
+  },
+  "integrator_only": [
+    "rust/Cargo.toml",
+    "rust/Cargo.lock",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "rust/crates/voiage-python/Cargo.toml",
+    "uv.lock",
+    ".github/workflows/ci.yml",
+    "conductor/tracks.md"
+  ],
+  "phases": [
+    {
+      "phase": 1,
+      "task_ids": [
+        "T1.1",
+        "T1.2",
+        "T1.3"
+      ],
+      "acceptance_id": "AC1",
+      "title": "Inventory",
+      "implementation": "Map existing package, public API, C ABI, schema, algorithm, RNG and checkpoint identities and their authoritative files.",
+      "expected_result": "Each identity has one owner, increment rule and declared consumers; independent identities are not conflated.",
+      "prerequisite": "upstream-tracks-accepted",
+      "focused_command": "python -m pytest tests/test_version_identity_contracts.py tests/test_version_sync.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 2,
+      "task_ids": [
+        "T2.1",
+        "T2.2",
+        "T2.3"
+      ],
+      "acceptance_id": "AC2",
+      "title": "Policy",
+      "implementation": "Specify compatible versus breaking changes, supported read/write windows and deprecation decisions.",
+      "expected_result": "Examples cover additive fields, changed units, renamed fields, numerical fixes and RNG changes; no silent version bump.",
+      "prerequisite": "phase-1-accepted",
+      "focused_command": "python -m pytest tests/test_version_identity_contracts.py tests/test_version_sync.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 3,
+      "task_ids": [
+        "T3.1",
+        "T3.2",
+        "T3.3"
+      ],
+      "acceptance_id": "AC3",
+      "title": "Fixtures",
+      "implementation": "Create old-reader/new-writer and new-reader/old-writer fixtures for one existing serialized VOI contract.",
+      "expected_result": "Supported combinations pass; unsupported major versions and missing required fields fail explicitly.",
+      "prerequisite": "phase-2-accepted",
+      "focused_command": "python -m pytest tests/test_version_identity_contracts.py tests/test_version_sync.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 4,
+      "task_ids": [
+        "T4.1",
+        "T4.2",
+        "T4.3"
+      ],
+      "acceptance_id": "AC4",
+      "title": "Identity",
+      "implementation": "Implement the smallest version-envelope/validation change using Rust-owned semantics and thin bindings.",
+      "expected_result": "Package synchronization still passes and provider APIs do not leak into public identities.",
+      "prerequisite": "phase-3-accepted",
+      "focused_command": "python -m pytest tests/test_version_identity_contracts.py tests/test_version_sync.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 5,
+      "task_ids": [
+        "T5.1",
+        "T5.2",
+        "T5.3"
+      ],
+      "acceptance_id": "AC5",
+      "title": "Migration",
+      "implementation": "Test a single explicit migration and replay invalidation before enabling it.",
+      "expected_result": "Original artifacts remain immutable; changed algorithm/RNG/input identities invalidate incompatible checkpoints; migration records both identities.",
+      "prerequisite": "phase-4-accepted",
+      "focused_command": "python -m pytest tests/test_version_identity_contracts.py tests/test_version_sync.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    }
+  ],
+  "native_command": "cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked",
+  "final_command": "tox run-parallel -p 2",
+  "stop_conditions": [
+    "Input hashes changed without rebase review",
+    "Foreign file reservation or lease",
+    "Unaccepted prerequisite or ambiguous oracle",
+    "Scope requires another repository",
+    "Two unsuccessful repairs to same failure"
+  ],
+  "rollback": "Revert only owned commit through reviewed PR; preserve artifacts and old versions.",
+  "completion": "All phase ACs, final local/native checks, reviewed diff and required hosted source-bound evidence; external release not included.",
+  "hash_review": "Refreshed after reviewed preparation changes to parent packet; implementation not started."
+}

--- a/conductor/tracks/version_identity_contracts_20260907/index.md
+++ b/conductor/tracks/version_identity_contracts_20260907/index.md
@@ -1,0 +1,12 @@
+# Track: Version identities and compatibility policy
+
+Status: new.
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [Evidence](./evidence.jsonl)
+- [Orchestration](../agent_safe_engineering_20260907/orchestration.md)
+- [Worker guide](../agent_safe_engineering_20260907/worker-guide.md)
+- [Implementation start](./START_HERE.md)
+- [Implementation packet](./implementation-packet.json)

--- a/conductor/tracks/version_identity_contracts_20260907/index.md
+++ b/conductor/tracks/version_identity_contracts_20260907/index.md
@@ -2,6 +2,8 @@
 
 Status: new.
 
+GitHub issue: https://github.com/edithatogo/voiage/issues/1112
+
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
 - [Metadata](./metadata.json)

--- a/conductor/tracks/version_identity_contracts_20260907/metadata.json
+++ b/conductor/tracks/version_identity_contracts_20260907/metadata.json
@@ -1,0 +1,28 @@
+{
+  "track_id": "version_identity_contracts_20260907",
+  "type": "feature",
+  "status": "new",
+  "created_at": "2026-09-07T01:59:07Z",
+  "updated_at": "2026-09-07T02:55:24Z",
+  "description": "Version identities and compatibility policy",
+  "evidence_schema": "1.0",
+  "depends_on": [
+    "execution_packet_guard_20260907"
+  ],
+  "authorization": {
+    "scope": "Detailed track planning; implementation remains pending",
+    "source": "Owner request to create comprehensive granular tracks and sequencing"
+  },
+  "gates": [
+    {
+      "id": "prerequisites",
+      "kind": "repository",
+      "status": "pending",
+      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+    }
+  ],
+  "implementation_preparation": {
+    "packet": "implementation-packet.json",
+    "state": "waiting_for_prerequisites"
+  }
+}

--- a/conductor/tracks/version_identity_contracts_20260907/metadata.json
+++ b/conductor/tracks/version_identity_contracts_20260907/metadata.json
@@ -5,7 +5,9 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Version identities and compatibility policy",
-  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1112"},
+  "github_cross_reference": {
+    "issue": "https://github.com/edithatogo/voiage/issues/1112"
+  },
   "evidence_schema": "1.0",
   "depends_on": [
     "execution_packet_guard_20260907"

--- a/conductor/tracks/version_identity_contracts_20260907/metadata.json
+++ b/conductor/tracks/version_identity_contracts_20260907/metadata.json
@@ -5,6 +5,7 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Version identities and compatibility policy",
+  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1112"},
   "evidence_schema": "1.0",
   "depends_on": [
     "execution_packet_guard_20260907"

--- a/conductor/tracks/version_identity_contracts_20260907/plan.md
+++ b/conductor/tracks/version_identity_contracts_20260907/plan.md
@@ -1,0 +1,38 @@
+# Implementation plan: Version identities and compatibility policy
+
+All tasks are pending. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: execution_packet_guard_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+
+## Phase 1: Inventory
+
+- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [ ] T1.2 — Map existing package, public API, C ABI, schema, algorithm, RNG and checkpoint identities and their authoritative files. (AC1).
+- [ ] T1.3 — Validate: Each identity has one owner, increment rule and declared consumers; independent identities are not conflated. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+
+## Phase 2: Policy
+
+- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [ ] T2.2 — Specify compatible versus breaking changes, supported read/write windows and deprecation decisions. (AC2).
+- [ ] T2.3 — Validate: Examples cover additive fields, changed units, renamed fields, numerical fixes and RNG changes; no silent version bump. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+
+## Phase 3: Fixtures
+
+- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [ ] T3.2 — Create old-reader/new-writer and new-reader/old-writer fixtures for one existing serialized VOI contract. (AC3).
+- [ ] T3.3 — Validate: Supported combinations pass; unsupported major versions and missing required fields fail explicitly. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+
+## Phase 4: Identity
+
+- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [ ] T4.2 — Implement the smallest version-envelope/validation change using Rust-owned semantics and thin bindings. (AC4).
+- [ ] T4.3 — Validate: Package synchronization still passes and provider APIs do not leak into public identities. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+
+## Phase 5: Migration
+
+- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [ ] T5.2 — Test a single explicit migration and replay invalidation before enabling it. (AC5).
+- [ ] T5.3 — Validate: Original artifacts remain immutable; changed algorithm/RNG/input identities invalidate incompatible checkpoints; migration records both identities. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+
+## Final acceptance
+
+- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/conductor/tracks/version_identity_contracts_20260907/spec.md
+++ b/conductor/tracks/version_identity_contracts_20260907/spec.md
@@ -1,0 +1,52 @@
+# Specification: Version identities and compatibility policy
+
+## Scope and authority
+
+Baseline: `1207cef979311d1f39b3e41c32e165907303dec2`. Follow root AGENTS.md and the parent programme repository boundaries. This track owns only the named Voiage slice; it authorizes no sibling changes or external operations.
+
+## Required context
+
+- `voiage/versioning.py`
+- `scripts/validate_version_sync.py`
+- `tests/test_version_sync.py`
+- `rust/Cargo.toml`
+
+## Acceptance criteria
+
+### AC1: Inventory
+
+Map existing package, public API, C ABI, schema, algorithm, RNG and checkpoint identities and their authoritative files.
+
+Acceptance: Each identity has one owner, increment rule and declared consumers; independent identities are not conflated.
+
+### AC2: Policy
+
+Specify compatible versus breaking changes, supported read/write windows and deprecation decisions.
+
+Acceptance: Examples cover additive fields, changed units, renamed fields, numerical fixes and RNG changes; no silent version bump.
+
+### AC3: Fixtures
+
+Create old-reader/new-writer and new-reader/old-writer fixtures for one existing serialized VOI contract.
+
+Acceptance: Supported combinations pass; unsupported major versions and missing required fields fail explicitly.
+
+### AC4: Identity
+
+Implement the smallest version-envelope/validation change using Rust-owned semantics and thin bindings.
+
+Acceptance: Package synchronization still passes and provider APIs do not leak into public identities.
+
+### AC5: Migration
+
+Test a single explicit migration and replay invalidation before enabling it.
+
+Acceptance: Original artifacts remain immutable; changed algorithm/RNG/input identities invalidate incompatible checkpoints; migration records both identities.
+
+## Non-functional and external boundaries
+
+Rust-first dependencies; no silent numerical fallback, global logging initialization, API-policy change, tolerance inflation or golden-fixture rewrite. Preserve current version synchronization and declared public compatibility. Applications own telemetry sinks and retention. No cloud account, paid runner, publication, registry submission or release is included.
+
+## Verification
+
+Freeze exact test commands in the first task of each phase before implementation. Existing context files above are starting points, not unrestricted write permission. Add meaningful negative tests before code; test collection of zero is failure. Final candidate uses `tox run-parallel -p 2` under AGENTS.md and affected native gates, including `cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked` for Rust changes. Required hosted checks apply to the delivered PR revision.

--- a/conductor/tracks/vop_logging_version_pilot_20260907/AGENTS.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/AGENTS.md
@@ -1,0 +1,3 @@
+# Worker boundary
+
+Read spec.md, plan.md and ../agent_safe_engineering_20260907/worker-guide.md before any implementation. Read ../agent_safe_engineering_20260907/orchestration.md for prerequisite and file reservations. One phase at a time; freeze exact files and behavioral witnesses first. Stop when scope, dependency evidence, scientific semantics or baseline changes. No sibling repository writes, invented test commands, weakened gates or external actions.

--- a/conductor/tracks/vop_logging_version_pilot_20260907/START_HERE.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/START_HERE.md
@@ -1,0 +1,25 @@
+# Implementation handoff: VOP-to-VOI version and logging pilot
+
+Prepared; current eligibility: **waiting_for_prerequisites**.
+
+1. Read spec.md, plan.md, implementation-packet.json and the shared orchestration.
+2. Use a clean, isolated worktree from the accepted planning commit. Compare the
+   packet input hashes with its current files; changed inputs require review.
+3. Confirm prerequisite tracks have source-bound acceptance evidence. Reading a
+   packet or a green schema check does not satisfy a prerequisite.
+4. Run existing baseline checks: `python -m pytest tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q`.
+5. Start T1.1. Reserved paths include proposed new files; do not claim they exist.
+   Author the specified acceptance tests before implementing behavior.
+6. Use `python -m pytest tests/test_vop_logging_version_pilot.py tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q` for focused verification. Run native checks for Rust changes and
+   the final local gate required by AGENTS.md. Record actual commands/results.
+
+Each phase in implementation-packet.json states the behavior, observable result,
+exact test command and ordered task IDs. Shared dependency/workflow files are
+integrator-only. No package upgrade is implicit; follow isolated dependency
+frontier preflight before runtime/dependency work. Dependencies remain unchosen
+until their existing qualification task supplies a compatible pinned graph.
+
+The first task is bounded contract/design work. It must produce the exact
+negative-test witness before code. No scientific assumptions or ABI policy may
+be invented by the worker. Preserve runtime-neutral interchange and independent
+provider APIs as specified in repository-boundaries.md.

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": "1.0",
+  "prepared_at": "2026-09-07T02:55:24Z",
+  "track_id": "vop_logging_version_pilot_20260907",
+  "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
+  "preparation_state": "prepared",
+  "execution_state": "waiting_for_prerequisites",
+  "prerequisite_tracks": [
+    "logging_privacy_resilience_20260907"
+  ],
+  "delivery_repository": "edithatogo/voiage",
+  "read_before_start": [
+    "specs/integration/vop-voiage/bundles/UPSTREAM.json",
+    "tests/test_logging_contract.py",
+    "tests/test_consumer_matrix.py",
+    "voiage/logging.py",
+    "conductor/tracks/agent_safe_engineering_20260907/orchestration.md",
+    "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
+  ],
+  "input_sha256": {
+    "specs/integration/vop-voiage/bundles/UPSTREAM.json": "0f65af398e1ba2bbac704f6bb5dedc10548c6120ba6e377cb4254bc7813086d0",
+    "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
+    "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
+    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea"
+  },
+  "reserved_implementation_files": [
+    "tests/test_vop_logging_version_pilot.py",
+    "specs/integration/vop-voiage/pilot-logging-version.json",
+    "tests/test_consumer_matrix.py",
+    "tests/test_vop_research_handoff.py"
+  ],
+  "initial_file_state": {
+    "tests/test_vop_logging_version_pilot.py": "new-file-must-be-absent",
+    "specs/integration/vop-voiage/pilot-logging-version.json": "new-file-must-be-absent",
+    "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
+    "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a"
+  },
+  "integrator_only": [
+    "rust/Cargo.toml",
+    "rust/Cargo.lock",
+    "rust/crates/voiage-diagnostics/Cargo.toml",
+    "rust/crates/voiage-python/Cargo.toml",
+    "uv.lock",
+    ".github/workflows/ci.yml",
+    "conductor/tracks.md"
+  ],
+  "phases": [
+    {
+      "phase": 1,
+      "task_ids": [
+        "T1.1",
+        "T1.2",
+        "T1.3"
+      ],
+      "acceptance_id": "AC1",
+      "title": "Pin",
+      "implementation": "Select one existing VOP export contract and exact producer/consumer revisions; identify any producer change as a separate upstream handoff.",
+      "expected_result": "Existing contracts are reused; no upstream task is assumed accepted or implemented.",
+      "prerequisite": "upstream-tracks-accepted",
+      "focused_command": "python -m pytest tests/test_vop_logging_version_pilot.py tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 2,
+      "task_ids": [
+        "T2.1",
+        "T2.2",
+        "T2.3"
+      ],
+      "acceptance_id": "AC2",
+      "title": "Negative",
+      "implementation": "Create wrong-unit, wrong-weight, unknown-version and malformed-correlation cases.",
+      "expected_result": "Invalid inputs are rejected before model evaluation with stable diagnostics.",
+      "prerequisite": "phase-1-accepted",
+      "focused_command": "python -m pytest tests/test_vop_logging_version_pilot.py tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 3,
+      "task_ids": [
+        "T3.1",
+        "T3.2",
+        "T3.3"
+      ],
+      "acceptance_id": "AC3",
+      "title": "Consumer",
+      "implementation": "Implement only the missing consumer slice and run it from an installed artifact outside the source tree.",
+      "expected_result": "The reference result, version identities and cross-boundary correlation agree on the qualified installed combination.",
+      "prerequisite": "phase-2-accepted",
+      "focused_command": "python -m pytest tests/test_vop_logging_version_pilot.py tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 4,
+      "task_ids": [
+        "T4.1",
+        "T4.2",
+        "T4.3"
+      ],
+      "acceptance_id": "AC4",
+      "title": "Replacement",
+      "implementation": "Test two small providers with deliberately different APIs against the same semantic input contract.",
+      "expected_result": "Both yield the expected VOI result without requiring third-party API/ABI equivalence.",
+      "prerequisite": "phase-3-accepted",
+      "focused_command": "python -m pytest tests/test_vop_logging_version_pilot.py tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    },
+    {
+      "phase": 5,
+      "task_ids": [
+        "T5.1",
+        "T5.2",
+        "T5.3"
+      ],
+      "acceptance_id": "AC5",
+      "title": "Replay",
+      "implementation": "Reproduce the complete export-to-result workflow and publish a local redacted validation packet.",
+      "expected_result": "Packet records hashes, versions, expected results and limitations; synthetic data are labelled and no hosted publication is implied.",
+      "prerequisite": "phase-4-accepted",
+      "focused_command": "python -m pytest tests/test_vop_logging_version_pilot.py tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q",
+      "red_test_rule": "Create the named test first; run it and observe the intended behavioral assertion failure. Missing test/module/tool is not a valid red result.",
+      "write_policy": "Use only the reserved files below; if another file is required, integrator updates this packet before code. At most five implementation files per slice."
+    }
+  ],
+  "native_command": "cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked",
+  "final_command": "tox run-parallel -p 2",
+  "stop_conditions": [
+    "Input hashes changed without rebase review",
+    "Foreign file reservation or lease",
+    "Unaccepted prerequisite or ambiguous oracle",
+    "Scope requires another repository",
+    "Two unsuccessful repairs to same failure"
+  ],
+  "rollback": "Revert only owned commit through reviewed PR; preserve artifacts and old versions.",
+  "completion": "All phase ACs, final local/native checks, reviewed diff and required hosted source-bound evidence; external release not included.",
+  "hash_review": "Refreshed after reviewed preparation changes to parent packet; implementation not started."
+}

--- a/conductor/tracks/vop_logging_version_pilot_20260907/index.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/index.md
@@ -1,0 +1,12 @@
+# Track: VOP-to-VOI version and logging pilot
+
+Status: new.
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [Evidence](./evidence.jsonl)
+- [Orchestration](../agent_safe_engineering_20260907/orchestration.md)
+- [Worker guide](../agent_safe_engineering_20260907/worker-guide.md)
+- [Implementation start](./START_HERE.md)
+- [Implementation packet](./implementation-packet.json)

--- a/conductor/tracks/vop_logging_version_pilot_20260907/index.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/index.md
@@ -2,6 +2,8 @@
 
 Status: new.
 
+GitHub issue: https://github.com/edithatogo/voiage/issues/1115
+
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
 - [Metadata](./metadata.json)

--- a/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
@@ -1,0 +1,28 @@
+{
+  "track_id": "vop_logging_version_pilot_20260907",
+  "type": "feature",
+  "status": "new",
+  "created_at": "2026-09-07T01:59:07Z",
+  "updated_at": "2026-09-07T02:55:24Z",
+  "description": "VOP-to-VOI version and logging pilot",
+  "evidence_schema": "1.0",
+  "depends_on": [
+    "logging_privacy_resilience_20260907"
+  ],
+  "authorization": {
+    "scope": "Detailed track planning; implementation remains pending",
+    "source": "Owner request to create comprehensive granular tracks and sequencing"
+  },
+  "gates": [
+    {
+      "id": "prerequisites",
+      "kind": "repository",
+      "status": "pending",
+      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+    }
+  ],
+  "implementation_preparation": {
+    "packet": "implementation-packet.json",
+    "state": "waiting_for_prerequisites"
+  }
+}

--- a/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
@@ -5,7 +5,9 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "VOP-to-VOI version and logging pilot",
-  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1115"},
+  "github_cross_reference": {
+    "issue": "https://github.com/edithatogo/voiage/issues/1115"
+  },
   "evidence_schema": "1.0",
   "depends_on": [
     "logging_privacy_resilience_20260907"

--- a/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
@@ -5,6 +5,7 @@
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "VOP-to-VOI version and logging pilot",
+  "github_cross_reference": {"issue": "https://github.com/edithatogo/voiage/issues/1115"},
   "evidence_schema": "1.0",
   "depends_on": [
     "logging_privacy_resilience_20260907"

--- a/conductor/tracks/vop_logging_version_pilot_20260907/plan.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/plan.md
@@ -1,0 +1,38 @@
+# Implementation plan: VOP-to-VOI version and logging pilot
+
+All tasks are pending. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: logging_privacy_resilience_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+
+## Phase 1: Pin
+
+- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [ ] T1.2 — Select one existing VOP export contract and exact producer/consumer revisions; identify any producer change as a separate upstream handoff. (AC1).
+- [ ] T1.3 — Validate: Existing contracts are reused; no upstream task is assumed accepted or implemented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+
+## Phase 2: Negative
+
+- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [ ] T2.2 — Create wrong-unit, wrong-weight, unknown-version and malformed-correlation cases. (AC2).
+- [ ] T2.3 — Validate: Invalid inputs are rejected before model evaluation with stable diagnostics. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+
+## Phase 3: Consumer
+
+- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [ ] T3.2 — Implement only the missing consumer slice and run it from an installed artifact outside the source tree. (AC3).
+- [ ] T3.3 — Validate: The reference result, version identities and cross-boundary correlation agree on the qualified installed combination. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+
+## Phase 4: Replacement
+
+- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [ ] T4.2 — Test two small providers with deliberately different APIs against the same semantic input contract. (AC4).
+- [ ] T4.3 — Validate: Both yield the expected VOI result without requiring third-party API/ABI equivalence. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+
+## Phase 5: Replay
+
+- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [ ] T5.2 — Reproduce the complete export-to-result workflow and publish a local redacted validation packet. (AC5).
+- [ ] T5.3 — Validate: Packet records hashes, versions, expected results and limitations; synthetic data are labelled and no hosted publication is implied. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+
+## Final acceptance
+
+- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/conductor/tracks/vop_logging_version_pilot_20260907/spec.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/spec.md
@@ -1,0 +1,52 @@
+# Specification: VOP-to-VOI version and logging pilot
+
+## Scope and authority
+
+Baseline: `1207cef979311d1f39b3e41c32e165907303dec2`. Follow root AGENTS.md and the parent programme repository boundaries. This track owns only the named Voiage slice; it authorizes no sibling changes or external operations.
+
+## Required context
+
+- `specs/integration/vop-voiage/bundles/UPSTREAM.json`
+- `tests/test_logging_contract.py`
+- `tests/test_consumer_matrix.py`
+- `voiage/logging.py`
+
+## Acceptance criteria
+
+### AC1: Pin
+
+Select one existing VOP export contract and exact producer/consumer revisions; identify any producer change as a separate upstream handoff.
+
+Acceptance: Existing contracts are reused; no upstream task is assumed accepted or implemented.
+
+### AC2: Negative
+
+Create wrong-unit, wrong-weight, unknown-version and malformed-correlation cases.
+
+Acceptance: Invalid inputs are rejected before model evaluation with stable diagnostics.
+
+### AC3: Consumer
+
+Implement only the missing consumer slice and run it from an installed artifact outside the source tree.
+
+Acceptance: The reference result, version identities and cross-boundary correlation agree on the qualified installed combination.
+
+### AC4: Replacement
+
+Test two small providers with deliberately different APIs against the same semantic input contract.
+
+Acceptance: Both yield the expected VOI result without requiring third-party API/ABI equivalence.
+
+### AC5: Replay
+
+Reproduce the complete export-to-result workflow and publish a local redacted validation packet.
+
+Acceptance: Packet records hashes, versions, expected results and limitations; synthetic data are labelled and no hosted publication is implied.
+
+## Non-functional and external boundaries
+
+Rust-first dependencies; no silent numerical fallback, global logging initialization, API-policy change, tolerance inflation or golden-fixture rewrite. Preserve current version synchronization and declared public compatibility. Applications own telemetry sinks and retention. No cloud account, paid runner, publication, registry submission or release is included.
+
+## Verification
+
+Freeze exact test commands in the first task of each phase before implementation. Existing context files above are starting points, not unrestricted write permission. Add meaningful negative tests before code; test collection of zero is failure. Final candidate uses `tox run-parallel -p 2` under AGENTS.md and affected native gates, including `cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked` for Rust changes. Required hosted checks apply to the delivered PR revision.

--- a/roadmap.md
+++ b/roadmap.md
@@ -44,6 +44,34 @@ created for the proposed packages, and no dependency upgrade or scientific
 promotion is implied. The former [software frontier page](docs/reviews/roadmaps/software-frontier.md)
 now directs readers to the consolidated plan.
 
+## Engineering execution follow-up (2026-09-07)
+
+[Agent-safe engineering improvements](conductor/tracks/agent_safe_engineering_20260907/index.md)
+adds eight bounded workstreams for drift checks, dependency features, API/ABI
+compatibility, measured CI, adversarial numerics, bounded execution, capability
+reports and automation recovery. All implementation tasks remain pending; the
+worker guide specifies exact scopes, prerequisites, witnesses and escalation.
+[Repository allocations and integration order](conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md)
+keep generic engines and applications in their capability-owner repositories.
+Future Rust-first providers may expose distinct APIs; semantic interchange and
+Voiage's own promised interfaces have separate compatibility gates.
+The original twenty method/software packages remain proposed and are mapped
+to these engineering prerequisites without activating them.
+
+Prepared track records:
+
+- `conductor/tracks/execution_packet_guard_20260907/`
+- `conductor/tracks/version_identity_contracts_20260907/`
+- `conductor/tracks/native_structured_logging_20260907/`
+- `conductor/tracks/logging_privacy_resilience_20260907/`
+- `conductor/tracks/vop_logging_version_pilot_20260907/`
+- `conductor/tracks/optional_native_telemetry_20260907/`
+
+The ordered implementation tracks are individually registered under issues
+[#1111](https://github.com/edithatogo/voiage/issues/1111) through
+[#1116](https://github.com/edithatogo/voiage/issues/1116), with execution
+guard delivery proceeding first and dependent tracks held until its merge.
+
 ## Comprehensive Rust-First Polyglot Programme
 
 GitHub issue #1033 and archived Conductor track
@@ -1306,3 +1334,10 @@ flowchart LR
   Review[pyOpenSci / rOpenSci / JOSS / NumFOCUS] --> Docs[Docs, tests, citation, support, CI]
   Docs --> Users
 ```
+
+## Detailed logging and versioning sequence
+
+Six pending tracks and their parallel investigation/serial integration boundaries
+are defined in [Conductor orchestration](conductor/tracks/agent_safe_engineering_20260907/orchestration.md).
+They separate execution controls, version identities, native logging, privacy and
+resilience, the first installed VOP pilot, and optional telemetry qualification.

--- a/scripts/repo_harness.py
+++ b/scripts/repo_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import asdict, dataclass
 import json
+import os
 from pathlib import Path
 import re
 import shutil
@@ -374,6 +375,29 @@ def check_operational_assurance(root: Path) -> list[Finding]:
     return findings
 
 
+def _changed_paths(root: Path) -> list[str]:
+    """Return staged, unstaged, and untracked paths from the current worktree."""
+    git = shutil.which("git")
+    if git is None:
+        return []
+    result = subprocess.run(  # noqa: S603 -- executable is resolved from PATH.
+        [git, "-C", str(root), "status", "--porcelain", "-z"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    paths: list[str] = []
+    for record in result.stdout.decode("utf-8", errors="surrogateescape").split("\0"):
+        if not record:
+            continue
+        value = record[3:]
+        if " -> " in value:
+            value = value.split(" -> ", 1)[1]
+        paths.append(value)
+    return paths
+
+
 def check_execution_packets(root: Path) -> list[Finding]:
     """Validate checked-in implementation packets without running their commands."""
     try:
@@ -388,7 +412,12 @@ def check_execution_packets(root: Path) -> list[Finding]:
     ):
         try:
             packet = json.loads(packet_path.read_text(encoding="utf-8"))
-            errors = validate_packet(packet, root)
+            errors = validate_packet(
+                packet,
+                root,
+                require_ready=packet.get("track_id") == "execution_packet_guard_20260907",
+                changed_paths=_changed_paths(root) if os.environ.get("CI") else None,
+            )
         except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
             errors = [str(exc)]
         findings.extend(

--- a/scripts/repo_harness.py
+++ b/scripts/repo_harness.py
@@ -374,6 +374,29 @@ def check_operational_assurance(root: Path) -> list[Finding]:
     return findings
 
 
+def check_execution_packets(root: Path) -> list[Finding]:
+    """Validate checked-in implementation packets without running their commands."""
+    try:
+        from scripts.validate_execution_packets import validate_packet
+    except ModuleNotFoundError:
+        # ``python scripts/repo_harness.py`` puts scripts/ on sys.path.
+        from validate_execution_packets import validate_packet
+
+    findings: list[Finding] = []
+    for packet_path in sorted(
+        (root / "conductor" / "tracks").glob("*/implementation-packet.json")
+    ):
+        try:
+            packet = json.loads(packet_path.read_text(encoding="utf-8"))
+            errors = validate_packet(packet, root)
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            errors = [str(exc)]
+        findings.extend(
+            Finding(packet_path.relative_to(root).as_posix(), error) for error in errors
+        )
+    return findings
+
+
 def collect_findings(root: Path) -> list[Finding]:
     """Run all deterministic harness checks."""
     return (
@@ -383,6 +406,7 @@ def collect_findings(root: Path) -> list[Finding]:
         + check_docs_platform(root)
         + check_contract_governance(root)
         + check_operational_assurance(root)
+        + check_execution_packets(root)
         + check_conflict_markers(root)
     )
 

--- a/scripts/validate_execution_packets.py
+++ b/scripts/validate_execution_packets.py
@@ -1,0 +1,221 @@
+"""Validate Conductor implementation packets without executing packet commands."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+TASK_ID = re.compile(r"^(?:T\d+\.\d+|CLOSE\.\d+)$")
+RESULT_STATES = {"pending", "passed", "failed", "blocked"}
+REQUIRED = {
+    "schema_version",
+    "track_id",
+    "source_baseline",
+    "preparation_state",
+    "execution_state",
+    "delivery_repository",
+    "read_before_start",
+    "input_sha256",
+    "reserved_implementation_files",
+    "phases",
+}
+
+
+def _error(message: str) -> ValueError:
+    return ValueError(message)
+
+
+def _safe_relative(root: Path, value: Any, label: str) -> Path:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise _error(f"{label} must be a non-empty relative path")
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise _error(f"{label} escapes repository root: {value}")
+    candidate = root / path
+    try:
+        candidate.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise _error(f"{label} escapes repository root: {value}") from exc
+    if candidate.is_symlink():
+        try:
+            candidate.resolve().relative_to(root.resolve())
+        except ValueError as exc:
+            raise _error(f"{label} follows an escaping symlink: {value}") from exc
+    return path
+
+
+def _plan_task_ids(track_dir: Path) -> set[str]:
+    plan = track_dir / "plan.md"
+    if not plan.is_file():
+        return set()
+    return set(re.findall(r"\b(?:T\d+\.\d+|CLOSE\.\d+)\b", plan.read_text()))
+
+
+def validate_packet(
+    packet: dict[str, Any],
+    root: Path,
+    *,
+    require_ready: bool = False,
+    changed_paths: list[str] | None = None,
+) -> list[str]:
+    """Return deterministic validation errors for one packet."""
+    errors: list[str] = []
+    missing = sorted(REQUIRED - packet.keys())
+    if missing:
+        errors.append("missing required fields: " + ", ".join(missing))
+        return errors
+    if packet.get("schema_version") != "1.0":
+        errors.append("unsupported schema_version")
+    track_id = packet.get("track_id")
+    if not isinstance(track_id, str) or not re.fullmatch(r"[a-z0-9_]+", track_id):
+        errors.append("track_id is invalid")
+    if packet.get("source_baseline") and not re.fullmatch(
+        r"[0-9a-f]{40}", str(packet["source_baseline"])
+    ):
+        errors.append("source_baseline must be a 40-character commit SHA")
+    for field in ("read_before_start", "reserved_implementation_files"):
+        values = packet.get(field)
+        if not isinstance(values, list):
+            errors.append(f"{field} must be a list")
+            continue
+        for value in values:
+            try:
+                _safe_relative(root, value, field)
+            except ValueError as exc:
+                errors.append(str(exc))
+    hashes = packet.get("input_sha256")
+    if not isinstance(hashes, dict):
+        errors.append("input_sha256 must be an object")
+    else:
+        for name, expected in hashes.items():
+            try:
+                relative = _safe_relative(root, name, "input_sha256 path")
+            except ValueError as exc:
+                errors.append(str(exc))
+                continue
+            if not isinstance(expected, str) or not re.fullmatch(
+                r"[0-9a-f]{64}", expected
+            ):
+                errors.append(f"invalid SHA-256 for {name}")
+                continue
+            path = root / relative
+            if not path.is_file():
+                errors.append(f"input file is missing: {name}")
+                continue
+            actual = hashlib.sha256(path.read_bytes()).hexdigest()
+            if actual != expected:
+                errors.append(f"stale baseline hash: {name}")
+    phases = packet.get("phases")
+    ids: list[str] = []
+    dependencies: dict[str, list[str]] = {}
+    if not isinstance(phases, list):
+        errors.append("phases must be a list")
+    else:
+        known = _plan_task_ids(root / "conductor" / "tracks" / str(track_id))
+        for phase in phases:
+            if not isinstance(phase, dict):
+                errors.append("each phase must be an object")
+                continue
+            task_ids = phase.get("task_ids")
+            if not isinstance(task_ids, list):
+                errors.append("phase task_ids must be a list")
+                continue
+            for task_id in task_ids:
+                if not isinstance(task_id, str) or not TASK_ID.fullmatch(task_id):
+                    errors.append(f"unknown task ID: {task_id}")
+                    continue
+                if task_id in ids:
+                    errors.append(f"duplicate task ID: {task_id}")
+                ids.append(task_id)
+                if known and task_id not in known:
+                    errors.append(f"unknown task ID: {task_id}")
+            dependencies.update(
+                {str(k): list(v) for k, v in phase.get("dependencies", {}).items()}
+                if isinstance(phase.get("dependencies", {}), dict)
+                else {}
+            )
+        all_ids = set(ids)
+        for deps in dependencies.values():
+            for dep in deps:
+                if dep not in all_ids:
+                    errors.extend([f"dependency references unknown task ID: {dep}"])
+        visiting: set[str] = set()
+        visited: set[str] = set()
+
+        def visit(node: str) -> None:
+            if node in visiting:
+                errors.append("dependency cycle detected")
+                return
+            if node in visited:
+                return
+            visiting.add(node)
+            for dep in dependencies.get(node, []):
+                visit(dep)
+            visiting.remove(node)
+            visited.add(node)
+
+        for task_id in ids:
+            visit(task_id)
+    if require_ready:
+        if packet.get("execution_state") != "ready_for_preflight":
+            errors.append("packet is not ready_for_preflight")
+        prerequisites = packet.get("prerequisite_tracks", [])
+        if not isinstance(prerequisites, list):
+            errors.append("prerequisite_tracks must be a list")
+        for prerequisite in prerequisites if isinstance(prerequisites, list) else []:
+            if (
+                not isinstance(prerequisite, dict)
+                or prerequisite.get("result_status") != "passed"
+                or not prerequisite.get("evidence")
+            ):
+                errors.extend(["pending or failed prerequisite lacks passing evidence"])
+    for value in (
+        packet.get("result_states", [])
+        if isinstance(packet.get("result_states", []), list)
+        else []
+    ):
+        if value not in RESULT_STATES:
+            errors.extend([f"unsupported result state: {value}"])
+    if changed_paths:
+        allowed = set(packet.get("reserved_implementation_files", []))
+        for changed in changed_paths:
+            try:
+                relative = _safe_relative(root, changed, "changed path").as_posix()
+            except ValueError as exc:
+                errors.append(str(exc))
+                continue
+            if relative not in allowed:
+                errors.append(f"out-of-scope changed path: {relative}")
+    return sorted(set(errors))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate one packet and return a process status."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packet", type=Path)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--require-ready", action="store_true")
+    parser.add_argument("--changed-file", action="append", default=[])
+    args = parser.parse_args(argv)
+    try:
+        packet = json.loads(args.packet.read_text(encoding="utf-8"))
+        errors = validate_packet(
+            packet,
+            args.repo_root.resolve(),
+            require_ready=args.require_ready,
+            changed_paths=args.changed_file,
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        errors = [str(exc)]
+    for error in errors:
+        print(error, file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_execution_packets.py
+++ b/tests/test_execution_packets.py
@@ -1,0 +1,90 @@
+"""Tests for fail-closed Conductor packet validation."""
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_execution_packets import validate_packet
+
+ROOT = Path(__file__).parents[1]
+PACKET_PATH = (
+    ROOT / "conductor/tracks/execution_packet_guard_20260907/implementation-packet.json"
+)
+
+
+@pytest.fixture
+def packet() -> dict:
+    return json.loads(PACKET_PATH.read_text(encoding="utf-8"))
+
+
+def test_real_packet_preserves_track_identity(packet: dict) -> None:
+    assert validate_packet(packet, ROOT) == []
+    assert packet["track_id"] == "execution_packet_guard_20260907"
+    assert packet["delivery_repository"] == "edithatogo/voiage"
+
+
+@pytest.mark.parametrize(
+    "field", ["schema_version", "track_id", "phases", "input_sha256"]
+)
+def test_missing_required_field_is_rejected(packet: dict, field: str) -> None:
+    packet.pop(field)
+    assert any(
+        "missing required fields" in error for error in validate_packet(packet, ROOT)
+    )
+
+
+def test_unknown_and_duplicate_task_ids_are_rejected(packet: dict) -> None:
+    packet["phases"][0]["task_ids"] = ["T1.1", "T1.1", "T99.9"]
+    errors = validate_packet(packet, ROOT)
+    assert any("duplicate task ID" in error for error in errors)
+    assert any("unknown task ID" in error for error in errors)
+
+
+def test_dependency_cycle_is_rejected(packet: dict) -> None:
+    packet["phases"][0]["dependencies"] = {"T1.1": ["T1.2"], "T1.2": ["T1.1"]}
+    errors = validate_packet(packet, ROOT)
+    assert "dependency cycle detected" in errors
+
+
+@pytest.mark.parametrize("path", ["/var/voiage-outside", "../outside"])
+def test_escaping_changed_path_is_rejected_without_mutation(
+    packet: dict, path: str
+) -> None:
+    before = copy.deepcopy(packet)
+    assert validate_packet(packet, ROOT, changed_paths=[path])
+    assert packet == before
+
+
+def test_out_of_scope_staged_unstaged_or_untracked_path_is_rejected(
+    packet: dict,
+) -> None:
+    errors = validate_packet(packet, ROOT, changed_paths=["roadmap.md", "new-file.py"])
+    assert any("out-of-scope changed path" in error for error in errors)
+
+
+def test_stale_hash_and_unsupported_result_state_are_rejected(packet: dict) -> None:
+    packet["input_sha256"]["scripts/repo_harness.py"] = "0" * 64
+    packet["result_states"] = ["unknown"]
+    errors = validate_packet(packet, ROOT)
+    assert any("stale baseline hash" in error for error in errors)
+    assert "unsupported result state: unknown" in errors
+
+
+def test_pending_prerequisite_cannot_authorize_ready_packet(packet: dict) -> None:
+    packet["prerequisite_tracks"] = [
+        {"track_id": "upstream", "result_status": "pending"}
+    ]
+    assert validate_packet(packet, ROOT, require_ready=True)
+
+
+def test_no_commands_are_executed_by_validation(
+    packet: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import subprocess
+
+    monkeypatch.setattr(
+        subprocess, "run", lambda *args, **kwargs: pytest.fail("command executed")
+    )
+    assert validate_packet(packet, ROOT) == []

--- a/todo.md
+++ b/todo.md
@@ -4,6 +4,9 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 ## To Do
 
+- [ ] Ordered implementation tracks: `conductor/tracks/agent_safe_engineering_20260907/`, `conductor/tracks/execution_packet_guard_20260907/`, `conductor/tracks/version_identity_contracts_20260907/`, `conductor/tracks/native_structured_logging_20260907/`, `conductor/tracks/logging_privacy_resilience_20260907/`, `conductor/tracks/vop_logging_version_pilot_20260907/`, and `conductor/tracks/optional_native_telemetry_20260907/`.
+- [ ] Existing active delivery tracks: `conductor/tracks/remaining_backlog_delivery_20260831/` and `conductor/tracks/v2_2_release_and_venue_submissions_20260830/`.
+
 *   [x] Advance the fourteen open issue deliverables with source-bound agent
     review, current venue inputs, upstream Julia delivery, guarded HPC retry
     and security/badge evidence in `docs/release/issue-deliverables-20260906.md`.
@@ -1317,3 +1320,17 @@ as recorded in the active task above; earlier route decisions below are historic
         from one coherent programme-adoption model for the arXiv manuscript.
 *   **[NMA]** Began the Network Meta-Analysis VOI implementation.
     *   Added the `voiage/methods/network_nma.py` workflow and supporting schema/tests.
+
+## Planned engineering improvements (2026-09-07)
+
+- [ ] Start G01.1 in `conductor/tracks/agent_safe_engineering_20260907/plan.md`: confirm repository allocations and conductor-next reuse, then freeze the Voiage drift-validator profile before implementation.
+- [ ] Follow G02–G08 only when their packet prerequisites and file reservations are satisfied. Existing active backlog/venue work retains its ownership.
+
+- [ ] Execute the logging/versioning sequence only after packet readiness: execution guard, version identities, native logging, privacy/resilience, VOP pilot, then optional telemetry. Canonical tasks: `conductor/tracks/agent_safe_engineering_20260907/orchestration.md`.
+
+- [ ] Begin prepared implementation at `execution_packet_guard_20260907/START_HERE.md`; use the active-track readiness matrix for all dependent and externally gated work.
+- [ ] Continue in order with `conductor/tracks/version_identity_contracts_20260907/`.
+- [ ] Continue in order with `conductor/tracks/native_structured_logging_20260907/`.
+- [ ] Continue in order with `conductor/tracks/logging_privacy_resilience_20260907/`.
+- [ ] Continue in order with `conductor/tracks/vop_logging_version_pilot_20260907/`.
+- [ ] Continue in order with `conductor/tracks/optional_native_telemetry_20260907/`.


### PR DESCRIPTION
## Summary
- add fail-closed Conductor implementation-packet validation
- reject schema, dependency, path-scope, stale-hash, readiness, and result-state drift
- integrate validation into the repository harness with focused contract tests

## Validation
- `python3 scripts/repo_harness.py`
- `python3 -m pytest tests/test_execution_packets.py tests/test_repo_harness.py -q`
- `uv run --with 'ruff>=0.15.22,<0.16' ruff check scripts/validate_execution_packets.py scripts/repo_harness.py tests/test_execution_packets.py tests/test_repo_harness.py`
- `python3 /Users/doughnut/.codex/skills/conductor/scripts/validate_conductor.py --root . --mode full --json`

The broader tox matrix has unrelated pre-existing registry and docs-tooling failures recorded in the review evidence.
