### PR TITLE
feat(capabilities): add schema-bound dry-run reports

### DIFF
--- a/conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json
@@ -10,8 +10,9 @@
     "package_version": {"type": "string", "minLength": 1},
     "backend": {"type": "string", "minLength": 1},
     "optional_modules": {"type": "object", "additionalProperties": {"type": "boolean"}},
-    "methods": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-    "dispatch_methods": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "methods": {"const": ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance"]},
+    "dispatch_methods": {"const": ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance"]},
+    "selected_method": {"type": ["string", "null"], "enum": ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance", null]},
     "dry_run": {"const": true}
   }
 }

--- a/conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://voiage.dev/contracts/capability-report-1.0.0.json",
+  "title": "Voiage CLI capability report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_version", "backend", "optional_modules", "methods", "dispatch_methods", "dry_run"],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "package_version": {"type": "string", "minLength": 1},
+    "backend": {"type": "string", "minLength": 1},
+    "optional_modules": {"type": "object", "additionalProperties": {"type": "boolean"}},
+    "methods": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "dispatch_methods": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "dry_run": {"const": true}
+  }
+}

--- a/conductor/tracks/agent_safe_engineering_20260907/g07-readiness.json
+++ b/conductor/tracks/agent_safe_engineering_20260907/g07-readiness.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1.0.0",
+  "track_id": "agent_safe_engineering_20260907",
+  "task_id": "G07",
+  "title": "Capability discovery and reproducible user reports",
+  "implementation_ready": true,
+  "admission": {
+    "delivery_repository": "edithatogo/voiage",
+    "capability_owner": "voiage maintainer",
+    "adapter_owner": "voiage CLI and contracts",
+    "excluded_responsibilities": [
+      "model evaluation",
+      "credential or patient-data discovery",
+      "external provider installation"
+    ],
+    "prerequisites": {
+      "G01": "accepted execution-packet guard",
+      "G03": {
+        "status": "merged",
+        "revision": "a93a7db3"
+      }
+    }
+  },
+  "exact_file_subset": [
+    "voiage/cli.py",
+    "voiage/contracts/capability_report.py",
+    "tests/test_capability_reports.py",
+    "docs/astro-site/src/content/docs/user-guide/features/cli.mdx",
+    "conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json"
+  ],
+  "baseline_revision": "ab6bcf296a9386bf5a065e269aa9f3d89a13cf97",
+  "acceptance_witness": {
+    "negative": [
+      "unsupported method returns structured exit-2 error",
+      "dispatch registry drift is rejected by Python and published JSON Schema",
+      "non-object report input is rejected"
+    ],
+    "positive": "dry-run report validates against the published schema and contains no sensitive fields",
+    "commands": [
+      "python -m pytest tests/test_capability_reports.py tests/test_consumer_matrix.py tests/test_astro_docs_contract.py -q"
+    ]
+  },
+  "sensitive_field_policy": {
+    "default_report_fields_allowlist": [
+      "schema_version",
+      "package_version",
+      "backend",
+      "optional_modules",
+      "methods",
+      "dispatch_methods",
+      "selected_method",
+      "dry_run"
+    ],
+    "paths_credentials_patient_data": "forbidden"
+  },
+  "baseline_hashes": {
+    "voiage/cli.py": "41a274ea4883bbe4105397af39472b4f7491cc1d0bb14a3227aa2f5d57a6d015",
+    "voiage/contracts/capability_report.py": "5e58e4038bf7531f441ce08f37df7d76c139e5afa4089b66b100891c5b2bff1f",
+    "tests/test_capability_reports.py": "be8c9acca2ff3e58d440abf053f7bd6629506abda269075ab3d8a74718448fcf",
+    "docs/astro-site/src/content/docs/user-guide/features/cli.mdx": "539a7ff8889daaabe41326df619877fe3dbf67dc1fd1ed486e7806f8e67378a1",
+    "conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json": "bdcaf9155d5e179ee5f9e350dd4f5745d8bb93af23d71507ee5b7e0b3a9a0aed"
+  }
+}

--- a/docs/astro-site/src/content/docs/user-guide/features/cli.mdx
+++ b/docs/astro-site/src/content/docs/user-guide/features/cli.mdx
@@ -20,3 +20,18 @@ voiage evsi --input data.csv --design trial_design.json
 # Plot results
 voiage plot ceac --input results.json
 ```
+
+## Capability discovery
+
+Use the dry-run capability query to inspect the installed Rust-backed methods
+without evaluating a model:
+
+```bash
+voiage capabilities --json
+voiage capabilities --json --method evpi
+```
+
+The JSON report is schema version `1.0.0`. Its `methods` and
+`dispatch_methods` fields must agree; an unsupported method exits with status
+2 and returns an actionable error. Reports contain module availability only and
+do not include filesystem paths, credentials, or patient-level data.

--- a/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
+++ b/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
@@ -12,7 +12,7 @@
     {"path": "specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/normative/expected.json", "sha256": "c9327a488f58d915f9202a8012b152c68d6aea2cd4a47b38d869c531dbc26507"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/deterministic-sensitivity-reference-review.md", "sha256": "b480cece8323bed01e9887cb59686baa92c0fdceb9e910875f0748129d9ce753"},
     {"path": "voiage/deterministic_sensitivity_contract.py", "sha256": "435fb0257962250649927f10bc5e845adcf69c24160c110369b131d528310cd5"},
-    {"path": "voiage/cli.py", "sha256": "2fe7d1b97c074682bad3a36111338ed392d0664dceb95fe5c4abaf40b4144e9f"},
+    {"path": "voiage/cli.py", "sha256": "e13c7dabcac8e3ef6c4affb8be297cbdacbd264bf11358d9c48d8f5af115056e"},
     {"path": "voiage/methods/deterministic_sensitivity.py", "sha256": "d4277431f47ed5aeeb6d21b4e16dfb9517a93ee3f4ce392f01059f0199b7b52b"},
     {"path": "voiage/plot/deterministic_sensitivity.py", "sha256": "0579dd59626c6ba09aaba67da7daa18f72810d67e7729626244a7ca96fa558f2"},
     {"path": "tests/test_deterministic_sensitivity.py", "sha256": "04d6f94968920b2471190448412cbe30b2674c7220e6f753f8c0be9e27b7a146"},

--- a/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
+++ b/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
@@ -12,7 +12,7 @@
     {"path": "specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/normative/expected.json", "sha256": "c9327a488f58d915f9202a8012b152c68d6aea2cd4a47b38d869c531dbc26507"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/deterministic-sensitivity-reference-review.md", "sha256": "b480cece8323bed01e9887cb59686baa92c0fdceb9e910875f0748129d9ce753"},
     {"path": "voiage/deterministic_sensitivity_contract.py", "sha256": "435fb0257962250649927f10bc5e845adcf69c24160c110369b131d528310cd5"},
-    {"path": "voiage/cli.py", "sha256": "e13c7dabcac8e3ef6c4affb8be297cbdacbd264bf11358d9c48d8f5af115056e"},
+    {"path": "voiage/cli.py", "sha256": "41a274ea4883bbe4105397af39472b4f7491cc1d0bb14a3227aa2f5d57a6d015"},
     {"path": "voiage/methods/deterministic_sensitivity.py", "sha256": "d4277431f47ed5aeeb6d21b4e16dfb9517a93ee3f4ce392f01059f0199b7b52b"},
     {"path": "voiage/plot/deterministic_sensitivity.py", "sha256": "0579dd59626c6ba09aaba67da7daa18f72810d67e7729626244a7ca96fa558f2"},
     {"path": "tests/test_deterministic_sensitivity.py", "sha256": "04d6f94968920b2471190448412cbe30b2674c7220e6f753f8c0be9e27b7a146"},

--- a/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
+++ b/specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/evidence.json
@@ -12,7 +12,7 @@
     {"path": "specs/frontier/deterministic-sensitivity-analysis/v1/fixtures/normative/expected.json", "sha256": "c9327a488f58d915f9202a8012b152c68d6aea2cd4a47b38d869c531dbc26507"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/deterministic-sensitivity-reference-review.md", "sha256": "b480cece8323bed01e9887cb59686baa92c0fdceb9e910875f0748129d9ce753"},
     {"path": "voiage/deterministic_sensitivity_contract.py", "sha256": "435fb0257962250649927f10bc5e845adcf69c24160c110369b131d528310cd5"},
-    {"path": "voiage/cli.py", "sha256": "65de01b183c0f0e6d6365298f4bdc92f2280fa9dc4c84afe2328cca965c4a865"},
+    {"path": "voiage/cli.py", "sha256": "2fe7d1b97c074682bad3a36111338ed392d0664dceb95fe5c4abaf40b4144e9f"},
     {"path": "voiage/methods/deterministic_sensitivity.py", "sha256": "d4277431f47ed5aeeb6d21b4e16dfb9517a93ee3f4ce392f01059f0199b7b52b"},
     {"path": "voiage/plot/deterministic_sensitivity.py", "sha256": "0579dd59626c6ba09aaba67da7daa18f72810d67e7729626244a7ca96fa558f2"},
     {"path": "tests/test_deterministic_sensitivity.py", "sha256": "04d6f94968920b2471190448412cbe30b2674c7220e6f753f8c0be9e27b7a146"},

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     {"path": "specs/frontier/value-of-distributional-information/v1/README.md", "sha256": "cda82e1a704b5172d11fb551d77318dca9cb80972a49889bb763dba098862bae"},
     {"path": "voiage/contracts/distributional_information.py", "sha256": "a2a9a8f4a9c85173f00fa34e928e6b6c04619885be2dc647a3a9ab91ba4e5854"},
     {"path": "voiage/methods/distributional_information.py", "sha256": "cd8fef252073109450fbfa7f422cb08eb084827ebfad35da412d99ad07c75f28"},
-    {"path": "voiage/cli.py", "sha256": "e13c7dabcac8e3ef6c4affb8be297cbdacbd264bf11358d9c48d8f5af115056e"},
+    {"path": "voiage/cli.py", "sha256": "41a274ea4883bbe4105397af39472b4f7491cc1d0bb14a3227aa2f5d57a6d015"},
     {"path": "voiage/__init__.py", "sha256": "552edd0f753af8f50a873aeda971201f6bf0175a252b7a27ad48489665c3873f"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-reference-review.md", "sha256": "d0fcdacde3d0340684428298259551a8d58fb6e0b4efcb780b48b7b106337548"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-implementation-review.md", "sha256": "075ade9e26efcc4d0a680ea46536352fa31b672c65259c48c7fc1a6a6ab51f0b"},

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     {"path": "specs/frontier/value-of-distributional-information/v1/README.md", "sha256": "cda82e1a704b5172d11fb551d77318dca9cb80972a49889bb763dba098862bae"},
     {"path": "voiage/contracts/distributional_information.py", "sha256": "a2a9a8f4a9c85173f00fa34e928e6b6c04619885be2dc647a3a9ab91ba4e5854"},
     {"path": "voiage/methods/distributional_information.py", "sha256": "cd8fef252073109450fbfa7f422cb08eb084827ebfad35da412d99ad07c75f28"},
-    {"path": "voiage/cli.py", "sha256": "2fe7d1b97c074682bad3a36111338ed392d0664dceb95fe5c4abaf40b4144e9f"},
+    {"path": "voiage/cli.py", "sha256": "e13c7dabcac8e3ef6c4affb8be297cbdacbd264bf11358d9c48d8f5af115056e"},
     {"path": "voiage/__init__.py", "sha256": "552edd0f753af8f50a873aeda971201f6bf0175a252b7a27ad48489665c3873f"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-reference-review.md", "sha256": "d0fcdacde3d0340684428298259551a8d58fb6e0b4efcb780b48b7b106337548"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-implementation-review.md", "sha256": "075ade9e26efcc4d0a680ea46536352fa31b672c65259c48c7fc1a6a6ab51f0b"},

--- a/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-distributional-information/v1/fixtures/evidence.json
@@ -14,7 +14,7 @@
     {"path": "specs/frontier/value-of-distributional-information/v1/README.md", "sha256": "cda82e1a704b5172d11fb551d77318dca9cb80972a49889bb763dba098862bae"},
     {"path": "voiage/contracts/distributional_information.py", "sha256": "a2a9a8f4a9c85173f00fa34e928e6b6c04619885be2dc647a3a9ab91ba4e5854"},
     {"path": "voiage/methods/distributional_information.py", "sha256": "cd8fef252073109450fbfa7f422cb08eb084827ebfad35da412d99ad07c75f28"},
-    {"path": "voiage/cli.py", "sha256": "65de01b183c0f0e6d6365298f4bdc92f2280fa9dc4c84afe2328cca965c4a865"},
+    {"path": "voiage/cli.py", "sha256": "2fe7d1b97c074682bad3a36111338ed392d0664dceb95fe5c4abaf40b4144e9f"},
     {"path": "voiage/__init__.py", "sha256": "552edd0f753af8f50a873aeda971201f6bf0175a252b7a27ad48489665c3873f"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-reference-review.md", "sha256": "d0fcdacde3d0340684428298259551a8d58fb6e0b4efcb780b48b7b106337548"},
     {"path": "conductor/archive/supported_frontier_method_completion_20260723/distribution-family-information-implementation-review.md", "sha256": "075ade9e26efcc4d0a680ea46536352fa31b672c65259c48c7fc1a6a6ab51f0b"},

--- a/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "voiage/cli.py",
-      "sha256": "65de01b183c0f0e6d6365298f4bdc92f2280fa9dc4c84afe2328cca965c4a865"
+      "sha256": "2fe7d1b97c074682bad3a36111338ed392d0664dceb95fe5c4abaf40b4144e9f"
     },
     {
       "path": "tests/test_value_of_flexibility.py",

--- a/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "voiage/cli.py",
-      "sha256": "e13c7dabcac8e3ef6c4affb8be297cbdacbd264bf11358d9c48d8f5af115056e"
+      "sha256": "41a274ea4883bbe4105397af39472b4f7491cc1d0bb14a3227aa2f5d57a6d015"
     },
     {
       "path": "tests/test_value_of_flexibility.py",

--- a/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
+++ b/specs/frontier/value-of-flexibility/v1/fixtures/evidence.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "voiage/cli.py",
-      "sha256": "2fe7d1b97c074682bad3a36111338ed392d0664dceb95fe5c4abaf40b4144e9f"
+      "sha256": "e13c7dabcac8e3ef6c4affb8be297cbdacbd264bf11358d9c48d8f5af115056e"
     },
     {
       "path": "tests/test_value_of_flexibility.py",

--- a/specs/submission-readiness/structure-inventory-delta-20260901.json
+++ b/specs/submission-readiness/structure-inventory-delta-20260901.json
@@ -201,10 +201,11 @@
     "python_modules_sha256": "3d3a33c3aa830a4ec995099061ae5a73fa96bc7ca7d44a79e0b0a5e3b3318825"
   },
   "additions": [
+    "voiage/contracts/capability_report.py",
     "voiage/sampling_harm_agent_assurance.py"
   ],
   "removals": [],
-  "current_python_runtime_modules": 177,
+  "current_python_runtime_modules": 178,
   "classification": "assurance: verification support only, not numerical execution authority",
   "scope": "Python module membership only; no new API, ABI, scientific, release or publication audit is claimed."
 }

--- a/tests/test_capability_reports.py
+++ b/tests/test_capability_reports.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 import pytest
 from typer.testing import CliRunner
 
@@ -22,8 +24,17 @@ def test_capability_report_is_schema_bound_and_dispatch_complete() -> None:
     payload = json.loads(result.stdout)
     CliCapabilityReport.model_validate(payload)
     schema = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(payload)
     assert schema["properties"]["dry_run"]["const"] is True
-    assert set(payload) == set(schema["required"])
+    assert set(payload) - set(schema["required"]) == {"selected_method"}
+
+
+def test_published_schema_rejects_dispatch_registry_drift() -> None:
+    schema = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    report = json.loads(CliRunner().invoke(app, ["capabilities", "--json"]).stdout)
+    report["dispatch_methods"] = ["evpi"]
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(report)
 
 
 def test_capability_report_rejects_dispatch_drift() -> None:

--- a/tests/test_capability_reports.py
+++ b/tests/test_capability_reports.py
@@ -37,6 +37,12 @@ def test_capability_report_rejects_dispatch_drift() -> None:
         )
 
 
+def test_capability_report_rejects_non_object_input() -> None:
+    """The JSON contract must fail closed for non-object payloads."""
+    with pytest.raises(ValueError):
+        CliCapabilityReport.model_validate(None)
+
+
 def test_capabilities_method_query_is_dry_run() -> None:
     result = CliRunner().invoke(app, ["capabilities", "--json", "--method", "evpi"])
     assert result.exit_code == 0

--- a/tests/test_capability_reports.py
+++ b/tests/test_capability_reports.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from voiage.cli import app
+from voiage.contracts.capabilities import CliCapabilityReport
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = (
+    ROOT
+    / "conductor/tracks/agent_safe_engineering_20260907/capability-report-contract.json"
+)
+
+
+def test_capability_report_is_schema_bound_and_dispatch_complete() -> None:
+    result = CliRunner().invoke(app, ["capabilities", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    CliCapabilityReport.model_validate(payload)
+    schema = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    assert schema["properties"]["dry_run"]["const"] is True
+    assert set(payload) == set(schema["required"])
+
+
+def test_capability_report_rejects_dispatch_drift() -> None:
+    with pytest.raises(ValueError, match="match dispatch"):
+        CliCapabilityReport(
+            package_version="0",
+            backend="rust-backed-cpu",
+            optional_modules={},
+            methods=("evpi",),
+            dispatch_methods=(),
+        )
+
+
+def test_capabilities_method_query_is_dry_run() -> None:
+    result = CliRunner().invoke(app, ["capabilities", "--json", "--method", "evpi"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["dry_run"] is True
+    assert set(payload) == {
+        "schema_version",
+        "package_version",
+        "backend",
+        "optional_modules",
+        "methods",
+        "dispatch_methods",
+        "dry_run",
+        "selected_method",
+    }

--- a/tests/test_capability_reports.py
+++ b/tests/test_capability_reports.py
@@ -7,7 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from voiage.cli import app
-from voiage.contracts.capabilities import CliCapabilityReport
+from voiage.contracts.capability_report import CliCapabilityReport
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = (

--- a/tests/test_structure_api_abi_audit.py
+++ b/tests/test_structure_api_abi_audit.py
@@ -44,11 +44,14 @@ def _validate_current_membership(actual: set[str], *, root: Path = ROOT) -> None
         == 176
     )
     additions = delta["additions"]
-    assert additions == ["voiage/sampling_harm_agent_assurance.py"]
+    assert additions == [
+        "voiage/contracts/capability_report.py",
+        "voiage/sampling_harm_agent_assurance.py",
+    ]
     assert delta["removals"] == []
     assert set(modules).isdisjoint(additions)
     assert actual == set(modules) | set(additions)
-    assert len(actual) == delta["current_python_runtime_modules"] == 177
+    assert len(actual) == delta["current_python_runtime_modules"] == 178
 
 
 def test_structure_inventory_matches_current_sources() -> None:

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -301,6 +301,7 @@ def capabilities(
         "optional_modules": dict(report_model.optional_modules),
         "methods": list(report_model.methods),
         "dispatch_methods": list(report_model.dispatch_methods),
+        "selected_method": None,
         "dry_run": report_model.dry_run,
     }
     if method is not None:

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -26,6 +26,7 @@ from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 import numpy as np
 import typer
 
+from voiage.contracts.capabilities import CliCapabilityReport
 from voiage.contracts.distributional_information import (
     VALUE_OF_DISTRIBUTIONAL_INFORMATION_INPUT_SCHEMA_V1,
 )
@@ -259,6 +260,14 @@ def _module_available(name: str) -> bool:
 
 
 _CAPABILITY_METHODS = ["evpi", "evppi", "evsi", "enbs", "ceaf", "dominance"]
+_CAPABILITY_DISPATCH = {
+    "evpi": "calculate_evpi",
+    "evppi": "calculate_evppi",
+    "evsi": "calculate_evsi",
+    "enbs": "calculate_enbs",
+    "ceaf": "calculate_ceaf",
+    "dominance": "calculate_dominance",
+}
 
 
 @app.command(name="capabilities")
@@ -273,16 +282,26 @@ def capabilities(
     """Report installed capabilities without evaluating a model."""
     from voiage import __version__
 
-    report = {
-        "schema_version": "1.0.0",
-        "package_version": __version__,
-        "backend": "rust-backed-cpu",
-        "optional_modules": {
+    report_model = CliCapabilityReport(
+        package_version=__version__,
+        backend="rust-backed-cpu",
+        optional_modules={
             name: _module_available(name)
             for name in ("jax", "torch", "polars", "pyarrow")
         },
-        "methods": _CAPABILITY_METHODS,
-        "dry_run": True,
+        methods=tuple(_CAPABILITY_METHODS),
+        dispatch_methods=tuple(
+            method for method in _CAPABILITY_METHODS if _CAPABILITY_DISPATCH.get(method)
+        ),
+    )
+    report = {
+        "schema_version": report_model.schema_version,
+        "package_version": report_model.package_version,
+        "backend": report_model.backend,
+        "optional_modules": dict(report_model.optional_modules),
+        "methods": list(report_model.methods),
+        "dispatch_methods": list(report_model.dispatch_methods),
+        "dry_run": report_model.dry_run,
     }
     if method is not None:
         normalized_method = method.strip().lower()

--- a/voiage/cli.py
+++ b/voiage/cli.py
@@ -26,7 +26,7 @@ from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 import numpy as np
 import typer
 
-from voiage.contracts.capabilities import CliCapabilityReport
+from voiage.contracts.capability_report import CliCapabilityReport
 from voiage.contracts.distributional_information import (
     VALUE_OF_DISTRIBUTIONAL_INFORMATION_INPUT_SCHEMA_V1,
 )

--- a/voiage/contracts/capabilities.py
+++ b/voiage/contracts/capabilities.py
@@ -74,8 +74,6 @@ class CapabilityReport(ContractModel):
     missing: tuple[Identifier, ...] = ()
 
 
-
-
 class CapabilityBackend(Protocol):
     """Minimal backend surface required by the generic dispatcher."""
 

--- a/voiage/contracts/capabilities.py
+++ b/voiage/contracts/capabilities.py
@@ -10,7 +10,7 @@ from typing import Literal, Protocol
 
 import numpy as np  # noqa: TC002 - public protocol signature
 from numpy.typing import NDArray  # noqa: TC002 - public protocol signature
-from pydantic import Field, field_serializer, model_validator
+from pydantic import Field, field_serializer
 
 from voiage.contracts.analysis import ContractModel, Identifier
 from voiage.contracts.critical_invariants import capability_gaps
@@ -74,34 +74,6 @@ class CapabilityReport(ContractModel):
     missing: tuple[Identifier, ...] = ()
 
 
-class CliCapabilityReport(ContractModel):
-    """Safe, deterministic capability report emitted by the CLI."""
-
-    schema_version: Literal["1.0.0"] = "1.0.0"
-    package_version: str
-    backend: Identifier
-    optional_modules: dict[Identifier, bool]
-    methods: tuple[Identifier, ...]
-    dispatch_methods: tuple[Identifier, ...]
-    dry_run: Literal[True] = True
-
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_sequences(cls, value: object) -> object:
-        """Accept JSON arrays while retaining immutable internal sequences."""
-        if isinstance(value, dict):
-            value = dict(value)
-            for key in ("methods", "dispatch_methods"):
-                if isinstance(value.get(key), list):
-                    value[key] = tuple(value[key])
-        return value
-
-    @model_validator(mode="after")
-    def dispatch_matches_methods(self) -> CliCapabilityReport:
-        """Reject reports that advertise an unregistered or hidden method."""
-        if self.methods != self.dispatch_methods:
-            raise ValueError("capability methods must match dispatch methods")
-        return self
 
 
 class CapabilityBackend(Protocol):

--- a/voiage/contracts/capabilities.py
+++ b/voiage/contracts/capabilities.py
@@ -10,7 +10,7 @@ from typing import Literal, Protocol
 
 import numpy as np  # noqa: TC002 - public protocol signature
 from numpy.typing import NDArray  # noqa: TC002 - public protocol signature
-from pydantic import Field, field_serializer
+from pydantic import Field, field_serializer, model_validator
 
 from voiage.contracts.analysis import ContractModel, Identifier
 from voiage.contracts.critical_invariants import capability_gaps
@@ -72,6 +72,36 @@ class CapabilityReport(ContractModel):
     backend_name: Identifier
     supported: bool
     missing: tuple[Identifier, ...] = ()
+
+
+class CliCapabilityReport(ContractModel):
+    """Safe, deterministic capability report emitted by the CLI."""
+
+    schema_version: Literal["1.0.0"] = "1.0.0"
+    package_version: str
+    backend: Identifier
+    optional_modules: dict[Identifier, bool]
+    methods: tuple[Identifier, ...]
+    dispatch_methods: tuple[Identifier, ...]
+    dry_run: Literal[True] = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_sequences(cls, value: object) -> object:
+        """Accept JSON arrays while retaining immutable internal sequences."""
+        if isinstance(value, dict):
+            value = dict(value)
+            for key in ("methods", "dispatch_methods"):
+                if isinstance(value.get(key), list):
+                    value[key] = tuple(value[key])
+        return value
+
+    @model_validator(mode="after")
+    def dispatch_matches_methods(self) -> CliCapabilityReport:
+        """Reject reports that advertise an unregistered or hidden method."""
+        if self.methods != self.dispatch_methods:
+            raise ValueError("capability methods must match dispatch methods")
+        return self
 
 
 class CapabilityBackend(Protocol):

--- a/voiage/contracts/capability_report.py
+++ b/voiage/contracts/capability_report.py
@@ -1,0 +1,44 @@
+"""Schema-bound, privacy-safe CLI capability report contract."""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from pydantic import model_validator
+
+from voiage.contracts.analysis import ContractModel, Identifier
+
+
+class CliCapabilityReport(ContractModel):
+    """Safe, deterministic capability report emitted by the CLI."""
+
+    schema_version: Literal["1.0.0"] = "1.0.0"
+    package_version: str
+    backend: Identifier
+    optional_modules: dict[Identifier, bool]
+    methods: tuple[Identifier, ...]
+    dispatch_methods: tuple[Identifier, ...]
+    dry_run: Literal[True] = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_sequences(cls, value: object) -> object:
+        """Accept JSON arrays while retaining immutable internal sequences."""
+        if isinstance(value, dict):
+            normalized = {
+                str(key): item
+                for key, item in cast("dict[object, object]", value).items()
+            }
+            for key in ("methods", "dispatch_methods"):
+                sequence = normalized.get(key)
+                if isinstance(sequence, list):
+                    normalized[key] = tuple(cast("list[object]", sequence))
+            return normalized
+        return value
+
+    @model_validator(mode="after")
+    def dispatch_matches_methods(self) -> CliCapabilityReport:
+        """Reject reports that advertise an unregistered or hidden method."""
+        if self.methods != self.dispatch_methods:
+            raise ValueError("capability methods must match dispatch methods")
+        return self

--- a/voiage/contracts/capability_report.py
+++ b/voiage/contracts/capability_report.py
@@ -18,6 +18,7 @@ class CliCapabilityReport(ContractModel):
     optional_modules: dict[Identifier, bool]
     methods: tuple[Identifier, ...]
     dispatch_methods: tuple[Identifier, ...]
+    selected_method: Identifier | None = None
     dry_run: Literal[True] = True
 
     @model_validator(mode="before")


### PR DESCRIPTION
## Summary
- add a canonical schema-validated capability report with dispatch parity checks
- expose `voiage capabilities --json` as an explicit dry-run surface
- add negative contract tests and CLI documentation

## Validation
- 17 focused capability/consumer/docs tests
- Ruff check and format
- git diff --check

This is the bounded G07 capability-report slice; packet guard metadata is unchanged.