### PR TITLE
feat(vop): add logging and version pilot contract

### DIFF
--- a/conductor/tracks/logging_privacy_resilience_20260907/evidence.jsonl
+++ b/conductor/tracks/logging_privacy_resilience_20260907/evidence.jsonl
@@ -1,0 +1,1 @@
+{"event": "track_completed", "track_id": "logging_privacy_resilience_20260907", "pr": "https://github.com/edithatogo/voiage/pull/1119", "merge_commit": "3e33feafd68d718142b083de12d697e2ec5f42e5", "hosted_checks": "passed"}

--- a/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
@@ -17,7 +17,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
+    "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61"
   },
@@ -29,7 +29,7 @@
   ],
   "initial_file_state": {
     "tests/test_logging_resilience.py": "new-file-must-be-absent",
-    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
+    "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b"
   },

--- a/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/implementation-packet.json
@@ -17,7 +17,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
+    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61"
   },
@@ -29,7 +29,7 @@
   ],
   "initial_file_state": {
     "tests/test_logging_resilience.py": "new-file-must-be-absent",
-    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
+    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
     "voiage/assurance_policy.py": "128e1f598a3523605a6b7436a06fe1e9dd76a68f5bde62e73a746ffd2b38dd61",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b"
   },

--- a/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
@@ -3,7 +3,7 @@
   "type": "feature",
   "status": "new",
   "created_at": "2026-09-07T01:59:07Z",
-  "updated_at": "2026-09-07T02:55:24Z",
+  "updated_at": "2026-09-08T00:00:00Z",
   "description": "Logging privacy and bounded delivery",
   "github_cross_reference": {
     "issue": "https://github.com/edithatogo/voiage/issues/1114"
@@ -20,12 +20,12 @@
     {
       "id": "prerequisites",
       "kind": "repository",
-      "status": "pending",
-      "evidence": "See orchestration.md and prerequisite track acceptance evidence."
+      "status": "satisfied",
+      "evidence": "PR #1119 merged at 3e33feafd68d718142b083de12d697e2ec5f42e5; hosted checks passed."
     }
   ],
   "implementation_preparation": {
     "packet": "implementation-packet.json",
-    "state": "waiting_for_prerequisites"
+    "state": "completed"
   }
 }

--- a/conductor/tracks/logging_privacy_resilience_20260907/plan.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/plan.md
@@ -1,38 +1,38 @@
 # Implementation plan: Logging privacy and bounded delivery
 
-All tasks are pending. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: native_structured_logging_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+Implementation completed in PR #1119. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: native_structured_logging_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
 
 ## Phase 1: Privacy
 
-- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
-- [ ] T1.2 — Define event field allowlists and deployment-owned retention/redaction policy. (AC1).
-- [ ] T1.3 — Validate: Raw patient records, parameter draws, credentials and sensitive filesystem paths are excluded by default; no universal retention period is invented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+- [x] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [x] T1.2 — Define event field allowlists and deployment-owned retention/redaction policy. (AC1).
+- [x] T1.3 — Validate: Raw patient records, parameter draws, credentials and sensitive filesystem paths are excluded by default; no universal retention period is invented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
 
 ## Phase 2: Adversarial
 
-- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
-- [ ] T2.2 — Write nested secret, exception, object-formatting, Unicode and forged-correlation tests before extending sanitization. (AC2).
-- [ ] T2.3 — Validate: All secret sentinels are absent from emitted records; untrusted fields cannot impersonate trusted correlation fields. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+- [x] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [x] T2.2 — Write nested secret, exception, object-formatting, Unicode and forged-correlation tests before extending sanitization. (AC2).
+- [x] T2.3 — Validate: All secret sentinels are absent from emitted records; untrusted fields cannot impersonate trusted correlation fields. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
 
 ## Phase 3: Queue
 
-- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
-- [ ] T3.2 — Specify bounded queue capacity, severity-aware drop behavior and low-cardinality loss counters before implementing an optional queue. (AC3).
-- [ ] T3.3 — Validate: A full queue has deterministic bounded behavior; numerical execution does not wait indefinitely; audit evidence is never silently dropped through this queue. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+- [x] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [x] T3.2 — Specify bounded queue capacity, severity-aware drop behavior and low-cardinality loss counters before implementing an optional queue. (AC3).
+- [x] T3.3 — Validate: A full queue has deterministic bounded behavior; numerical execution does not wait indefinitely; audit evidence is never silently dropped through this queue. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
 
 ## Phase 4: Failure
 
-- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
-- [ ] T4.2 — Inject disk-full, failed writer, recursive logging and stalled sink behavior. (AC4).
-- [ ] T4.3 — Validate: Logging failures do not mask the original calculation error or deadlock computation; loss is observable without recursive failure. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+- [x] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [x] T4.2 — Inject disk-full, failed writer, recursive logging and stalled sink behavior. (AC4).
+- [x] T4.3 — Validate: Logging failures do not mask the original calculation error or deadlock computation; loss is observable without recursive failure. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
 
 ## Phase 5: Shutdown
 
-- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
-- [ ] T5.2 — Test cancellation, flush timeout and process shutdown ownership. (AC5).
-- [ ] T5.3 — Validate: Applications control shutdown; bounded flushing reports incomplete delivery; hosts are not terminated and retention stays deployment-owned. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+- [x] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [x] T5.2 — Test cancellation, flush timeout and process shutdown ownership. (AC5).
+- [x] T5.3 — Validate: Applications control shutdown; bounded flushing reports incomplete delivery; hosts are not terminated and retention stays deployment-owned. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
 
 ## Final acceptance
 
-- [ ] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
-- [ ] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.
+- [x] CLOSE.1 — Review every AC, run final required local/native gates and record exact source/environment evidence; reuse only eligible unchanged evidence.
+- [x] CLOSE.2 — Reconcile plan, metadata, registry and append-only evidence; require satisfied upstream contracts and applicable hosted evidence before completion. Do not infer release or scientific acceptance.

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
+    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
@@ -37,7 +37,7 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/telemetry.rs": "new-file-must-be-absent",
     "tests/test_native_logging_contract.py": "new-file-must-be-absent",
-    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0",
+    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
     "conductor/tracks/agent_safe_engineering_20260907/repository-boundaries.md"
   ],
   "input_sha256": {
-    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
+    "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
@@ -37,7 +37,7 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/telemetry.rs": "new-file-must-be-absent",
     "tests/test_native_logging_contract.py": "new-file-must-be-absent",
-    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47",
+    "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
     "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -25,20 +25,21 @@
     "specs/integration/vop-voiage/bundles/UPSTREAM.json": "0f65af398e1ba2bbac704f6bb5dedc10548c6120ba6e377cb4254bc7813086d0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
-    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0"
+    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47"
   },
   "reserved_implementation_files": [
     "tests/test_vop_logging_version_pilot.py",
     "specs/integration/vop-voiage/pilot-logging-version.json",
     "tests/test_consumer_matrix.py",
-    "tests/test_vop_research_handoff.py"
+    "tests/test_vop_research_handoff.py",
+    "voiage/logging.py"
   ],
   "initial_file_state": {
     "tests/test_vop_logging_version_pilot.py": "new-file-must-be-absent",
     "specs/integration/vop-voiage/pilot-logging-version.json": "new-file-must-be-absent",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
     "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a",
-    "voiage/logging.py": "d7257ebff8716d788b928dc6b24bdcf5564ba21df6a30744c6b12ed7bcc659a0"
+    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -4,9 +4,13 @@
   "track_id": "vop_logging_version_pilot_20260907",
   "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
   "preparation_state": "prepared",
-  "execution_state": "waiting_for_prerequisites",
+  "execution_state": "ready_for_preflight",
   "prerequisite_tracks": [
-    "logging_privacy_resilience_20260907"
+    {
+      "track_id": "logging_privacy_resilience_20260907",
+      "result_status": "passed",
+      "evidence": "3e33feafd68d718142b083de12d697e2ec5f42e5"
+    }
   ],
   "delivery_repository": "edithatogo/voiage",
   "read_before_start": [

--- a/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/implementation-packet.json
@@ -25,7 +25,7 @@
     "specs/integration/vop-voiage/bundles/UPSTREAM.json": "0f65af398e1ba2bbac704f6bb5dedc10548c6120ba6e377cb4254bc7813086d0",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
-    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47"
+    "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8"
   },
   "reserved_implementation_files": [
     "tests/test_vop_logging_version_pilot.py",
@@ -39,7 +39,7 @@
     "specs/integration/vop-voiage/pilot-logging-version.json": "new-file-must-be-absent",
     "tests/test_consumer_matrix.py": "694abce953a5ea040bf034aba9fcef6649570d5549aeab015103742b41eccb07",
     "tests/test_vop_research_handoff.py": "e4097c9971847e7c829f85f9a1bd60147707c2a905b949a1c6331537e1384f0a",
-    "voiage/logging.py": "69c868df4e40753105b08664c0f02bd6e1c2b413dc460b7dcf0f97d97b9f6b47"
+    "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/specs/integration/vop-voiage/pilot-logging-version.json
+++ b/specs/integration/vop-voiage/pilot-logging-version.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0.0",
+  "pilot_id": "vop-voiage-logging-version-20260908",
+  "source_bundle": "specs/integration/vop-voiage/bundles/UPSTREAM.json",
+  "source_revision": "3c841cd054666cf3d9ebefd962fc2ea07c20a510",
+  "consumer_version": "2.2.0",
+  "identity": {
+    "algorithm_id": "evpi:analytic:v1",
+    "rng_id": "pcg64:seeded:v1",
+    "input_schema_id": "vop-net-benefit:v1"
+  },
+  "correlation": {
+    "run_id": "pilot-synthetic-run-001",
+    "analysis_id": "pilot-synthetic-analysis-001",
+    "trace_id": "11111111111111111111111111111111"
+  },
+  "data_policy": "synthetic-only; local validation packet; no hosted publication",
+  "provider_policy": "semantic contract only; provider APIs are not interchangeable"
+}

--- a/specs/integration/vop-voiage/pilot-logging-version.json
+++ b/specs/integration/vop-voiage/pilot-logging-version.json
@@ -15,5 +15,7 @@
     "trace_id": "11111111111111111111111111111111"
   },
   "data_policy": "synthetic-only; local validation packet; no hosted publication",
-  "provider_policy": "semantic contract only; provider APIs are not interchangeable"
+  "provider_policy": "semantic contract only; provider APIs are not interchangeable",
+  "unit": "nzd_per_qaly",
+  "weight_field": "population_weight"
 }

--- a/tests/test_vop_logging_version_pilot.py
+++ b/tests/test_vop_logging_version_pilot.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from voiage.logging import validate_vop_pilot_contract
+
 ROOT = Path(__file__).resolve().parents[1]
 PILOT = ROOT / "specs/integration/vop-voiage/pilot-logging-version.json"
 UPSTREAM = ROOT / "specs/integration/vop-voiage/bundles/UPSTREAM.json"
@@ -17,26 +19,6 @@ def test_pilot_reuses_pinned_upstream_and_semantic_identities() -> None:
     assert pilot["source_bundle"] == str(UPSTREAM.relative_to(ROOT))
     assert set(pilot["identity"]) == {"algorithm_id", "rng_id", "input_schema_id"}
     assert pilot["data_policy"].startswith("synthetic-only")
-
-
-def _validate(pilot: dict[str, object]) -> None:
-    upstream = json.loads(UPSTREAM.read_text())
-    if pilot["source_revision"] != upstream["canonical_git_commit"]:
-        raise ValueError("source revision mismatch")
-    identity = pilot["identity"]
-    if not isinstance(identity, dict) or not all(
-        identity.get(key) for key in ("algorithm_id", "rng_id", "input_schema_id")
-    ):
-        raise ValueError("identity is incomplete")
-    correlation = pilot["correlation"]
-    if (
-        not isinstance(correlation, dict)
-        or not correlation.get("run_id")
-        or len(str(correlation.get("trace_id", ""))) != 32
-    ):
-        raise ValueError("correlation is malformed")
-    if pilot["consumer_version"] != "2.2.0":
-        raise ValueError("unknown consumer version")
 
 
 @pytest.mark.parametrize(
@@ -52,10 +34,12 @@ def _validate(pilot: dict[str, object]) -> None:
         },
         {"correlation": {"run_id": "", "analysis_id": "a", "trace_id": "bad"}},
         {"consumer_version": "unknown"},
+        {"unit": "usd_per_qaly"},
+        {"weight_field": "wrong_weight"},
     ],
 )
 def test_pilot_rejects_contract_mutations(mutation: dict[str, object]) -> None:
     pilot = json.loads(PILOT.read_text())
     pilot.update(mutation)
-    with pytest.raises(ValueError):
-        _validate(pilot)
+    with pytest.raises((ValueError, TypeError, RuntimeError)):
+        validate_vop_pilot_contract(pilot)

--- a/tests/test_vop_logging_version_pilot.py
+++ b/tests/test_vop_logging_version_pilot.py
@@ -43,3 +43,21 @@ def test_pilot_rejects_contract_mutations(mutation: dict[str, object]) -> None:
     pilot.update(mutation)
     with pytest.raises((ValueError, TypeError, RuntimeError)):
         validate_vop_pilot_contract(pilot)
+
+
+def test_production_validator_rejects_missing_identity_and_correlation() -> None:
+    pilot = json.loads(PILOT.read_text())
+    for key, value in (("identity", None), ("correlation", None)):
+        candidate = dict(pilot)
+        candidate[key] = value
+        with pytest.raises((ValueError, TypeError, RuntimeError)):
+            validate_vop_pilot_contract(candidate)
+
+    candidate = dict(pilot)
+    candidate["correlation"] = {
+        "run_id": "",
+        "analysis_id": "analysis",
+        "trace_id": pilot["correlation"]["trace_id"],
+    }
+    with pytest.raises(ValueError):
+        validate_vop_pilot_contract(candidate)

--- a/tests/test_vop_logging_version_pilot.py
+++ b/tests/test_vop_logging_version_pilot.py
@@ -1,0 +1,61 @@
+"""Fail-closed VOP/VOI pilot contract tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PILOT = ROOT / "specs/integration/vop-voiage/pilot-logging-version.json"
+UPSTREAM = ROOT / "specs/integration/vop-voiage/bundles/UPSTREAM.json"
+
+
+def test_pilot_reuses_pinned_upstream_and_semantic_identities() -> None:
+    pilot = json.loads(PILOT.read_text())
+    upstream = json.loads(UPSTREAM.read_text())
+    assert pilot["source_revision"] == upstream["canonical_git_commit"]
+    assert pilot["source_bundle"] == str(UPSTREAM.relative_to(ROOT))
+    assert set(pilot["identity"]) == {"algorithm_id", "rng_id", "input_schema_id"}
+    assert pilot["data_policy"].startswith("synthetic-only")
+
+
+def _validate(pilot: dict[str, object]) -> None:
+    upstream = json.loads(UPSTREAM.read_text())
+    if pilot["source_revision"] != upstream["canonical_git_commit"]:
+        raise ValueError("source revision mismatch")
+    identity = pilot["identity"]
+    if not isinstance(identity, dict) or not all(
+        identity.get(key) for key in ("algorithm_id", "rng_id", "input_schema_id")
+    ):
+        raise ValueError("identity is incomplete")
+    correlation = pilot["correlation"]
+    if (
+        not isinstance(correlation, dict)
+        or not correlation.get("run_id")
+        or len(str(correlation.get("trace_id", ""))) != 32
+    ):
+        raise ValueError("correlation is malformed")
+    if pilot["consumer_version"] != "2.2.0":
+        raise ValueError("unknown consumer version")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"source_revision": "0" * 40},
+        {
+            "identity": {
+                "algorithm_id": "",
+                "rng_id": "pcg64:seeded:v1",
+                "input_schema_id": "vop-net-benefit:v1",
+            }
+        },
+        {"correlation": {"run_id": "", "analysis_id": "a", "trace_id": "bad"}},
+        {"consumer_version": "unknown"},
+    ],
+)
+def test_pilot_rejects_contract_mutations(mutation: dict[str, object]) -> None:
+    pilot = json.loads(PILOT.read_text())
+    pilot.update(mutation)
+    with pytest.raises(ValueError):
+        _validate(pilot)

--- a/voiage/logging.py
+++ b/voiage/logging.py
@@ -272,6 +272,37 @@ class BoundedLogQueue:
         return self._items.popleft() if self._items else None
 
 
+def validate_vop_pilot_contract(payload: Mapping[str, object]) -> None:
+    """Validate the synthetic VOP pilot before any model evaluation."""
+    from voiage.versioning import validate_version_envelope
+
+    if payload.get("source_revision") != "3c841cd054666cf3d9ebefd962fc2ea07c20a510":
+        raise ValueError("pilot source revision mismatch")
+    envelope = payload.get("identity")
+    if not isinstance(envelope, Mapping):
+        raise TypeError("pilot identity is missing")
+    validate_version_envelope(
+        {
+            "schema_version": "1.0",
+            "package_version": payload.get("consumer_version"),
+            "algorithm_id": envelope.get("algorithm_id"),
+            "rng_id": envelope.get("rng_id"),
+            "input_schema_id": envelope.get("input_schema_id"),
+        }
+    )
+    correlation = payload.get("correlation")
+    if not isinstance(correlation, Mapping):
+        raise TypeError("pilot correlation is missing")
+    TraceContext(trace_id=str(correlation.get("trace_id", "")))
+    if not correlation.get("run_id") or not correlation.get("analysis_id"):
+        raise ValueError("pilot correlation identifiers must be non-empty")
+    if (
+        payload.get("unit") != "nzd_per_qaly"
+        or payload.get("weight_field") != "population_weight"
+    ):
+        raise ValueError("pilot units or weights are incompatible")
+
+
 @final
 class _ContextFilter(logging.Filter):
     def __init__(self, settings: LoggingSettings) -> None:

--- a/voiage/logging.py
+++ b/voiage/logging.py
@@ -281,7 +281,8 @@ def validate_vop_pilot_contract(payload: Mapping[str, object]) -> None:
     envelope = payload.get("identity")
     if not isinstance(envelope, Mapping):
         raise TypeError("pilot identity is missing")
-    validate_version_envelope(
+    envelope = cast("Mapping[str, object]", envelope)
+    _ = validate_version_envelope(
         {
             "schema_version": "1.0",
             "package_version": payload.get("consumer_version"),
@@ -293,7 +294,8 @@ def validate_vop_pilot_contract(payload: Mapping[str, object]) -> None:
     correlation = payload.get("correlation")
     if not isinstance(correlation, Mapping):
         raise TypeError("pilot correlation is missing")
-    TraceContext(trace_id=str(correlation.get("trace_id", "")))
+    correlation = cast("Mapping[str, object]", correlation)
+    _ = TraceContext(trace_id=str(correlation.get("trace_id", "")))
     if not correlation.get("run_id") or not correlation.get("analysis_id"):
         raise ValueError("pilot correlation identifiers must be non-empty")
     if (


### PR DESCRIPTION
## Summary
- pin the existing VOP export bundle and VOI consumer identities
- add fail-closed correlation and version pilot validation
- preserve semantic provider boundaries and synthetic-only replay policy

## Validation
- `python3 -m pytest tests/test_vop_logging_version_pilot.py -q`
- `python3 scripts/repo_harness.py`
