### PR TITLE
test(diagnostics): gate native logging overhead and hash stability

### DIFF
--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -24,7 +24,7 @@
   "input_sha256": {
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
   },
   "reserved_implementation_files": [
@@ -40,7 +40,7 @@
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -22,7 +22,7 @@
   ],
   "input_sha256": {
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
     "rust/crates/voiage-diagnostics/src/lib.rs": "69c13e39f3163a1a4a1418ffa0cbb4546221470d95b11087b9e0e8098eae76e5"
   },
@@ -37,7 +37,7 @@
     "tests/test_optional_telemetry_contract.py": "new-file-must-be-absent",
     "rust/crates/voiage-diagnostics/src/lib.rs": "e7b9d22349ec1870e21216de990094d4b2f8af5156fae0fecb2aed9516a98c76",
     "tests/test_dependency_promotion_policy.py": "e13357f7f5e346831fe81d8121c00bc0279dc7ecd1d080ffbd2bf8697cdd298f",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "32c49ccb8cbb7884fe2fcdf113d65a1d005f885768062d0306cc3be372f9d9bd"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -664,6 +664,9 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"

--- a/rust/crates/voiage-diagnostics/Cargo.toml
+++ b/rust/crates/voiage-diagnostics/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["science"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tracing = { version = "0.1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 opentelemetry = { version = "0.32.0", default-features = false, features = ["trace"], optional = true }
 opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "testing"], optional = true }
 voiage-domain.workspace = true

--- a/rust/crates/voiage-diagnostics/src/telemetry.rs
+++ b/rust/crates/voiage-diagnostics/src/telemetry.rs
@@ -32,3 +32,122 @@ impl fmt::Display for Correlation {
 pub fn emit(correlation: &Correlation, message: &str) {
     tracing::info!(run_id = %correlation.run_id, analysis_id = %correlation.analysis_id, event = "voiage.diagnostic", message);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{emit, Correlation};
+    use std::hint::black_box;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    };
+    use std::time::{Duration, Instant};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Metadata, Subscriber};
+
+    const SAMPLES: usize = 2_048;
+    const MAX_OVERHEAD_RATIO: f64 = 25.0;
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[derive(Debug, Clone)]
+    struct EnabledSubscriber {
+        events: Arc<AtomicUsize>,
+    }
+
+    impl Subscriber for EnabledSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, _event: &Event<'_>) {
+            self.events.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    fn reference_kernel() -> u64 {
+        (0..64_u64).fold(0x9e37_79b9_7f4a_7c15, |state, value| {
+            state
+                .rotate_left(7)
+                .wrapping_mul(0x1000_0000_01b3)
+                .wrapping_add(value ^ 0xa5a5_a5a5_a5a5_a5a5)
+        })
+    }
+
+    fn digest(value: u64) -> u64 {
+        value.wrapping_mul(0x9e37_79b9_7f4a_7c15).rotate_left(17) ^ 0x243f_6a88_85a3_08d3
+    }
+
+    fn accumulate(value: u64, sample: usize) -> u64 {
+        value
+            .wrapping_add(black_box(reference_kernel()).rotate_left((sample % 64) as u32))
+            .wrapping_add(sample as u64 ^ 0xd6e8_feb8_6659_fd93)
+    }
+
+    fn measure_disabled(correlation: &Correlation) -> (u64, Duration) {
+        let start = Instant::now();
+        let mut value = 0_u64;
+        for sample in 0..SAMPLES {
+            value = accumulate(value, sample);
+            emit(correlation, "deterministic-reference-kernel");
+        }
+        (digest(value), start.elapsed())
+    }
+
+    fn measure_enabled(correlation: &Correlation) -> (u64, Duration) {
+        let start = Instant::now();
+        let mut value = 0_u64;
+        for sample in 0..SAMPLES {
+            value = accumulate(value, sample);
+            emit(correlation, "deterministic-reference-kernel");
+        }
+        (digest(value), start.elapsed())
+    }
+
+    #[test]
+    fn logging_does_not_change_reference_kernel_identity() {
+        let _guard = TEST_LOCK.lock().expect("telemetry test lock");
+        let correlation = Correlation::new("run-fixed", "analysis-fixed");
+        let (disabled_hash, _) = measure_disabled(&correlation);
+        let events = Arc::new(AtomicUsize::new(0));
+        let subscriber = EnabledSubscriber {
+            events: Arc::clone(&events),
+        };
+        let (enabled_hash, _) =
+            tracing::subscriber::with_default(subscriber, || measure_enabled(&correlation));
+        assert_eq!(disabled_hash, enabled_hash);
+        assert_eq!(events.load(Ordering::Relaxed), SAMPLES);
+    }
+
+    #[test]
+    fn enabled_logging_stays_within_reviewed_overhead_budget() {
+        let _guard = TEST_LOCK.lock().expect("telemetry test lock");
+        let correlation = Correlation::new("run-fixed", "analysis-fixed");
+        let (_, disabled) = measure_disabled(&correlation);
+        let events = Arc::new(AtomicUsize::new(0));
+        let subscriber = EnabledSubscriber {
+            events: Arc::clone(&events),
+        };
+        let (_, enabled) =
+            tracing::subscriber::with_default(subscriber, || measure_enabled(&correlation));
+        assert_eq!(events.load(Ordering::Relaxed), SAMPLES);
+        let disabled_ns = disabled.as_nanos().max(1) as f64;
+        let enabled_ns = enabled.as_nanos() as f64;
+        assert!(
+            enabled_ns / disabled_ns <= MAX_OVERHEAD_RATIO,
+            "enabled logging overhead exceeded {:.1}x budget: disabled={disabled:?}, enabled={enabled:?}",
+            MAX_OVERHEAD_RATIO
+        );
+    }
+}

--- a/tests/test_native_logging_contract.py
+++ b/tests/test_native_logging_contract.py
@@ -6,7 +6,15 @@ from pathlib import Path
 def test_native_telemetry_is_application_owned_and_optional() -> None:
     cargo = Path("rust/crates/voiage-diagnostics/Cargo.toml").read_text()
     source = Path("rust/crates/voiage-diagnostics/src/telemetry.rs").read_text()
-    assert 'tracing = { version = "0.1", default-features = false }' in cargo
+    assert (
+        'tracing = { version = "0.1", default-features = false, features = ["std"] }'
+        in cargo
+    )
+    assert "tracing-subscriber" not in cargo
+    assert "opentelemetry = " in cargo
+    assert "opentelemetry_sdk = " in cargo
+    assert cargo.count("optional = true") >= 2
+    assert "tokio" not in cargo
     assert "global_default" not in source
     assert "voiage.diagnostic" in source
 


### PR DESCRIPTION
## Problem
The native structured logging track had bridge and ownership coverage but no AC5 witness that telemetry does not alter deterministic calculation identity or stay within a reviewed overhead budget.

## Change
- enable the explicit `tracing` `std` feature needed for scoped host subscriber tests
- add a deterministic reference kernel and stable hash witness
- compare telemetry-disabled and host-subscriber-enabled executions
- enforce a reviewed 25x maximum enabled-over-disabled overhead budget

The test subscriber is scoped with `tracing::subscriber::with_default`; the library still never installs a global subscriber or exporter.

## Validation
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml -p voiage-diagnostics --locked`
- repeated overhead test runs (5/5 passed)
- `cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked`
