### PR TITLE
fix(conductor): keep privacy prerequisite acceptance pending

### DIFF
--- a/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
+++ b/conductor/tracks/logging_privacy_resilience_20260907/metadata.json
@@ -3,7 +3,7 @@
   "type": "feature",
   "status": "new",
   "created_at": "2026-09-07T01:59:07Z",
-  "updated_at": "2026-09-08T00:00:00Z",
+  "updated_at": "2026-09-08T16:45:00Z",
   "description": "Logging privacy and bounded delivery",
   "github_cross_reference": {
     "issue": "https://github.com/edithatogo/voiage/issues/1114"
@@ -20,8 +20,8 @@
     {
       "id": "prerequisites",
       "kind": "repository",
-      "status": "satisfied",
-      "evidence": "PR #1119 merged at 3e33feafd68d718142b083de12d697e2ec5f42e5; hosted checks passed."
+      "status": "pending",
+      "evidence": "PR #1119 implementation is merged, but native structured logging final acceptance and this track CLOSE.1/CLOSE.2 remain open; retain prerequisite pending until source-bound acceptance evidence exists."
     }
   ],
   "implementation_preparation": {

--- a/conductor/tracks/logging_privacy_resilience_20260907/plan.md
+++ b/conductor/tracks/logging_privacy_resilience_20260907/plan.md
@@ -1,6 +1,6 @@
 # Implementation plan: Logging privacy and bounded delivery
 
-Implementation exists in PR #1119; final acceptance remains pending the required full local/native gate. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: native_structured_logging_20260907. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
+Implementation exists in PR #1119; final acceptance remains pending the required full local/native gate. Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json). Prerequisites: native_structured_logging_20260907 remains pending final acceptance; PR #1139 is implementation evidence only. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md).
 
 ## Phase 1: Privacy
 


### PR DESCRIPTION
## Summary
- keep logging privacy acceptance pending until native logging final acceptance is source-bound
- preserve the merged PR #1119 implementation as implementation evidence only
- align the plan prerequisite wording with the fail-closed gate

## Validation
- `git diff --check`
