### PR TITLE
fix(conductor): reject unknown packet fields

### DIFF
--- a/scripts/validate_execution_packets.py
+++ b/scripts/validate_execution_packets.py
@@ -28,6 +28,7 @@ REQUIRED = {
 ALLOWED_FIELDS = REQUIRED | {
     "prepared_at",
     "prerequisite_tracks",
+    "result_states",
     "initial_file_state",
     "integrator_only",
     "native_command",

--- a/scripts/validate_execution_packets.py
+++ b/scripts/validate_execution_packets.py
@@ -25,6 +25,19 @@ REQUIRED = {
     "phases",
 }
 
+ALLOWED_FIELDS = REQUIRED | {
+    "prepared_at",
+    "prerequisite_tracks",
+    "initial_file_state",
+    "integrator_only",
+    "native_command",
+    "final_command",
+    "hash_review",
+    "rollback",
+    "stop_conditions",
+    "completion",
+}
+
 
 def _error(message: str) -> ValueError:
     return ValueError(message)
@@ -65,6 +78,9 @@ def validate_packet(
 ) -> list[str]:
     """Return deterministic validation errors for one packet."""
     errors: list[str] = []
+    unknown = sorted(set(packet) - ALLOWED_FIELDS)
+    if unknown:
+        errors.append("unknown packet fields: " + ", ".join(unknown))
     missing = sorted(REQUIRED - packet.keys())
     if missing:
         errors.append("missing required fields: " + ", ".join(missing))

--- a/tests/test_execution_packets.py
+++ b/tests/test_execution_packets.py
@@ -35,6 +35,12 @@ def test_missing_required_field_is_rejected(packet: dict, field: str) -> None:
     )
 
 
+def test_unknown_packet_fields_are_rejected(packet: dict) -> None:
+    packet["unexpected"] = "must fail closed"
+    errors = validate_packet(packet, ROOT)
+    assert any("unknown packet fields: unexpected" in error for error in errors)
+
+
 def test_unknown_and_duplicate_task_ids_are_rejected(packet: dict) -> None:
     packet["phases"][0]["task_ids"] = ["T1.1", "T1.1", "T99.9"]
     errors = validate_packet(packet, ROOT)


### PR DESCRIPTION
Fail closed when execution packets contain fields outside the declared contract. Adds a regression test and preserves the existing valid packet and harness behavior.