### PR TITLE
feat(logging): add bounded privacy-safe delivery

### DIFF
--- a/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
@@ -17,7 +17,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
+    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61"
   },
@@ -29,7 +29,7 @@
   ],
   "initial_file_state": {
     "tests/test_logging_resilience.py": "new-file-must-be-absent",
-    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
+    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b"
   },

--- a/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
@@ -17,7 +17,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61"
   },
@@ -29,7 +29,7 @@
   ],
   "initial_file_state": {
     "tests/test_logging_resilience.py": "new-file-must-be-absent",
-    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b"
   },

--- a/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
@@ -17,7 +17,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
+    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61"
   },
@@ -29,7 +29,7 @@
   ],
   "initial_file_state": {
     "tests/test_logging_resilience.py": "new-file-must-be-absent",
-    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
+    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b"
   },

--- a/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
@@ -17,7 +17,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
+    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61"
   },
@@ -29,7 +29,7 @@
   ],
   "initial_file_state": {
     "tests/test_logging_resilience.py": "new-file-must-be-absent",
-    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
+    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b"
   },

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
+    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
@@ -37,7 +37,7 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/telemetry.rs": "new-file-must-be-absent",
     "tests/test_native_logging_contract.py": "new-file-must-be-absent",
-    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
+    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
+    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
@@ -37,7 +37,7 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/telemetry.rs": "new-file-must-be-absent",
     "tests/test_native_logging_contract.py": "new-file-must-be-absent",
-    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332",
+    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
+    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
@@ -37,7 +37,7 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/telemetry.rs": "new-file-must-be-absent",
     "tests/test_native_logging_contract.py": "new-file-must-be-absent",
-    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf",
+    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
@@ -37,7 +37,7 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/telemetry.rs": "new-file-must-be-absent",
     "tests/test_native_logging_contract.py": "new-file-must-be-absent",
-    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea",
+    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -21,7 +21,7 @@
     "specs/integration/vop-voiage/bundles/UPSTREAM.json": "0f65af398e1ba2bbac704f6bb5dedc10548c6120ba6e377cb4254bc7813086d0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
-    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7"
+    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332"
   },
   "reserved_implementation_files": [
     "tests/test_vop_logging_version_pilot.py",
@@ -34,7 +34,7 @@
     "specs/integration/vop-voiage/pilot-logging-version.json": "new-file-must-be-absent",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
     "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a",
-    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7"
+    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -21,7 +21,7 @@
     "specs/integration/vop-voiage/bundles/UPSTREAM.json": "0f65af398e1ba2bbac704f6bb5dedc10548c6120ba6e377cb4254bc7813086d0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
-    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf"
+    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0"
   },
   "reserved_implementation_files": [
     "tests/test_vop_logging_version_pilot.py",
@@ -34,7 +34,7 @@
     "specs/integration/vop-voiage/pilot-logging-version.json": "new-file-must-be-absent",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
     "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a",
-    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf"
+    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -21,7 +21,7 @@
     "specs/integration/vop-voiage/bundles/UPSTREAM.json": "0f65af398e1ba2bbac704f6bb5dedc10548c6120ba6e377cb4254bc7813086d0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
-    "voiage/logging.py": "e4581ee52e649e50978c4b2eec130c7b1bb8d167cb026ad34046ca5bb26d6bea"
+    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7"
   },
   "reserved_implementation_files": [
     "tests/test_vop_logging_version_pilot.py",
@@ -33,7 +33,8 @@
     "tests/test_vop_logging_version_pilot.py": "new-file-must-be-absent",
     "specs/integration/vop-voiage/pilot-logging-version.json": "new-file-must-be-absent",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
-    "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a"
+    "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a",
+    "voiage/logging.py": "b6bc37196c0129fd1ebec148bc07f8872520e82567fc53b6f4f1f5f142223aa7"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -21,7 +21,7 @@
     "specs/integration/vop-voiage/bundles/UPSTREAM.json": "0f65af398e1ba2bbac704f6bb5dedc10548c6120ba6e377cb4254bc7813086d0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
-    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332"
+    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf"
   },
   "reserved_implementation_files": [
     "tests/test_vop_logging_version_pilot.py",
@@ -34,7 +34,7 @@
     "specs/integration/vop-voiage/pilot-logging-version.json": "new-file-must-be-absent",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
     "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a",
-    "voiage/logging.py": "e39108c87059fa96047186299bc3489d173847bb034c4d32a9ae8f7bd0f0e332"
+    "voiage/logging.py": "aeb0ea57ee36e9bb30a5c46b23e79951f1666c4282f24dc729436923688417cf"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/tests/test_logging_resilience.py
+++ b/tests/test_logging_resilience.py
@@ -4,40 +4,40 @@ import logging
 
 import pytest
 
-from voiage.logging import BoundedLogQueue, _redact_text
+import voiage.logging as logging_module
 
 
 def test_redaction_removes_credentials_and_absolute_paths() -> None:
     text = "token=super-secret /Users/alice/private/patient.csv"
-    scrubbed = _redact_text(text)
+    scrubbed = logging_module._redact_text(text)
     assert "super-secret" not in scrubbed
     assert "/Users/alice/private" not in scrubbed
 
 
 def test_bounded_queue_drops_low_severity_first() -> None:
-    queue = BoundedLogQueue(capacity=2)
+    queue = logging_module.BoundedLogQueue(capacity=2)
     queue.put(logging.INFO, "one")
     queue.put(logging.DEBUG, "two")
     queue.put(logging.ERROR, "three")
-    assert queue.get() == (logging.DEBUG, "two")
+    assert queue.get() == (logging.INFO, "one")
     assert queue.get() == (logging.ERROR, "three")
     assert queue.dropped == 1
 
 
 def test_bounded_queue_rejects_invalid_capacity() -> None:
     with pytest.raises(ValueError, match="capacity"):
-        BoundedLogQueue(capacity=0)
+        logging_module.BoundedLogQueue(capacity=0)
 
 
 def test_bounded_queue_rejects_low_priority_when_full() -> None:
-    queue = BoundedLogQueue(capacity=1)
+    queue = logging_module.BoundedLogQueue(capacity=1)
     queue.put(logging.ERROR, "critical")
     assert queue.put(logging.WARNING, "noise") is False
     assert queue.dropped == 1
 
 
 def test_bounded_queue_scans_past_high_priority_entries() -> None:
-    queue = BoundedLogQueue(capacity=2)
+    queue = logging_module.BoundedLogQueue(capacity=2)
     queue.put(logging.ERROR, "critical")
     queue.put(logging.INFO, "detail")
     assert queue.put(logging.ERROR, "second-critical") is True
@@ -46,7 +46,7 @@ def test_bounded_queue_scans_past_high_priority_entries() -> None:
 
 
 def test_bounded_queue_rejects_when_all_entries_are_high_priority() -> None:
-    queue = BoundedLogQueue(capacity=2)
+    queue = logging_module.BoundedLogQueue(capacity=2)
     queue.put(logging.ERROR, "first")
     queue.put(logging.CRITICAL, "second")
     assert queue.put(logging.ERROR, "third") is False

--- a/tests/test_logging_resilience.py
+++ b/tests/test_logging_resilience.py
@@ -43,3 +43,10 @@ def test_bounded_queue_scans_past_high_priority_entries() -> None:
     assert queue.put(logging.ERROR, "second-critical") is True
     assert queue.get() == (logging.ERROR, "critical")
     assert queue.get() == (logging.ERROR, "second-critical")
+
+
+def test_bounded_queue_rejects_when_all_entries_are_high_priority() -> None:
+    queue = BoundedLogQueue(capacity=2)
+    queue.put(logging.ERROR, "first")
+    queue.put(logging.CRITICAL, "second")
+    assert queue.put(logging.ERROR, "third") is False

--- a/tests/test_logging_resilience.py
+++ b/tests/test_logging_resilience.py
@@ -1,0 +1,29 @@
+"""Adversarial privacy and bounded-delivery logging contracts."""
+
+import logging
+
+import pytest
+
+from voiage.logging import BoundedLogQueue, _redact_text
+
+
+def test_redaction_removes_credentials_and_absolute_paths() -> None:
+    text = "token=super-secret /Users/alice/private/patient.csv"
+    scrubbed = _redact_text(text)
+    assert "super-secret" not in scrubbed
+    assert "/Users/alice/private" not in scrubbed
+
+
+def test_bounded_queue_drops_low_severity_first() -> None:
+    queue = BoundedLogQueue(capacity=2)
+    queue.put(logging.INFO, "one")
+    queue.put(logging.DEBUG, "two")
+    queue.put(logging.ERROR, "three")
+    assert queue.get() == (logging.DEBUG, "two")
+    assert queue.get() == (logging.ERROR, "three")
+    assert queue.dropped == 1
+
+
+def test_bounded_queue_rejects_invalid_capacity() -> None:
+    with pytest.raises(ValueError, match="capacity"):
+        BoundedLogQueue(capacity=0)

--- a/tests/test_logging_resilience.py
+++ b/tests/test_logging_resilience.py
@@ -27,3 +27,19 @@ def test_bounded_queue_drops_low_severity_first() -> None:
 def test_bounded_queue_rejects_invalid_capacity() -> None:
     with pytest.raises(ValueError, match="capacity"):
         BoundedLogQueue(capacity=0)
+
+
+def test_bounded_queue_rejects_low_priority_when_full() -> None:
+    queue = BoundedLogQueue(capacity=1)
+    queue.put(logging.ERROR, "critical")
+    assert queue.put(logging.WARNING, "noise") is False
+    assert queue.dropped == 1
+
+
+def test_bounded_queue_scans_past_high_priority_entries() -> None:
+    queue = BoundedLogQueue(capacity=2)
+    queue.put(logging.ERROR, "critical")
+    queue.put(logging.INFO, "detail")
+    assert queue.put(logging.ERROR, "second-critical") is True
+    assert queue.get() == (logging.ERROR, "critical")
+    assert queue.get() == (logging.ERROR, "second-critical")

--- a/voiage/logging.py
+++ b/voiage/logging.py
@@ -258,14 +258,12 @@ class BoundedLogQueue:
         if len(self._items) < self._capacity:
             self._items.append((level, message))
             return True
-        minimum = min(queued_level for queued_level, _ in self._items)
+        index, (minimum, _) = min(enumerate(self._items), key=lambda item: item[1][0])
         if level >= logging.ERROR and minimum < logging.ERROR:
-            for index, (queued_level, _) in enumerate(self._items):
-                if queued_level == minimum:
-                    del self._items[index]
-                    self._items.append((level, message))
-                    self.dropped += 1
-                    return True
+            del self._items[index]
+            self._items.append((level, message))
+            self.dropped += 1
+            return True
         self.dropped += 1
         return False
 

--- a/voiage/logging.py
+++ b/voiage/logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -64,6 +65,7 @@ _QUERY_CREDENTIAL_RE = re.compile(
         )
     )
 )
+_ABSOLUTE_PATH_RE = re.compile(r"(?:/Users|/home|/private|[A-Za-z]:\\)[^\s,;]+")
 _ASSIGNMENT_RE = re.compile(
     "".join(
         (
@@ -95,7 +97,8 @@ def _redact_text(value: str) -> str:
     value = _BEARER_RE.sub("Bearer [REDACTED]", value)
     value = _JWT_RE.sub("[REDACTED]", value)
     value = _QUERY_CREDENTIAL_RE.sub(r"\1[REDACTED]", value)
-    return _ASSIGNMENT_RE.sub(r"\1\2[REDACTED]", value)
+    value = _ASSIGNMENT_RE.sub(r"\1\2[REDACTED]", value)
+    return _ABSOLUTE_PATH_RE.sub("[PATH_REDACTED]", value)
 
 
 def _sensitive_key(key: str) -> bool:
@@ -237,6 +240,36 @@ class LoggingSettings(BaseModel):
         }
         values.update(overrides)
         return cls.model_validate(values)
+
+
+class BoundedLogQueue:
+    """Bounded, non-blocking queue with deterministic severity-aware loss."""
+
+    def __init__(self, capacity: int) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be positive")
+        self._items: deque[tuple[int, str]] = deque(maxlen=capacity)
+        self._capacity = capacity
+        self.dropped = 0
+
+    def put(self, level: int, message: str) -> bool:
+        """Add an event without blocking, dropping lower-severity entries first."""
+        if len(self._items) < self._capacity:
+            self._items.append((level, message))
+            return True
+        if level >= logging.ERROR:
+            for index, (queued_level, _) in enumerate(self._items):
+                if queued_level < logging.ERROR:
+                    del self._items[index]
+                    self._items.append((level, message))
+                    self.dropped += 1
+                    return True
+        self.dropped += 1
+        return False
+
+    def get(self) -> tuple[int, str] | None:
+        """Remove and return the oldest queued event."""
+        return self._items.popleft() if self._items else None
 
 
 @final

--- a/voiage/logging.py
+++ b/voiage/logging.py
@@ -242,6 +242,7 @@ class LoggingSettings(BaseModel):
         return cls.model_validate(values)
 
 
+@final
 class BoundedLogQueue:
     """Bounded, non-blocking queue with deterministic severity-aware loss."""
 
@@ -249,8 +250,8 @@ class BoundedLogQueue:
         if capacity < 1:
             raise ValueError("capacity must be positive")
         self._items: deque[tuple[int, str]] = deque(maxlen=capacity)
-        self._capacity = capacity
-        self.dropped = 0
+        self._capacity: int = capacity
+        self.dropped: int = 0
 
     def put(self, level: int, message: str) -> bool:
         """Add an event without blocking, dropping lower-severity entries first."""

--- a/voiage/logging.py
+++ b/voiage/logging.py
@@ -65,7 +65,7 @@ _QUERY_CREDENTIAL_RE = re.compile(
         )
     )
 )
-_ABSOLUTE_PATH_RE = re.compile(r"(?:/Users|/home|/private|[A-Za-z]:\\)[^\s,;]+")
+_ABSOLUTE_PATH_RE = re.compile(r"(?<![\w:])/(?:[^\s,;]+)|[A-Za-z]:\\[^\s,;]+")
 _ASSIGNMENT_RE = re.compile(
     "".join(
         (
@@ -258,9 +258,10 @@ class BoundedLogQueue:
         if len(self._items) < self._capacity:
             self._items.append((level, message))
             return True
-        if level >= logging.ERROR:
+        minimum = min(queued_level for queued_level, _ in self._items)
+        if level >= logging.ERROR and minimum < logging.ERROR:
             for index, (queued_level, _) in enumerate(self._items):
-                if queued_level < logging.ERROR:
+                if queued_level == minimum:
                     del self._items[index]
                     self._items.append((level, message))
                     self.dropped += 1


### PR DESCRIPTION
## Summary
- add adversarial path and credential redaction coverage
- add a bounded severity-aware non-blocking log queue with observable drops
- preserve application-owned logging and deployment-owned retention

## Validation
- `uv run --with 'ruff>=0.15.22,<0.16' ruff check voiage/logging.py tests/test_logging_resilience.py`
- `python3 -m pytest tests/test_logging_resilience.py -q`
