### PR TITLE
feat(diagnostics): persist recoverable execution checkpoints

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Make Rust checkpoint persistence recover safely from stale temporary files,
+  use distinct temporary names, and preserve portable directory-durability
+  behavior.
+
 - Add dry-run capability queries with structured unsupported-method errors and normalized supported-method selection.
 
 - Bind the authoritative coverage job to the exact pull-request source head and record that provenance in CI summaries.

--- a/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
+++ b/conductor/tracks/native_structured_logging_20260907/implementation-packet.json
@@ -24,7 +24,7 @@
   "input_sha256": {
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "tests/test_logging_contract.py": "e815c8d7091c2bf7d1b50201a77be48f20a718354f4cbe29086e5c8a6fb22c6b",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "9234a8feff5362262664a7c92b37323829cc4f0da502ba068de057b1dc68ba85",
     "rust/crates/voiage-python/Cargo.toml": "4067a621998aececd693832bf1a98fb856b02111ae6d06f092fb6e44bd598d1b"
   },
   "reserved_implementation_files": [
@@ -40,7 +40,7 @@
     "voiage/logging.py": "06ea144518de66ac1af70c0be1699304aa7e07e14285e950ae4fda9feff246c8",
     "rust/crates/voiage-diagnostics/src/lib.rs": "897c4fe00e12a4b911d1ff6e2c23c643b9febefaffaf0d7fd1bfa5b9f4b07aeb",
     "rust/crates/voiage-python/src/lib.rs": "f3e646181ee83bf6e6ba4d2f43d4ccc8c6d5414634a50eeb5108c366f2a4cbf3",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "9234a8feff5362262664a7c92b37323829cc4f0da502ba068de057b1dc68ba85"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -22,9 +22,9 @@
   ],
   "input_sha256": {
     "rust/Cargo.toml": "91c0037f1361b837afc5c45c1e1d6edec1f51b094ee2739cc963895e930c7c36",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b",
+    "rust/crates/voiage-diagnostics/Cargo.toml": "9234a8feff5362262664a7c92b37323829cc4f0da502ba068de057b1dc68ba85",
     "tests/test_dependency_promotion_policy.py": "120debad7b5f2d5fed9f5ca89113d390d41ee12219d51fde3b31423f226360d4",
-    "rust/crates/voiage-diagnostics/src/lib.rs": "82e56e83f8f6ecf3b357d0fb372a967dec9f1b1fdd79938451c53bb7549cac2c"
+    "rust/crates/voiage-diagnostics/src/lib.rs": "d8067e0b78f20f6f1f4f8e7b619fc12129b340bceb3fb117c698685514632060"
   },
   "reserved_implementation_files": [
     "rust/crates/voiage-diagnostics/src/otel_export.rs",

--- a/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
+++ b/conductor/tracks/optional_native_telemetry_20260907/implementation-packet.json
@@ -35,9 +35,9 @@
   "initial_file_state": {
     "rust/crates/voiage-diagnostics/src/otel_export.rs": "new-file-must-be-absent",
     "tests/test_optional_telemetry_contract.py": "new-file-must-be-absent",
-    "rust/crates/voiage-diagnostics/src/lib.rs": "e7b9d22349ec1870e21216de990094d4b2f8af5156fae0fecb2aed9516a98c76",
+    "rust/crates/voiage-diagnostics/src/lib.rs": "d8067e0b78f20f6f1f4f8e7b619fc12129b340bceb3fb117c698685514632060",
     "tests/test_dependency_promotion_policy.py": "120debad7b5f2d5fed9f5ca89113d390d41ee12219d51fde3b31423f226360d4",
-    "rust/crates/voiage-diagnostics/Cargo.toml": "7e606d8030efcd379af2271db3064c4f5ab12916c2e6d9fe4df668885c079c8b"
+    "rust/crates/voiage-diagnostics/Cargo.toml": "9234a8feff5362262664a7c92b37323829cc4f0da502ba068de057b1dc68ba85"
   },
   "integrator_only": [
     "rust/Cargo.toml",

--- a/rust/crates/voiage-diagnostics/Cargo.toml
+++ b/rust/crates/voiage-diagnostics/Cargo.toml
@@ -16,13 +16,11 @@ categories = ["science"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 opentelemetry = { version = "0.32.0", default-features = false, features = ["trace"], optional = true }
 opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "testing"], optional = true }
 voiage-domain.workspace = true
-
-[dev-dependencies]
-serde_json = "1.0"
 
 [lints]
 workspace = true

--- a/rust/crates/voiage-diagnostics/src/checkpoint.rs
+++ b/rust/crates/voiage-diagnostics/src/checkpoint.rs
@@ -2,6 +2,9 @@
 
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -289,6 +292,70 @@ impl ExecutionCheckpoint {
     }
 }
 
+/// A file-backed checkpoint store that replaces a checkpoint atomically.
+#[derive(Clone, Debug)]
+pub struct CheckpointStore {
+    path: PathBuf,
+}
+
+impl CheckpointStore {
+    /// Create a store for a checkpoint path.
+    #[must_use]
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Persist a checkpoint through a same-directory temporary file and rename.
+    ///
+    /// The previous valid file remains in place if any write step fails before
+    /// the final rename.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CheckpointError::PersistenceFailure`] when the file cannot be
+    /// written, or [`CheckpointError::InvalidCheckpointEncoding`] when it
+    /// cannot be encoded.
+    pub fn save(&self, checkpoint: &ExecutionCheckpoint) -> Result<(), CheckpointError> {
+        let bytes = serde_json::to_vec(checkpoint)
+            .map_err(|_| CheckpointError::InvalidCheckpointEncoding)?;
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        let temporary = self.path.with_extension("tmp");
+        let result = (|| {
+            let mut file = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&temporary)
+                .map_err(|_| CheckpointError::PersistenceFailure)?;
+            file.write_all(&bytes)
+                .and_then(|()| file.sync_all())
+                .map_err(|_| CheckpointError::PersistenceFailure)?;
+            fs::rename(&temporary, &self.path).map_err(|_| CheckpointError::PersistenceFailure)?;
+            File::open(parent)
+                .and_then(|directory| directory.sync_all())
+                .map_err(|_| CheckpointError::PersistenceFailure)
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        result
+    }
+
+    /// Load and validate the latest complete checkpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CheckpointError::PersistenceFailure`] when the file cannot
+    /// be read, or [`CheckpointError::InvalidCheckpointEncoding`] when its
+    /// contents are malformed or violate checkpoint invariants.
+    pub fn load(&self) -> Result<ExecutionCheckpoint, CheckpointError> {
+        let mut file = File::open(&self.path).map_err(|_| CheckpointError::PersistenceFailure)?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|_| CheckpointError::PersistenceFailure)?;
+        serde_json::from_slice(&bytes).map_err(|_| CheckpointError::InvalidCheckpointEncoding)
+    }
+}
+
 /// Fail-closed checkpoint construction or resume error.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CheckpointError {
@@ -302,6 +369,10 @@ pub enum CheckpointError {
     InvalidStateTransition,
     /// Cooperative cancellation was observed at a batch boundary.
     Cancelled,
+    /// Checkpoint bytes could not be durably persisted or read.
+    PersistenceFailure,
+    /// Checkpoint bytes were malformed or violated serialization invariants.
+    InvalidCheckpointEncoding,
 }
 
 impl fmt::Display for CheckpointError {
@@ -312,6 +383,8 @@ impl fmt::Display for CheckpointError {
             Self::IdentityMismatch => "checkpoint identity does not match the requested resume",
             Self::InvalidStateTransition => "execution state transition is not permitted",
             Self::Cancelled => "execution was cancelled before batch admission",
+            Self::PersistenceFailure => "checkpoint persistence failed",
+            Self::InvalidCheckpointEncoding => "checkpoint encoding is invalid",
         })
     }
 }
@@ -396,5 +469,51 @@ mod tests {
             ExecutionCheckpoint::new(identity(), 0, 0, ""),
             Err(CheckpointError::EmptyPayloadDigest)
         );
+    }
+
+    #[test]
+    fn atomic_store_round_trip_preserves_checkpoint_identity() {
+        let path = std::env::temp_dir().join(format!(
+            "voiage-checkpoint-{}-{}.json",
+            std::process::id(),
+            "round-trip"
+        ));
+        let _ = std::fs::remove_file(&path);
+        let store = CheckpointStore::new(&path);
+        let checkpoint = ExecutionCheckpoint::new(identity(), 4, 40, "sha256:stable").unwrap();
+        store.save(&checkpoint).unwrap();
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded, checkpoint);
+        loaded.ensure_compatible(&identity()).unwrap();
+        let changed = CheckpointIdentity::new("model-v2", "seed-7", "evsi-v2").unwrap();
+        assert_eq!(
+            loaded.ensure_compatible(&changed),
+            Err(CheckpointError::IdentityMismatch)
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn failed_atomic_replacement_keeps_last_valid_checkpoint() {
+        let path = std::env::temp_dir().join(format!(
+            "voiage-checkpoint-{}-{}.json",
+            std::process::id(),
+            "failure"
+        ));
+        let temporary = path.with_extension("tmp");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&temporary);
+        let store = CheckpointStore::new(&path);
+        let checkpoint = ExecutionCheckpoint::new(identity(), 2, 20, "sha256:last-valid").unwrap();
+        store.save(&checkpoint).unwrap();
+        std::fs::write(&temporary, b"interrupted").unwrap();
+        let replacement = ExecutionCheckpoint::new(identity(), 3, 30, "sha256:new").unwrap();
+        assert_eq!(
+            store.save(&replacement),
+            Err(CheckpointError::PersistenceFailure)
+        );
+        assert_eq!(store.load().unwrap(), checkpoint);
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(temporary);
     }
 }

--- a/rust/crates/voiage-diagnostics/src/checkpoint.rs
+++ b/rust/crates/voiage-diagnostics/src/checkpoint.rs
@@ -318,8 +318,12 @@ impl CheckpointStore {
     pub fn save(&self, checkpoint: &ExecutionCheckpoint) -> Result<(), CheckpointError> {
         let bytes = serde_json::to_vec(checkpoint)
             .map_err(|_| CheckpointError::InvalidCheckpointEncoding)?;
-        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
-        let temporary = self.path.with_extension("tmp");
+        let parent = self
+            .path
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let temporary = temporary_path(&self.path)?;
         let result = (|| {
             let mut file = OpenOptions::new()
                 .create_new(true)
@@ -330,9 +334,7 @@ impl CheckpointStore {
                 .and_then(|()| file.sync_all())
                 .map_err(|_| CheckpointError::PersistenceFailure)?;
             fs::rename(&temporary, &self.path).map_err(|_| CheckpointError::PersistenceFailure)?;
-            File::open(parent)
-                .and_then(|directory| directory.sync_all())
-                .map_err(|_| CheckpointError::PersistenceFailure)
+            sync_parent_directory(parent)
         })();
         if result.is_err() {
             let _ = fs::remove_file(&temporary);
@@ -354,6 +356,46 @@ impl CheckpointStore {
             .map_err(|_| CheckpointError::PersistenceFailure)?;
         serde_json::from_slice(&bytes).map_err(|_| CheckpointError::InvalidCheckpointEncoding)
     }
+}
+
+static TEMPORARY_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn temporary_path(destination: &Path) -> Result<PathBuf, CheckpointError> {
+    let parent = destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let name = destination
+        .file_name()
+        .ok_or(CheckpointError::PersistenceFailure)?;
+    for _ in 0..128 {
+        let sequence = TEMPORARY_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let temporary_name = format!(
+            ".{}.tmp.{}.{}",
+            name.to_string_lossy(),
+            std::process::id(),
+            sequence
+        );
+        let candidate = parent.join(temporary_name);
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(CheckpointError::PersistenceFailure)
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(parent: &Path) -> Result<(), CheckpointError> {
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| CheckpointError::PersistenceFailure)
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_parent: &Path) -> Result<(), CheckpointError> {
+    // Windows does not provide a portable directory-handle fsync operation.
+    // The file is flushed before rename; the rename remains the commit point.
+    Ok(())
 }
 
 /// Fail-closed checkpoint construction or resume error.
@@ -494,7 +536,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_atomic_replacement_keeps_last_valid_checkpoint() {
+    fn stale_temporary_file_does_not_block_future_saves() {
         let path = std::env::temp_dir().join(format!(
             "voiage-checkpoint-{}-{}.json",
             std::process::id(),
@@ -508,12 +550,36 @@ mod tests {
         store.save(&checkpoint).unwrap();
         std::fs::write(&temporary, b"interrupted").unwrap();
         let replacement = ExecutionCheckpoint::new(identity(), 3, 30, "sha256:new").unwrap();
-        assert_eq!(
-            store.save(&replacement),
-            Err(CheckpointError::PersistenceFailure)
-        );
-        assert_eq!(store.load().unwrap(), checkpoint);
+        store.save(&replacement).unwrap();
+        assert_eq!(store.load().unwrap(), replacement);
         let _ = std::fs::remove_file(path);
         let _ = std::fs::remove_file(temporary);
+    }
+
+    #[test]
+    fn destination_with_tmp_suffix_gets_distinct_temporary_path() {
+        let path = std::env::temp_dir().join(format!(
+            "voiage-checkpoint-{}-{}.tmp",
+            std::process::id(),
+            "suffix"
+        ));
+        let store = CheckpointStore::new(&path);
+        let checkpoint = ExecutionCheckpoint::new(identity(), 1, 10, "sha256:suffix").unwrap();
+        store.save(&checkpoint).unwrap();
+        assert_eq!(store.load().unwrap(), checkpoint);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn bare_relative_path_uses_current_directory_as_parent() {
+        let path = PathBuf::from(format!(
+            "voiage-checkpoint-{}-bare.json",
+            std::process::id()
+        ));
+        let store = CheckpointStore::new(&path);
+        let checkpoint = ExecutionCheckpoint::new(identity(), 1, 10, "sha256:bare").unwrap();
+        store.save(&checkpoint).unwrap();
+        assert_eq!(store.load().unwrap(), checkpoint);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/rust/crates/voiage-diagnostics/src/lib.rs
+++ b/rust/crates/voiage-diagnostics/src/lib.rs
@@ -12,7 +12,8 @@ pub mod otel_export;
 pub mod telemetry;
 
 pub use checkpoint::{
-    CheckpointError, CheckpointIdentity, ExecutionBudget, ExecutionCheckpoint,
+    CancellationToken, CheckpointError, CheckpointIdentity, CheckpointStore, ExecutionBudget,
+    ExecutionCheckpoint, ExecutionState,
 };
 pub use contracts::{
     ApproximationStatus, DiagnosticStatus, Diagnostics, MethodMaturity, MethodMetadata,


### PR DESCRIPTION
## Summary
- add atomic same-directory checkpoint persistence with durable flush and cleanup
- fail closed on malformed or incompatible checkpoint payloads
- add interrupted-replacement and deterministic replay/identity witnesses

## Validation
- `cargo test --manifest-path rust/Cargo.toml --locked -p voiage-diagnostics`
- strict diagnostics Clippy with all targets/features
- `git diff --check`

The broader domain/numerics command was attempted locally but was stopped after host disk exhaustion; the focused diagnostics gate and strict Clippy passed.
