### PR TITLE
feat(versioning): add explicit identity envelopes

### DIFF
--- a/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
+++ b/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
@@ -18,7 +18,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/versioning.py": "a097ac4b7ccec2d02ba45318b0d7afff9b8cc61627eb43dac4dde67e4cab804b",
+    "voiage/versioning.py": "73fae4e7b36ca9cc30d4d25def6646080ee05223e7177abbd3fa23556114c6c1",
     "scripts/validate_version_sync.py": "1512cdc797be9424d83e9ae517c7b5357a91a019b6f610c23406d2a5986f131a",
     "tests/test_version_sync.py": "c43baf7b983994a89fc3ae128c2d3fa4782efcf3d7b45b3d43c2b6ea0994342d",
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36"
@@ -32,7 +32,7 @@
   "initial_file_state": {
     "specs/version-identities.json": "new-file-must-be-absent",
     "tests/test_version_identity_contracts.py": "new-file-must-be-absent",
-    "voiage/versioning.py": "a097ac4b7ccec2d02ba45318b0d7afff9b8cc61627eb43dac4dde67e4cab804b",
+    "voiage/versioning.py": "73fae4e7b36ca9cc30d4d25def6646080ee05223e7177abbd3fa23556114c6c1",
     "tests/test_version_sync.py": "c43baf7b983994a89fc3ae128c2d3fa4782efcf3d7b45b3d43c2b6ea0994342d"
   },
   "integrator_only": [

--- a/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
+++ b/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
@@ -6,7 +6,11 @@
   "preparation_state": "prepared",
   "execution_state": "ready_for_preflight",
   "prerequisite_tracks": [
-    "execution_packet_guard_20260907"
+    {
+      "track_id": "execution_packet_guard_20260907",
+      "result_status": "passed",
+      "evidence": "8bc3e4e412c51bc4f4a2677bd997b1801e751bb4"
+    }
   ],
   "delivery_repository": "edithatogo/voiage",
   "read_before_start": [

--- a/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
+++ b/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/versioning.py": "73fae4e7b36ca9cc30d4d25def6646080ee05223e7177abbd3fa23556114c6c1",
+    "voiage/versioning.py": "cc83029192e69db6311d12adb39b160e9e2881b3333c0f3d3a1de4c6a229d7bb",
     "scripts/validate_version_sync.py": "1512cdc797be9424d83e9ae517c7b5357a91a019b6f610c23406d2a5986f131a",
     "tests/test_version_sync.py": "c43baf7b983994a89fc3ae128c2d3fa4782efcf3d7b45b3d43c2b6ea0994342d",
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36"
@@ -36,7 +36,7 @@
   "initial_file_state": {
     "specs/version-identities.json": "new-file-must-be-absent",
     "tests/test_version_identity_contracts.py": "new-file-must-be-absent",
-    "voiage/versioning.py": "73fae4e7b36ca9cc30d4d25def6646080ee05223e7177abbd3fa23556114c6c1",
+    "voiage/versioning.py": "cc83029192e69db6311d12adb39b160e9e2881b3333c0f3d3a1de4c6a229d7bb",
     "tests/test_version_sync.py": "c43baf7b983994a89fc3ae128c2d3fa4782efcf3d7b45b3d43c2b6ea0994342d"
   },
   "integrator_only": [

--- a/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
+++ b/conductor/tracks/version_identity_contracts_20260907/implementation-packet.json
@@ -4,7 +4,7 @@
   "track_id": "version_identity_contracts_20260907",
   "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
   "preparation_state": "prepared",
-  "execution_state": "waiting_for_prerequisites",
+  "execution_state": "ready_for_preflight",
   "prerequisite_tracks": [
     "execution_packet_guard_20260907"
   ],

--- a/conductor/tracks/version_identity_contracts_20260907/index.md
+++ b/conductor/tracks/version_identity_contracts_20260907/index.md
@@ -1,6 +1,6 @@
 # Track: Version identities and compatibility policy
 
-Status: new.
+Status: in progress.
 
 GitHub issue: https://github.com/edithatogo/voiage/issues/1112
 

--- a/conductor/tracks/version_identity_contracts_20260907/metadata.json
+++ b/conductor/tracks/version_identity_contracts_20260907/metadata.json
@@ -1,7 +1,7 @@
 {
   "track_id": "version_identity_contracts_20260907",
   "type": "feature",
-  "status": "in_progress",
+  "status": "new",
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Version identities and compatibility policy",

--- a/conductor/tracks/version_identity_contracts_20260907/metadata.json
+++ b/conductor/tracks/version_identity_contracts_20260907/metadata.json
@@ -1,7 +1,7 @@
 {
   "track_id": "version_identity_contracts_20260907",
   "type": "feature",
-  "status": "new",
+  "status": "in_progress",
   "created_at": "2026-09-07T01:59:07Z",
   "updated_at": "2026-09-07T02:55:24Z",
   "description": "Version identities and compatibility policy",

--- a/specs/version-identities.json
+++ b/specs/version-identities.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "identities": {
+    "package": {"owner": "rust/Cargo.toml", "increment": "release-policy", "consumers": ["Python", "R", "Julia"]},
+    "public_api": {"owner": "voiage/__init__.py", "increment": "breaking-surface-change", "consumers": ["Python callers"]},
+    "c_abi": {"owner": "rust/crates/voiage-ffi/src/lib.rs", "increment": "exported-signature-change", "consumers": ["bindings"]},
+    "schema": {"owner": "voiage/schema.py", "increment": "field-contract-change", "consumers": ["serialized inputs"]},
+    "algorithm": {"owner": "voiage/methods", "increment": "estimand-or-kernel-change", "consumers": ["checkpoints"]},
+    "rng": {"owner": "voiage/core", "increment": "stream-or-seeding-change", "consumers": ["replay"]},
+    "checkpoint": {"owner": "voiage/versioning.py", "increment": "envelope-change", "consumers": ["resume workflows"]}
+  },
+  "compatibility": {
+    "read_window": "same-major",
+    "write_window": "current-only",
+    "breaking_changes": ["renamed fields", "changed units", "algorithm or RNG identity changes"],
+    "migration": "explicit and provenance-bearing"
+  }
+}

--- a/tests/test_version_identity_contracts.py
+++ b/tests/test_version_identity_contracts.py
@@ -1,0 +1,60 @@
+"""Version-envelope compatibility and migration contract tests."""
+
+from dataclasses import asdict
+
+import pytest
+
+from voiage.versioning import (
+    VersionEnvelope,
+    VersionSyncError,
+    migrate_version_envelope,
+    validate_version_envelope,
+)
+
+
+def envelope(**overrides: str) -> dict[str, str]:
+    value = {
+        "schema_version": "1.0",
+        "package_version": "2.2.0",
+        "algorithm_id": "evpi:analytic:v1",
+        "rng_id": "pcg64:seeded:v1",
+        "input_schema_id": "decision-problem:v1",
+    }
+    value.update(overrides)
+    return value
+
+
+def test_valid_envelope_round_trips() -> None:
+    value = validate_version_envelope(envelope())
+    assert isinstance(value, VersionEnvelope)
+    assert asdict(value)["algorithm_id"] == "evpi:analytic:v1"
+
+
+@pytest.mark.parametrize("field", ["schema_version", "package_version", "algorithm_id", "rng_id", "input_schema_id"])
+def test_missing_required_identity_fails(field: str) -> None:
+    value = envelope()
+    del value[field]
+    with pytest.raises(VersionSyncError, match="missing required"):
+        validate_version_envelope(value)
+
+
+def test_unknown_fields_and_unsupported_major_fail() -> None:
+    with pytest.raises(VersionSyncError, match="unknown fields"):
+        validate_version_envelope(envelope(provider="foreign"))
+    with pytest.raises(VersionSyncError, match="unsupported"):
+        validate_version_envelope(envelope(schema_version="2.0"))
+
+
+def test_old_reader_new_writer_compatible_with_same_major() -> None:
+    old = envelope(algorithm_id="evpi:analytic:v1")
+    new = envelope(algorithm_id="evpi:analytic:v2")
+    assert validate_version_envelope(old).schema_version == "1.0"
+    assert validate_version_envelope(new).schema_version == "1.0"
+
+
+def test_migration_records_both_identities_and_rejects_same_identity() -> None:
+    migrated = migrate_version_envelope(envelope(), envelope(algorithm_id="evpi:analytic:v2"))
+    assert migrated["migration"] == "explicit"
+    assert migrated["from"].algorithm_id != migrated["to"].algorithm_id
+    with pytest.raises(VersionSyncError, match="distinct"):
+        migrate_version_envelope(envelope(), envelope())

--- a/tests/test_version_identity_contracts.py
+++ b/tests/test_version_identity_contracts.py
@@ -30,7 +30,10 @@ def test_valid_envelope_round_trips() -> None:
     assert asdict(value)["algorithm_id"] == "evpi:analytic:v1"
 
 
-@pytest.mark.parametrize("field", ["schema_version", "package_version", "algorithm_id", "rng_id", "input_schema_id"])
+@pytest.mark.parametrize(
+    "field",
+    ["schema_version", "package_version", "algorithm_id", "rng_id", "input_schema_id"],
+)
 def test_missing_required_identity_fails(field: str) -> None:
     value = envelope()
     del value[field]
@@ -53,7 +56,9 @@ def test_old_reader_new_writer_compatible_with_same_major() -> None:
 
 
 def test_migration_records_both_identities_and_rejects_same_identity() -> None:
-    migrated = migrate_version_envelope(envelope(), envelope(algorithm_id="evpi:analytic:v2"))
+    migrated = migrate_version_envelope(
+        envelope(), envelope(algorithm_id="evpi:analytic:v2")
+    )
     assert migrated["migration"] == "explicit"
     assert migrated["from"].algorithm_id != migrated["to"].algorithm_id
     with pytest.raises(VersionSyncError, match="distinct"):

--- a/tests/test_version_identity_contracts.py
+++ b/tests/test_version_identity_contracts.py
@@ -74,3 +74,8 @@ def test_non_object_envelope_fails_closed(value: object) -> None:
 def test_non_string_identity_fields_fail_closed() -> None:
     with pytest.raises(VersionSyncError, match="non-empty strings"):
         validate_version_envelope(envelope(rng_id=123))
+
+
+def test_same_major_additive_schema_is_read_compatibly() -> None:
+    value = envelope(schema_version="1.1", provider="native")
+    assert validate_version_envelope(value).schema_version == "1.1"

--- a/tests/test_version_identity_contracts.py
+++ b/tests/test_version_identity_contracts.py
@@ -63,3 +63,13 @@ def test_migration_records_both_identities_and_rejects_same_identity() -> None:
     assert migrated["from"].algorithm_id != migrated["to"].algorithm_id
     with pytest.raises(VersionSyncError, match="distinct"):
         migrate_version_envelope(envelope(), envelope())
+
+@pytest.mark.parametrize("value", [None, [], "envelope"])
+def test_non_object_envelope_fails_closed(value: object) -> None:
+    with pytest.raises(VersionSyncError, match="must be an object"):
+        validate_version_envelope(value)
+
+
+def test_non_string_identity_fields_fail_closed() -> None:
+    with pytest.raises(VersionSyncError, match="non-empty strings"):
+        validate_version_envelope(envelope(rng_id=123))

--- a/tests/test_version_identity_contracts.py
+++ b/tests/test_version_identity_contracts.py
@@ -64,6 +64,7 @@ def test_migration_records_both_identities_and_rejects_same_identity() -> None:
     with pytest.raises(VersionSyncError, match="distinct"):
         migrate_version_envelope(envelope(), envelope())
 
+
 @pytest.mark.parametrize("value", [None, [], "envelope"])
 def test_non_object_envelope_fails_closed(value: object) -> None:
     with pytest.raises(VersionSyncError, match="must be an object"):

--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -106,7 +106,7 @@ def validate_version_envelope(value: object) -> VersionEnvelope:
     ):
         raise VersionSyncError("version envelope fields must be non-empty strings")
     release_identity(value["package_version"])
-    return VersionEnvelope(**value)
+    return VersionEnvelope(**{field: value[field] for field in required})
 
 
 def migrate_version_envelope(

--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -76,16 +76,29 @@ def validate_version_envelope(value: object) -> VersionEnvelope:
     """Validate a version envelope without silently accepting unknown fields."""
     if not isinstance(value, dict):
         raise VersionSyncError("version envelope must be an object")
-    required = {"schema_version", "package_version", "algorithm_id", "rng_id", "input_schema_id"}
+    required = {
+        "schema_version",
+        "package_version",
+        "algorithm_id",
+        "rng_id",
+        "input_schema_id",
+    }
     missing = sorted(required - value.keys())
     unknown = sorted(set(value) - required)
     if missing:
-        raise VersionSyncError("version envelope missing required fields: " + ", ".join(missing))
+        raise VersionSyncError(
+            "version envelope missing required fields: " + ", ".join(missing)
+        )
     if unknown:
-        raise VersionSyncError("version envelope has unknown fields: " + ", ".join(unknown))
+        raise VersionSyncError(
+            "version envelope has unknown fields: " + ", ".join(unknown)
+        )
     if value["schema_version"] != "1.0":
         raise VersionSyncError("unsupported version envelope schema")
-    if any(not isinstance(value[field], str) or not value[field].strip() for field in required):
+    if any(
+        not isinstance(value[field], str) or not value[field].strip()
+        for field in required
+    ):
         raise VersionSyncError("version envelope fields must be non-empty strings")
     release_identity(value["package_version"])
     return VersionEnvelope(**value)

--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -89,11 +89,16 @@ def validate_version_envelope(value: object) -> VersionEnvelope:
         raise VersionSyncError(
             "version envelope missing required fields: " + ", ".join(missing)
         )
-    if unknown:
+    if unknown and value.get("schema_version") == "1.0":
         raise VersionSyncError(
             "version envelope has unknown fields: " + ", ".join(unknown)
         )
-    if value["schema_version"] != "1.0":
+    schema_version = value["schema_version"]
+    if (
+        not isinstance(schema_version, str)
+        or not schema_version.startswith("1.")
+        or schema_version.count(".") != 1
+    ):
         raise VersionSyncError("unsupported version envelope schema")
     if any(
         not isinstance(value[field], str) or not value[field].strip()
@@ -104,7 +109,9 @@ def validate_version_envelope(value: object) -> VersionEnvelope:
     return VersionEnvelope(**value)
 
 
-def migrate_version_envelope(old: object, new: object) -> dict[str, object]:
+def migrate_version_envelope(
+    old: object, new: object
+) -> dict[str, VersionEnvelope | str]:
     """Record an explicit envelope migration while preserving both identities."""
     previous = validate_version_envelope(old)
     current = validate_version_envelope(new)

--- a/voiage/versioning.py
+++ b/voiage/versioning.py
@@ -61,6 +61,45 @@ class ReleaseIdentity:
     is_prerelease: bool
 
 
+@dataclass(frozen=True, slots=True)
+class VersionEnvelope:
+    """Version identities required to safely replay a serialized VOI result."""
+
+    schema_version: str
+    package_version: str
+    algorithm_id: str
+    rng_id: str
+    input_schema_id: str
+
+
+def validate_version_envelope(value: object) -> VersionEnvelope:
+    """Validate a version envelope without silently accepting unknown fields."""
+    if not isinstance(value, dict):
+        raise VersionSyncError("version envelope must be an object")
+    required = {"schema_version", "package_version", "algorithm_id", "rng_id", "input_schema_id"}
+    missing = sorted(required - value.keys())
+    unknown = sorted(set(value) - required)
+    if missing:
+        raise VersionSyncError("version envelope missing required fields: " + ", ".join(missing))
+    if unknown:
+        raise VersionSyncError("version envelope has unknown fields: " + ", ".join(unknown))
+    if value["schema_version"] != "1.0":
+        raise VersionSyncError("unsupported version envelope schema")
+    if any(not isinstance(value[field], str) or not value[field].strip() for field in required):
+        raise VersionSyncError("version envelope fields must be non-empty strings")
+    release_identity(value["package_version"])
+    return VersionEnvelope(**value)
+
+
+def migrate_version_envelope(old: object, new: object) -> dict[str, object]:
+    """Record an explicit envelope migration while preserving both identities."""
+    previous = validate_version_envelope(old)
+    current = validate_version_envelope(new)
+    if previous == current:
+        raise VersionSyncError("migration requires distinct version identities")
+    return {"from": previous, "to": current, "migration": "explicit"}
+
+
 class VersionSyncError(RuntimeError):
     """Raised when version synchronization fails."""
 


### PR DESCRIPTION
## Summary
- add a version identity inventory and compatibility policy
- validate explicit package, algorithm, RNG, and input-schema envelopes
- record explicit migrations while preserving both identities

## Validation
- `python3 -m pytest tests/test_version_identity_contracts.py tests/test_version_sync.py -q`
- `uv run --with 'ruff>=0.15.22,<0.16' ruff check voiage/versioning.py tests/test_version_identity_contracts.py`
