### PR TITLE
🧪 Add test for metamodel score method

### DIFF
--- a/tests/test_metamodels.py
+++ b/tests/test_metamodels.py
@@ -108,6 +108,25 @@ def test_linear_metamodel(sample_data) -> None:
     assert rmse >= 0
 
 
+def test_metamodel_protocol_score(sample_data) -> None:
+    """Test the score method in Metamodel protocol implementations."""
+    if not SKLEARN_AVAILABLE:
+        pytest.skip("sklearn not available")
+
+    x, y = sample_data
+
+    # We test on RandomForestMetamodel as a concrete implementation
+    model = RandomForestMetamodel()
+    model.fit(x, y)
+
+    # Check that score exists and returns a float
+    score = model.score(x, y)
+    assert isinstance(score, float)
+
+    # The score should be R^2, so it should be bounded above by 1.0
+    assert score <= 1.0
+
+
 def test_random_forest_metamodel(sample_data) -> None:
     """Test the RandomForestMetamodel."""
     # Skip if sklearn is not available


### PR DESCRIPTION
🎯 **What:** Added a unit test (`test_metamodel_protocol_score`) for the `score` method in `tests/test_metamodels.py`.
📊 **Coverage:** The test ensures that an implementation of `Metamodel` (e.g. `RandomForestMetamodel`) correctly exposes a `score` method that takes `(x, y)` as arguments and returns a `float` value representing the R^2 score (<= 1.0).
✨ **Result:** Increased test coverage by verifying the behavior of the `score` method specified in the `Metamodel` protocol interface.

---
*PR created automatically by Jules for task [555481459443272329](https://jules.google.com/task/555481459443272329) started by @edithatogo*