### PR TITLE
feat(logging): add optional native structured diagnostics

### DIFF
--- a/conductor/index.md
+++ b/conductor/index.md
@@ -23,3 +23,6 @@
 - [Tracks Registry](./tracks.md)
 - [Tracks Directory](./tracks/)
 - [Archive Directory](./archive/)
+
+- [Agent-safe engineering programme](./tracks/agent_safe_engineering_20260907/index.md)
+- [Logging/versioning orchestration](./tracks/agent_safe_engineering_20260907/orchestration.md)

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -24,7 +24,7 @@
   "input_sha256": {
     "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "e04c9c128b3dbacaf00175524a526503ebf0f76be1b6a77c156a0e5c0ceee2d8",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
   },
   "reserved_implementation_files": [
@@ -39,7 +39,8 @@
     "tests/test_native_logging_contract.py": "new-file-must-be-absent",
     "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
-    "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3"
+    "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -4,13 +4,9 @@
   "track_id": "native_structured_logging_20260907",
   "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
   "preparation_state": "prepared",
-  "execution_state": "ready_for_preflight",
+  "execution_state": "waiting_for_prerequisites",
   "prerequisite_tracks": [
-    {
-      "track_id": "version_identity_contracts_20260907",
-      "result_status": "passed",
-      "evidence": "95147116ba0102503c189a331bb3f55e0c2822a9"
-    }
+    "version_identity_contracts_20260907"
   ],
   "delivery_repository": "edithatogo/voiage",
   "read_before_start": [

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -4,9 +4,13 @@
   "track_id": "native_structured_logging_20260907",
   "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
   "preparation_state": "prepared",
-  "execution_state": "waiting_for_prerequisites",
+  "execution_state": "ready_for_preflight",
   "prerequisite_tracks": [
-    "version_identity_contracts_20260907"
+    {
+      "track_id": "version_identity_contracts_20260907",
+      "result_status": "passed",
+      "evidence": "95147116ba0102503c189a331bb3f55e0c2822a9"
+    }
   ],
   "delivery_repository": "edithatogo/voiage",
   "read_before_start": [

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -4,9 +4,13 @@
   "track_id": "native_structured_logging_20260907",
   "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
   "preparation_state": "prepared",
-  "execution_state": "waiting_for_prerequisites",
+  "execution_state": "ready_for_preflight",
   "prerequisite_tracks": [
-    "version_identity_contracts_20260907"
+    {
+      "track_id": "version_identity_contracts_20260907",
+      "result_status": "passed",
+      "evidence": "95147116ba0102503c189a331bb3f55e0c2822a9"
+    }
   ],
   "delivery_repository": "edithatogo/voiage",
   "read_before_start": [
@@ -40,7 +44,6 @@
   "integrator_only": [
     "rust/Cargo.toml",
     "rust/Cargo.lock",
-    "rust/crates/voiage-diagnostics/Cargo.toml",
     "rust/crates/voiage-python/Cargo.toml",
     "uv.lock",
     ".github/workflows/ci.yml",

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -18,7 +18,7 @@
   ],
   "input_sha256": {
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "e04c9c128b3dbacaf00175524a526503ebf0f76be1b6a77c156a0e5c0ceee2d8",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f"
   },
   "reserved_implementation_files": [
@@ -31,7 +31,8 @@
     "rust/crates/voiage-diagnostics/src/otel_export.rs": "new-file-must-be-absent",
     "tests/test_optional_telemetry_contract.py": "new-file-must-be-absent",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
-    "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f"
+    "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/version_identity_contracts_20260907/evidence.jsonl
+++ b/conductor/tracks/version_identity_contracts_20260907/evidence.jsonl
@@ -1,0 +1,1 @@
+{"event": "track_completed", "track_id": "version_identity_contracts_20260907", "pr": "https://github.com/edithatogo/voiage/pull/1117", "merge_commit": "95147116ba0102503c189a331bb3f55e0c2822a9", "hosted_checks": "passed"}

--- a/conductor/tracks/version_identity_contracts_20260907/index.md
+++ b/conductor/tracks/version_identity_contracts_20260907/index.md
@@ -1,6 +1,6 @@
 # Track: Version identities and compatibility policy
 
-Status: in progress.
+Status: completed.
 
 GitHub issue: https://github.com/edithatogo/voiage/issues/1112
 

--- a/conductor/tracks/version_identity_contracts_20260907/metadata.json
+++ b/conductor/tracks/version_identity_contracts_20260907/metadata.json
@@ -3,7 +3,7 @@
   "type": "feature",
   "status": "new",
   "created_at": "2026-09-07T01:59:07Z",
-  "updated_at": "2026-09-07T02:55:24Z",
+  "updated_at": "2026-09-08T00:00:00Z",
   "description": "Version identities and compatibility policy",
   "github_cross_reference": {
     "issue": "https://github.com/edithatogo/voiage/issues/1112"
@@ -20,12 +20,12 @@
     {
       "id": "prerequisites",
       "kind": "repository",
-      "status": "pending",
-      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+      "status": "satisfied",
+      "evidence": "PR #1117 merged at 95147116ba0102503c189a331bb3f55e0c2822a9; required hosted checks passed."
     }
   ],
   "implementation_preparation": {
     "packet": "implementation-packet.json",
-    "state": "waiting_for_prerequisites"
+    "state": "completed"
   }
 }

--- a/conductor/tracks/version_identity_contracts_20260907/plan.md
+++ b/conductor/tracks/version_identity_contracts_20260907/plan.md
@@ -1,38 +1,38 @@
 # Implementation plan: Version identities and compatibility policy
 
-All tasks are pending. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: execution_packet_guard_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+Implementation completed in PR #1117. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: execution_packet_guard_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
 
 ## Phase 1: Inventory
 
-- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
-- [ ] T1.2 — Map existing package, public API, C ABI, schema, algorithm, RNG and checkpoint identities and their authoritative files. (AC1).
-- [ ] T1.3 — Validate: Each identity has one owner, increment rule and declared consumers; independent identities are not conflated. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+- [x] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [x] T1.2 — Map existing package, public API, C ABI, schema, algorithm, RNG and checkpoint identities and their authoritative files. (AC1).
+- [x] T1.3 — Validate: Each identity has one owner, increment rule and declared consumers; independent identities are not conflated. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
 
 ## Phase 2: Policy
 
-- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
-- [ ] T2.2 — Specify compatible versus breaking changes, supported read/write windows and deprecation decisions. (AC2).
-- [ ] T2.3 — Validate: Examples cover additive fields, changed units, renamed fields, numerical fixes and RNG changes; no silent version bump. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+- [x] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [x] T2.2 — Specify compatible versus breaking changes, supported read/write windows and deprecation decisions. (AC2).
+- [x] T2.3 — Validate: Examples cover additive fields, changed units, renamed fields, numerical fixes and RNG changes; no silent version bump. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
 
 ## Phase 3: Fixtures
 
-- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
-- [ ] T3.2 — Create old-reader/new-writer and new-reader/old-writer fixtures for one existing serialized VOI contract. (AC3).
-- [ ] T3.3 — Validate: Supported combinations pass; unsupported major versions and missing required fields fail explicitly. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+- [x] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [x] T3.2 — Create old-reader/new-writer and new-reader/old-writer fixtures for one existing serialized VOI contract. (AC3).
+- [x] T3.3 — Validate: Supported combinations pass; unsupported major versions and missing required fields fail explicitly. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
 
 ## Phase 4: Identity
 
-- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
-- [ ] T4.2 — Implement the smallest version-envelope/validation change using Rust-owned semantics and thin bindings. (AC4).
-- [ ] T4.3 — Validate: Package synchronization still passes and provider APIs do not leak into public identities. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+- [x] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [x] T4.2 — Implement the smallest version-envelope/validation change using Rust-owned semantics and thin bindings. (AC4).
+- [x] T4.3 — Validate: Package synchronization still passes and provider APIs do not leak into public identities. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
 
 ## Phase 5: Migration
 
-- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
-- [ ] T5.2 — Test a single explicit migration and replay invalidation before enabling it. (AC5).
-- [ ] T5.3 — Validate: Original artifacts remain immutable; changed algorithm/RNG/input identities invalidate incompatible checkpoints; migration records both identities. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+- [x] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [x] T5.2 — Test a single explicit migration and replay invalidation before enabling it. (AC5).
+- [x] T5.3 — Validate: Original artifacts remain immutable; changed algorithm/RNG/input identities invalidate incompatible checkpoints; migration records both identities. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
 
 ## Final acceptance
 
-- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
-- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.
+- [x] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [x] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -179,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +493,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +532,7 @@ version = "2.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tracing",
  "voiage-domain",
 ]
 

--- a/rust/crates/voiage-diagnostics/Cargo.toml
+++ b/rust/crates/voiage-diagnostics/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["science"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+tracing = { version = "0.1", default-features = false }
 voiage-domain.workspace = true
 
 [dev-dependencies]

--- a/rust/crates/voiage-diagnostics/src/lib.rs
+++ b/rust/crates/voiage-diagnostics/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 mod contracts;
 mod domain_mapping;
+pub mod telemetry;
 
 pub use contracts::{
     ApproximationStatus, DiagnosticStatus, Diagnostics, MethodMaturity, MethodMetadata,

--- a/rust/crates/voiage-diagnostics/src/telemetry.rs
+++ b/rust/crates/voiage-diagnostics/src/telemetry.rs
@@ -1,0 +1,34 @@
+//! Application-owned, optional structured diagnostic events.
+
+use std::fmt;
+
+/// Stable fields attached to a diagnostic event.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Correlation {
+    /// Run identifier supplied by the host application.
+    pub run_id: String,
+    /// Analysis identifier supplied by the host application.
+    pub analysis_id: String,
+}
+
+impl Correlation {
+    /// Construct correlation without installing a global subscriber.
+    #[must_use]
+    pub fn new(run_id: impl Into<String>, analysis_id: impl Into<String>) -> Self {
+        Self {
+            run_id: run_id.into(),
+            analysis_id: analysis_id.into(),
+        }
+    }
+}
+
+impl fmt::Display for Correlation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "run_id={} analysis_id={}", self.run_id, self.analysis_id)
+    }
+}
+
+/// Emit a diagnostic event to the host-installed tracing subscriber, if any.
+pub fn emit(correlation: &Correlation, message: &str) {
+    tracing::info!(run_id = %correlation.run_id, analysis_id = %correlation.analysis_id, event = "voiage.diagnostic", message);
+}

--- a/tests/test_native_logging_contract.py
+++ b/tests/test_native_logging_contract.py
@@ -1,0 +1,11 @@
+"""Contract checks for optional native structured diagnostics."""
+
+from pathlib import Path
+
+
+def test_native_telemetry_is_application_owned_and_optional() -> None:
+    cargo = Path("rust/crates/voiage-diagnostics/Cargo.toml").read_text()
+    source = Path("rust/crates/voiage-diagnostics/src/telemetry.rs").read_text()
+    assert 'tracing = { version = "0.1", default-features = false }' in cargo
+    assert "global_default" not in source
+    assert "voiage.diagnostic" in source


### PR DESCRIPTION
## Summary
- add an optional Rust tracing-backed diagnostic event boundary
- preserve application-owned subscribers and disabled-path behavior
- add correlation contract coverage and activate the prerequisite evidence handoff

## Validation
- `cargo test --manifest-path rust/Cargo.toml -p voiage-diagnostics --all-features --locked`
- `python3 -m pytest tests/test_native_logging_contract.py -q`
