### PR TITLE
ci: bind coverage to exact source head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,8 +424,17 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
         persist-credentials: false
+
+    - name: Assert and record exact source head
+      env:
+        EXPECTED_SOURCE_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: |
+        tested_head="$(git rev-parse HEAD)"
+        test "${tested_head}" = "${EXPECTED_SOURCE_HEAD}"
+        printf 'tested source head: %s\n' "${tested_head}" >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Bind the authoritative coverage job to the exact pull-request source head and record that provenance in CI summaries.
+
 - Add a Rust-native execution budget with atomic batch reservations and validated checkpoint resume identities.
 
 - Add a deterministic Rust feature/MSRV qualification matrix covering default,

--- a/tests/test_exact_head_workflows.py
+++ b/tests/test_exact_head_workflows.py
@@ -40,3 +40,8 @@ def test_every_polyglot_job_binds_and_records_exact_source_head() -> None:
 def test_mutation_job_binds_and_records_exact_source_head() -> None:
     workflow = yaml.safe_load((WORKFLOWS / "ci.yml").read_text(encoding="utf-8"))
     _assert_exact_head_steps(workflow["jobs"]["test-mutation"]["steps"])
+
+
+def test_coverage_job_binds_and_records_exact_source_head() -> None:
+    workflow = yaml.safe_load((WORKFLOWS / "ci.yml").read_text(encoding="utf-8"))
+    _assert_exact_head_steps(workflow["jobs"]["coverage-report"]["steps"])


### PR DESCRIPTION
Ensure the authoritative coverage job checks out and records the pull request head SHA, preventing coverage artifacts from a merge commit or unrelated source tree from being accepted.