### PR TITLE
feat(diagnostics): enforce bounded execution budgets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add a Rust-native execution budget with atomic batch reservations and validated checkpoint resume identities.
+
 - Add a deterministic Rust feature/MSRV qualification matrix covering default,
   no-default, optional-feature and all-feature lanes, with an explicit locked
   Cargo verification mode.

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -24,7 +24,7 @@
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
     "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
-    "rust/crates/voiage-diagnostics/src/lib.rs": "dddac88a04d43afdb496991f62a5b522d6c68235d5fc9a18659438822e321b1a"
+    "rust/crates/voiage-diagnostics/src/lib.rs": "69c13e39f3163a1a4a1418ffa0cbb4546221470d95b11087b9e0e8098eae76e5"
   },
   "reserved_implementation_files": [
     "rust/crates/voiage-diagnostics/src/otel_export.rs",

--- a/rust/crates/voiage-diagnostics/src/checkpoint.rs
+++ b/rust/crates/voiage-diagnostics/src/checkpoint.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 /// Immutable identities that must match before a checkpoint can be resumed.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -53,27 +55,56 @@ impl CheckpointIdentity {
     }
 }
 
-/// A finite evaluation budget enforced at batch boundaries.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+/// A finite evaluation budget with atomic batch reservations.
+#[derive(Clone, Debug)]
 pub struct ExecutionBudget {
     /// Maximum model evaluations permitted for the complete execution.
     pub max_evaluations: u64,
+    remaining: Arc<AtomicU64>,
 }
 
 impl ExecutionBudget {
     /// Construct a budget. Zero is valid and permits no evaluations.
     #[must_use]
-    pub const fn new(max_evaluations: u64) -> Self {
-        Self { max_evaluations }
+    pub fn new(max_evaluations: u64) -> Self {
+        Self {
+            max_evaluations,
+            remaining: Arc::new(AtomicU64::new(max_evaluations)),
+        }
     }
 
     /// Return whether a batch can execute without exceeding the budget.
     #[must_use]
-    pub const fn allows(self, completed_evaluations: u64, batch_size: u64) -> bool {
-        match completed_evaluations.checked_add(batch_size) {
-            Some(total) => total <= self.max_evaluations,
-            None => false,
+    pub fn allows(&self, completed_evaluations: u64, batch_size: u64) -> bool {
+        completed_evaluations
+            .checked_add(batch_size)
+            .is_some_and(|total| total <= self.max_evaluations)
+            && self.remaining.load(Ordering::Acquire) >= batch_size
+    }
+
+    /// Atomically reserve a complete batch, preventing concurrent over-admission.
+    pub fn try_reserve(&self, batch_size: u64) -> bool {
+        let mut current = self.remaining.load(Ordering::Acquire);
+        loop {
+            if current < batch_size {
+                return false;
+            }
+            match self.remaining.compare_exchange_weak(
+                current,
+                current - batch_size,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
         }
+    }
+
+    /// Return the unreserved evaluation count.
+    #[must_use]
+    pub fn remaining(&self) -> u64 {
+        self.remaining.load(Ordering::Acquire)
     }
 }
 
@@ -136,8 +167,8 @@ impl ExecutionCheckpoint {
 
     /// Return whether the next complete batch fits the supplied budget.
     #[must_use]
-    pub fn next_batch_allowed(&self, budget: ExecutionBudget, batch_size: u64) -> bool {
-        budget.allows(self.evaluations, batch_size)
+    pub fn next_batch_allowed(&self, budget: &ExecutionBudget, batch_size: u64) -> bool {
+        self.evaluations.checked_add(batch_size).is_some() && budget.try_reserve(batch_size)
     }
 
     /// Reject resume when model, RNG, or algorithm identity changed.
@@ -184,9 +215,9 @@ mod tests {
     #[test]
     fn zero_budget_performs_no_evaluations_and_batches_are_atomic() {
         let checkpoint = ExecutionCheckpoint::new(identity(), 0, 0, "sha256:empty").unwrap();
-        assert!(!checkpoint.next_batch_allowed(ExecutionBudget::new(0), 1));
-        assert!(checkpoint.next_batch_allowed(ExecutionBudget::new(2), 2));
-        assert!(!checkpoint.next_batch_allowed(ExecutionBudget::new(2), 3));
+        assert!(!checkpoint.next_batch_allowed(&ExecutionBudget::new(0), 1));
+        assert!(checkpoint.next_batch_allowed(&ExecutionBudget::new(2), 2));
+        assert!(!checkpoint.next_batch_allowed(&ExecutionBudget::new(2), 3));
     }
 
     #[test]

--- a/rust/crates/voiage-diagnostics/src/checkpoint.rs
+++ b/rust/crates/voiage-diagnostics/src/checkpoint.rs
@@ -53,6 +53,30 @@ impl CheckpointIdentity {
     }
 }
 
+/// A finite evaluation budget enforced at batch boundaries.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionBudget {
+    /// Maximum model evaluations permitted for the complete execution.
+    pub max_evaluations: u64,
+}
+
+impl ExecutionBudget {
+    /// Construct a budget. Zero is valid and permits no evaluations.
+    #[must_use]
+    pub const fn new(max_evaluations: u64) -> Self {
+        Self { max_evaluations }
+    }
+
+    /// Return whether a batch can execute without exceeding the budget.
+    #[must_use]
+    pub const fn allows(self, completed_evaluations: u64, batch_size: u64) -> bool {
+        match completed_evaluations.checked_add(batch_size) {
+            Some(total) => total <= self.max_evaluations,
+            None => false,
+        }
+    }
+}
+
 /// A serializable, last-valid checkpoint at a batch boundary.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ExecutionCheckpoint {
@@ -110,6 +134,12 @@ impl ExecutionCheckpoint {
         })
     }
 
+    /// Return whether the next complete batch fits the supplied budget.
+    #[must_use]
+    pub fn next_batch_allowed(&self, budget: ExecutionBudget, batch_size: u64) -> bool {
+        budget.allows(self.evaluations, batch_size)
+    }
+
     /// Reject resume when model, RNG, or algorithm identity changed.
     pub fn ensure_compatible(&self, identity: &CheckpointIdentity) -> Result<(), CheckpointError> {
         if &self.identity == identity {
@@ -149,6 +179,14 @@ mod tests {
 
     fn identity() -> CheckpointIdentity {
         CheckpointIdentity::new("model-v1", "seed-7", "evsi-v2").unwrap()
+    }
+
+    #[test]
+    fn zero_budget_performs_no_evaluations_and_batches_are_atomic() {
+        let checkpoint = ExecutionCheckpoint::new(identity(), 0, 0, "sha256:empty").unwrap();
+        assert!(!checkpoint.next_batch_allowed(ExecutionBudget::new(0), 1));
+        assert!(checkpoint.next_batch_allowed(ExecutionBudget::new(2), 2));
+        assert!(!checkpoint.next_batch_allowed(ExecutionBudget::new(2), 3));
     }
 
     #[test]

--- a/rust/crates/voiage-diagnostics/src/lib.rs
+++ b/rust/crates/voiage-diagnostics/src/lib.rs
@@ -11,7 +11,7 @@ mod domain_mapping;
 pub mod otel_export;
 pub mod telemetry;
 
-pub use checkpoint::{CheckpointError, CheckpointIdentity, ExecutionCheckpoint};
+pub use checkpoint::{CheckpointError, CheckpointIdentity, ExecutionBudget, ExecutionCheckpoint};
 pub use contracts::{
     ApproximationStatus, DiagnosticStatus, Diagnostics, MethodMaturity, MethodMetadata,
     WarningRecord, WarningSeverity,


### PR DESCRIPTION
Extends the Rust-native checkpoint contract with explicit evaluation budgets and atomic batch admission. Zero budgets perform no evaluations, overflow is rejected, and packet baselines are refreshed so the repository harness remains fail-closed.