### PR TITLE
feat(cli): add structured capability query errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add dry-run capability queries with structured unsupported-method errors and normalized supported-method selection.
+
 - Bind the authoritative coverage job to the exact pull-request source head and record that provenance in CI summaries.
 
 - Add a Rust-native execution budget with atomic batch reservations and validated checkpoint resume identities.

--- a/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
+++ b/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
@@ -12,7 +12,7 @@
     {"path": "specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/normative/expected.json", "sha256": "c9327a488f58d915f9202a8012b152c68d6aea2cd4a47b38d869c531dbc26507"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/deterministic-sensitivity-reference-review.md", "sha256": "b480cece8323bed01e9887cb59686baa92c0fdceb9e910875f0748129d9ce753"},
     {"path": "voiage/deterministic_sensitivity_contract.py", "sha256": "435fb0257962250649927f10bc5e845adcf69c24160c110369b131d528310cd5"},
-    {"path": "voiage/cli.py", "sha256": "2d7ca4edd1a50d8dfdcc470641883a21868ee0ce86b7b6d7c4bb10a0770d9ddd"},
+    {"path": "voiage/cli.py", "sha256": "e4129ccc743f4f1997997e3c231110b5b1eabc9fd917b00d80344f6e5bf25e94"},
     {"path": "voiage/methods/deterministic_sensitivity.py", "sha256": "d4277431f47ed5aeeb6d21b4e16dfb9517a93ee3f4ce392f01059f0199b7b52b"},
     {"path": "voiage/plot/deterministic_sensitivity.py", "sha256": "0579dd59626c6ba09aaba67da7daa18f72810d67e7729626244a7ca96fa558f2"},
     {"path": "tests/test_deterministic_sensitivity.py", "sha256": "04d6f94968920b2471190448412cbe30b2674c7220e6f753f8c0be9e27b7a146"},

--- a/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
+++ b/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
@@ -12,7 +12,7 @@
     {"path": "specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/normative/expected.json", "sha256": "c9327a488f58d915f9202a8012b152c68d6aea2cd4a47b38d869c531dbc26507"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/deterministic-sensitivity-reference-review.md", "sha256": "b480cece8323bed01e9887cb59686baa92c0fdceb9e910875f0748129d9ce753"},
     {"path": "voiage/deterministic_sensitivity_contract.py", "sha256": "435fb0257962250649927f10bc5e845adcf69c24160c110369b131d528310cd5"},
-    {"path": "voiage/cli.py", "sha256": "e4129ccc743f4f1997997e3c231110b5b1eabc9fd917b00d80344f6e5bf25e94"},
+    {"path": "voiage/cli.py", "sha256": "65de01b183c0f0e6d6365298f4bdc92f2280fa9dc4c84afe2328cca965c4a865"},
     {"path": "voiage/methods/deterministic_sensitivity.py", "sha256": "d4277431f47ed5aeeb6d21b4e16dfb9517a93ee3f4ce392f01059f0199b7b52b"},
     {"path": "voiage/plot/deterministic_sensitivity.py", "sha256": "0579dd59626c6ba09aaba67da7daa18f72810d67e7729626244a7ca96fa558f2"},
     {"path": "tests/test_deterministic_sensitivity.py", "sha256": "04d6f94968920b2471190448412cbe30b2674c7220e6f753f8c0be9e27b7a146"},

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     {"path": "specs/frontier/value-of-distributional-information/v1/README.md", "sha256": "cda82e1a704b5172d11fb551d77318dca9cb80972a49889bb763dba098862bae"},
     {"path": "voiage/contracts/distributional_information.py", "sha256": "a2a9a8f4a9c85173f00fa34e928e6b6c04619885be2dc647a3a9ab91ba4e5854"},
     {"path": "voiage/methods/distributional_information.py", "sha256": "cd8fef252073109450fbfa7f422cb08eb084827ebfad35da412d99ad07c75f28"},
-    {"path": "voiage/cli.py", "sha256": "2d7ca4edd1a50d8dfdcc470641883a21868ee0ce86b7b6d7c4bb10a0770d9ddd"},
+    {"path": "voiage/cli.py", "sha256": "e4129ccc743f4f1997997e3c231110b5b1eabc9fd917b00d80344f6e5bf25e94"},
     {"path": "voiage/__init__.py", "sha256": "552edd0f753af8f50a873aeda971201f6bf0175a252b7a27ad48489665c3873f"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-reference-review.md", "sha256": "d0fcdacde3d0340684428298259551a8d58fb6e0b4efcb780b48b7b106337548"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-implementation-review.md", "sha256": "075ade9e26efcc4d0a680ea46536352fa31b672c65259c48c7fc1a6a6ab51f0b"},

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     {"path": "specs/frontier/value-of-distributional-information/v1/README.md", "sha256": "cda82e1a704b5172d11fb551d77318dca9cb80972a49889bb763dba098862bae"},
     {"path": "voiage/contracts/distributional_information.py", "sha256": "a2a9a8f4a9c85173f00fa34e928e6b6c04619885be2dc647a3a9ab91ba4e5854"},
     {"path": "voiage/methods/distributional_information.py", "sha256": "cd8fef252073109450fbfa7f422cb08eb084827ebfad35da412d99ad07c75f28"},
-    {"path": "voiage/cli.py", "sha256": "e4129ccc743f4f1997997e3c231110b5b1eabc9fd917b00d80344f6e5bf25e94"},
+    {"path": "voiage/cli.py", "sha256": "65de01b183c0f0e6d6365298f4bdc92f2280fa9dc4c84afe2328cca965c4a865"},
     {"path": "voiage/__init__.py", "sha256": "552edd0f753af8f50a873aeda971201f6bf0175a252b7a27ad48489665c3873f"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-reference-review.md", "sha256": "d0fcdacde3d0340684428298259551a8d58fb6e0b4efcb780b48b7b106337548"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-implementation-review.md", "sha256": "075ade9e26efcc4d0a680ea46536352fa31b672c65259c48c7fc1a6a6ab51f0b"},

--- a/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "voiage/cli.py",
-      "sha256": "e4129ccc743f4f1997997e3c231110b5b1eabc9fd917b00d80344f6e5bf25e94"
+      "sha256": "65de01b183c0f0e6d6365298f4bdc92f2280fa9dc4c84afe2328cca965c4a865"
     },
     {
       "path": "tests/test_value_of_flexibility.py",

--- a/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "voiage/cli.py",
-      "sha256": "2d7ca4edd1a50d8dfdcc470641883a21868ee0ce86b7b6d7c4bb10a0770d9ddd"
+      "sha256": "e4129ccc743f4f1997997e3c231110b5b1eabc9fd917b00d80344f6e5bf25e94"
     },
     {
       "path": "tests/test_value_of_flexibility.py",

--- a/tests/test_cli_capabilities.py
+++ b/tests/test_cli_capabilities.py
@@ -37,3 +37,9 @@ def test_capabilities_selects_supported_method_without_evaluation() -> None:
     payload = json.loads(result.stdout)
     assert payload["selected_method"] == "evpi"
     assert payload["dry_run"] is True
+
+
+def test_capabilities_text_reports_selected_method() -> None:
+    result = CliRunner().invoke(cli.app, ["capabilities", "--method", "EVPI"])
+    assert result.exit_code == 0
+    assert "selected method: evpi (available)" in result.stdout

--- a/tests/test_cli_capabilities.py
+++ b/tests/test_cli_capabilities.py
@@ -18,3 +18,22 @@ def test_capabilities_json_is_dry_run_and_machine_readable() -> None:
     assert all(
         isinstance(value, bool) for value in payload["optional_modules"].values()
     )
+
+
+def test_capabilities_reports_structured_unsupported_method_error() -> None:
+    result = CliRunner().invoke(
+        cli.app, ["capabilities", "--json", "--method", "not-a-method"]
+    )
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "unsupported_method"
+    assert payload["error"]["action"] == "choose one of available_methods"
+    assert payload["dry_run"] is True
+
+
+def test_capabilities_selects_supported_method_without_evaluation() -> None:
+    result = CliRunner().invoke(cli.app, ["capabilities", "--json", "--method", "EVPI"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["selected_method"] == "evpi"
+    assert payload["dry_run"] is True

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -258,10 +258,16 @@ def _module_available(name: str) -> bool:
     return True
 
 
+_CAPABILITY_METHODS = ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance"]
+
+
 @app.command(name="capabilities")
 def capabilities(
     json_output: bool = typer.Option(
         False, "--json", help="Emit machine-readable JSON."
+    ),
+    method: str | None = typer.Option(
+        None, "--method", help="Check one method and return its capability status."
     ),
 ) -> None:
     """Report installed capabilities without evaluating a model."""
@@ -275,9 +281,28 @@ def capabilities(
             name: _module_available(name)
             for name in ("jax", "torch", "polars", "pyarrow")
         },
-        "methods": ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance"],
+        "methods": _CAPABILITY_METHODS,
         "dry_run": True,
     }
+    if method is not None:
+        normalized_method = method.strip().lower()
+        if normalized_method not in _CAPABILITY_METHODS:
+            error = {
+                "schema_version": report["schema_version"],
+                "error": {
+                    "code": "unsupported_method",
+                    "message": f"unsupported capability method: {method}",
+                    "available_methods": _CAPABILITY_METHODS,
+                    "action": "choose one of available_methods",
+                },
+                "dry_run": True,
+            }
+            if json_output:
+                typer.echo(json.dumps(error, sort_keys=True))
+            else:
+                typer.echo(error["error"]["message"])
+            raise typer.Exit(code=2)
+        report["selected_method"] = normalized_method
     if json_output:
         typer.echo(json.dumps(report, sort_keys=True))
     else:

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -308,6 +308,8 @@ def capabilities(
     else:
         typer.echo(f"voiage {report['package_version']} ({report['backend']})")
         typer.echo("methods: " + ", ".join(report["methods"]))
+        if "selected_method" in report:
+            typer.echo(f"selected method: {report['selected_method']} (available)")
 
 
 OutputFormat = Literal["text", "json", "csv"]


### PR DESCRIPTION
Extend the dry-run capability report with method selection and actionable JSON errors for unsupported methods, without evaluating a model.