### PR TITLE
feat(diagnostics): add recoverable checkpoint identity contract

### DIFF
--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -24,7 +24,7 @@
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
     "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
-    "rust/crates/voiage-diagnostics/src/lib.rs": "e7b9d22349ec1870e21216de990094d4b2f8af5156fae0fecb2aed9516a98c76"
+    "rust/crates/voiage-diagnostics/src/lib.rs": "dddac88a04d43afdb496991f62a5b522d6c68235d5fc9a18659438822e321b1a"
   },
   "reserved_implementation_files": [
     "rust/crates/voiage-diagnostics/src/otel_export.rs",

--- a/rust/crates/voiage-diagnostics/src/checkpoint.rs
+++ b/rust/crates/voiage-diagnostics/src/checkpoint.rs
@@ -1,10 +1,10 @@
 //! Durable identity and resume contracts for bounded executions.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 /// Immutable identities that must match before a checkpoint can be resumed.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CheckpointIdentity {
     /// Identity of the model and its input data.
     pub model_input: String,
@@ -12,6 +12,23 @@ pub struct CheckpointIdentity {
     pub rng: String,
     /// Identity of the algorithm and its configuration.
     pub algorithm: String,
+}
+
+#[derive(Deserialize)]
+struct CheckpointIdentityWire {
+    model_input: String,
+    rng: String,
+    algorithm: String,
+}
+
+impl<'de> Deserialize<'de> for CheckpointIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = CheckpointIdentityWire::deserialize(deserializer)?;
+        Self::new(wire.model_input, wire.rng, wire.algorithm).map_err(serde::de::Error::custom)
+    }
 }
 
 impl CheckpointIdentity {
@@ -37,7 +54,7 @@ impl CheckpointIdentity {
 }
 
 /// A serializable, last-valid checkpoint at a batch boundary.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ExecutionCheckpoint {
     /// Identities required for safe resume.
     pub identity: CheckpointIdentity,
@@ -47,6 +64,30 @@ pub struct ExecutionCheckpoint {
     pub evaluations: u64,
     /// Digest of the committed partial result payload.
     pub payload_digest: String,
+}
+
+#[derive(Deserialize)]
+struct ExecutionCheckpointWire {
+    identity: CheckpointIdentity,
+    completed_batches: u64,
+    evaluations: u64,
+    payload_digest: String,
+}
+
+impl<'de> Deserialize<'de> for ExecutionCheckpoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ExecutionCheckpointWire::deserialize(deserializer)?;
+        Self::new(
+            wire.identity,
+            wire.completed_batches,
+            wire.evaluations,
+            wire.payload_digest,
+        )
+        .map_err(serde::de::Error::custom)
+    }
 }
 
 impl ExecutionCheckpoint {
@@ -119,6 +160,14 @@ mod tests {
             checkpoint.ensure_compatible(&changed),
             Err(CheckpointError::IdentityMismatch)
         );
+    }
+
+    #[test]
+    fn deserialization_revalidates_persisted_identity_and_digest() {
+        let invalid = r#"{"identity":{"model_input":"","rng":"seed","algorithm":"evsi"},"completed_batches":1,"evaluations":1,"payload_digest":"sha256:x"}"#;
+        assert!(serde_json::from_str::<ExecutionCheckpoint>(invalid).is_err());
+        let invalid_digest = r#"{"identity":{"model_input":"model","rng":"seed","algorithm":"evsi"},"completed_batches":1,"evaluations":1,"payload_digest":""}"#;
+        assert!(serde_json::from_str::<ExecutionCheckpoint>(invalid_digest).is_err());
     }
 
     #[test]

--- a/rust/crates/voiage-diagnostics/src/checkpoint.rs
+++ b/rust/crates/voiage-diagnostics/src/checkpoint.rs
@@ -1,0 +1,135 @@
+//! Durable identity and resume contracts for bounded executions.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Immutable identities that must match before a checkpoint can be resumed.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CheckpointIdentity {
+    /// Identity of the model and its input data.
+    pub model_input: String,
+    /// Identity of the random-number stream or deterministic seed.
+    pub rng: String,
+    /// Identity of the algorithm and its configuration.
+    pub algorithm: String,
+}
+
+impl CheckpointIdentity {
+    /// Construct an identity, rejecting empty components.
+    pub fn new(
+        model_input: impl Into<String>,
+        rng: impl Into<String>,
+        algorithm: impl Into<String>,
+    ) -> Result<Self, CheckpointError> {
+        let identity = Self {
+            model_input: model_input.into(),
+            rng: rng.into(),
+            algorithm: algorithm.into(),
+        };
+        if identity.model_input.is_empty()
+            || identity.rng.is_empty()
+            || identity.algorithm.is_empty()
+        {
+            return Err(CheckpointError::EmptyIdentity);
+        }
+        Ok(identity)
+    }
+}
+
+/// A serializable, last-valid checkpoint at a batch boundary.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionCheckpoint {
+    /// Identities required for safe resume.
+    pub identity: CheckpointIdentity,
+    /// Number of fully committed batches.
+    pub completed_batches: u64,
+    /// Number of model evaluations committed in those batches.
+    pub evaluations: u64,
+    /// Digest of the committed partial result payload.
+    pub payload_digest: String,
+}
+
+impl ExecutionCheckpoint {
+    /// Construct a checkpoint with a non-empty payload digest.
+    pub fn new(
+        identity: CheckpointIdentity,
+        completed_batches: u64,
+        evaluations: u64,
+        payload_digest: impl Into<String>,
+    ) -> Result<Self, CheckpointError> {
+        let payload_digest = payload_digest.into();
+        if payload_digest.is_empty() {
+            return Err(CheckpointError::EmptyPayloadDigest);
+        }
+        Ok(Self {
+            identity,
+            completed_batches,
+            evaluations,
+            payload_digest,
+        })
+    }
+
+    /// Reject resume when model, RNG, or algorithm identity changed.
+    pub fn ensure_compatible(&self, identity: &CheckpointIdentity) -> Result<(), CheckpointError> {
+        if &self.identity == identity {
+            Ok(())
+        } else {
+            Err(CheckpointError::IdentityMismatch)
+        }
+    }
+}
+
+/// Fail-closed checkpoint construction or resume error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CheckpointError {
+    /// One identity component was empty.
+    EmptyIdentity,
+    /// The persisted result payload has no digest.
+    EmptyPayloadDigest,
+    /// Resume identities do not match the checkpoint.
+    IdentityMismatch,
+}
+
+impl fmt::Display for CheckpointError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::EmptyIdentity => "checkpoint identity components must not be empty",
+            Self::EmptyPayloadDigest => "checkpoint payload digest must not be empty",
+            Self::IdentityMismatch => "checkpoint identity does not match the requested resume",
+        })
+    }
+}
+
+impl std::error::Error for CheckpointError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> CheckpointIdentity {
+        CheckpointIdentity::new("model-v1", "seed-7", "evsi-v2").unwrap()
+    }
+
+    #[test]
+    fn resume_requires_all_execution_identities_to_match() {
+        let checkpoint = ExecutionCheckpoint::new(identity(), 3, 30, "sha256:abc").unwrap();
+        assert!(checkpoint.ensure_compatible(&identity()).is_ok());
+        let changed = CheckpointIdentity::new("model-v1", "seed-8", "evsi-v2").unwrap();
+        assert_eq!(
+            checkpoint.ensure_compatible(&changed),
+            Err(CheckpointError::IdentityMismatch)
+        );
+    }
+
+    #[test]
+    fn empty_identity_and_digest_fail_closed() {
+        assert_eq!(
+            CheckpointIdentity::new("", "seed", "algorithm"),
+            Err(CheckpointError::EmptyIdentity)
+        );
+        assert_eq!(
+            ExecutionCheckpoint::new(identity(), 0, 0, ""),
+            Err(CheckpointError::EmptyPayloadDigest)
+        );
+    }
+}

--- a/rust/crates/voiage-diagnostics/src/lib.rs
+++ b/rust/crates/voiage-diagnostics/src/lib.rs
@@ -4,12 +4,14 @@
 
 use std::collections::BTreeMap;
 
+mod checkpoint;
 mod contracts;
 mod domain_mapping;
 #[cfg(feature = "otel")]
 pub mod otel_export;
 pub mod telemetry;
 
+pub use checkpoint::{CheckpointError, CheckpointIdentity, ExecutionCheckpoint};
 pub use contracts::{
     ApproximationStatus, DiagnosticStatus, Diagnostics, MethodMaturity, MethodMetadata,
     WarningRecord, WarningSeverity,


### PR DESCRIPTION
Adds a Rust-native, serializable checkpoint contract for bounded execution. Resume requires matching model/input, RNG, and algorithm identities, and checkpoint construction rejects empty payload digests.