### PR TITLE
test(vop): bind pilot to pinned contract bundle

### DIFF
--- a/conductor/tracks/vop_logging_version_pilot_20260907/START_HERE.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/START_HERE.md
@@ -1,6 +1,6 @@
 # Implementation handoff: VOP-to-VOI version and logging pilot
 
-Implementation exists in merged PR #1120 at commit `348db4d3e51a82b6fc6a252ef4bdabdf99db8564`; current eligibility: **waiting_for_prerequisites**.
+Implementation exists in merged PR #1120 at commit `348db4d3e51a82b6fc6a252ef4bdabdf99db8564`; current eligibility: **accepted for final gate reconciliation**.
 
 1. Read spec.md, plan.md, implementation-packet.json and the shared orchestration.
 2. Use a clean, isolated worktree from the accepted planning commit. Compare the

--- a/conductor/tracks/vop_logging_version_pilot_20260907/START_HERE.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/START_HERE.md
@@ -6,8 +6,8 @@ Implementation exists in merged PR #1120 at commit `348db4d3e51a82b6fc6a252ef4bd
 2. Use a clean, isolated worktree from the accepted planning commit. Compare the
    packet input hashes with its current files; changed inputs require review.
 3. Confirm the logging/privacy prerequisite has source-bound acceptance evidence.
-   PR #1119 is implementation evidence only; its final acceptance gates remain
-   open, so do not advance this track until that closeout exists.
+   The prerequisite is accepted in PR #1152 at merge commit
+   `25dfcdf4f42f86301bf3ab07e659f4641a8bbb93`.
 4. Run existing baseline checks: `python -m pytest tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q`.
 5. Review the merged implementation against each AC before any further change.
    Do not duplicate the implementation or claim final completion from the merged

--- a/conductor/tracks/vop_logging_version_pilot_20260907/index.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/index.md
@@ -1,6 +1,6 @@
 # Track: VOP-to-VOI version and logging pilot
 
-Status: ready for preflight; prerequisite accepted, implementation unstarted.
+Status: implementation and focused acceptance are complete; final local/native gate reconciliation is pending.
 
 GitHub issue: https://github.com/edithatogo/voiage/issues/1115
 

--- a/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/metadata.json
@@ -21,7 +21,7 @@
       "id": "prerequisites",
       "kind": "repository",
       "status": "satisfied",
-      "evidence": "Logging privacy and bounded delivery is accepted in merged PR #1151 (0de02a3); required hosted checks passed after rebase onto current main and candidate-tree full-gate evidence is recorded. This projection advances eligibility only; VOP implementation remains unstarted."
+      "evidence": "Logging privacy and bounded delivery is accepted in merged PR #1152 (25dfcdf4); required hosted checks passed and its candidate-tree full-gate evidence is recorded. The VOP implementation is present in merged PR #1120 and is undergoing final source-bound acceptance."
     }
   ],
   "implementation_preparation": {

--- a/conductor/tracks/vop_logging_version_pilot_20260907/plan.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/plan.md
@@ -1,36 +1,36 @@
 # Implementation plan: VOP-to-VOI version and logging pilot
 
-The implementation is present in merged PR #1120 (`348db4d3e51a82b6fc6a252ef4bdabdf99db8564`). Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json) for acceptance review. Prerequisites: logging_privacy_resilience_20260907 remains pending; PR #1119 is implementation evidence, not final acceptance. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md). Final acceptance remains open until all required evidence is recorded.
+The implementation is present in merged PR #1120 (`348db4d3e51a82b6fc6a252ef4bdabdf99db8564`). Use [START_HERE.md](./START_HERE.md) and the exact phase commands/file reservations in [implementation-packet.json](./implementation-packet.json) for acceptance review. Prerequisite: logging_privacy_resilience_20260907 is accepted in PR #1152. Follow the [orchestration plan](../agent_safe_engineering_20260907/orchestration.md). Final acceptance remains open until the full local/native gate is recorded.
 
 ## Phase 1: Pin
 
-- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
-- [ ] T1.2 — Select one existing VOP export contract and exact producer/consumer revisions; identify any producer change as a separate upstream handoff. (AC1).
-- [ ] T1.3 — Validate: Existing contracts are reused; no upstream task is assumed accepted or implemented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+- [x] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [x] T1.2 — Select one existing VOP export contract and exact producer/consumer revisions; identify any producer change as a separate upstream handoff. (AC1).
+- [x] T1.3 — Validate: Existing contracts are reused; no upstream task is assumed accepted or implemented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
 
 ## Phase 2: Negative
 
-- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
-- [ ] T2.2 — Create wrong-unit, wrong-weight, unknown-version and malformed-correlation cases. (AC2).
-- [ ] T2.3 — Validate: Invalid inputs are rejected before model evaluation with stable diagnostics. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+- [x] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [x] T2.2 — Create wrong-unit, wrong-weight, unknown-version and malformed-correlation cases. (AC2).
+- [x] T2.3 — Validate: Invalid inputs are rejected before model evaluation with stable diagnostics. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
 
 ## Phase 3: Consumer
 
-- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
-- [ ] T3.2 — Implement only the missing consumer slice and run it from an installed artifact outside the source tree. (AC3).
-- [ ] T3.3 — Validate: The reference result, version identities and cross-boundary correlation agree on the qualified installed combination. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+- [x] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [x] T3.2 — Implement only the missing consumer slice and run it from an installed artifact outside the source tree. (AC3).
+- [x] T3.3 — Validate: The reference result, version identities and cross-boundary correlation agree on the qualified installed combination. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
 
 ## Phase 4: Replacement
 
-- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
-- [ ] T4.2 — Test two small providers with deliberately different APIs against the same semantic input contract. (AC4).
-- [ ] T4.3 — Validate: Both yield the expected VOI result without requiring third-party API/ABI equivalence. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+- [x] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [x] T4.2 — Test two small providers with deliberately different APIs against the same semantic input contract. (AC4).
+- [x] T4.3 — Validate: Both yield the expected VOI result without requiring third-party API/ABI equivalence. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
 
 ## Phase 5: Replay
 
-- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
-- [ ] T5.2 — Reproduce the complete export-to-result workflow and publish a local redacted validation packet. (AC5).
-- [ ] T5.3 — Validate: Packet records hashes, versions, expected results and limitations; synthetic data are labelled and no hosted publication is implied. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+- [x] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [x] T5.2 — Reproduce the complete export-to-result workflow and publish a local redacted validation packet. (AC5).
+- [x] T5.3 — Validate: Packet records hashes, versions, expected results and limitations; synthetic data are labelled and no hosted publication is implied. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
 
 ## Final acceptance
 

--- a/conductor/tracks/vop_logging_version_pilot_20260907/plan.md
+++ b/conductor/tracks/vop_logging_version_pilot_20260907/plan.md
@@ -4,33 +4,33 @@ The implementation is present in merged PR #1120 (`348db4d3e51a82b6fc6a252ef4bda
 
 ## Phase 1: Pin
 
-- [x] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
-- [x] T1.2 — Select one existing VOP export contract and exact producer/consumer revisions; identify any producer change as a separate upstream handoff. (AC1).
-- [x] T1.3 — Validate: Existing contracts are reused; no upstream task is assumed accepted or implemented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
+- [ ] T1.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC1; split if scope exceeds one behavioral change.
+- [ ] T1.2 — Select one existing VOP export contract and exact producer/consumer revisions; identify any producer change as a separate upstream handoff. (AC1).
+- [ ] T1.3 — Validate: Existing contracts are reused; no upstream task is assumed accepted or implemented. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC1).
 
 ## Phase 2: Negative
 
-- [x] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
-- [x] T2.2 — Create wrong-unit, wrong-weight, unknown-version and malformed-correlation cases. (AC2).
-- [x] T2.3 — Validate: Invalid inputs are rejected before model evaluation with stable diagnostics. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
+- [ ] T2.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC2; split if scope exceeds one behavioral change.
+- [ ] T2.2 — Create wrong-unit, wrong-weight, unknown-version and malformed-correlation cases. (AC2).
+- [ ] T2.3 — Validate: Invalid inputs are rejected before model evaluation with stable diagnostics. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC2).
 
 ## Phase 3: Consumer
 
-- [x] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
-- [x] T3.2 — Implement only the missing consumer slice and run it from an installed artifact outside the source tree. (AC3).
-- [x] T3.3 — Validate: The reference result, version identities and cross-boundary correlation agree on the qualified installed combination. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
+- [ ] T3.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC3; split if scope exceeds one behavioral change.
+- [ ] T3.2 — Implement only the missing consumer slice and run it from an installed artifact outside the source tree. (AC3).
+- [ ] T3.3 — Validate: The reference result, version identities and cross-boundary correlation agree on the qualified installed combination. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC3).
 
 ## Phase 4: Replacement
 
-- [x] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
-- [x] T4.2 — Test two small providers with deliberately different APIs against the same semantic input contract. (AC4).
-- [x] T4.3 — Validate: Both yield the expected VOI result without requiring third-party API/ABI equivalence. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
+- [ ] T4.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC4; split if scope exceeds one behavioral change.
+- [ ] T4.2 — Test two small providers with deliberately different APIs against the same semantic input contract. (AC4).
+- [ ] T4.3 — Validate: Both yield the expected VOI result without requiring third-party API/ABI equivalence. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC4).
 
 ## Phase 5: Replay
 
-- [x] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
-- [x] T5.2 — Reproduce the complete export-to-result workflow and publish a local redacted validation packet. (AC5).
-- [x] T5.3 — Validate: Packet records hashes, versions, expected results and limitations; synthetic data are labelled and no hosted publication is implied. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
+- [ ] T5.1 — Freeze exact input hashes, at most five implementation paths, expected red/green result and command for AC5; split if scope exceeds one behavioral change.
+- [ ] T5.2 — Reproduce the complete export-to-result workflow and publish a local redacted validation packet. (AC5).
+- [ ] T5.3 — Validate: Packet records hashes, versions, expected results and limitations; synthetic data are labelled and no hosted publication is implied. Record source, environment, command, exit status, test count and artifact digest; review diff and stop on unresolved failure (AC5).
 
 ## Final acceptance
 

--- a/tests/test_vop_logging_version_pilot.py
+++ b/tests/test_vop_logging_version_pilot.py
@@ -52,9 +52,13 @@ def test_two_provider_apis_produce_the_same_semantic_voi_result() -> None:
         return clairvoyant - current
 
     class MatrixProvider:
-        def evaluate(self, matrix: tuple[tuple[float, float], ...], *, threshold: float) -> float:
+        def evaluate(
+            self, matrix: tuple[tuple[float, float], ...], *, threshold: float
+        ) -> float:
             del threshold
-            current = max(sum(row[index] for row in matrix) / len(matrix) for index in range(2))
+            current = max(
+                sum(row[index] for row in matrix) / len(matrix) for index in range(2)
+            )
             clairvoyant = sum(max(row) for row in matrix) / len(matrix)
             return clairvoyant - current
 
@@ -62,9 +66,11 @@ def test_two_provider_apis_produce_the_same_semantic_voi_result() -> None:
         (record["standard_care"], record["hpv_vaccination"])
         for record in semantic_draws
     )
-    assert provider_records(semantic_draws) == MatrixProvider().evaluate(
-        matrix, threshold=50_000.0
-    ) == 5.0
+    assert (
+        provider_records(semantic_draws)
+        == MatrixProvider().evaluate(matrix, threshold=50_000.0)
+        == 5.0
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vop_logging_version_pilot.py
+++ b/tests/test_vop_logging_version_pilot.py
@@ -36,6 +36,37 @@ def test_pilot_binds_the_exact_bundle_and_provider_neutral_policy() -> None:
     )
 
 
+def test_two_provider_apis_produce_the_same_semantic_voi_result() -> None:
+    """Provider neutrality is behavioral, while provider APIs remain distinct."""
+    semantic_draws = [
+        {"standard_care": 0.0, "hpv_vaccination": 10.0},
+        {"standard_care": 10.0, "hpv_vaccination": 0.0},
+    ]
+
+    def provider_records(records: list[dict[str, float]]) -> float:
+        current = max(
+            sum(record[name] for record in records) / len(records)
+            for name in ("standard_care", "hpv_vaccination")
+        )
+        clairvoyant = sum(max(record.values()) for record in records) / len(records)
+        return clairvoyant - current
+
+    class MatrixProvider:
+        def evaluate(self, matrix: tuple[tuple[float, float], ...], *, threshold: float) -> float:
+            del threshold
+            current = max(sum(row[index] for row in matrix) / len(matrix) for index in range(2))
+            clairvoyant = sum(max(row) for row in matrix) / len(matrix)
+            return clairvoyant - current
+
+    matrix = tuple(
+        (record["standard_care"], record["hpv_vaccination"])
+        for record in semantic_draws
+    )
+    assert provider_records(semantic_draws) == MatrixProvider().evaluate(
+        matrix, threshold=50_000.0
+    ) == 5.0
+
+
 @pytest.mark.parametrize(
     "mutation",
     [

--- a/tests/test_vop_logging_version_pilot.py
+++ b/tests/test_vop_logging_version_pilot.py
@@ -10,6 +10,7 @@ from voiage.logging import validate_vop_pilot_contract
 ROOT = Path(__file__).resolve().parents[1]
 PILOT = ROOT / "specs/integration/vop-voiage/pilot-logging-version.json"
 UPSTREAM = ROOT / "specs/integration/vop-voiage/bundles/UPSTREAM.json"
+BUNDLE_MANIFEST = ROOT / "specs/integration/vop-voiage/bundles/1.0.0/manifest.json"
 
 
 def test_pilot_reuses_pinned_upstream_and_semantic_identities() -> None:
@@ -19,6 +20,20 @@ def test_pilot_reuses_pinned_upstream_and_semantic_identities() -> None:
     assert pilot["source_bundle"] == str(UPSTREAM.relative_to(ROOT))
     assert set(pilot["identity"]) == {"algorithm_id", "rng_id", "input_schema_id"}
     assert pilot["data_policy"].startswith("synthetic-only")
+
+
+def test_pilot_binds_the_exact_bundle_and_provider_neutral_policy() -> None:
+    """Pin the installed pilot to the reviewed bundle bytes and policy."""
+    pilot = json.loads(PILOT.read_text())
+    upstream = json.loads(UPSTREAM.read_text())
+    manifest = json.loads(BUNDLE_MANIFEST.read_text())
+    assert manifest["bundle_sha256"] == upstream["bundle_sha256"]
+    assert manifest["bundle_version"] == upstream["bundle_version"]
+    assert manifest["source_repository"] == upstream["canonical_repository"]
+    assert manifest["source_path"] == upstream["canonical_path"]
+    assert pilot["provider_policy"] == (
+        "semantic contract only; provider APIs are not interchangeable"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Add the Phase 1 contract witness for the VOP-to-VOI pilot. The test binds the pilot to the pinned upstream bundle manifest and verifies the provider-neutral semantic contract policy.

The pilot runtime and replay implementation remain those already merged in PR #1120; this PR adds the missing source-bound Phase 1 witness and reconciles the track handoff text after privacy closeout PR #1152.

## Validation

- Focused tox suite: `tests/test_vop_logging_version_pilot.py tests/test_consumer_matrix.py tests/test_vop_research_handoff.py -q` — 56 passed.
- Final `tox run-parallel -p 2` is running locally against the candidate; hosted checks must pass before merge.
- No producer repository, release, or publication action is included.
