### PR TITLE
feat(telemetry): add opt-in native export boundary

### DIFF
--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -24,7 +24,7 @@
   "input_sha256": {
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
   },
   "reserved_implementation_files": [
@@ -40,7 +40,7 @@
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -4,9 +4,13 @@
   "track_id": "optional_native_telemetry_20260907",
   "source_baseline": "1207cef979311d1f39b3e41c32e165907303dec2",
   "preparation_state": "prepared",
-  "execution_state": "waiting_for_prerequisites",
+  "execution_state": "ready_for_preflight",
   "prerequisite_tracks": [
-    "vop_logging_version_pilot_20260907"
+    {
+      "track_id": "vop_logging_version_pilot_20260907",
+      "result_status": "passed",
+      "evidence": "348db4d3e51a82b6fc6a252ef4bdabdf99db8564"
+    }
   ],
   "delivery_repository": "edithatogo/voiage",
   "read_before_start": [
@@ -18,7 +22,7 @@
   ],
   "input_sha256": {
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f"
   },
   "reserved_implementation_files": [
@@ -32,7 +36,7 @@
     "tests/test_optional_telemetry_contract.py": "new-file-must-be-absent",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "fbc5abbdd7b779af218bd033aeeb721c3f718bf3fb08c6d782fdea3a1e09ba4c"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -23,7 +23,8 @@
   "input_sha256": {
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
     "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3",
-    "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f"
+    "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
+    "rust/crates/voiage-diagnostics/src/lib.rs": "e7b9d22349ec1870e21216de990094d4b2f8af5156fae0fecb2aed9516a98c76"
   },
   "reserved_implementation_files": [
     "rust/crates/voiage-diagnostics/src/otel_export.rs",
@@ -34,7 +35,7 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/otel_export.rs": "new-file-must-be-absent",
     "tests/test_optional_telemetry_contract.py": "new-file-must-be-absent",
-    "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
+    "rust/crates/voiage-diagnostics/src/lib.rs": "e7b9d22349ec1870e21216de990094d4b2f8af5156fae0fecb2aed9516a98c76",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
     "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3"
   },

--- a/rust/crates/voiage-diagnostics/Cargo.toml
+++ b/rust/crates/voiage-diagnostics/Cargo.toml
@@ -1,3 +1,7 @@
+[features]
+default = []
+otel = []
+
 [package]
 name = "voiage-diagnostics"
 description = "Structured diagnostics and error contracts for voiage."

--- a/rust/crates/voiage-diagnostics/src/lib.rs
+++ b/rust/crates/voiage-diagnostics/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 mod contracts;
 mod domain_mapping;
+#[cfg(feature = "otel")]
 pub mod otel_export;
 pub mod telemetry;
 

--- a/rust/crates/voiage-diagnostics/src/lib.rs
+++ b/rust/crates/voiage-diagnostics/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 mod contracts;
 mod domain_mapping;
+pub mod otel_export;
 pub mod telemetry;
 
 pub use contracts::{

--- a/rust/crates/voiage-diagnostics/src/otel_export.rs
+++ b/rust/crates/voiage-diagnostics/src/otel_export.rs
@@ -9,15 +9,6 @@ pub struct TraceExportConfig {
     pub max_retries: u8,
 }
 
-impl Default for TraceExportConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            max_retries: 0,
-        }
-    }
-}
-
 impl TraceExportConfig {
     /// Reject unbounded retry policies and preserve feature-off operation.
     ///

--- a/rust/crates/voiage-diagnostics/src/otel_export.rs
+++ b/rust/crates/voiage-diagnostics/src/otel_export.rs
@@ -1,7 +1,7 @@
 //! Optional trace-export boundary, intentionally inert until an application opts in.
 
 /// Explicit opt-in configuration for a future OpenTelemetry bridge.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TraceExportConfig {
     /// Whether an application explicitly enabled export.
     pub enabled: bool,
@@ -20,6 +20,10 @@ impl Default for TraceExportConfig {
 
 impl TraceExportConfig {
     /// Reject unbounded retry policies and preserve feature-off operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the retry budget exceeds three attempts.
     pub fn new(enabled: bool, max_retries: u8) -> Result<Self, &'static str> {
         if max_retries > 3 {
             return Err("max_retries must be <= 3");

--- a/rust/crates/voiage-diagnostics/src/otel_export.rs
+++ b/rust/crates/voiage-diagnostics/src/otel_export.rs
@@ -4,9 +4,9 @@
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TraceExportConfig {
     /// Whether an application explicitly enabled export.
-    pub enabled: bool,
+    enabled: bool,
     /// Maximum number of export retries before giving up.
-    pub max_retries: u8,
+    max_retries: u8,
 }
 
 impl TraceExportConfig {
@@ -23,5 +23,17 @@ impl TraceExportConfig {
             enabled,
             max_retries,
         })
+    }
+
+    /// Returns whether export was explicitly enabled.
+    #[must_use]
+    pub const fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Returns the bounded retry budget.
+    #[must_use]
+    pub const fn max_retries(&self) -> u8 {
+        self.max_retries
     }
 }

--- a/rust/crates/voiage-diagnostics/src/otel_export.rs
+++ b/rust/crates/voiage-diagnostics/src/otel_export.rs
@@ -1,0 +1,32 @@
+//! Optional trace-export boundary, intentionally inert until an application opts in.
+
+/// Explicit opt-in configuration for a future OpenTelemetry bridge.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraceExportConfig {
+    /// Whether an application explicitly enabled export.
+    pub enabled: bool,
+    /// Maximum number of export retries before giving up.
+    pub max_retries: u8,
+}
+
+impl Default for TraceExportConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_retries: 0,
+        }
+    }
+}
+
+impl TraceExportConfig {
+    /// Reject unbounded retry policies and preserve feature-off operation.
+    pub fn new(enabled: bool, max_retries: u8) -> Result<Self, &'static str> {
+        if max_retries > 3 {
+            return Err("max_retries must be <= 3");
+        }
+        Ok(Self {
+            enabled,
+            max_retries,
+        })
+    }
+}

--- a/tests/test_optional_telemetry_contract.py
+++ b/tests/test_optional_telemetry_contract.py
@@ -1,0 +1,11 @@
+"""Contract checks for explicitly opt-in native telemetry qualification."""
+
+from pathlib import Path
+
+
+def test_telemetry_is_feature_off_by_default_and_bounded() -> None:
+    cargo = Path("rust/crates/voiage-diagnostics/Cargo.toml").read_text()
+    source = Path("rust/crates/voiage-diagnostics/src/otel_export.rs").read_text()
+    assert "default = []" in cargo
+    assert "max_retries must be <= 3" in source
+    assert "dashboard" not in source.lower()


### PR DESCRIPTION
## Summary
- add a feature-off-by-default Rust telemetry boundary
- bound opt-in retry policy without adding exporters or dashboards
- record explicit prerequisite evidence and native contract coverage

## Validation
- `cargo test --manifest-path rust/Cargo.toml -p voiage-diagnostics --all-features --locked`
- `python3 -m pytest tests/test_optional_telemetry_contract.py -q`
- `python3 scripts/repo_harness.py`
