### PR TITLE
feat(telemetry): qualify optional Rust trace export

### DIFF
--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -24,7 +24,7 @@
   "input_sha256": {
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
   },
   "reserved_implementation_files": [
@@ -40,7 +40,7 @@
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
   ],
   "input_sha256": {
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
     "rust/crates/voiage-diagnostics/src/lib.rs": "e7b9d22349ec1870e21216de990094d4b2f8af5156fae0fecb2aed9516a98c76"
   },
@@ -37,7 +37,7 @@
     "tests/test_optional_telemetry_contract.py": "new-file-must-be-absent",
     "rust/crates/voiage-diagnostics/src/lib.rs": "e7b9d22349ec1870e21216de990094d4b2f8af5156fae0fecb2aed9516a98c76",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "232949ed8d743ffe36a2fd9213a42cf9083de7e6e478075fe038ccd7b8a42ba3"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +108,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +215,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +257,42 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -369,6 +485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +621,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +687,8 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 name = "voiage-diagnostics"
 version = "2.2.0"
 dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "tracing",
@@ -618,6 +777,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/rust/crates/voiage-diagnostics/Cargo.toml
+++ b/rust/crates/voiage-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [features]
 default = []
-otel = []
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk"]
 
 [package]
 name = "voiage-diagnostics"
@@ -17,6 +17,8 @@ categories = ["science"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tracing = { version = "0.1", default-features = false }
+opentelemetry = { version = "0.32.0", default-features = false, features = ["trace"], optional = true }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "testing"], optional = true }
 voiage-domain.workspace = true
 
 [dev-dependencies]

--- a/rust/crates/voiage-diagnostics/src/otel_export.rs
+++ b/rust/crates/voiage-diagnostics/src/otel_export.rs
@@ -1,20 +1,39 @@
-//! Optional trace-export boundary, intentionally inert until an application opts in.
+//! Bounded, application-owned trace export qualification.
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
 
-/// Explicit opt-in configuration for a future OpenTelemetry bridge.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// OpenTelemetry API line qualified by this optional feature.
+pub const OPENTELEMETRY_API_VERSION: &str = "0.32";
+
+/// A bounded trace record suitable for an application-owned exporter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraceEvent {
+    /// Stable operation name.
+    pub name: String,
+    /// W3C trace identifier.
+    pub trace_id: String,
+    /// Optional parent span identifier.
+    pub parent_id: Option<String>,
+    /// Bounded semantic attributes.
+    pub attributes: BTreeMap<String, String>,
+}
+
+/// Explicit opt-in and resource limits for trace export.
+#[derive(Clone, Debug, PartialEq)]
 pub struct TraceExportConfig {
-    /// Whether an application explicitly enabled export.
     enabled: bool,
-    /// Maximum number of export retries before giving up.
     max_retries: u8,
+    sample_rate: f64,
+    max_attributes: usize,
+    capacity: usize,
 }
 
 impl TraceExportConfig {
-    /// Reject unbounded retry policies and preserve feature-off operation.
+    /// Creates a bounded configuration with conservative defaults.
     ///
     /// # Errors
     ///
-    /// Returns an error when the retry budget exceeds three attempts.
+    /// Returns an error when retries exceed three attempts.
     pub fn new(enabled: bool, max_retries: u8) -> Result<Self, &'static str> {
         if max_retries > 3 {
             return Err("max_retries must be <= 3");
@@ -22,10 +41,34 @@ impl TraceExportConfig {
         Ok(Self {
             enabled,
             max_retries,
+            sample_rate: 1.0,
+            max_attributes: 32,
+            capacity: 1024,
         })
     }
 
-    /// Returns whether export was explicitly enabled.
+    /// Sets a sampling probability in the inclusive range `0..=1`.
+    #[must_use]
+    pub fn with_sample_rate(mut self, sample_rate: f64) -> Self {
+        self.sample_rate = sample_rate.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Sets the maximum number of attributes retained per event.
+    #[must_use]
+    pub fn with_max_attributes(mut self, max_attributes: usize) -> Self {
+        self.max_attributes = max_attributes;
+        self
+    }
+
+    /// Sets the bounded in-process queue capacity.
+    #[must_use]
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = capacity;
+        self
+    }
+
+    /// Returns whether export is explicitly enabled.
     #[must_use]
     pub const fn enabled(&self) -> bool {
         self.enabled
@@ -35,5 +78,113 @@ impl TraceExportConfig {
     #[must_use]
     pub const fn max_retries(&self) -> u8 {
         self.max_retries
+    }
+}
+
+/// A non-blocking, bounded collector for local qualification and adapters.
+#[derive(Clone, Debug)]
+pub struct TraceCollector {
+    config: TraceExportConfig,
+    events: Arc<Mutex<VecDeque<TraceEvent>>>,
+}
+
+impl TraceCollector {
+    /// Creates a collector without initializing global logging state.
+    #[must_use]
+    pub fn new(config: TraceExportConfig) -> Self {
+        Self {
+            config,
+            events: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    /// Records an event when sampling and opt-in policy allow it.
+    #[must_use]
+    pub fn record(&self, mut event: TraceEvent) -> bool {
+        if !self.config.enabled || !sampled(&event.trace_id, self.config.sample_rate) {
+            return false;
+        }
+        while event.attributes.len() > self.config.max_attributes {
+            if let Some(key) = event.attributes.keys().next().cloned() {
+                event.attributes.remove(&key);
+            } else {
+                break;
+            }
+        }
+        let Ok(mut events) = self.events.lock() else {
+            return false;
+        };
+        if self.config.capacity == 0 {
+            return false;
+        }
+        if events.len() >= self.config.capacity {
+            events.pop_front();
+        }
+        events.push_back(event);
+        true
+    }
+
+    /// Drains records for an application-owned exporter or shutdown hook.
+    #[must_use]
+    pub fn drain(&self) -> Vec<TraceEvent> {
+        self.events
+            .lock()
+            .map(|mut events| events.drain(..).collect())
+            .unwrap_or_default()
+    }
+}
+
+fn sampled(trace_id: &str, sample_rate: f64) -> bool {
+    let bucket = trace_id
+        .bytes()
+        .fold(0_u16, |sum, byte| sum.wrapping_add(u16::from(byte)))
+        % 1000;
+    f64::from(bucket) / 1000.0 < sample_rate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TraceCollector, TraceEvent, TraceExportConfig};
+    use std::collections::BTreeMap;
+
+    fn event(id: &str) -> TraceEvent {
+        TraceEvent {
+            name: "voi.run".into(),
+            trace_id: id.into(),
+            parent_id: Some("parent".into()),
+            attributes: BTreeMap::from([(String::from("run_id"), String::from("redacted"))]),
+        }
+    }
+
+    #[test]
+    fn opt_in_and_parent_context_are_preserved() {
+        let collector = TraceCollector::new(TraceExportConfig::new(true, 3).expect("valid"));
+        assert!(collector.record(event("trace-1")));
+        let records = collector.drain();
+        assert_eq!(records[0].parent_id.as_deref(), Some("parent"));
+    }
+
+    #[test]
+    fn disabled_sampling_and_capacity_do_not_block() {
+        let config = TraceExportConfig::new(false, 0)
+            .expect("valid")
+            .with_capacity(1);
+        let collector = TraceCollector::new(config);
+        assert!(!collector.record(event("trace-2")));
+        assert!(collector.drain().is_empty());
+    }
+
+    #[test]
+    fn attributes_are_bounded_and_queue_evicts_oldest() {
+        let config = TraceExportConfig::new(true, 0)
+            .expect("valid")
+            .with_max_attributes(1)
+            .with_capacity(1);
+        let collector = TraceCollector::new(config);
+        assert!(collector.record(event("trace-3")));
+        assert!(collector.record(event("trace-4")));
+        let records = collector.drain();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].attributes.len(), 1);
     }
 }

--- a/rust/crates/voiage-diagnostics/src/otel_export.rs
+++ b/rust/crates/voiage-diagnostics/src/otel_export.rs
@@ -2,6 +2,8 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
+use opentelemetry::trace::SpanContext;
+
 /// OpenTelemetry API line qualified by this optional feature.
 pub const OPENTELEMETRY_API_VERSION: &str = "0.32";
 
@@ -111,7 +113,7 @@ impl TraceCollector {
                 break;
             }
         }
-        let Ok(mut events) = self.events.lock() else {
+        let Ok(mut events) = self.events.try_lock() else {
             return false;
         };
         if self.config.capacity == 0 {
@@ -124,21 +126,37 @@ impl TraceCollector {
         true
     }
 
+    /// Records a span context supplied by an application-owned OpenTelemetry tracer.
+    #[must_use]
+    pub fn record_span_context(
+        &self,
+        name: impl Into<String>,
+        context: &SpanContext,
+        attributes: BTreeMap<String, String>,
+    ) -> bool {
+        self.record(TraceEvent {
+            name: name.into(),
+            trace_id: context.trace_id().to_string(),
+            parent_id: context.is_valid().then(|| context.span_id().to_string()),
+            attributes,
+        })
+    }
+
     /// Drains records for an application-owned exporter or shutdown hook.
     #[must_use]
     pub fn drain(&self) -> Vec<TraceEvent> {
-        self.events
-            .lock()
-            .map(|mut events| events.drain(..).collect())
-            .unwrap_or_default()
+        let Ok(mut events) = self.events.try_lock() else {
+            return Vec::new();
+        };
+        std::mem::take(&mut *events).into_iter().collect()
     }
 }
 
 fn sampled(trace_id: &str, sample_rate: f64) -> bool {
-    let bucket = trace_id
-        .bytes()
-        .fold(0_u16, |sum, byte| sum.wrapping_add(u16::from(byte)))
-        % 1000;
+    let hash = trace_id.bytes().fold(0x811c_9dc5_u32, |hash, byte| {
+        hash.wrapping_mul(16_777_619) ^ u32::from(byte)
+    });
+    let bucket = hash % 1000;
     f64::from(bucket) / 1000.0 < sample_rate
 }
 
@@ -161,6 +179,7 @@ mod tests {
         let collector = TraceCollector::new(TraceExportConfig::new(true, 3).expect("valid"));
         assert!(collector.record(event("trace-1")));
         let records = collector.drain();
+        assert!(!records.is_empty(), "expected at least one record");
         assert_eq!(records[0].parent_id.as_deref(), Some("parent"));
     }
 
@@ -184,6 +203,7 @@ mod tests {
         assert!(collector.record(event("trace-3")));
         assert!(collector.record(event("trace-4")));
         let records = collector.drain();
+        assert!(!records.is_empty(), "expected at least one record");
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].attributes.len(), 1);
     }

--- a/tests/test_optional_telemetry_contract.py
+++ b/tests/test_optional_telemetry_contract.py
@@ -9,3 +9,13 @@ def test_telemetry_is_feature_off_by_default_and_bounded() -> None:
     assert "default = []" in cargo
     assert "max_retries must be <= 3" in source
     assert "dashboard" not in source.lower()
+
+
+def test_telemetry_qualifies_pinned_rust_stack_and_local_limits() -> None:
+    cargo = Path("rust/crates/voiage-diagnostics/Cargo.toml").read_text()
+    assert 'opentelemetry = { version = "0.32.0"' in cargo
+    assert 'opentelemetry_sdk = { version = "0.32.1"' in cargo
+    assert 'otel = ["dep:opentelemetry", "dep:opentelemetry_sdk"]' in cargo
+    assert "TraceCollector" in Path(
+        "rust/crates/voiage-diagnostics/src/otel_export.rs"
+    ).read_text()

--- a/tests/test_optional_telemetry_contract.py
+++ b/tests/test_optional_telemetry_contract.py
@@ -16,6 +16,7 @@ def test_telemetry_qualifies_pinned_rust_stack_and_local_limits() -> None:
     assert 'opentelemetry = { version = "0.32.0"' in cargo
     assert 'opentelemetry_sdk = { version = "0.32.1"' in cargo
     assert 'otel = ["dep:opentelemetry", "dep:opentelemetry_sdk"]' in cargo
-    assert "TraceCollector" in Path(
-        "rust/crates/voiage-diagnostics/src/otel_export.rs"
-    ).read_text()
+    assert (
+        "TraceCollector"
+        in Path("rust/crates/voiage-diagnostics/src/otel_export.rs").read_text()
+    )


### PR DESCRIPTION
Implements the optional native telemetry qualification track with pinned Rust OpenTelemetry dependencies behind the disabled-by-default otel feature. Adds a bounded application-owned trace collector with sampling, attribute and queue limits, parent-context preservation, drain semantics, and focused contract tests. No global provider, network exporter, or dashboard is introduced.