### PR TITLE
feat(deps): add Rust feature qualification matrix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add a deterministic Rust feature/MSRV qualification matrix covering default,
+  no-default, optional-feature and all-feature lanes, with an explicit locked
+  Cargo verification mode.
+
 - Use Astro 7.3.1 to repair the 7.3.0 internal logger export regression in
   documentation builds.
 - Cancel superseded PR assurance runs, bound local tox parallelism and native

--- a/scripts/rust_feature_matrix.py
+++ b/scripts/rust_feature_matrix.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Emit a deterministic Rust feature/MSRV qualification matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import tomllib
+
+
+def package_matrix(manifest: Path) -> dict[str, object]:
+    """Return feature lanes and MSRV metadata for one Cargo package."""
+    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    package = data.get("package", {})
+    features = data.get("features", {})
+    assert isinstance(package, dict)
+    assert isinstance(features, dict)
+    names = sorted(str(name) for name in features if name != "default")
+    lanes = [
+        "default",
+        "no-default-features",
+        *[f"feature:{name}" for name in names],
+        "all-features",
+    ]
+    return {
+        "package": package.get("name"),
+        "manifest": str(manifest),
+        "rust_version": package.get("rust-version"),
+        "features": names,
+        "lanes": lanes,
+    }
+
+
+def build_matrix(root: Path) -> dict[str, object]:
+    """Return the workspace-wide deterministic feature qualification matrix."""
+    workspace = tomllib.loads((root / "rust/Cargo.toml").read_text(encoding="utf-8"))
+    members = workspace["workspace"]["members"]
+    assert isinstance(members, list)
+    rows = [
+        package_matrix(root / "rust" / str(member) / "Cargo.toml") for member in members
+    ]
+    return {
+        "schema_version": "1.0",
+        "workspace_rust_version": workspace["workspace"]["package"]["rust-version"],
+        "packages": rows,
+    }
+
+
+def main() -> int:
+    """Write the matrix report and return a successful process status."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path, nargs="?", default=Path.cwd())
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = build_matrix(args.root.resolve())
+    destination = args.output or args.root / ".conductor/local/rust-feature-matrix.json"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(destination)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rust_feature_matrix.py
+++ b/scripts/rust_feature_matrix.py
@@ -6,16 +6,20 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import subprocess
 import tomllib
 
 
-def package_matrix(manifest: Path) -> dict[str, object]:
+def package_matrix(manifest: Path, workspace_rust_version: str) -> dict[str, object]:
     """Return feature lanes and MSRV metadata for one Cargo package."""
-    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    try:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise FileNotFoundError(f"Package manifest not found: {manifest}") from error
     package = data.get("package", {})
     features = data.get("features", {})
-    assert isinstance(package, dict)
-    assert isinstance(features, dict)
+    if not isinstance(package, dict) or not isinstance(features, dict):
+        raise TypeError(f"Invalid package manifest structure: {manifest}")
     names = sorted(str(name) for name in features if name != "default")
     lanes = [
         "default",
@@ -26,7 +30,9 @@ def package_matrix(manifest: Path) -> dict[str, object]:
     return {
         "package": package.get("name"),
         "manifest": str(manifest),
-        "rust_version": package.get("rust-version"),
+        "rust_version": workspace_rust_version
+        if package.get("rust-version") == {"workspace": True}
+        else package.get("rust-version"),
         "features": names,
         "lanes": lanes,
     }
@@ -34,15 +40,26 @@ def package_matrix(manifest: Path) -> dict[str, object]:
 
 def build_matrix(root: Path) -> dict[str, object]:
     """Return the workspace-wide deterministic feature qualification matrix."""
-    workspace = tomllib.loads((root / "rust/Cargo.toml").read_text(encoding="utf-8"))
-    members = workspace["workspace"]["members"]
-    assert isinstance(members, list)
+    manifest = root / "rust/Cargo.toml"
+    try:
+        workspace = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        workspace_table = workspace["workspace"]
+        members = workspace_table["members"]
+        workspace_package = workspace_table["package"]
+        workspace_rust_version = workspace_package["rust-version"]
+    except (FileNotFoundError, KeyError, TypeError) as error:
+        raise ValueError(f"Invalid workspace manifest structure: {manifest}") from error
+    if not isinstance(members, list) or not isinstance(workspace_rust_version, str):
+        raise TypeError("Workspace members must be a list and rust-version a string")
     rows = [
-        package_matrix(root / "rust" / str(member) / "Cargo.toml") for member in members
+        package_matrix(
+            root / "rust" / str(member) / "Cargo.toml", workspace_rust_version
+        )
+        for member in members
     ]
     return {
         "schema_version": "1.0",
-        "workspace_rust_version": workspace["workspace"]["package"]["rust-version"],
+        "workspace_rust_version": workspace_rust_version,
         "packages": rows,
     }
 
@@ -52,8 +69,33 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("root", type=Path, nargs="?", default=Path.cwd())
     parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="run locked cargo checks for every feature lane",
+    )
     args = parser.parse_args()
     report = build_matrix(args.root.resolve())
+    if args.verify:
+        for row in report["packages"]:
+            package = row["package"]
+            for lane in row["lanes"]:
+                command = [
+                    "cargo",
+                    "check",
+                    "--manifest-path",
+                    "rust/Cargo.toml",
+                    "-p",
+                    str(package),
+                    "--locked",
+                ]
+                if lane == "no-default-features":
+                    command.append("--no-default-features")
+                elif lane == "all-features":
+                    command.append("--all-features")
+                elif lane.startswith("feature:"):
+                    command.extend(["--features", lane.removeprefix("feature:")])
+                subprocess.run(command, cwd=args.root.resolve(), check=True)  # noqa: S603 -- command is constructed from Cargo metadata
     destination = args.output or args.root / ".conductor/local/rust-feature-matrix.json"
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_dependency_frontier_script.py
+++ b/tests/test_dependency_frontier_script.py
@@ -57,3 +57,20 @@ def test_yanked_and_prerelease_versions_are_not_stable_frontier() -> None:
     )
 
     assert [str(version) for version in versions] == ["1.0"]
+
+
+def test_rust_feature_matrix_names_default_optional_and_all_feature_lanes() -> None:
+    from scripts.rust_feature_matrix import build_matrix
+
+    report = build_matrix(__import__("pathlib").Path.cwd())
+    diagnostics = next(
+        row for row in report["packages"] if row["package"] == "voiage-diagnostics"
+    )
+    assert report["workspace_rust_version"] == "1.85"
+    assert diagnostics["features"] == ["otel"]
+    assert diagnostics["lanes"] == [
+        "default",
+        "no-default-features",
+        "feature:otel",
+        "all-features",
+    ]

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,7 @@ This document lists the actionable tasks for `voiage` development. Agents should
 
 - [ ] Ordered implementation tracks: `conductor/tracks/agent_safe_engineering_20260907/`, `conductor/tracks/execution_packet_guard_20260907/`, `conductor/tracks/version_identity_contracts_20260907/`, `conductor/tracks/native_structured_logging_20260907/`, `conductor/tracks/logging_privacy_resilience_20260907/`, `conductor/tracks/vop_logging_version_pilot_20260907/`, and `conductor/tracks/optional_native_telemetry_20260907/`.
 - [ ] Existing active delivery tracks: `conductor/tracks/remaining_backlog_delivery_20260831/` and `conductor/tracks/v2_2_release_and_venue_submissions_20260830/`.
+- [x] Add the Rust feature/MSRV qualification matrix and locked verification lane.
 
 *   [x] Advance the fourteen open issue deliverables with source-bound agent
     review, current venue inputs, upstream Julia delivery, guarded HPC retry


### PR DESCRIPTION
Adds a deterministic Rust workspace feature/MSRV matrix covering default, no-default, each optional feature, and all-features lanes. The matrix is derived from Cargo manifests and has contract tests so optional native dependencies remain auditable without changing stable defaults.