### PR TITLE
feat(cli): add dry-run capability report

### DIFF
--- a/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
+++ b/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
@@ -12,7 +12,7 @@
     {"path": "specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/normative/expected.json", "sha256": "c9327a488f58d915f9202a8012b152c68d6aea2cd4a47b38d869c531dbc26507"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/deterministic-sensitivity-reference-review.md", "sha256": "b480cece8323bed01e9887cb59686baa92c0fdceb9e910875f0748129d9ce753"},
     {"path": "voiage/deterministic_sensitivity_contract.py", "sha256": "435fb0257962250649927f10bc5e845adcf69c24160c110369b131d528310cd5"},
-    {"path": "voiage/cli.py", "sha256": "e63fb6520b2cca9d682a6513c131180e6d0613efdad456c38ab053cf26a6eb15"},
+    {"path": "voiage/cli.py", "sha256": "f431e38308d7dec54d585165a7bb5a413ac79fd5316b18454a31ca9d7d68ec80"},
     {"path": "voiage/methods/deterministic_sensitivity.py", "sha256": "d4277431f47ed5aeeb6d21b4e16dfb9517a93ee3f4ce392f01059f0199b7b52b"},
     {"path": "voiage/plot/deterministic_sensitivity.py", "sha256": "0579dd59626c6ba09aaba67da7daa18f72810d67e7729626244a7ca96fa558f2"},
     {"path": "tests/test_deterministic_sensitivity.py", "sha256": "04d6f94968920b2471190448412cbe30b2674c7220e6f753f8c0be9e27b7a146"},

--- a/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
+++ b/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
@@ -12,7 +12,7 @@
     {"path": "specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/normative/expected.json", "sha256": "c9327a488f58d915f9202a8012b152c68d6aea2cd4a47b38d869c531dbc26507"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/deterministic-sensitivity-reference-review.md", "sha256": "b480cece8323bed01e9887cb59686baa92c0fdceb9e910875f0748129d9ce753"},
     {"path": "voiage/deterministic_sensitivity_contract.py", "sha256": "435fb0257962250649927f10bc5e845adcf69c24160c110369b131d528310cd5"},
-    {"path": "voiage/cli.py", "sha256": "f431e38308d7dec54d585165a7bb5a413ac79fd5316b18454a31ca9d7d68ec80"},
+    {"path": "voiage/cli.py", "sha256": "2d7ca4edd1a50d8dfdcc470641883a21868ee0ce86b7b6d7c4bb10a0770d9ddd"},
     {"path": "voiage/methods/deterministic_sensitivity.py", "sha256": "d4277431f47ed5aeeb6d21b4e16dfb9517a93ee3f4ce392f01059f0199b7b52b"},
     {"path": "voiage/plot/deterministic_sensitivity.py", "sha256": "0579dd59626c6ba09aaba67da7daa18f72810d67e7729626244a7ca96fa558f2"},
     {"path": "tests/test_deterministic_sensitivity.py", "sha256": "04d6f94968920b2471190448412cbe30b2674c7220e6f753f8c0be9e27b7a146"},

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     {"path": "specs/frontier/value-of-distributional-information/v1/README.md", "sha256": "cda82e1a704b5172d11fb551d77318dca9cb80972a49889bb763dba098862bae"},
     {"path": "voiage/contracts/distributional_information.py", "sha256": "a2a9a8f4a9c85173f00fa34e928e6b6c04619885be2dc647a3a9ab91ba4e5854"},
     {"path": "voiage/methods/distributional_information.py", "sha256": "cd8fef252073109450fbfa7f422cb08eb084827ebfad35da412d99ad07c75f28"},
-    {"path": "voiage/cli.py", "sha256": "f431e38308d7dec54d585165a7bb5a413ac79fd5316b18454a31ca9d7d68ec80"},
+    {"path": "voiage/cli.py", "sha256": "2d7ca4edd1a50d8dfdcc470641883a21868ee0ce86b7b6d7c4bb10a0770d9ddd"},
     {"path": "voiage/__init__.py", "sha256": "552edd0f753af8f50a873aeda971201f6bf0175a252b7a27ad48489665c3873f"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-reference-review.md", "sha256": "d0fcdacde3d0340684428298259551a8d58fb6e0b4efcb780b48b7b106337548"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-implementation-review.md", "sha256": "075ade9e26efcc4d0a680ea46536352fa31b672c65259c48c7fc1a6a6ab51f0b"},

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     {"path": "specs/frontier/value-of-distributional-information/v1/README.md", "sha256": "cda82e1a704b5172d11fb551d77318dca9cb80972a49889bb763dba098862bae"},
     {"path": "voiage/contracts/distributional_information.py", "sha256": "a2a9a8f4a9c85173f00fa34e928e6b6c04619885be2dc647a3a9ab91ba4e5854"},
     {"path": "voiage/methods/distributional_information.py", "sha256": "cd8fef252073109450fbfa7f422cb08eb084827ebfad35da412d99ad07c75f28"},
-    {"path": "voiage/cli.py", "sha256": "e63fb6520b2cca9d682a6513c131180e6d0613efdad456c38ab053cf26a6eb15"},
+    {"path": "voiage/cli.py", "sha256": "f431e38308d7dec54d585165a7bb5a413ac79fd5316b18454a31ca9d7d68ec80"},
     {"path": "voiage/__init__.py", "sha256": "552edd0f753af8f50a873aeda971201f6bf0175a252b7a27ad48489665c3873f"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-reference-review.md", "sha256": "d0fcdacde3d0340684428298259551a8d58fb6e0b4efcb780b48b7b106337548"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-implementation-review.md", "sha256": "075ade9e26efcc4d0a680ea46536352fa31b672c65259c48c7fc1a6a6ab51f0b"},

--- a/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "voiage/cli.py",
-      "sha256": "f431e38308d7dec54d585165a7bb5a413ac79fd5316b18454a31ca9d7d68ec80"
+      "sha256": "2d7ca4edd1a50d8dfdcc470641883a21868ee0ce86b7b6d7c4bb10a0770d9ddd"
     },
     {
       "path": "tests/test_value_of_flexibility.py",

--- a/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "voiage/cli.py",
-      "sha256": "e63fb6520b2cca9d682a6513c131180e6d0613efdad456c38ab053cf26a6eb15"
+      "sha256": "f431e38308d7dec54d585165a7bb5a413ac79fd5316b18454a31ca9d7d68ec80"
     },
     {
       "path": "tests/test_value_of_flexibility.py",

--- a/tests/test_cli_capabilities.py
+++ b/tests/test_cli_capabilities.py
@@ -1,0 +1,17 @@
+"""Tests for the side-effect-free capability report."""
+
+import json
+
+from typer.testing import CliRunner
+
+from voiage import cli
+
+
+def test_capabilities_json_is_dry_run_and_machine_readable() -> None:
+    result = CliRunner().invoke(cli.app, ["capabilities", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "1.0.0"
+    assert payload["dry_run"] is True
+    assert "evpi" in payload["methods"]
+    assert set(payload["optional_modules"]) == {"jax", "torch", "polars", "pyarrow"}

--- a/tests/test_cli_capabilities.py
+++ b/tests/test_cli_capabilities.py
@@ -15,4 +15,6 @@ def test_capabilities_json_is_dry_run_and_machine_readable() -> None:
     assert payload["dry_run"] is True
     assert "evpi" in payload["methods"]
     assert set(payload["optional_modules"]) == {"jax", "torch", "polars", "pyarrow"}
-    assert all(isinstance(value, bool) for value in payload["optional_modules"].values())
+    assert all(
+        isinstance(value, bool) for value in payload["optional_modules"].values()
+    )

--- a/tests/test_cli_capabilities.py
+++ b/tests/test_cli_capabilities.py
@@ -15,3 +15,4 @@ def test_capabilities_json_is_dry_run_and_machine_readable() -> None:
     assert payload["dry_run"] is True
     assert "evpi" in payload["methods"]
     assert set(payload["optional_modules"]) == {"jax", "torch", "polars", "pyarrow"}
+    assert all(isinstance(value, bool) for value in payload["optional_modules"].values())

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -780,6 +780,7 @@ def test_cli_command_registry_matches_expected_surface() -> None:
         "calculate-validation",
         "calculate-value-of-flexibility",
         "calculate-value-of-distributional-information",
+        "capabilities",
         "assess-qualitative-information",
         "create-distributed-large-scale",
         "generate-config",

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -13,7 +13,7 @@ It uses Typer for command-line argument parsing.
 
 from collections.abc import Callable, Iterable
 import csv
-import importlib.util
+import importlib
 import io
 import json
 import logging
@@ -249,6 +249,15 @@ app = typer.Typer(
 app.add_typer(ingestion_app, name="ingest")
 
 
+def _module_available(name: str) -> bool:
+    """Return whether an optional module can be imported successfully."""
+    try:
+        importlib.import_module(name)
+    except (ImportError, OSError, RuntimeError):
+        return False
+    return True
+
+
 @app.command(name="capabilities")
 def capabilities(
     json_output: bool = typer.Option(
@@ -263,7 +272,7 @@ def capabilities(
         "package_version": __version__,
         "backend": "rust-backed-cpu",
         "optional_modules": {
-            name: importlib.util.find_spec(name) is not None
+            name: _module_available(name)
             for name in ("jax", "torch", "polars", "pyarrow")
         },
         "methods": ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance"],

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -13,6 +13,7 @@ It uses Typer for command-line argument parsing.
 
 from collections.abc import Callable, Iterable
 import csv
+import importlib.util
 import io
 import json
 import logging
@@ -246,6 +247,34 @@ app = typer.Typer(
     help="voiage: A Command-Line Interface for Value of Information Analysis."
 )
 app.add_typer(ingestion_app, name="ingest")
+
+
+@app.command(name="capabilities")
+def capabilities(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON."
+    ),
+) -> None:
+    """Report installed capabilities without evaluating a model."""
+    from voiage import __version__
+
+    report = {
+        "schema_version": "1.0.0",
+        "package_version": __version__,
+        "backend": "rust-backed-cpu",
+        "optional_modules": {
+            name: importlib.util.find_spec(name) is not None
+            for name in ("jax", "torch", "polars", "pyarrow")
+        },
+        "methods": ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance"],
+        "dry_run": True,
+    }
+    if json_output:
+        typer.echo(json.dumps(report, sort_keys=True))
+    else:
+        typer.echo(f"voiage {report['package_version']} ({report['backend']})")
+        typer.echo("methods: " + ", ".join(report["methods"]))
+
 
 OutputFormat = Literal["text", "json", "csv"]
 


### PR DESCRIPTION
Adds a side-effect-free capabilities command with stable JSON schema, package/backend identity, optional-module discovery, core method inventory, and explicit dry-run semantics. Includes a CLI contract test.