### PR TITLE
test(ffi): add independent v1 consumer compatibility witness

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,10 @@
 
 ## Unreleased
 
+- Add an independent C consumer compatibility witness for the versioned v1
+  ABI, including exact public function-pointer signatures, fixed-width layout
+  assertions and checked handle lifecycle usage.
+
 - Add an integrated 20-package VOI and software roadmap with Rust-first
   dependencies, statistical/economic/public-health extensions, dated dependency
   evidence, and parallel delivery lanes that resolve shared-contract, scientific,

--- a/tests/fixtures/compatibility_witnesses/voiage_v1_consumer.c
+++ b/tests/fixtures/compatibility_witnesses/voiage_v1_consumer.c
@@ -9,21 +9,40 @@ _Static_assert(sizeof(VoiageHandleV1) == 8, "handle width changed");
 
 int main(void) {
     const double values[4] = {10.0, 1.0, 2.0, 8.0};
+    double evsi_result = 1.0;
+    double research_cost = 0.5;
     double result = 0.0;
-    int32_t status = 0;
+    int32_t enbs_status = 0;
+    int32_t evpi_status = 0;
     int32_t rows = 2;
     int32_t columns = 2;
     VoiageHandleV1 handle = VOIAGE_V1_NULL_HANDLE;
+    VoiageAbiVersionV1 (*version_query)(void) = voiage_v1_abi_version;
+    VoiageAbiCapabilitiesV1 (*capabilities_query)(void) = voiage_v1_capabilities;
+    voiage_v1_status (*evpi_query)(const double *, uint64_t, uint64_t, double *) =
+        voiage_v1_evpi;
+    voiage_v1_status (*enbs_query)(double, double, double *) = voiage_v1_enbs;
+    void (*enbs_r_query)(const double *, const double *, double *, int32_t *) =
+        voiage_v1_enbs_r;
+    voiage_v1_status (*evpi_i32_query)(const double *, int32_t, int32_t, double *) =
+        voiage_v1_evpi_i32;
+    void (*evpi_i32_r_query)(const double *, const int32_t *, const int32_t *, double *, int32_t *) =
+        voiage_v1_evpi_i32_r;
+    voiage_v1_status (*handle_create_query)(VoiageHandleV1 *) = voiage_v1_handle_create;
+    voiage_v1_status (*handle_free_query)(VoiageHandleV1) = voiage_v1_handle_free;
+    voiage_v1_status (*error_message_query)(char *, uint64_t, uint64_t *) =
+        voiage_v1_error_message;
 
-    (void)voiage_v1_abi_version();
-    (void)voiage_v1_capabilities();
-    (void)voiage_v1_evpi(values, 2, 2, &result);
-    (void)voiage_v1_enbs(1.0, 0.5, &result);
-    voiage_v1_enbs_r(&result, &result, &result, &status);
-    (void)voiage_v1_evpi_i32(values, rows, columns, &result);
-    voiage_v1_evpi_i32_r(values, &rows, &columns, &result, &status);
-    (void)voiage_v1_handle_create(&handle);
-    (void)voiage_v1_handle_free(handle);
-    (void)voiage_v1_error_message(NULL, 0, NULL);
+    (void)version_query();
+    (void)capabilities_query();
+    (void)evpi_query(values, 2, 2, &result);
+    (void)enbs_query(evsi_result, research_cost, &result);
+    enbs_r_query(&evsi_result, &research_cost, &result, &enbs_status);
+    (void)evpi_i32_query(values, rows, columns, &result);
+    evpi_i32_r_query(values, &rows, &columns, &result, &evpi_status);
+    if (handle_create_query(&handle) == VOIAGE_V1_STATUS_OK) {
+        (void)handle_free_query(handle);
+    }
+    (void)error_message_query(NULL, 0, NULL);
     return 0;
 }

--- a/tests/fixtures/compatibility_witnesses/voiage_v1_consumer.c
+++ b/tests/fixtures/compatibility_witnesses/voiage_v1_consumer.c
@@ -1,0 +1,29 @@
+#include <stdint.h>
+#include <stddef.h>
+
+#include "voiage_v1.h"
+
+_Static_assert(sizeof(VoiageAbiVersionV1) == 12, "version layout changed");
+_Static_assert(sizeof(VoiageAbiCapabilitiesV1) == 16, "capability layout changed");
+_Static_assert(sizeof(VoiageHandleV1) == 8, "handle width changed");
+
+int main(void) {
+    const double values[4] = {10.0, 1.0, 2.0, 8.0};
+    double result = 0.0;
+    int32_t status = 0;
+    int32_t rows = 2;
+    int32_t columns = 2;
+    VoiageHandleV1 handle = VOIAGE_V1_NULL_HANDLE;
+
+    (void)voiage_v1_abi_version();
+    (void)voiage_v1_capabilities();
+    (void)voiage_v1_evpi(values, 2, 2, &result);
+    (void)voiage_v1_enbs(1.0, 0.5, &result);
+    voiage_v1_enbs_r(&result, &result, &result, &status);
+    (void)voiage_v1_evpi_i32(values, rows, columns, &result);
+    voiage_v1_evpi_i32_r(values, &rows, &columns, &result, &status);
+    (void)voiage_v1_handle_create(&handle);
+    (void)voiage_v1_handle_free(handle);
+    (void)voiage_v1_error_message(NULL, 0, NULL);
+    return 0;
+}

--- a/tests/test_ffi_sanitizer_contract.py
+++ b/tests/test_ffi_sanitizer_contract.py
@@ -58,5 +58,6 @@ def test_public_c_consumer_compiles_against_the_versioned_header() -> None:
         check=False,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_ffi_sanitizer_contract.py
+++ b/tests/test_ffi_sanitizer_contract.py
@@ -54,7 +54,15 @@ def test_public_c_consumer_compiles_against_the_versioned_header() -> None:
     fixture = ROOT / "tests/fixtures/compatibility_witnesses/voiage_v1_consumer.c"
     header_dir = ROOT / "rust/crates/voiage-ffi/include"
     result = subprocess.run(
-        [compiler, "-std=c11", "-Werror", "-fsyntax-only", "-I", str(header_dir), str(fixture)],
+        [
+            compiler,
+            "-std=c11",
+            "-Werror",
+            "-fsyntax-only",
+            "-I",
+            str(header_dir),
+            str(fixture),
+        ],
         check=False,
         capture_output=True,
         text=True,

--- a/tests/test_ffi_sanitizer_contract.py
+++ b/tests/test_ffi_sanitizer_contract.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 import re
+import shutil
+import subprocess
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -43,3 +45,18 @@ def test_consumer_pairs_every_successful_handle_and_allocation() -> None:
     assert "voiage_v1_error_message" in consumer
     assert "malloc" in consumer
     assert "free(message)" in consumer
+
+
+def test_public_c_consumer_compiles_against_the_versioned_header() -> None:
+    """A deliberately independent C consumer freezes the additive ABI surface."""
+    compiler = shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+    assert compiler is not None, "a C compiler is required for the ABI witness"
+    fixture = ROOT / "tests/fixtures/compatibility_witnesses/voiage_v1_consumer.c"
+    header_dir = ROOT / "rust/crates/voiage-ffi/include"
+    result = subprocess.run(
+        [compiler, "-std=c11", "-Werror", "-fsyntax-only", "-I", str(header_dir), str(fixture)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- add an independently compiled C consumer for the public versioned header
- exercise ABI version/capability discovery, EVPI/ENBS, adapters, handles, and error transport
- assert public structure sizes and handle widths at compile time

## Validation
- `TMPDIR=/Volumes/PortableSSD/tmp/voiage-g03 python -m pytest tests/test_ffi_sanitizer_contract.py tests/test_consumer_matrix.py -q --no-cov`
